### PR TITLE
wgetopt: remove support for abbreviated long options. Closes #7341.

### DIFF
--- a/src/tests/wgetopt.rs
+++ b/src/tests/wgetopt.rs
@@ -41,3 +41,40 @@ fn test_wgetopt() {
     assert_eq!(arguments.len(), 3);
     assert_eq!(join_strings(&arguments, ' '), "emacsnw emacs -nw");
 }
+
+#[test]
+fn test_wgetopt_proper_longopts() {
+    // Test for issue #7341 (disable abbreviated long options, e.g. --forc shouldn't work as an alias to --force).
+    const short_options: &wstr = L!("-f");
+    const long_options: &[WOption] = &[wopt(L!("force"), ArgType::NoArgument, 'f')];
+    let mut argv = [L!("rm"), L!("--forc"), L!("filename1"), L!("filename2")];
+    let mut w = WGetopter::new(short_options, long_options, &mut argv);
+    let mut f_count = 0;
+    let mut unknown_count = 0;
+    let mut arguments = vec![];
+    while let Some(opt) = w.next_opt() {
+        match opt {
+            'f' => {
+                f_count += 1;
+            }
+            '\x01' => {
+                // non-option argument
+                arguments.push(w.woptarg.as_ref().unwrap().to_owned());
+            }
+            '?' => {
+                // unrecognized option
+                unknown_count += 1;
+                if let Some(arg) = w.argv.get(w.wopt_index - 1) {
+                    arguments.push(arg.to_owned());
+                }
+            }
+            _ => {
+                panic!("unexpected option: {:?}", opt);
+            }
+        }
+    }
+    assert_eq!(f_count, 0);
+    assert_eq!(unknown_count, 1);
+    assert_eq!(arguments.len(), 3);
+    assert_eq!(join_strings(&arguments, ' '), "--forc filename1 filename2");
+}

--- a/src/wgetopt.rs
+++ b/src/wgetopt.rs
@@ -91,13 +91,9 @@ pub const fn wopt(name: &wstr, arg_type: ArgType, val: char) -> WOption<'_> {
 
 /// Used internally by [Wgetopter::find_matching_long_opt]. See there for further
 /// details.
-#[derive(Default)]
-enum LongOptMatch<'a> {
-    Exact(WOption<'a>, usize),
-    NonExact(WOption<'a>, usize),
-    Ambiguous,
-    #[default]
-    NoMatch,
+struct LongOptMatch<'a> {
+    option: WOption<'a>,
+    index: usize,
 }
 
 /// Used internally by [Wgetopter::next_argv]. See there for further details.
@@ -407,13 +403,8 @@ impl<'opts, 'args, 'argarray> WGetopter<'opts, 'args, 'argarray> {
     }
 
     /// Find a matching long-named option.
-    fn find_matching_long_opt(&self, name_end: usize) -> LongOptMatch<'opts> {
-        let mut opt = None;
-        let mut index = 0;
-        let mut exact = false;
-        let mut ambiguous = false;
-
-        // Test all long options for either exact match or abbreviated matches.
+    fn find_matching_long_opt(&self, name_end: usize) -> Option<LongOptMatch<'opts>> {
+        // Test all long options for exact matches.
         for (i, potential_match) in self.longopts.iter().enumerate() {
             // Check if current option is prefix of long opt
             if potential_match
@@ -422,31 +413,14 @@ impl<'opts, 'args, 'argarray> WGetopter<'opts, 'args, 'argarray> {
             {
                 if name_end == potential_match.name.len() {
                     // The option matches the text exactly, so we're finished.
-                    opt = Some(*potential_match);
-                    index = i;
-                    exact = true;
-                    break;
-                } else if opt.is_none() {
-                    // The option begins with the matching text, but is not
-                    // exactly equal.
-                    opt = Some(*potential_match);
-                    index = i;
-                } else {
-                    // There are multiple options that match the text non-exactly.
-                    ambiguous = true;
+                    return Some(LongOptMatch {
+                        option: *potential_match,
+                        index: i,
+                    });
                 }
             }
         }
-
-        opt.map_or(LongOptMatch::NoMatch, |opt| {
-            if exact {
-                LongOptMatch::Exact(opt, index)
-            } else if ambiguous {
-                LongOptMatch::Ambiguous
-            } else {
-                LongOptMatch::NonExact(opt, index)
-            }
-        })
+        None
     }
 
     /// Check for a matching long-named option.
@@ -457,16 +431,8 @@ impl<'opts, 'args, 'argarray> WGetopter<'opts, 'args, 'argarray> {
             self.remaining_text.len()
         };
 
-        match self.find_matching_long_opt(name_end) {
-            LongOptMatch::Exact(opt, index) | LongOptMatch::NonExact(opt, index) => {
-                return Some(self.update_long_opt(&opt, name_end, longopt_index, index));
-            }
-            LongOptMatch::Ambiguous => {
-                self.remaining_text = empty_wstr();
-                self.wopt_index += 1;
-                return Some('?');
-            }
-            LongOptMatch::NoMatch => {}
+        if let Some(opt) = self.find_matching_long_opt(name_end) {
+            return Some(self.update_long_opt(&opt.option, name_end, longopt_index, opt.index));
         }
 
         // If we can't find a long option, try to interpret it as a short option.


### PR DESCRIPTION
## Description

As per #7341, this PR removes support for abbreviated long options from wgetopt implementation — for example, `--forc` is no longer considered a valid form of `--force`. The PR removes inexact matching of long options altogether and adds a new test to make sure it doesn't come back somehow.

&nbsp;

Regarding documentation, I kinda failed to find the right words. For example,

```
- Support for for abbreviated long options has been removed, e.g. `--reg` is no longer considered
  a valid form of `--regex`.
```

is technically correct, but I'm worried that some users might overestimate the scope if it's phrased like that.

## TODOs:

<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] (AFAIK, support for abbreviated long options isn't mentioned anywhere, so maybe no changes required) Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
