### PR TITLE
fix unknown command __fish_diskutil_volumes

### DIFF
--- a/share/completions/diskutil.fish
+++ b/share/completions/diskutil.fish
@@ -53,7 +53,7 @@ complete -f -c diskutil -n '__fish_diskutil_using_not_subcommand umountDisk' -a 
 
 # eject
 complete -f -c diskutil -n __fish_use_subcommand -a eject -d 'Eject a volume or disk'
-complete -f -c diskutil -n '__fish_diskutil_using_not_subcommand eject' -a '(__fish_diskutil_volumes ; __fish_diskutil_devices)'
+complete -f -c diskutil -n '__fish_diskutil_using_not_subcommand eject' -a '(__fish_diskutil_mounted_volumes ; __fish_diskutil_devices)'
 
 # mount
 complete -f -c diskutil -n __fish_use_subcommand -a mount -d 'Mount a single volume'


### PR DESCRIPTION
## Description

This pull request includes a small change to the `share/completions/diskutil.fish` file. The change modifies the completion function for the `eject` subcommand to use `__fish_diskutil_mounted_volumes` instead of `__fish_diskutil_volumes`.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
