### PR TITLE
Fix bug where newlines are printed to stdout on path warnings

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -183,7 +183,7 @@ fn maybe_issue_path_warning(
             )
         );
     }
-    printf!("\n");
+    eprintf!("\n");
 }
 
 /// Finds the path of an executable named `cmd`, by looking in $PATH taken from `vars`.


### PR DESCRIPTION
## Description

Currently fish prints a newline to stdout in maybe_issue_path_warning. Warnings are printed to stderr, just the newline is printed to stdout. This PR prints the newline to stderr too. This bug changes a program's stdout if such warnings are emitted, e.g. "error: can not save history" on startup if home is not writable.

I found the problem when running non-interactive scripts with homeless users.
![image](https://github.com/user-attachments/assets/31859ed5-31c1-446f-a965-8502061a1e50)

## TODOs:
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
  - Unsure how to test for this. But I can add it if required
- [ ] User-visible changes noted in CHANGELOG.rst
  - Is it a "notable fix"?
