### PR TITLE
edit_command_buffer: support passing cursor position to helix

### DIFF
--- a/share/functions/edit_command_buffer.fish
+++ b/share/functions/edit_command_buffer.fish
@@ -75,6 +75,8 @@ function edit_command_buffer --description 'Edit the command buffer in an extern
                 set -a editor $f:$line:$col --wait
             case micro
                 set -a editor $f +$line:$col
+            case helix hx
+                set -a editor $f:$line:$col
             case '*'
                 continue
         end


### PR DESCRIPTION
## Description

Detect both `hx`, the default binary name from upstream, and `helix`, the name used by at least [Arch](https://gitlab.archlinux.org/archlinux/packaging/packages/helix/-/blob/main/helix.install?ref_type=heads).

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
