### PR TITLE
clippy: remove redundant `.collect::<Vec<_>>()`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -327,7 +327,7 @@ fn get_version(src_dir: &Path) -> String {
             // .git/HEAD contains ref: refs/heads/branch
             let headpath = gitdir.join("HEAD");
             let headstr = read_to_string(headpath)?;
-            let headref = headstr.split(' ').collect::<Vec<_>>()[1].trim();
+            let headref = headstr.split(' ').nth(1).unwrap().trim();
 
             // .git/refs/heads/branch contains the SHA
             let refpath = gitdir.join(headref);


### PR DESCRIPTION
## Description

Improve performance a bit




<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
