### PR TITLE
Add transient prompt

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Notable improvements and fixes
 ------------------------------
 - Compound commands (``begin; echo 1; echo 2; end``) can now be now be abbreviated using braces (``{ echo1; echo 2 }``), like in other shells.
 - When tab completion results are truncated, any common directory name is omitted.
+- Fish now supports transient prompts: if ``fish_transient_prompt`` is set to 1, fish will reexecute prompt functions with the ``--final-rendering`` argument before running a commandline.
 
 Deprecations and removed features
 ---------------------------------

--- a/doc_src/cmds/fish_prompt.rst
+++ b/doc_src/cmds/fish_prompt.rst
@@ -20,9 +20,11 @@ Synopsis
 Description
 -----------
 
-The ``fish_prompt`` function is executed when the prompt is to be shown, and the output is used as a prompt.
+The ``fish_prompt`` function is executed when the prompt is to be shown and, if ``fish_transient_prompt`` is set to 1, before running a commandline. The output of this function is used as a prompt.
 
 The exit status of commands within ``fish_prompt`` will not modify the value of :ref:`$status <variables-status>` outside of the ``fish_prompt`` function.
+
+When the function is executed before running a commandline, it is passed a ``--final-rendering`` argument.
 
 ``fish`` ships with a number of example prompts that can be chosen with the ``fish_config`` command.
 

--- a/doc_src/interactive.rst
+++ b/doc_src/interactive.rst
@@ -217,6 +217,8 @@ This prompt is determined by running the :doc:`fish_prompt <cmds/fish_prompt>` a
 The output of the former is displayed on the left and the latter's output on the right side of the terminal.
 For :ref:`vi mode <vi-mode>`, the output of :doc:`fish_mode_prompt <cmds/fish_mode_prompt>` will be prepended on the left.
 
