### PR TITLE
Rebuild on changes relevant to build artifacts

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -48,8 +48,7 @@ fn main() {
         let targetman = cman.as_path().join("target").join("man");
         build_man(&targetman);
     }
-    rsconf::rebuild_if_path_changed("src/libc.c");
-    rsconf::rebuild_if_path_changed("src/");
+    rsconf::rebuild_if_paths_changed(&["src", "printf", "Cargo.toml", "Cargo.lock", "build.rs"]);
     cc::Build::new()
         .file("src/libc.c")
         .include(build_dir)


### PR DESCRIPTION
## Description

If anything changes in one of the listed directories or files, trigger a rebuild.

Rebuilds are needed to update the version info built into the binaries. The version info includes an abbreviated git commit hash, as well as information about whether the repo was in a dirty state (uncommitted changes) when building. Changes to files not explicitly listed will not trigger a rebuild, so to get accurate version info upon such changes (also when checking out a different commit which does not differ in any of the listed files), a rebuild needs to be triggered manually (e.g. via `cargo clean` or `touch build.rs`).

Fixes issue #11332

## TODOs:
- [ ] Check if any other files/directories should be included
