### PR TITLE
Fix regression causing crash with negative wcwidth

### DIFF
--- a/src/screen.rs
+++ b/src/screen.rs
@@ -1811,7 +1811,7 @@ fn measure_run_from(
             width = next_tab_stop(width);
         } else {
             // Ordinary char. Add its width with care to ignore control chars which have width -1.
-            width += usize::try_from(fish_wcwidth_visible(input.char_at(idx))).unwrap();
+            width += usize::try_from(fish_wcwidth_visible(input.char_at(idx))).unwrap_or_default();
         }
         idx += 1;
     }
@@ -1857,7 +1857,7 @@ fn truncate_run(
             curr_width = measure_run_from(run, 0, None, cache);
             idx = 0;
         } else {
-            let char_width = usize::try_from(fish_wcwidth_visible(c)).unwrap();
+            let char_width = usize::try_from(fish_wcwidth_visible(c)).unwrap_or_default();
             curr_width -= std::cmp::min(curr_width, char_width);
             run.remove(idx);
         }


### PR DESCRIPTION
fish_wcwidth_visible may return negative value.


## Description

Talk about your changes here.

Fixes issue: #11280

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
