### PR TITLE
Update lru to 0.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,9 +194,9 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 dependencies = [
  "hashbrown",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ libc = "0.2"
 # lru pulls in hashbrown by default, which uses a faster (though less DoS resistant) hashing algo.
 # disabling default features uses the stdlib instead, but it doubles the time to rewrite the history
 # files as of 22 April 2024.
-lru = "0.12.3"
+lru = "0.13.0"
 nix = { version = "0.29.0", default-features = false, features = [
     "event",
     "inotify",


### PR DESCRIPTION
## Description

This updates the `lru` crate dependency to the latest version.

Looking at the [changelog](https://github.com/jeromefroe/lru-rs/blob/master/CHANGELOG.md#v0130---2025-01-27), the only breaking change was that the MSRV was updated to 1.65.0. This is not a problem because it is still less than fish’s MSRV of 1.70. For extra confidence, I built fish and ran the tests (`cmake . && make fish_run_tests`).

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages. **N/A**
- [ ] Tests have been added for regressions fixed **N/A**
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits --> **N/A**
