### PR TITLE
Fixes for unnecessary undos

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -2982,7 +2982,7 @@ impl<'a> Reader<'a> {
 
                 let was_active_before = self.history_search.active();
 
-                if self.history_search.is_at_present() {
+                if self.history_search.is_at_present() && mode != self.history_search.mode() {
                     let el = &self.data.command_line;
                     if mode == SearchMode::Token {
                         // Searching by token.
@@ -3331,15 +3331,13 @@ impl<'a> Reader<'a> {
                         },
                         false,
                     );
-                } else {
+                } else if self.history_search.active() {
                     if up {
                         self.history_search.go_to_oldest();
                     } else {
                         self.history_search.go_to_present();
                     }
-                    if self.history_search.active() {
-                        self.update_command_line_from_history_search();
-                    }
+                    self.update_command_line_from_history_search();
                 }
             }
             rl::UpLine | rl::DownLine => {

--- a/src/reader_history_search.rs
+++ b/src/reader_history_search.rs
@@ -79,6 +79,9 @@ impl ReaderHistorySearch {
     pub fn by_prefix(&self) -> bool {
         self.mode == SearchMode::Prefix
     }
+    pub fn mode(&self) -> SearchMode {
+        self.mode
+    }
 
     /// Move the history search in the given direction `dir`.
     pub fn move_in_direction(&mut self, dir: SearchDirection) -> bool {

--- a/tests/checks/tmux-history-pager.fish
+++ b/tests/checks/tmux-history-pager.fish
@@ -141,3 +141,9 @@ isolated-tmux capture-pane -p
 # CHECK: ► true 2   ► true 4   ► true 6   ► true 8   ► true 10   ► true 12
 # CHECK: ► true 3!  ► true 5!  ► true 7!  ► true 9!  ► true 11!  ► true 13!
 # CHECK: Items 1 to 12 of 35
+
+isolated-tmux send-keys -
+isolated-tmux send-keys Escape
+tmux-sleep
+isolated-tmux capture-pane -p
+# CHECK: prompt 50>

--- a/tests/checks/tmux-history-search2.fish
+++ b/tests/checks/tmux-history-search2.fish
@@ -4,11 +4,12 @@
 
 isolated-tmux-start
 isolated-tmux send-keys ': 1' Enter
-isolated-tmux send-keys ': ' M-Up M-Down M-Up M-Up M-Up Enter
-isolated-tmux send-keys C-l 'echo still alive' Enter
+isolated-tmux send-keys ': ' M-Up M-Down M-Up M-Up M-Up M-Down Enter
+isolated-tmux send-keys 'echo still alive' Enter
 tmux-sleep
-# isolated-tmux capture-pane -p | tail -2
 isolated-tmux capture-pane -p
+# CHECK: prompt 0> : 1
+# CHECK: prompt 1> : 1
 # CHECK: prompt 2> echo still alive
 # CHECK: still alive
 # CHECK: prompt 3>


### PR DESCRIPTION
## Description

Fixes:
- Currently, if we return to the present, fish thinks that it still has a transient edit. This results in an unnecessary undo when performing a backward search. For example:
1. Type ': '.
2. Do a backward token search.
3. Do a forward token search.
4. Do another backward token search - this will result in the undo of ': '.
- Currently, when the history pager is selected, fish always one undo away from the original search term. If the search has no matches, the fish replaces the search term with itself (resulting in no visible change, but it is still treated as a transient edit). However, fish ignores undo operations where the replacement is "" by "", leading to an unnecessary undo. For example:
1. Type 'test'.
2. Do ctrl-c.
3. Open the history pager.
4. Make so there are no matches.
5. Exit - you will undo back to 'test'.
- Currently, if you select a pager element that does not change the content of the commandline, it will still be added to the undo history.

Also, it changes that fish always restarts the history search when moving from the present even if the search mode is maintained. For example:
1. Do a few backward searches.
2. Use PageDown to return to the present.
3. Do another backward search.
4. Now, PageUp does nothing because the search was restarted, even if we maintained search mode.