### PR TITLE
completions/git: show url as description for remote completion

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -62,6 +62,7 @@ New or improved bindings
 
 Completions
 ^^^^^^^^^^^
+- ``git`` completions now show the remote url as a description when completing remotes.
 
 Improved terminal support
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -96,7 +96,9 @@ function __fish_git_refs
 end
 
 function __fish_git_remotes
-    __fish_git remote 2>/dev/null
+    # Example of output parsed:
+    # "remote.upstream.url git@github.com:fish-shell/fish-shell.git" -> "upstream\tgit@github.com:fish-shell/fish-shell.git"
+    __fish_git config --get-regexp 'remote\.[a-z]+\.url' | string replace -rf 'remote\.(.*)\.url (.*)' '$1\t$2'
 end
 
 function __fish_git_files


### PR DESCRIPTION
## Description

Before:

![image](https://github.com/user-attachments/assets/255f2b49-286d-4d89-a8a1-f6c4d7feee81)


After:

![image](https://github.com/user-attachments/assets/f948b9bc-248d-49eb-a1b6-28a77e85ecb3)

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- ~[ ] Changes to fish usage are reflected in user documentation/manpages.~
- ~[ ] Tests have been added for regressions fixed~
- [x] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
