### PR TITLE
completions/iwctl: fix parsing bug with multi-column characters

### DIFF
--- a/share/completions/iwctl.fish
+++ b/share/completions/iwctl.fish
@@ -20,6 +20,8 @@ function __iwctl_filter -w iwctl
 
     if set -ql _flag_all_columns
         for line in (string match "  *" -- $results[5..] | string sub -s (math $leading_ws + 1))
+            set -l column_widths $column_widths
+            set column_widths[1] (math $column_widths[1] - (string length -V $line) + (string length $line))
             for column_width in $column_widths
                 printf %s\t (string sub -l $column_width -- $line | string trim -r)
                 set line (string sub -s (math $column_width + 1) -- $line)
@@ -29,7 +31,9 @@ function __iwctl_filter -w iwctl
     else if set -q column_widths[1]
         # only take lines starting with `  `, i.e., no `No devices ...`
         # then take the first column as substring
-        string match "  *" $results[5..] | string sub -s (math $leading_ws + 1) -l $column_widths[1] | string trim -r
+        for line in (string match "  *" -- $results[5..] | string sub -s (math $leading_ws + 1))
+            string sub -l (math $column_widths[1] - (string length -V $line) + (string length $line)) $line | string trim -r
+        end
     end
 end
 


### PR DESCRIPTION
## Description

`__iwctl_filter` parses column information by splitting based on a fixed number
of characters. However, some runes, such as `📡`, are multiple columns wide. The
iwctl client uses wcwidth to visually align strings containing such runes. The
current implementation does not take this into account, resulting in errors in
the `__iwctl_connect` function.

## PoC

```fish
set wide "📡📡📡  0123456"
set norm "memchr  0123456"

# the columns are visually aligned
echo $wide
echo $norm

echo (string sub -l 9 $wide)+
echo (string sub -l 9 $norm)+
```
result
![Pasted image](https://github.com/user-attachments/assets/b5289b33-6bef-4669-92dc-98f293706644)

