### PR TITLE
Attempt at fixing history corruption

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -152,19 +152,18 @@ const MAX_SAVE_TRIES: usize = 1024;
 
 pub const VACUUM_FREQUENCY: usize = 25;
 
-/// If the size of `buffer` is at least `min_size`, output the contents `buffer` to `fd`,
-/// and clear the string.
-fn flush_to_file(buffer: &mut Vec<u8>, file: &mut File, min_size: usize) -> std::io::Result<()> {
-    if buffer.is_empty() || buffer.len() < min_size {
-        return Ok(());
-    }
-
+/// Output the contents `buffer` to `file` and clear the `buffer`.
+fn drain_buffer_into_file_no_flush(buffer: &mut Vec<u8>, file: &mut File) -> std::io::Result<()> {
     file.write_all(buffer)?;
     buffer.clear();
-    // Ensure that the file content is actually written to persistent storage.
-    // This might be unnecessary.
-    // It is used to help eliminate possible causes for
-    // https://github.com/fish-shell/fish-shell/issues/10300
+    Ok(())
+}
+
+/// Output the contents `buffer` to `file` and clear the `buffer`.
+/// Flush the file and sync it to ensure that the updates actually reach the file system.
+fn drain_buffer_into_file_and_flush(buffer: &mut Vec<u8>, file: &mut File) -> std::io::Result<()> {
+    drain_buffer_into_file_no_flush(buffer, file)?;
+    file.flush()?;
     file.sync_all()
 }
 
@@ -575,10 +574,10 @@ impl HistoryImpl {
             usize::min(self.first_unwritten_new_item_index, self.new_items.len());
     }
 
-    /// Given the fd of an existing history file, write a new history file to `dst_fd`.
+    /// Given an existing history file, write a new history file to `dst`.
     /// Returns false on error, true on success
     fn rewrite_to_temporary_file(&self, existing_file: Option<&mut File>, dst: &mut File) -> bool {
-        // We are reading FROM existing_fd and writing TO dst_fd
+        // We are reading FROM existing_file and writing TO dst
 
         // Make an LRU cache to save only the last N elements.
         let mut lru = LruCache::new(HISTORY_SAVE_MAX);
@@ -637,9 +636,16 @@ impl HistoryImpl {
         let mut buffer = Vec::with_capacity(HISTORY_OUTPUT_BUFFER_SIZE + 128);
         for item in items {
             append_history_item_to_buffer(&item, &mut buffer);
-            if let Err(e) = flush_to_file(&mut buffer, dst, HISTORY_OUTPUT_BUFFER_SIZE) {
+            if buffer.len() >= HISTORY_OUTPUT_BUFFER_SIZE {
+                if let Err(e) = drain_buffer_into_file_no_flush(&mut buffer, dst) {
+                    err = Some(e);
+                    break;
+                }
+            }
+        }
+        if err.is_none() {
+            if let Err(e) = drain_buffer_into_file_and_flush(&mut buffer, dst) {
                 err = Some(e);
-                break;
             }
         }
         if let Some(err) = err {
@@ -651,7 +657,7 @@ impl HistoryImpl {
 
             false
         } else {
-            flush_to_file(&mut buffer, dst, 0).is_ok()
+            true
         }
     }
 
@@ -815,6 +821,7 @@ impl HistoryImpl {
     }
 
     /// Saves history by appending to the file.
+    // TODO: return error information
     fn save_internal_via_appending(&mut self) -> bool {
         FLOGF!(
             history,
@@ -831,6 +838,7 @@ impl HistoryImpl {
 
         // Get the path to the real history file.
         let Some(history_path) = history_filename(&self.name, L!("")) else {
+            // TODO: Why have a successful return here?
             return true;
         };
 
@@ -898,17 +906,18 @@ impl HistoryImpl {
                 let item = &self.new_items[self.first_unwritten_new_item_index];
                 if item.should_write_to_disk() {
                     append_history_item_to_buffer(item, &mut buffer);
-                    res = flush_to_file(&mut buffer, &mut history_file, HISTORY_OUTPUT_BUFFER_SIZE);
+                    // Ensure that each item is written individually and makes it to storage.
+                    // This is done to keep `self.first_unwritten_new_item_index` consistent with
+                    // the file system.
+                    // Flushing and syncing each iteration adds overhead,
+                    // but hopefully there are not that many items to write when appending.
+                    res = drain_buffer_into_file_and_flush(&mut buffer, &mut history_file);
                     if res.is_err() {
                         break;
                     }
                 }
                 // We wrote or skipped this item, hooray.
                 self.first_unwritten_new_item_index += 1;
-            }
-
-            if res.is_ok() {
-                res = flush_to_file(&mut buffer, &mut history_file, 0);
             }
 
             // Since we just modified the file, update our history_file_id to match its current state


### PR DESCRIPTION
- Replace the write_loop call with Writer::write_all.
- Call sync_all on the file to ensure it gets written to storage.

## Description

This is an attempt at fixing #10300, which I have been experiencing for months.

The idea is to introduce flushing and using Rusts `Writer::write_all` instead of the custom `write_loop` function (which should probably be replaced by `write_all` in the entire codebase, alongside `read_loop`).

I have first tested running cc455ff97677c0085de480f37af05d07d127739e, on which I observed the history corruption after a few days. Then, I applied the changes present in this PR on top of cc455ff97677c0085de480f37af05d07d127739e, and have not observed any history corruption for over two weeks now. This does not mean that the issue is definitely fixed by these changes, but I think it might be useful for other people to have a look at this and maybe test the changes on their systems to see if history corruption still occurs for them with these changes applied.

Fixes issue #10300, maybe.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Have others who experience history corruption test these changes.