+If ``fish_transient_prompt`` is set to 1, fish will redraw the prompt with a ``--final-rendering`` argument before running a commandline, allowing you to change it before pushing it to the scrollback.
+
 Fish ships with a few prompts which you can see with :doc:`fish_config <cmds/fish_config>`. If you run just ``fish_config`` it will open a web interface [#]_ where you'll be shown the prompts and can pick which one you want. ``fish_config prompt show`` will show you the prompts right in your terminal.
 
 For example ``fish_config prompt choose disco`` will temporarily select the "disco" prompt. If you like it and decide to keep it, run ``fish_config prompt save``.

--- a/doc_src/prompt.rst
+++ b/doc_src/prompt.rst
@@ -148,9 +148,48 @@ And it looks like:
 .. parsed-literal::
     :class: highlight
 
+    :green:`~/M/L/Oneknowing`>false
     :green:`~/M/L/Oneknowing`\ :red:`[1]`>_
 
 after we run ``false`` (which returns 1).
+
+Transient prompt
+----------------
+
+To enable transient prompt functionality, set the ``fish_transient_prompt`` variable to 1::
+
+  set -g fish_transient_prompt 1
+
+With this set, fish re-runs prompt functions with a ``--final-rendering`` argument before running a commandline.
+So you can use it to declutter your old prompts. For example if you want to see only the current directory name when you scroll up::
+
+  function fish_prompt
+      set -l last_status $status
+      set -l stat
+      set -l pwd
+      # Check if it's a transient or final prompt
+      if contains -- --final-rendering $argv
+          set pwd (path basename $PWD)
+      else
+          set pwd (prompt_pwd)
+          # Prompt status only if it's not 0
+          if test $last_status -ne 0
+              set stat (set_color red)"[$last_status]"(set_color normal)
+          end
+      end
+
+      string join '' -- (set_color green) $pwd (set_color normal) $stat '>'
+  end
+
+Now this would print:
+
+.. role:: green
+.. role:: red
+.. parsed-literal::
+    :class: highlight
+
+    :green:`Oneknowing`>false
+    :green:`~/M/L/Oneknowing`\ :red:`[1]`>_
 
 Save the prompt
 ---------------

--- a/doc_src/tutorial.rst
+++ b/doc_src/tutorial.rst
@@ -649,6 +649,29 @@ This prompt would look like:
     :purple:`02/06/13`
     :red:`/home/tutorial >` _
 
+You can make your prompt transient by setting ``fish_transient_prompt`` to 1. That means fish will redraw the prompt before running a commandline, so you can change it then. Usually this is used to trim it down to declutter your terminal's scrollback history. When it runs the prompt again, it will pass a ``--final-rendering`` argument, so check for this to distinguish::
+
+    function fish_prompt
+        if contains -- --final-rendering $argv
+            set_color F00
+            echo '$' (set_color normal)
+        else
+            set_color purple
+            date "+%m/%d/%y"
+            set_color F00
+            echo (pwd) '>' (set_color normal)
+        end
+    end
+
+
+This would look like:
+
+.. parsed-literal::
+    :class: highlight
+
+    :red:`$` command
+    :purple:`02/06/13`
+    :red:`/home/tutorial >` _
 
 You can choose among some sample prompts by running ``fish_config`` for a web UI or ``fish_config prompt`` for a simpler version inside your terminal.
 

--- a/share/functions/fish_mode_prompt.fish
+++ b/share/functions/fish_mode_prompt.fish
@@ -1,5 +1,8 @@
 # The fish_mode_prompt function is prepended to the prompt
 function fish_mode_prompt --description "Displays the current mode"
-    # To reuse the mode indicator use this function instead
-    fish_default_mode_prompt
+    # Don't show mode indicator for final rendering in case transient mode is enabled
+    if ! contains -- --final-rendering $argv
+        # To reuse the mode indicator use this function instead
+        fish_default_mode_prompt
+    end
 end

--- a/share/functions/fish_prompt.fish
+++ b/share/functions/fish_prompt.fish
@@ -18,17 +18,20 @@ function fish_prompt --description 'Write out the prompt'
         set suffix '#'
     end
 
-    # Write pipestatus
-    # If the status was carried over (if no command is issued or if `set` leaves the status untouched), don't bold it.
-    set -l bold_flag --bold
-    set -q __fish_prompt_status_generation; or set -g __fish_prompt_status_generation $status_generation
-    if test $__fish_prompt_status_generation = $status_generation
-        set bold_flag
+    # Write pipestatus if prompt is transient or transient prompt is disabled.
+    set -l prompt_status
+    if ! contains -- --final-rendering $argv
+        # If the status was carried over (if no command is issued or if `set` leaves the status untouched), don't bold it.
+        set -l bold_flag --bold
+        set -q __fish_prompt_status_generation; or set -g __fish_prompt_status_generation $status_generation
+        if test $__fish_prompt_status_generation = $status_generation
+            set bold_flag
+        end
+        set __fish_prompt_status_generation $status_generation
+        set -l status_color (set_color $fish_color_status)
+        set -l statusb_color (set_color $bold_flag $fish_color_status)
+        set prompt_status (__fish_print_pipestatus "[" "]" "|" "$status_color" "$statusb_color" $last_pipestatus)
     end
-    set __fish_prompt_status_generation $status_generation
-    set -l status_color (set_color $fish_color_status)
-    set -l statusb_color (set_color $bold_flag $fish_color_status)
-    set -l prompt_status (__fish_print_pipestatus "[" "]" "|" "$status_color" "$statusb_color" $last_pipestatus)
 
     echo -n -s (prompt_login)' ' (set_color $color_cwd) (prompt_pwd) $normal (fish_vcs_prompt) $normal " "$prompt_status $suffix " "
 end

--- a/src/env_dispatch.rs
+++ b/src/env_dispatch.rs
@@ -9,7 +9,7 @@ use crate::output::ColorSupport;
 use crate::proc::is_interactive_session;
 use crate::reader::{
     reader_change_cursor_end_mode, reader_change_cursor_selection_mode, reader_change_history,
-    reader_schedule_prompt_repaint, reader_set_autosuggestion_enabled,
+    reader_schedule_prompt_repaint, reader_set_autosuggestion_enabled, reader_set_transient_prompt,
 };
 use crate::screen::screen_set_midnight_commander_hack;
 use crate::screen::LAYOUT_CACHE_SHARED;
@@ -73,6 +73,7 @@ static VAR_DISPATCH_TABLE: once_cell::sync::Lazy<VarDispatchTable> =
             L!("fish_autosuggestion_enabled"),
             handle_autosuggestion_change,
         );
