### PR TITLE
Split content of *KnownHostsFile as this is a supported config option…

### DIFF
--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -111,7 +111,7 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
             # Multiple names for a single host can be given separated by spaces, so just split it explicitly (#6698).
             string replace -rfi '^\s*Host\s+(\S.*?)\s*$' '$1' -- $contents | string split " " | string match -rv '[\*\?]'
             # Also extract known_host paths.
-            set known_hosts $known_hosts (string replace -rfi '.*KnownHostsFile\s*' '' -- $contents)
+            set known_hosts $known_hosts (string replace -rfi '.*KnownHostsFile\s*' '' -- $contents | string split " ")
         end
     end
 


### PR DESCRIPTION
… by ssh.

## Description

*KnownHostsFile can contain multiple entries separated by a space. This split allows the use of multiple KnownHost files and still get "Host autocompletion".

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
