### PR TITLE
On macOS, swap alt-{left,right,backspace,delete} with ctrl-*

### DIFF
--- a/doc_src/cmds/status.rst
+++ b/doc_src/cmds/status.rst
@@ -17,6 +17,7 @@ Synopsis
     status is-no-job-control
     status is-full-job-control
     status is-interactive-job-control
+    status is-in-macos-terminal
     status current-command
     status current-commandline
     status filename
@@ -61,6 +62,10 @@ The following operations (subcommands) are available:
 
 **is-no-job-control** or **--is-no-job-control**
     Returns 0 if no job control is enabled.
+
+**is-in-macos-terminal**
+    Returns 0 if the terminal emulator is running on macOS.
+    Attempts to see through SSH and containers, unlike ``uname(1)``.
 
 **current-command**
     Prints the name of the currently-running function or command, like the deprecated :envvar:`_` variable.

--- a/share/completions/status.fish
+++ b/share/completions/status.fish
@@ -13,6 +13,7 @@ complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_com
 complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a is-no-job-control -d "Test if new jobs are never put under job control"
 complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a is-interactive-job-control -d "Test if only interactive new jobs are put under job control"
 complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a is-full-job-control -d "Test if all new jobs are put under job control"
+complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a is-in-macos-terminal -d "Test if the shell is running in a macOS terminal"
 
 # The subcommands that are not "is-something" which don't change the fish state.
 complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a buildinfo -d "Print information on how this version fish was built"

--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -217,6 +217,12 @@ end" >$__fish_config_dir/config.fish
     end
     __fish_update_cwd_osc # Run once because we might have already inherited a PWD from an old tab
 
+    if set -q TMUX
+        # NOTE This will be invalidated when the next tmux client attaches
+        # to fish's window; but we only use it to detect macOS.
+        set -g __fish_tmux_client_tty (tmux display-message -p '#{client_tty}' 2>/dev/null)
+    end
+
     # Bump this whenever some code below needs to run once when upgrading to a new version.
     # The universal variable __fish_initialized is initialized in share/config.fish.
     set __fish_initialized 3800

--- a/share/functions/__fish_shared_key_bindings.fish
+++ b/share/functions/__fish_shared_key_bindings.fish
@@ -21,8 +21,20 @@ function __fish_shared_key_bindings -d "Bindings shared between emacs and vi mod
     $legacy_bind --preset $argv -k left backward-char
 
     # Ctrl-left/right - these also work in vim.
-    bind --preset $argv ctrl-right forward-word
-    bind --preset $argv ctrl-left backward-word
+    bind --preset $argv ctrl-right '
+        if status is-in-macos-terminal
+            commandline -f forward-token
+        else
+            commandline -f forward-word
+        end
+    '
+    bind --preset $argv ctrl-left '
+        if status is-in-macos-terminal
+            commandline -f backward-token
+        else
+            commandline -f backward-word
+        end
+    '
 
     bind --preset $argv pageup beginning-of-history
     bind --preset $argv pagedown end-of-history
@@ -54,8 +66,20 @@ function __fish_shared_key_bindings -d "Bindings shared between emacs and vi mod
     $legacy_bind --preset $argv -k sright forward-bigword
     $legacy_bind --preset $argv -k sleft backward-bigword
 
-    bind --preset $argv alt-right nextd-or-forward-token
-    bind --preset $argv alt-left prevd-or-backward-token
+    bind --preset $argv alt-right '
+        if status is-in-macos-terminal
+            commandline -f nextd-or-forward-word
+        else
+            nextd-or-forward-token
+        end
+    '
+    bind --preset $argv alt-left '
+        if status is-in-macos-terminal
+            commandline -f prevd-or-backward-word
+        else
+            prevd-or-backward-token
+        end
+    '
 
     bind --preset $argv alt-up history-token-search-backward
     bind --preset $argv alt-down history-token-search-forward

--- a/share/functions/fish_default_key_bindings.fish
+++ b/share/functions/fish_default_key_bindings.fish
@@ -55,10 +55,34 @@ function fish_default_key_bindings -d "emacs-like key binds"
     bind --preset $argv alt-u upcase-word
 
     bind --preset $argv alt-c capitalize-word
