### PR TITLE
Fix profiling time log

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -179,12 +179,15 @@ impl TimeProfiler {
 impl Drop for TimeProfiler {
     fn drop(&mut self) {
         if let Ok(duration) = self.start.elapsed() {
+            let ns_per_ms = 1_000_000;
+            let ms = duration.as_millis();
+            let ns = duration.as_nanos() - (ms * ns_per_ms);
             FLOGF!(
                 profile_history,
                 "%s: %d.%06d ms",
                 self.what,
-                duration.as_millis() as u64, // todo!("remove cast")
-                (duration.as_nanos() / 1000) as u64  // todo!("remove cast")
+                ms as u64, // todo!("remove cast")
+                ns as u32
             )
         } else {
             FLOGF!(profile_history, "%s: ??? ms", self.what)


### PR DESCRIPTION
Fix profiling time log

`Duration::as_nanos()`
"Returns the total number of nanoseconds contained by this Duration."
https://doc.rust-lang.org/core/time/struct.Duration.html#method.as_nanos
    
Because we are indicating the time in milliseconds, we cannot use
`Duration::subsec_nanos()` but we need to manually get the whole duration in
nanoseconds and subtract the duration in milliseconds to get the fractional
part.