### PR TITLE
prevent integer overflow in screen name escape sequences

### DIFF
--- a/src/screen.rs
+++ b/src/screen.rs
@@ -1637,7 +1637,7 @@ fn is_screen_name_escape_seq(code: &wstr) -> Option<usize> {
                 continue;
             }
         }
-        escape_sequence_end = screen_name_end + screen_name_end_sentinel.len();
+        escape_sequence_end = screen_name_end.saturating_add(screen_name_end_sentinel.len());
         break;
     }
     Some(escape_sequence_end)

--- a/src/tests/screen.rs
+++ b/src/tests/screen.rs
@@ -249,6 +249,21 @@ fn test_prompt_truncation() {
 }
 
 #[test]
+#[serial]
+fn test_screen_name_escape_seq_overflow() {
+    let _cleanup = test_init();
+    let mut large_escape_seq = WString::from_str("\x1Bk");
+
+    for _ in 0..10000 {
+        large_escape_seq.push('x');
+    }
+    large_escape_seq.push_str("\x1B\\");
+
+    let escape_length = crate::screen::escape_code_length(&large_escape_seq);
+    assert!(escape_length.is_some());
+}
+
+#[test]
 fn test_compute_layout() {
     macro_rules! validate {
         (


### PR DESCRIPTION
## Description

Replaces addition with saturating_add to avoid panics when processing 
extremely large screen name escape sequences

Fixes issue https://github.com/fish-shell/fish-shell/issues/11378

## TODOs:
- [x] Tests have been added for regressions fixed