-    bind --preset $argv alt-backspace backward-kill-token
-    bind --preset $argv ctrl-backspace backward-kill-word
-    bind --preset $argv alt-delete kill-token
-    bind --preset $argv ctrl-delete kill-word
+    bind --preset $argv alt-backspace '
+        if status is-in-macos-terminal
+            commandline -f backward-kill-word
+        else
+            commandline -f backward-kill-token
+        end
+    '
+    bind --preset $argv ctrl-backspace '
+        if status is-in-macos-terminal
+            commandline -f backward-kill-token
+        else
+            commandline -f backward-kill-word
+        end
+    '
+    bind --preset $argv alt-delete '
+        if status is-in-macos-terminal
+            commandline -f kill-word
+        else
+            commandline -f kill-token
+        end
+    '
+    bind --preset $argv ctrl-delete '
+        if status is-in-macos-terminal
+            commandline -f kill-token
+        else
+            commandline -f kill-word
+        end
+    '
     bind --preset $argv alt-b backward-word
     bind --preset $argv alt-f forward-word
     if test "$TERM_PROGRAM" = Apple_Terminal

--- a/src/builtins/status.rs
+++ b/src/builtins/status.rs
@@ -3,6 +3,7 @@ use std::os::unix::prelude::*;
 use super::prelude::*;
 use crate::common::{get_executable_path, str2wcstring, PROGRAM_NAME};
 use crate::future_feature_flags::{self as features, feature_test};
+use crate::input_common::IN_MACOS_TERMINAL;
 use crate::proc::{
     get_job_control_mode, get_login, is_interactive_session, set_job_control_mode, JobControl,
 };
@@ -50,6 +51,7 @@ enum StatusCmd {
     STATUS_IS_FULL_JOB_CTRL,
     STATUS_IS_INTERACTIVE,
     STATUS_IS_INTERACTIVE_JOB_CTRL,
+    STATUS_IS_IN_MACOS_TERMINAL,
     STATUS_IS_LOGIN,
     STATUS_IS_NO_JOB_CTRL,
     STATUS_LINE_NUMBER,
@@ -65,6 +67,7 @@ str_enum!(
     (STATUS_BASENAME, "basename"),
     (STATUS_BASENAME, "current-basename"),
     (STATUS_BUILDINFO, "buildinfo"),
+    (STATUS_IS_IN_MACOS_TERMINAL, "is-in-macos-terminal"),
     (STATUS_CURRENT_CMD, "current-command"),
     (STATUS_CURRENT_COMMANDLINE, "current-commandline"),
     (STATUS_DIRNAME, "current-dirname"),
@@ -597,6 +600,13 @@ pub fn status(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> O
                         // This is a relative path, we can't canonicalize it
                         let path = str2wcstring(path.as_os_str().as_bytes());
                         streams.out.appendln(path);
+                    }
+                }
+                STATUS_IS_IN_MACOS_TERMINAL => {
+                    if IN_MACOS_TERMINAL.load() {
+                        return STATUS_CMD_OK;
+                    } else {
+                        return STATUS_CMD_ERROR;
                     }
                 }
                 STATUS_SET_JOB_CONTROL | STATUS_FEATURES | STATUS_TEST_FEATURE => {


### PR DESCRIPTION
Commit 6af96a81a8 (Default bindings for token movement commands,
2024-10-05) changed the behavior of keys like `alt-left` to move by
tokens instead of words.

This seems fine on non-macOS systems where GUI text fields use
`ctrl-left` for word movement.

But it's surprising on macOS where word movement is `alt-left`
everywhere.

Sublime Text uses the native key binding for word movement, and uses
the vacant chord (e.g. `alt-left` on Linux) for sub-word movement
(in camel case words).

Let's try to do the same, but for token movements.

There are not too many terminals that run on macOS. Try to detect
some of them in various ways, some more hacky than others.
1. Kitty supports reporting the client OS via `XTGETTCAP`[^XTGETTCAP].
   This is the most correct method, overriding others[^os-name]. 
   By default tmux doesn't let this request pass through.
   Add a workaround to bypass tmux, just like we do in
   `fish_clipboard_copy`.
2. We can detect iTerm2 based on LC_TERMINAL, even inside SSH.
3. Assume macOS if fish is built for macOS. This is not fully correct
   since the terminal may run on another system.

One of my concerns is that so far I personally override this change.
(when on macOS and running SSH into fish). Part of the reason is that
the version of tmux I use doesn't support binding ctrl-backspace
yet. I'm not sure if users prefer a native experience or consistency
across platforms. But users who regularly switch platforms have to
switch muscle memory regardless.

I don't know yet what I'd apply to the release branch.  Maybe a
subset of detection methods, or revert 6af96a81a8, I'm not sure how
many people are affected.

Alternatives:
1. revert and/or find different key bindings
2. leave things as they are

[^XTGETTCAP]: The current patch detects macOS only after sourcing
              config files. We can fix this by reshuffling some code.
[^os-name]: We might want to expose the (arbitrary) OS name,
            however the name reported by Kitty is like
            "bsd"/"linux"/"macos", which does not match `uname(1)`,
            so I'm not sure if that's stable enough for us. Hence
            the boolean macOS flag.

Closes #10926

## TODOs:
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