+        table.add_anon(L!("fish_transient_prompt"), handle_transient_prompt_change);
         table.add_anon(
             L!("fish_use_posix_spawn"),
             handle_fish_use_posix_spawn_change,
@@ -282,6 +283,10 @@ fn handle_fish_cursor_end_mode_change(vars: &EnvStack) {
 
 fn handle_autosuggestion_change(vars: &EnvStack) {
     reader_set_autosuggestion_enabled(vars);
+}
+
+fn handle_transient_prompt_change(vars: &EnvStack) {
+    reader_set_transient_prompt(vars);
 }
 
 fn handle_function_path_change(_: &EnvStack) {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -2235,7 +2235,7 @@ impl<'a> Reader<'a> {
         if !self.conf.event.is_empty() {
             event::fire_generic(self.parser, self.conf.event.to_owned(), vec![]);
         }
-        self.exec_prompt();
+        self.exec_prompt(true);
 
         // Start out as initially dirty.
         self.force_exec_prompt_and_repaint = true;
@@ -2753,7 +2753,7 @@ impl<'a> Reader<'a> {
                     // This can happen e.g. if a variable triggers a repaint,
                     // and the variable is set inside the prompt (#7324).
                     // builtin commandline will refuse to enqueue these.
-                    self.exec_mode_prompt();
+                    self.exec_prompt(false);
                     if !self.mode_prompt_buff.is_empty() {
                         if self.is_repaint_needed(None) {
                             self.screen.reset_line(/*repaint_prompt=*/ true);
@@ -2764,7 +2764,7 @@ impl<'a> Reader<'a> {
                     }
                     // Else we repaint as normal.
                 }
-                self.exec_prompt();
+                self.exec_prompt(true);
                 self.screen.reset_line(/*repaint_prompt=*/ true);
                 self.layout_and_repaint(L!("readline"));
                 self.force_exec_prompt_and_repaint = false;
@@ -3869,7 +3869,7 @@ impl<'a> Reader<'a> {
             self.screen.reset_line(/*repaint_prompt=*/ true);
             self.layout_and_repaint(L!("readline"));
         }
-        self.exec_prompt();
+        self.exec_prompt(true);
         self.screen.reset_line(/*repaint_prompt=*/ true);
         self.layout_and_repaint(L!("readline"));
         self.force_exec_prompt_and_repaint = false;
@@ -4553,78 +4553,56 @@ pub fn reader_write_title(
 }
 
 impl<'a> Reader<'a> {
-    fn exec_mode_prompt(&mut self) {
-        self.mode_prompt_buff.clear();
-        if function::exists(MODE_PROMPT_FUNCTION_NAME, self.parser) {
-            let mut mode_indicator_list = vec![];
-            let _ = exec_subshell(
-                MODE_PROMPT_FUNCTION_NAME,
-                self.parser,
-                Some(&mut mode_indicator_list),
-                false,
-            );
-            // We do not support multiple lines in the mode indicator, so just concatenate all of
-            // them.
-            for i in mode_indicator_list {
-                self.mode_prompt_buff.push_utfstr(&i);
-            }
-        }
+    fn exec_prompt_cmd(&self, prompt_cmd: &wstr) -> Vec<WString> {
+        let mut output = vec![];
+        let _ = exec_subshell(prompt_cmd, self.parser, Some(&mut output), false);
+        output
     }
 
-    /// Reexecute the prompt command. The output is inserted into prompt_buff.
-    fn exec_prompt(&mut self) {
-        // Clear existing prompts.
-        self.left_prompt_buff.clear();
-        self.right_prompt_buff.clear();
-
+    /// Execute prompt commands based on the provided arguments. The output is inserted into prompt_buff.
+    fn exec_prompt(&mut self, full_prompt: bool) {
         // Suppress fish_trace while in the prompt.
         let _suppress_trace = self.parser.push_scope(|s| s.suppress_fish_trace = true);
+
+        // Prompts must be run non-interactively.
+        let _noninteractive = self.parser.push_scope(|s| s.is_interactive = false);
 
         // Update the termsize now.
         // This allows prompts to react to $COLUMNS.
         self.update_termsize();
 
-        // If we have any prompts, they must be run non-interactively.
-        if !self.conf.left_prompt_cmd.is_empty() || !self.conf.right_prompt_cmd.is_empty() {
-            let _noninteractive = self.parser.push_scope(|s| s.is_interactive = false);
-            self.exec_mode_prompt();
+        self.mode_prompt_buff.clear();
+        if function::exists(MODE_PROMPT_FUNCTION_NAME, self.parser) {
+            // We do not support multiline mode indicators, so just concatenate all of them.
+            self.mode_prompt_buff =
+                WString::from_iter(self.exec_prompt_cmd(MODE_PROMPT_FUNCTION_NAME));
+        }
+
+        if full_prompt {
+            self.left_prompt_buff.clear();
+            self.right_prompt_buff.clear();
 
             if !self.conf.left_prompt_cmd.is_empty() {
-                // Status is ignored.
-                let mut prompt_list = vec![];
                 // Historic compatibility hack.
                 // If the left prompt function is deleted, then use a default prompt instead of
                 // producing an error.
-                let left_prompt_deleted = self.conf.left_prompt_cmd == LEFT_PROMPT_FUNCTION_NAME
-                    && !function::exists(&self.conf.left_prompt_cmd, self.parser);
-                let _ = exec_subshell(
-                    if left_prompt_deleted {
-                        DEFAULT_PROMPT
-                    } else {
-                        &self.conf.left_prompt_cmd
-                    },
-                    self.parser,
-                    Some(&mut prompt_list),
-                    /*apply_exit_status=*/ false,
-                );
-                self.left_prompt_buff = join_strings(&prompt_list, '\n');
+                let prompt_cmd = if self.conf.left_prompt_cmd == LEFT_PROMPT_FUNCTION_NAME
+                    && !function::exists(&self.conf.left_prompt_cmd, self.parser)
+                {
+                    DEFAULT_PROMPT
+                } else {
+                    &self.conf.left_prompt_cmd
+                };
+
+                self.left_prompt_buff = join_strings(&self.exec_prompt_cmd(prompt_cmd), '\n');
             }
 
-            if !self.conf.right_prompt_cmd.is_empty() {
-                if function::exists(&self.conf.right_prompt_cmd, self.parser) {
-                    // Status is ignored.
-                    let mut prompt_list = vec![];
-                    let _ = exec_subshell(
-                        &self.conf.right_prompt_cmd,
-                        self.parser,
-                        Some(&mut prompt_list),
-                        /*apply_exit_status=*/ false,
-                    );
-                    // Right prompt does not support multiple lines, so just concatenate all of them.
-                    for i in prompt_list {
-                        self.right_prompt_buff.push_utfstr(&i);
-                    }
-                }
+            if !self.conf.right_prompt_cmd.is_empty()
+                && function::exists(&self.conf.right_prompt_cmd, self.parser)
+            {
+                // Right prompt does not support multiple lines, so just concatenate all of them.
+                self.right_prompt_buff =
+                    WString::from_iter(self.exec_prompt_cmd(&self.conf.right_prompt_cmd));
             }
         }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -4586,19 +4586,21 @@ impl<'a> Reader<'a> {
                 // Historic compatibility hack.
                 // If the left prompt function is deleted, then use a default prompt instead of
                 // producing an error.
-                let prompt_cmd = if self.conf.left_prompt_cmd == LEFT_PROMPT_FUNCTION_NAME
-                    && !function::exists(&self.conf.left_prompt_cmd, self.parser)
+                let prompt_cmd = if self.conf.left_prompt_cmd != LEFT_PROMPT_FUNCTION_NAME
+                    || function::exists(&self.conf.left_prompt_cmd, self.parser)
                 {
-                    DEFAULT_PROMPT
-                } else {
                     &self.conf.left_prompt_cmd
+                } else {
+                    DEFAULT_PROMPT
                 };
 
                 self.left_prompt_buff = join_strings(&self.exec_prompt_cmd(prompt_cmd), '\n');
             }
 
+            // Don't execute the right prompt if it is undefined fish_right_prompt
             if !self.conf.right_prompt_cmd.is_empty()
-                && function::exists(&self.conf.right_prompt_cmd, self.parser)
+                && (self.conf.right_prompt_cmd != RIGHT_PROMPT_FUNCTION_NAME
+                    || function::exists(&self.conf.right_prompt_cmd, self.parser))
             {
                 // Right prompt does not support multiple lines, so just concatenate all of them.
                 self.right_prompt_buff =

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -311,6 +311,9 @@ pub struct ReaderConfig {
     /// Whether to allow autosuggestions.
     pub autosuggest_ok: bool,
 
+    /// Whether to reexecute prompt function before final rendering.
+    pub transient_prompt: bool,
+
     /// Whether to expand abbreviations.
     pub expand_abbrev_ok: bool,
 
@@ -657,12 +660,13 @@ fn read_i(parser: &Parser) {
     assert_is_main_thread();
     parser.assert_can_execute();
     let mut conf = ReaderConfig::default();
+    conf.event = L!("fish_prompt");
     conf.complete_ok = true;
     conf.highlight_ok = true;
     conf.syntax_check_ok = true;
-    conf.autosuggest_ok = check_autosuggestion_enabled(parser.vars());
     conf.expand_abbrev_ok = true;
-    conf.event = L!("fish_prompt");
+    conf.autosuggest_ok = check_bool_var(parser.vars(), L!("fish_autosuggestion_enabled"), true);
+    conf.transient_prompt = check_bool_var(parser.vars(), L!("fish_transient_prompt"), false);
 
     if parser.is_breakpoint() && function::exists(DEBUG_PROMPT_FUNCTION_NAME, parser) {
         conf.left_prompt_cmd = DEBUG_PROMPT_FUNCTION_NAME.to_owned();
@@ -946,25 +950,32 @@ pub fn reader_change_cursor_end_mode(end_mode: CursorEndMode) {
     }
 }
 
-fn check_autosuggestion_enabled(vars: &dyn Environment) -> bool {
-    vars.get(L!("fish_autosuggestion_enabled"))
+fn check_bool_var(vars: &dyn Environment, name: &wstr, default: bool) -> bool {
+    vars.get(name)
         .map(|v| v.as_string())
         .map(|v| v != L!("0"))
-        .unwrap_or(true)
+        .unwrap_or(default)
 }
 
 /// Enable or disable autosuggestions based on the associated variable.
 pub fn reader_set_autosuggestion_enabled(vars: &dyn Environment) {
     // We don't need to _change_ if we're not initialized yet.
-    let Some(data) = current_data() else {
-        return;
-    };
-    let enable = check_autosuggestion_enabled(vars);
-    if data.conf.autosuggest_ok != enable {
-        data.conf.autosuggest_ok = enable;
-        data.force_exec_prompt_and_repaint = true;
-        data.input_data
-            .queue_char(CharEvent::from_readline(ReadlineCmd::Repaint));
+    if let Some(data) = current_data() {
+        let enable = check_bool_var(vars, L!("fish_autosuggestion_enabled"), true);
+        if data.conf.autosuggest_ok != enable {
+            data.conf.autosuggest_ok = enable;
+            data.force_exec_prompt_and_repaint = true;
+            data.input_data
+                .queue_char(CharEvent::from_readline(ReadlineCmd::Repaint));
+        }
+    }
+}
+
+/// Enable or disable transient prompt based on the associated variable.
+pub fn reader_set_transient_prompt(vars: &dyn Environment) {
+    // We don't need to _change_ if we're not initialized yet.
+    if let Some(data) = current_data() {
+        data.conf.transient_prompt = check_bool_var(vars, L!("fish_transient_prompt"), false);
     }
 }
 
@@ -2235,7 +2246,7 @@ impl<'a> Reader<'a> {
         if !self.conf.event.is_empty() {
             event::fire_generic(self.parser, self.conf.event.to_owned(), vec![]);
         }
-        self.exec_prompt(true);
+        self.exec_prompt(true, false);
 
         // Start out as initially dirty.
         self.force_exec_prompt_and_repaint = true;
@@ -2244,6 +2255,10 @@ impl<'a> Reader<'a> {
             if self.handle_char_event(None).is_break() {
                 break;
             }
+        }
+
+        if self.conf.transient_prompt {
+            self.exec_prompt(true, true);
         }
 
         // Redraw the command line. This is what ensures the autosuggestion is hidden, etc. after the
@@ -2753,7 +2768,7 @@ impl<'a> Reader<'a> {
                     // This can happen e.g. if a variable triggers a repaint,
                     // and the variable is set inside the prompt (#7324).
                     // builtin commandline will refuse to enqueue these.
-                    self.exec_prompt(false);
+                    self.exec_prompt(false, false);
                     if !self.mode_prompt_buff.is_empty() {
                         if self.is_repaint_needed(None) {
                             self.screen.reset_line(/*repaint_prompt=*/ true);
@@ -2764,7 +2779,7 @@ impl<'a> Reader<'a> {
                     }
                     // Else we repaint as normal.
                 }
-                self.exec_prompt(true);
+                self.exec_prompt(true, false);
                 self.screen.reset_line(/*repaint_prompt=*/ true);
                 self.layout_and_repaint(L!("readline"));
                 self.force_exec_prompt_and_repaint = false;
@@ -3869,7 +3884,7 @@ impl<'a> Reader<'a> {
             self.screen.reset_line(/*repaint_prompt=*/ true);
             self.layout_and_repaint(L!("readline"));
         }
-        self.exec_prompt(true);
+        self.exec_prompt(true, false);
         self.screen.reset_line(/*repaint_prompt=*/ true);
         self.layout_and_repaint(L!("readline"));
         self.force_exec_prompt_and_repaint = false;
@@ -4553,14 +4568,23 @@ pub fn reader_write_title(
 }
 
 impl<'a> Reader<'a> {
-    fn exec_prompt_cmd(&self, prompt_cmd: &wstr) -> Vec<WString> {
+    fn exec_prompt_cmd(&self, prompt_cmd: &wstr, final_prompt: bool) -> Vec<WString> {
         let mut output = vec![];
-        let _ = exec_subshell(prompt_cmd, self.parser, Some(&mut output), false);
+        if final_prompt && function::exists(prompt_cmd, self.parser) {
+            let _ = exec_subshell(
+                &(prompt_cmd.to_owned() + L!(" --final-rendering")),
+                self.parser,
+                Some(&mut output),
+                false,
+            );
+        } else {
+            let _ = exec_subshell(prompt_cmd, self.parser, Some(&mut output), false);
+        };
         output
     }
 
     /// Execute prompt commands based on the provided arguments. The output is inserted into prompt_buff.
-    fn exec_prompt(&mut self, full_prompt: bool) {
+    fn exec_prompt(&mut self, full_prompt: bool, final_prompt: bool) {
         // Suppress fish_trace while in the prompt.
         let _suppress_trace = self.parser.push_scope(|s| s.suppress_fish_trace = true);
 
@@ -4575,7 +4599,7 @@ impl<'a> Reader<'a> {
         if function::exists(MODE_PROMPT_FUNCTION_NAME, self.parser) {
             // We do not support multiline mode indicators, so just concatenate all of them.
             self.mode_prompt_buff =
-                WString::from_iter(self.exec_prompt_cmd(MODE_PROMPT_FUNCTION_NAME));
+                WString::from_iter(self.exec_prompt_cmd(MODE_PROMPT_FUNCTION_NAME, final_prompt));
         }
 
         if full_prompt {
@@ -4594,7 +4618,12 @@ impl<'a> Reader<'a> {
                     DEFAULT_PROMPT
                 };
 
-                self.left_prompt_buff = join_strings(&self.exec_prompt_cmd(prompt_cmd), '\n');
+                self.left_prompt_buff =
+                    join_strings(&self.exec_prompt_cmd(prompt_cmd, final_prompt), '\n');
+
+                if final_prompt {
+                    self.screen.reset_line(true)
+                }
             }
 
             // Don't execute the right prompt if it is undefined fish_right_prompt
@@ -4603,8 +4632,9 @@ impl<'a> Reader<'a> {
                     || function::exists(&self.conf.right_prompt_cmd, self.parser))
             {
                 // Right prompt does not support multiple lines, so just concatenate all of them.
-                self.right_prompt_buff =
-                    WString::from_iter(self.exec_prompt_cmd(&self.conf.right_prompt_cmd));
+                self.right_prompt_buff = WString::from_iter(
+                    self.exec_prompt_cmd(&self.conf.right_prompt_cmd, final_prompt),
+                );
             }
         }
 

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -547,6 +547,7 @@ impl Screen {
                 .map_or(1, |p| calc_prompt_lines(p));
             self.actual.cursor.y += prompt_line_count.checked_sub(1).unwrap();
             self.actual_left_prompt = None;
+            self.need_clear_screen = true;
         }
         self.actual.resize(0);
         self.need_clear_lines = true;


### PR DESCRIPTION
## Description

Now, before the final redraw, fish will check if `fish_transient_prompt` or `fish_right_transient_prompt` is defined. If either is defined, fish will redraw the commandline using the defined transient prompt functions instead of the normal ones. 
Additionally, if the built-in `read` uses `fish_prompt` or `fish_right_prompt`, it will be redrawn using the defined transient prompt functions.

Fixes issue #11101

## TODOs:
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] User-visible changes noted in CHANGELOG.rst
