### PR TITLE
Idea - abbr descriptions for completion (at least)

### DIFF
--- a/share/completions/abbr.fish
+++ b/share/completions/abbr.fish
@@ -15,3 +15,4 @@ complete -c abbr -f -n $__fish_abbr_add_cond -s p -l position -a 'command anywhe
 complete -c abbr -f -n $__fish_abbr_add_cond -s f -l function -d 'Treat expansion argument as a fish function' -xa '(functions)'
 complete -c abbr -f -n $__fish_abbr_add_cond -s r -l regex -d 'Match a regular expression' -x
 complete -c abbr -f -n $__fish_abbr_add_cond -l set-cursor -d 'Position the cursor at % post-expansion'
+complete -c abbr -f -n $__fish_abbr_add_cond -l description  -d 'Describe (i.e. for abbr completions)'

--- a/src/abbrs.rs
+++ b/src/abbrs.rs
@@ -67,6 +67,8 @@ pub struct Abbreviation {
 
     /// Mark if we came from a universal variable.
     pub from_universal: bool,
+
+    pub description: Option<WString>,
 }
 
 impl Abbreviation {
@@ -89,6 +91,7 @@ impl Abbreviation {
             position,
             set_cursor_marker: None,
             from_universal,
+            description: None,
         }
     }
 
@@ -296,6 +299,7 @@ fn rename_abbrs() {
                 position,
                 set_cursor_marker: None,
                 from_universal: false,
+                description: None,
             })
         };
         add(L!("gc"), L!("git checkout"), Position::Command);

--- a/src/builtins/abbr.rs
+++ b/src/builtins/abbr.rs
@@ -152,6 +152,10 @@ fn abbr_show(streams: &mut IoStreams) -> BuiltinResult {
                 add_arg(L!("--set-cursor="));
                 add_arg(&escape_string(set_cursor_marker, style));
             }
+            if let Some(ref description) = abbr.description {
+                add_arg(L!("--description="));
+                add_arg(&escape_string(description, style))
+            }
             if abbr.replacement_is_function {
                 add_arg(L!("--function"));
                 add_arg(&escape_string(&abbr.replacement, style));
@@ -467,6 +471,7 @@ pub fn abbr(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
             ArgType::OptionalArgument,
             SET_CURSOR_SHORT,
         ),
+        wopt(L!("description"), ArgType::OptionalArgument,'d'),
         wopt(L!("function"), ArgType::RequiredArgument, 'f'),
         wopt(L!("rename"), ArgType::NoArgument, RENAME_SHORT),
         wopt(L!("erase"), ArgType::NoArgument, 'e'),
@@ -533,6 +538,9 @@ pub fn abbr(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
                     return Err(STATUS_INVALID_ARGS);
                 }
                 opts.regex_pattern = w.woptarg.map(ToOwned::to_owned);
+            }
+            'd' => {
+                opts.description = w.woptarg.map(ToOwned::to_owned);
             }
             SET_CURSOR_SHORT => {
                 if opts.set_cursor_marker.is_some() {

--- a/src/builtins/abbr.rs
+++ b/src/builtins/abbr.rs
@@ -21,6 +21,7 @@ struct Options {
     position: Option<Position>,
     set_cursor_marker: Option<WString>,
     args: Vec<WString>,
+    description: Option<WString>,
 }
 
 impl Options {
@@ -405,6 +406,7 @@ fn abbr_add(opts: &Options, streams: &mut IoStreams) -> BuiltinResult {
             set_cursor_marker: opts.set_cursor_marker.clone(),
             from_universal: false,
             commands: opts.commands.clone(),
+            description: opts.description.clone(),
         })
     });
 

--- a/src/builtins/abbr.rs
+++ b/src/builtins/abbr.rs
@@ -471,7 +471,7 @@ pub fn abbr(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
             ArgType::OptionalArgument,
             SET_CURSOR_SHORT,
         ),
-        wopt(L!("description"), ArgType::OptionalArgument,'d'),
+        wopt(L!("description"), ArgType::OptionalArgument, 'd'),
         wopt(L!("function"), ArgType::RequiredArgument, 'f'),
         wopt(L!("rename"), ArgType::NoArgument, RENAME_SHORT),
         wopt(L!("erase"), ArgType::NoArgument, 'e'),

--- a/src/complete.rs
+++ b/src/complete.rs
@@ -69,7 +69,8 @@ static COMPLETE_USER_DESC: Lazy<&wstr> = Lazy::new(|| wgettext!("Home for %ls"))
 static COMPLETE_VAR_DESC_VAL: Lazy<&wstr> = Lazy::new(|| wgettext!("Variable: %ls"));
 
 /// Description for abbreviations.
-static ABBR_DESC: Lazy<&wstr> = Lazy::new(|| wgettext!("Abbreviation: %ls"));
+static ABBR_DESC: Lazy<&wstr> = Lazy::new(|| wgettext!("Abbr: %ls"));
+static ABBR_WITH_DESCRIPTION: Lazy<&wstr> = Lazy::new(|| wgettext!("%ls # %ls"));
 
 /// The special cased translation macro for completions. The empty string needs to be special cased,
 /// since it can occur, and should not be translated. (Gettext returns the version information as
