### PR TITLE
completions/flatpak: don't ignore packages with uppercase in name

### DIFF
--- a/share/completions/flatpak.fish
+++ b/share/completions/flatpak.fish
@@ -55,7 +55,7 @@ function __fish_flatpak
     # We can't rely on the first line being the headers because modern flatpak will omit it when running in a "subshell".
     # Based off our invocations, we expect the first column of actual output to never contain a capitalized letter
     # (unlike the header row).
-    flatpak $argv | string replace -rf '^([^A-Z]+)(?: +|\t)(.*?)\s*$' '$1\t$2'
+    flatpak $argv | string replace -rf '^([^A-Z].*?)(?: +|\t)(.*?)\s*$' '$1\t$2'
 end
 
 complete -f -c flatpak -n "__fish_seen_subcommand_from run" -a "(__fish_flatpak list --app --columns=application,name)"

--- a/share/completions/flatpak.fish
+++ b/share/completions/flatpak.fish
@@ -58,12 +58,28 @@ function __fish_flatpak
     flatpak $argv | string replace -rf '^([^A-Z].*?)(?: +|\t)(.*?)\s*$' '$1\t$2'
 end
 
+function __fish_print_flatpak_packages
+    set -l xdg_cache_home (__fish_make_cache_dir)
+    or return
+    set -l cache_file $xdg_cache_home/flatpak
+    if test -f $cache_file
+        cat $cache_file
+        set -l age (path mtime -R -- $cache_file)
+        set -l max_age 250
+        if test $age -lt $max_age
+            return
+        end
+    end
+    __fish_flatpak remote-ls --columns=application,name >$cache_file &
+    return 0
+end
+
 complete -f -c flatpak -n "__fish_seen_subcommand_from run" -a "(__fish_flatpak list --app --columns=application,name)"
 complete -f -c flatpak -n "__fish_seen_subcommand_from info uninstall" -a "(__fish_flatpak list --columns=application,name)"
 complete -f -c flatpak -n "__fish_seen_subcommand_from enter kill" -a "(__fish_flatpak ps --columns=instance,application)"
 complete -f -c flatpak -n "__fish_seen_subcommand_from remote-info remote-ls remote-modify remote-delete" -a "(__fish_flatpak remotes --columns=name,title)"
 
-complete -c flatpak -n '__fish_seen_subcommand_from install' -xa "(__fish_flatpak remote-ls --columns=application,name)"
+complete -c flatpak -n '__fish_seen_subcommand_from install' -xa "(__fish_print_flatpak_packages)"
 
 # Plenty of the other stuff is too free-form to complete (e.g. remote-add).
 complete -f -c flatpak -s h -l help


### PR DESCRIPTION
`[^A-Z]+` here seems to trim header section in old version flatpak (avoid one more `tail -n -2`?).
But this can ignore packages have uppercase name like `org.gtk.Gtk3theme.Adwaita-dark`.

```fish
$ flatpak remote-ls --columns=application,name | string replace -rf '^([^A-Z]+)(?: +|\t)(.*?)\s*$' '$1\t$2' | wc -l
1254

$ flatpak remote-ls --columns=application,name | string replace -rf '^([^A-Z].*?)(?: +|\t)(.*?)\s*$' '$1\t$2' | wc -l
5059
```

And I add a `__fish_print_flatpak_packages` since complete `flatpak install xx` is really slow.