### PR TITLE
tests/checks: version: Relax regular expression for valid versions

### DIFF
--- a/tests/checks/version.fish
+++ b/tests/checks/version.fish
@@ -1,2 +1,2 @@
 #RUN: %fish -v
-# CHECK: fish, version {{[-.gabcdeflphat0-9]*(irty)?}}
+# CHECK: fish, version {{[-.abcdefghilpt0-9~\^]*(irty)?}}


### PR DESCRIPTION
This relaxes the regular expression determining valid version strings such that packaging version strings used by Fedora and other Linux distributions can be successfully embedded.

This is related to #10633 work.