@@ -1169,7 +1170,13 @@ impl<'ctx> Completer<'ctx> {
             for abbr in set.list() {
                 if !abbr.is_regex() {
                     possible_comp.push(Completion::from_completion(abbr.key.clone()));
-                    descs.insert(abbr.key.clone(), abbr.replacement.clone());
+                    if let Some(ref description) = abbr.description {
+                        let desc = sprintf!(*ABBR_WITH_DESCRIPTION, abbr.replacement.clone(), description);
+                        descs.insert(abbr.key.clone(), desc);
+                    }
+                    else {
+                        descs.insert(abbr.key.clone(), abbr.replacement.clone());
+                    }
                 }
             }
         });

--- a/src/complete.rs
+++ b/src/complete.rs
@@ -1171,10 +1171,13 @@ impl<'ctx> Completer<'ctx> {
                 if !abbr.is_regex() {
                     possible_comp.push(Completion::from_completion(abbr.key.clone()));
                     if let Some(ref description) = abbr.description {
-                        let desc = sprintf!(*ABBR_WITH_DESCRIPTION, abbr.replacement.clone(), description);
+                        let desc = sprintf!(
+                            *ABBR_WITH_DESCRIPTION,
+                            abbr.replacement.clone(),
+                            description
+                        );
                         descs.insert(abbr.key.clone(), desc);
-                    }
-                    else {
+                    } else {
                         descs.insert(abbr.key.clone(), abbr.replacement.clone());
                     }
                 }

--- a/tests/checks/abbr.fish
+++ b/tests/checks/abbr.fish
@@ -94,7 +94,7 @@ abbr --rename __abbr11 __abbr12
 
 abbr __abbr-with-dashes omega
 complete -C__abbr-with
-# CHECK: __abbr-with-dashes	Abbreviation: omega
+# CHECK: __abbr-with-dashes	Abbr: omega
 
 abbr --add --global __abbr13 aaaaaaaaaaaaa
 abbr --add --global __abbr14 bbbbbbbbbbbbb

--- a/tests/checks/complete.fish
+++ b/tests/checks/complete.fish
@@ -632,4 +632,4 @@ complete -C'testcommand '
 
 abbr cat cat
 complete -C ca | string match -r '^cat(?:\t.*)?$'
-# CHECK: cat{{\t}}Abbreviation: cat
+# CHECK: cat{{\t}}Abbr: cat

--- a/wes_abbr_desc_examples.fish
+++ b/wes_abbr_desc_examples.fish
@@ -1,0 +1,8 @@
+
+abbr --description="uninstall" -a pmr 'sudo pacman -R --recursive'
+abbr --description="install" -a pm_install 'sudo pacman --noconfirm -S'
+abbr --description="search" --set-cursor=! -a pmss "sudo pacman -Ss '^!'"
+abbr --description="upgrade" -a pmsu 'sudo pacman -Syu'
+
+# source wes_abbr_desc_examples.fish
+# pm<TAB> => look at the description to right of # (after replacement)

--- a/wes_abbr_without_desc_examples.fish
+++ b/wes_abbr_without_desc_examples.fish
@@ -1,0 +1,4 @@
+abbr -a pmr 'sudo pacman -R --recursive'
+abbr -a pm_install 'sudo pacman --noconfirm -S'
+abbr --set-cursor=! -a pmss "sudo pacman -Ss '^!'"
+abbr -a pmsu 'sudo pacman -Syu'


### PR DESCRIPTION
## Description

Functions support a description, and in tab completion you can see the function name as well as description:
<img width="1213" alt="image" src="https://github.com/user-attachments/assets/29db0244-8b4a-4368-978c-d9bbef7ddc7d" />

Right now abbreviations show `Abbreviation: replacement` as a description:
<img width="938" alt="image" src="https://github.com/user-attachments/assets/d2c9bdfa-9785-47c7-b4d8-e61107c4052c" />

What if we add an optional description to abbreviations? i.e. `Abbr: replacement # desc`
<img width="1890" alt="image" src="https://github.com/user-attachments/assets/8eba653d-381e-4e51-adf3-28cd125454f5" />

And as a bonus, you can use `Ctrl-s` to search the descriptions too!
![image](https://github.com/user-attachments/assets/7a81e498-fdfa-410e-801c-7085b04c0792)

So, if I can't recall how to use `pacman` to install a package, I can quickly check my abbreviations: `pm<TAB><Ctrl-s>install`

Examples:
```fish
abbr --description="uninstall" -a pmr 'sudo pacman -R --recursive'
abbr --description="install" -a pm_install 'sudo pacman --noconfirm -S'
abbr --description="search" --set-cursor=! -a pmss "sudo pacman -Ss '^!'"
abbr --description="upgrade" -a pmsu 'sudo pacman -Syu'
```

The motivation is to add a brief explanation of the abbreviation. I believe this would be helpful for abbreviations that are new and I'm still habituating, and/or that I use infrequently but in bursts.

Just an idea and a quick POC to show how it works, I will polish the changes if it's of interest. And add docs/localization. 

## TODOs:

<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
- [ ] Decide on `ABBR_WITH_DESCRIPTION` format
- [ ] Localization, i.e. `ABBR_DESC`, `ABBR_WITH_DESCRIPTION`