### PR TITLE
completions/git: Added autostash option to git merge

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -1794,6 +1794,8 @@ complete -f -c git -n '__fish_git_using_command merge' -l rerere-autoupdate -d '
 complete -f -c git -n '__fish_git_using_command merge' -l no-rerere-autoupdate -d 'Do not use previous conflict resolutions'
 complete -f -c git -n '__fish_git_using_command merge' -l abort -d 'Abort the current conflict resolution process'
 complete -f -c git -n '__fish_git_using_command merge' -l continue -d 'Conclude current conflict resolution process'
+complete -f -c git -n '__fish_git_using_command merge' -l autostash -d 'Before starting merge, stash local changes, and apply stash when done'
+complete -f -c git -n '__fish_git_using_command merge' -l no-autostash -d 'Do not stash local changes before starting merge'
 
 ### merge-base
 complete -f -c git -n __fish_git_needs_command -a merge-base -d 'Find a common ancestor for a merge'


### PR DESCRIPTION
## Description

Added missing completions for git merge --autostash and git merge --no-autostash.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
