### PR TITLE
add history-last-token-search-backward/forward command

### DIFF
--- a/doc_src/cmds/bind.rst
+++ b/doc_src/cmds/bind.rst
@@ -265,6 +265,12 @@ The following special input functions are available:
 ``history-token-search-forward``
     search the history for the next matching argument
 
+``history-last-token-search-backward``
+    search the history for the last argument of the previous command
+
+``history-last-token-search-forward``
+    search the history for the last argument of the next command
+
 ``forward-jump`` and ``backward-jump``
     read another character and jump to its next occurrence after/before the cursor
 

--- a/doc_src/cmds/bind.rst
+++ b/doc_src/cmds/bind.rst
@@ -266,10 +266,10 @@ The following special input functions are available:
     search the history for the next matching argument
 
 ``history-last-token-search-backward``
-    search the history for the last argument of the previous command
+    search the history for the previous matching last argument
 
 ``history-last-token-search-forward``
-    search the history for the last argument of the next command
+    search the history for the next matching last argument
 
 ``forward-jump`` and ``backward-jump``
     read another character and jump to its next occurrence after/before the cursor

--- a/src/input.rs
+++ b/src/input.rs
@@ -175,6 +175,8 @@ const INPUT_FUNCTION_METADATA: &[InputFunctionMetadata] = &[
     make_md(L!("forward-token"), ReadlineCmd::ForwardToken),
     make_md(L!("forward-word"), ReadlineCmd::ForwardWord),
     make_md(L!("history-delete"), ReadlineCmd::HistoryDelete),
+    make_md(L!("history-last-token-search-backward"), ReadlineCmd::HistoryLastTokenSearchBackward),
+    make_md(L!("history-last-token-search-forward"), ReadlineCmd::HistoryLastTokenSearchForward),
     make_md(L!("history-pager"), ReadlineCmd::HistoryPager),
     #[allow(deprecated)]
     make_md(L!("history-pager-delete"), ReadlineCmd::HistoryPagerDelete),

--- a/src/input_common.rs
+++ b/src/input_common.rs
@@ -90,6 +90,8 @@ pub enum ReadlineCmd {
     BackwardKillToken,
     HistoryTokenSearchBackward,
     HistoryTokenSearchForward,
+    HistoryLastTokenSearchBackward,
+    HistoryLastTokenSearchForward,
     SelfInsert,
     SelfInsertNotFirst,
     TransposeChars,

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -2999,10 +2999,15 @@ impl<'a> Reader<'a> {
             | rl::HistorySearchBackward
             | rl::HistorySearchForward
             | rl::HistoryTokenSearchBackward
-            | rl::HistoryTokenSearchForward => {
+            | rl::HistoryTokenSearchForward
+            | rl::HistoryLastTokenSearchBackward
+            | rl::HistoryLastTokenSearchForward => {
                 let mode = match c {
                     rl::HistoryTokenSearchBackward | rl::HistoryTokenSearchForward => {
                         SearchMode::Token
+                    }
+                    rl::HistoryLastTokenSearchBackward | rl::HistoryLastTokenSearchForward => {
+                        SearchMode::LastToken
                     }
                     rl::HistoryPrefixSearchBackward | rl::HistoryPrefixSearchForward => {
                         SearchMode::Prefix
@@ -3015,13 +3020,13 @@ impl<'a> Reader<'a> {
 
                 if self.history_search.is_at_present() && mode != self.history_search.mode() {
                     let el = &self.data.command_line;
-                    if mode == SearchMode::Token {
+                    if matches!(mode, SearchMode::Token | SearchMode::LastToken) {
                         // Searching by token.
                         let (token_range, _) = parse_util_token_extent(el.text(), el.position());
                         self.data.history_search.reset_to_mode(
                             el.text()[token_range.clone()].to_owned(),
                             self.history.clone(),
-                            SearchMode::Token,
+                            mode,
                             token_range.start,
                         );
                     } else {
@@ -3047,9 +3052,11 @@ impl<'a> Reader<'a> {
                 let dir = match c {
                     rl::HistorySearchBackward
                     | rl::HistoryTokenSearchBackward
+                    | rl::HistoryLastTokenSearchBackward
                     | rl::HistoryPrefixSearchBackward => SearchDirection::Backward,
                     rl::HistorySearchForward
                     | rl::HistoryTokenSearchForward
+                    | rl::HistoryLastTokenSearchForward
                     | rl::HistoryPrefixSearchForward => SearchDirection::Forward,
                     _ => unreachable!(),
                 };
@@ -5532,6 +5539,8 @@ fn command_ends_paging(c: ReadlineCmd, focused_on_search_field: bool) -> bool {
         | rl::HistorySearchForward
         | rl::HistoryTokenSearchBackward
         | rl::HistoryTokenSearchForward
+        | rl::HistoryLastTokenSearchBackward
+        | rl::HistoryLastTokenSearchForward
         | rl::AcceptAutosuggestion
         | rl::DeleteOrExit
         | rl::CancelCommandline
@@ -5622,6 +5631,8 @@ fn command_ends_history_search(c: ReadlineCmd) -> bool {
             | rl::HistorySearchForward
             | rl::HistoryTokenSearchBackward
             | rl::HistoryTokenSearchForward
+            | rl::HistoryLastTokenSearchBackward
+            | rl::HistoryLastTokenSearchForward
             | rl::HistoryDelete
             | rl::HistoryPagerDelete
             | rl::BeginningOfHistory

--- a/src/reader_history_search.rs
+++ b/src/reader_history_search.rs
@@ -42,6 +42,8 @@ pub enum SearchMode {
     Prefix,
     /// searching by token
     Token,
+    /// search by the last token of the command
+    LastToken,
 }
 
 /// Encapsulation of the reader's history search functionality.
@@ -71,7 +73,7 @@ impl ReaderHistorySearch {
         self.mode != SearchMode::Inactive
     }
     pub fn by_token(&self) -> bool {
-        self.mode == SearchMode::Token
+        self.mode == SearchMode::Token || self.mode == SearchMode::LastToken
     }
     pub fn by_line(&self) -> bool {
         self.mode == SearchMode::Line
@@ -221,10 +223,11 @@ impl ReaderHistorySearch {
             if let Some(offset) = find(self, text, needle) {
                 self.add_if_new(SearchMatch::new(text.to_owned(), offset));
             }
-        } else if self.mode == SearchMode::Token {
+        } else if matches!(self.mode, SearchMode::Token | SearchMode::LastToken) {
             let mut tok = Tokenizer::new(text, TOK_ACCEPT_UNFINISHED);
 
             let mut local_tokens = vec![];
+
             while let Some(token) = tok.next() {
                 if token.type_ != TokenType::string {
                     continue;
@@ -235,9 +238,15 @@ impl ReaderHistorySearch {
                 }
             }
 
-            // Make sure tokens are added in reverse order. See #5150
-            for tok in local_tokens.into_iter().rev() {
-                self.add_if_new(tok);
+            if self.mode == SearchMode::LastToken {
+                if let Some(tok) = local_tokens.into_iter().next_back() {
+                    self.add_if_new(tok);
+                }
+            } else {
+                // Make sure tokens are added in reverse order. See #5150
+                for tok in local_tokens.into_iter().rev() {
+                    self.add_if_new(tok);
+                }
             }
         }
         self.matches.len() > before

--- a/src/reader_history_search.rs
+++ b/src/reader_history_search.rs
@@ -238,14 +238,11 @@ impl ReaderHistorySearch {
                 }
             }
 
-            if self.mode == SearchMode::LastToken {
-                if let Some(tok) = local_tokens.into_iter().next_back() {
-                    self.add_if_new(tok);
-                }
-            } else {
-                // Make sure tokens are added in reverse order. See #5150
-                for tok in local_tokens.into_iter().rev() {
-                    self.add_if_new(tok);
+            // Make sure tokens are added in reverse order. See #5150
+            for tok in local_tokens.into_iter().rev() {
+                self.add_if_new(tok);
+                if self.mode == SearchMode::LastToken {
+                    break;
                 }
             }
         }


### PR DESCRIPTION
## Description
This add two commands `history-last-token-search-backward` and `history-last-token-search-forward` which behaves like bash's yank-last-arg. So similar to `history-token-search-*` but only considers the last argument for each command.

Fixes issue #10756

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
