### PR TITLE
Remove folder name prefix in autocompletion suggestions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ fish 4.1.0 (released ???)
 Notable improvements and fixes
 ------------------------------
 - Compound commands (``begin; echo 1; echo 2; end``) can now be now be abbreviated using braces (``{ echo1; echo 2 }``), like in other shells.
+- When tab completion results are truncated, the common directory name is omitted.
 
 Deprecations and removed features
 ---------------------------------

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -6516,17 +6516,16 @@ impl<'a> Reader<'a> {
 
             let full = tok + &common_prefix[..];
             let truncated = &full[full.len() - PREFIX_MAX_LEN..];
-            let parts: Vec<&wstr> = truncated.split('/').collect();
-            if parts.len() < 2 {
+            let (i, last_component) = truncated.split('/').enumerate().last().unwrap();
+            if i == 0 {
                 // No path separators were found in the common prefix, so we can't collapse
                 // any further
                 prefix.push_utfstr(&truncated);
             } else {
                 // Discard any parent directories and include whats left
-                let last_part = parts.last().expect("parts is non-empty");
                 prefix.push('/');
-                prefix.push_utfstr(last_part);
-            }
+                prefix.push_utfstr(last_component);
+            };
         }
 
         // Update the pager data.

--- a/tests/checks/tmux-prefix.fish
+++ b/tests/checks/tmux-prefix.fish
@@ -1,0 +1,26 @@
+#RUN: %fish %s
+#REQUIRES: command -v tmux
+#REQUIRES: test -z "$CI"
+
+isolated-tmux-start
+
+# Check no collapse
+mkdir -p a/b
+echo > a/b/f1
+echo > a/b/f2
+isolated-tmux send-keys 'HOME=$PWD ls ~/a/b/' Tab
+tmux-sleep
+isolated-tmux capture-pane -p
+# CHECK: prompt 0> HOME=$PWD ls ~/a/b/f
+# CHECK: ~/a/b/f1  ~/a/b/f2
+
+# Check collapse
+isolated-tmux send-keys C-c
+mkdir -p dddddd/eeeeee
+echo > dddddd/eeeeee/file1
+echo > dddddd/eeeeee/file2
+isolated-tmux send-keys 'HOME=$PWD ls ~/dddddd/eeeeee/' Tab
+tmux-sleep
+isolated-tmux capture-pane -p
+# CHECK: prompt 0> HOME=$PWD ls ~/dddddd/eeeeee/file
+# CHECK: …/file1  …/file2


### PR DESCRIPTION
## Description

Remove folder name prefix in autocompletion suggestions

Fixes issue #8618

## Additional info

Example behavior:
![image](https://github.com/user-attachments/assets/52e34f39-801a-4ae7-ad8b-0abc9edb0798)

This didn't break any tests locally for me. I'm willing to add new tests for this behavior, but I could use some direction as to where they would need to go and what sort of setup and/or mocking would be required.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
