### PR TITLE
fish-printf: support empty arguments

### DIFF
--- a/printf/src/lib.rs
+++ b/printf/src/lib.rs
@@ -62,6 +62,26 @@ macro_rules! sprintf {
             ).unwrap()
         }
     };
+
+    // Handling the case where there is no arguments
+    (
+      $fmt:expr // format string
+      $(,)? // optional trailing comma
+    ) => {
+      {
+        String::from($fmt)
+      }
+    };
+
+    (
+      => $target:expr, // target string
+      $fmt:expr, // format string
+      $(,)? // optional trailing comma
+    ) => {
+      {
+        $target.write_str($fmt).unwrap()
+      }
+   };
 }
 
 /// Formats a string using the provided format specifiers and arguments, using the C locale,


### PR DESCRIPTION
## Description

fish-printf: support empty arguments
```
    let s = sprintf!("hello");
    println!("{s}");
    let mut s = String::new();
    sprintf!(=> s, "hello");
    println!("s2 {s}");
```
Fixes issue https://github.com/fish-shell/fish-shell/issues/11243

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
