### PR TITLE
Downgrade $TERM warnings to a term-support flog

### DIFF
--- a/src/env_dispatch.rs
+++ b/src/env_dispatch.rs
@@ -555,19 +555,16 @@ fn init_terminal(vars: &EnvStack) {
     if terminal::setup(None, |term| apply_term_hacks(vars, term)).is_none() {
         if is_interactive_session() {
             let term = vars.get_unless_empty(L!("TERM")).map(|v| v.as_string());
-            // We do not warn for xterm-256color at all, we know that one.
-            if term != Some("xterm-256color".into()) {
-                if let Some(term) = term {
-                    FLOG!(
-                        warning,
-                        wgettext_fmt!("Could not set up terminal for $TERM '%ls'. Falling back to hardcoded xterm-256color values", term)
-                    );
-                } else {
-                    FLOG!(
-                        warning,
-                        wgettext!("Could not set up terminal because $TERM is unset. Falling back to hardcoded xterm-256color values")
-                    );
-                }
+            if let Some(term) = term {
+                FLOG!(
+                    term_support,
+                    wgettext_fmt!("Could not set up terminal for $TERM '%ls'. Falling back to hardcoded xterm-256color values", term)
+                );
+            } else {
+                FLOG!(
+                    term_support,
+                    wgettext!("Could not set up terminal because $TERM is unset. Falling back to hardcoded xterm-256color values")
+                );
             }
         }
 


### PR DESCRIPTION
The chances that xterm-256color breaks anything are miniscule.

In the features we use, there are basically no differences, especially when you consider that we decode keys independently.

E.g. tmux-256color has differences, but they are either just taste questions (xterm's clear_screen will also clear scrollback), or they're just... not actually different?

Terminfo will claim that it uses a different cursor_up and exit_attribute_mode, but it also understands the xterm ones, and it sends a different key_home,
but we decode that even with TERM=xterm-256color.

In some cases, terminfo is also just outright *wrong* and will claim something does not support italics when it does.

So, since the differences are very likely to simply not matter, throwing a warning is more confusing than it is helpful.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->

I would like to include this in 4.0.2 because we've already had #11277, and that happened for at least two people. Even tho that was arguably a configuration error, the upshot is if we had just treated ghostty as xterm-256color literally nothing would have broken because there is no useful difference between these two for us.

I would actually go a step further and abolish our terminfo use altogether, but for that I would have to *quantify* just how many differences we have in practice, and that's hard because you need to throw away all the useless and sometimes outright *wrong* information terminfo gives you (e.g. the "konsole" terminfo entry is not used and does not document konsole's behavior, so you need to ignore it. some sequences like "cursor_normal" are sometimes equivalent but have their parts swapped, so `infocmp` will tell you there's a difference but it doesn't matter. tmux will understand xterm's sequences, so will screen (for the most part - but which parts exactly?). key_backspace is sometimes delete and sometimes ctrl-h but differs between terminals using the same TERM and can be configured).

So this is the next step.