### PR TITLE
Try to enable 24-bit RGB colors by default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,11 @@ Deprecations and removed features
     set -Ua fish_features no-ignore-terminfo
 
 - The `--install` option when fish is built as self-installable was removed. If you need to write out fish's data you can use the new `status list-files` and `status get-file` subcommands, but it should no longer be necessary. (:issue:`11143`)
+- RGB colors (``set_color ff0000``) now default to using 24-bit RGB true-color commands, even if the terminal does not advertise support via ``COLORTERM``.
+  - To go back to using the nearest match from the 256-color palette, use ``set fish_term24bit 0`` or ``set COLORTERM 0``.
+    - To make the nearest-match logic use the 16 color palette instead, use ``set fish_term256 0``.
+  - Inside macOS Terminal.app, fish makes an attempt to still use the palette colors.
+    If that doesn't work, use ``set fish_term24bit 0``.
 
 Scripting improvements
 ----------------------

--- a/doc_src/cmds/set_color.rst
+++ b/doc_src/cmds/set_color.rst
@@ -22,7 +22,13 @@ Valid colors include:
 
 The *br*- (as in 'bright') forms are full-brightness variants of the 8 standard-brightness colors on many terminals. **brblack** has higher brightness than **black** - towards gray.
 
-An RGB value with three or six hex digits, such as A0FF33 or f2f can be used. Fish will choose the closest supported color. A three digit value is equivalent to specifying each digit twice; e.g., ``set_color 2BC`` is the same as ``set_color 22BBCC``. Hexadecimal RGB values can be in lower or uppercase. Depending on the capabilities of your terminal (and the level of support ``set_color`` has for it) the actual color may be approximated by a nearby matching reserved color.
+An RGB value with three or six hex digits, such as A0FF33 or f2f can be used.
+A three digit value is equivalent to specifying each digit twice; e.g., ``set_color 2BC`` is the same as ``set_color 22BBCC``.
+Hexadecimal RGB values can be in lower or uppercase.
+
+If :envvar:`fish_term24bit` is set to 0, fish will translate RGB values to the nearest color on the 256-color palette.
+If :envvar:`fish_term256` is also set to 0, fish will translate them to the 16-color palette instead.
+Fish launched as ``fish -d term_support`` will include diagnostic messages that indicate the color support mode in use.
 
 A second color may be given as a desired fallback color. e.g. ``set_color 124212 brblue`` will instruct set_color to use *brblue* if a terminal is not capable of the exact shade of grey desired. This is very useful when an 8 or 16 color terminal might otherwise not use a color.
 
@@ -72,17 +78,3 @@ Examples
     set_color blue; echo "Violets are blue"
     set_color 62A; echo "Eggplants are dark purple"
     set_color normal; echo "Normal is nice" # Resets the background too
-
-
-Terminal Capability Detection
------------------------------
-
-Fish uses some heuristics to determine what colors a terminal supports to avoid sending sequences that it won't understand.
-
-In particular it will:
-
-- Enable 24-bit ("true-color") even if the $TERM entry only reports 256 colors. This includes modern xterm, VTE-based terminals like Gnome Terminal, Konsole and iTerm2.
-
-To force true-color support on or off, set :envvar:`fish_term24bit` to "1" for on and 0 for off - ``set -g fish_term24bit 1``.
-
-Fish launched as ``fish -d term_support`` will include diagnostic messages that indicate the color support mode in use.

--- a/doc_src/language.rst
+++ b/doc_src/language.rst
@@ -1566,12 +1566,12 @@ You can change the settings of fish by changing the values of certain variables.
 
 .. envvar:: fish_term24bit
 
-   If this is set to 1, fish will assume the terminal understands 24-bit RGB color sequences, and won't translate them to the 256 or 16 color palette.
-   This is often detected automatically.
+   If this is set to 0, fish will not output 24-bit RGB true-color sequences but the nearest color on the 256 color palette (or the 16 color palette, if :envvar:`fish_term256` is 0).
 
 .. envvar:: fish_term256
 
-   If this is set to 0, fish will not output 256 colors, but translate colors down to the 16 color palette.
+   If this is set to 0 and :envvar:`fish_term24bit` is 0, translate RGB colors down to the 16 color palette.
+   Also, if this is set to 0, :doc:`set_color <cmds/set_color>`/` commands such as ``set_color ff0000 red`` will prefer the named color.
 
 .. envvar:: fish_ambiguous_width
 

--- a/src/env_dispatch.rs
+++ b/src/env_dispatch.rs
@@ -53,6 +53,7 @@ static VAR_DISPATCH_TABLE: once_cell::sync::Lazy<VarDispatchTable> =
         }
 
         table.add(L!("TZ"), handle_tz_change);
+        table.add_anon(L!("COLORTERM"), handle_fish_term_change);
         table.add_anon(L!("fish_term256"), handle_fish_term_change);
         table.add_anon(L!("fish_term24bit"), handle_fish_term_change);
         table.add_anon(L!("fish_escape_delay_ms"), update_wait_on_escape_ms);


### PR DESCRIPTION
`COLORTERM=truecolor` doesn't work in some cases; I think we may want to
either default to assuming truecolor is supported, or use this [recommended
fix](https://github.com/termstandard/colors?tab=readme-ov-file#querying-the-terminal).

See the discussion around
https://github.com/fish-shell/fish-shell/pull/11345#issuecomment-2794920900

TODO: docs
- [ ] `fish_term24bit`
- [ ] `doc_src/cmds/set_color.rst`
- [ ] `doc_src/terminal-compatibility.rst`
