### PR TITLE
Fix alt-right binding

### DIFF
--- a/share/functions/__fish_shared_key_bindings.fish
+++ b/share/functions/__fish_shared_key_bindings.fish
@@ -51,14 +51,14 @@ function __fish_shared_key_bindings -d "Bindings shared between emacs and vi mod
     set -l alt_right_aliases alt-right \e\[1\;9C # iTerm2 < 3.5.12
     set -l alt_left_aliases alt-left \e\[1\;9D # iTerm2 < 3.5.12
     if test (__fish_uname) = Darwin
-        for alt_right in $alt_left_aliases
+        for alt_right in $alt_right_aliases
             bind --preset $argv $alt_right nextd-or-forward-word
         end
         for alt_left in $alt_left_aliases
             bind --preset $argv $alt_left prevd-or-backward-word
         end
     else
-        for alt_right in $alt_left_aliases
+        for alt_right in $alt_right_aliases
             bind --preset $argv $alt_right nextd-or-forward-token
         end
         for alt_left in $alt_left_aliases


### PR DESCRIPTION
## Description

Since 2bb5cbc, alt-right does not bind to anything. This fixes that so that alt-right should bind to one of `$alt_right_aliases`.


## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
