### PR TITLE
Curly and colored underlines

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -65,6 +65,7 @@ Completions
 
 Improved terminal support
 ^^^^^^^^^^^^^^^^^^^^^^^^^
+- Support for curly underlines in `fish_color_*` variables and :doc:`set_color <cmds/set_color>` (:issue:`10957`).
 - New documentation page `Terminal Compatibility <terminal-compatibility.html>`_ (also accessible via ``man fish-terminal-compatibility``) lists required and optional terminal control sequences used by fish.
 
 Other improvements

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -67,6 +67,7 @@ Improved terminal support
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 - Support for curly underlines in `fish_color_*` variables and :doc:`set_color <cmds/set_color>` (:issue:`10957`).
 - Error highlighting includes curly underlines.
+- Underlines can now be colored independent of foreground/background color.
 - New documentation page `Terminal Compatibility <terminal-compatibility.html>`_ (also accessible via ``man fish-terminal-compatibility``) lists required and optional terminal control sequences used by fish.
 
 Other improvements

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -66,6 +66,7 @@ Completions
 Improved terminal support
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 - Support for curly underlines in `fish_color_*` variables and :doc:`set_color <cmds/set_color>` (:issue:`10957`).
+- Error highlighting includes curly underlines.
 - New documentation page `Terminal Compatibility <terminal-compatibility.html>`_ (also accessible via ``man fish-terminal-compatibility``) lists required and optional terminal control sequences used by fish.
 
 Other improvements

--- a/doc_src/cmds/set_color.rst
+++ b/doc_src/cmds/set_color.rst
@@ -37,6 +37,9 @@ The following options are available:
 **-b** or **--background** *COLOR*
     Sets the background color.
 
+**--underline-color** *COLOR*
+    Set the underline color.
+
 **-c** or **--print-colors**
     Prints the given colors or a colored list of the 16 named colors.
 

--- a/doc_src/cmds/set_color.rst
+++ b/doc_src/cmds/set_color.rst
@@ -52,8 +52,8 @@ The following options are available:
 **-r** or **--reverse**
     Sets reverse mode.
 
-**-u** or **--underline**
-    Sets underlined mode.
+**-u** or **--underline** or **--curly-underline**
+    Set the underline mode.
 
 **-h** or **--help**
     Displays help about using this command.

--- a/doc_src/interactive.rst
+++ b/doc_src/interactive.rst
@@ -89,7 +89,14 @@ Or, to see all themes, right in your terminal::
 Syntax highlighting variables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The colors used by fish for syntax highlighting can be configured by changing the values of various variables. The value of these variables can be one of the colors accepted by the :doc:`set_color <cmds/set_color>` command. The modifier switches accepted by ``set_color`` like ``--bold``, ``--dim``, ``--italics``, ``--reverse`` and ``--underline`` are also accepted.
+The colors used by fish for syntax highlighting can be configured by changing the values of various variables. The value of these variables can be one of the colors accepted by the :doc:`set_color <cmds/set_color>` command.
+The modifier switches accepted by ``set_color`` like
+``--bold``,
+``--curly-underline``,
+``--dim``,
+``--italics``,
+``--reverse`` and
+``--underline`` are also accepted.
 
 
 Example: to make errors highlighted and red, use::

--- a/doc_src/terminal-compatibility.rst
+++ b/doc_src/terminal-compatibility.rst
@@ -102,7 +102,7 @@ Optional Commands
 
    * - ``\e[m``
      - sgr0
-     - Turn off bold/dim/italic/underline/reverse attribute modes.
+     - Turn off bold/dim/italic/underline/reverse attribute modes and select default colors.
      -
    * - ``\e[1m``
      - bold

--- a/doc_src/terminal-compatibility.rst
+++ b/doc_src/terminal-compatibility.rst
@@ -120,6 +120,10 @@ Optional Commands
      - smul
      - Enter underline mode.
      -
+   * - ``\e[4:3m``
+     - Su
+     - Enter curly underline mode.
+     - kitty
    * - ``\e[7m``
      - rev
      - Enter reverse video mode (swap foreground and background colors).

--- a/doc_src/terminal-compatibility.rst
+++ b/doc_src/terminal-compatibility.rst
@@ -144,6 +144,10 @@ Optional Commands
      - setab
      - Select background color Ps from the 256-color-palette.
      -
+   * - ``\e[58;5; Ps m``
+     - Su
+     - Select underline color Ps from the 256-color-palette.
+     - kitty
    * - ``\e[ Ps m``
      - setaf
        setab
@@ -161,6 +165,10 @@ Optional Commands
      -
      - Select background color from 24-bit RGB colors.
      -
+   * - ``\e[58;2; Ps ; Ps ; Ps m``
+     - Su
+     - Select underline color from 24-bit RGB colors.
+     - kitty
    * - ``\e[ Ps S``
      - indn
      - Scroll forward Ps lines.

--- a/share/completions/set.fish
+++ b/share/completions/set.fish
@@ -124,6 +124,7 @@ complete -c set -n '__fish_seen_argument -s e -l erase; and __fish_seen_argument
 complete -c set -n '__fish_set_is_color true false' -x -a '(set_color --print-colors)' -d 'text color'
 complete -c set -n '__fish_set_is_color false true' -a '--background=(set_color --print-colors)'
 complete -c set -n '__fish_set_is_color true false' -a --bold -x
+complete -c set -n '__fish_set_is_color true false' -a --curly-underline -x
 complete -c set -n '__fish_set_is_color true false' -a --dim -x
 complete -c set -n '__fish_set_is_color true false' -a --italics -x
 complete -c set -n '__fish_set_is_color true true' -a --reverse -x

--- a/share/completions/set.fish
+++ b/share/completions/set.fish
@@ -123,6 +123,7 @@ complete -c set -n '__fish_seen_argument -s e -l erase; and __fish_seen_argument
 # Color completions
 complete -c set -n '__fish_set_is_color true false' -x -a '(set_color --print-colors)' -d 'text color'
 complete -c set -n '__fish_set_is_color false true' -a '--background=(set_color --print-colors)'
+complete -c set -n '__fish_set_is_color false true' -a '--underline-color=(set_color --print-colors)'
 complete -c set -n '__fish_set_is_color true false' -a --bold -x
 complete -c set -n '__fish_set_is_color true false' -a --curly-underline -x
 complete -c set -n '__fish_set_is_color true false' -a --dim -x

--- a/share/completions/set_color.fish
+++ b/share/completions/set_color.fish
@@ -1,5 +1,6 @@
 complete -c set_color -x -d Color -a '(set_color --print-colors)'
 complete -c set_color -s b -l background -x -a '(set_color --print-colors)' -d "Change background color"
+complete -c set_color -s b -l underline-color -x -a '(set_color --print-colors)' -d "Change underline color"
 complete -c set_color -s o -l bold -d 'Make font bold'
 complete -c set_color -s i -l italics -d Italicise
 complete -c set_color -s d -l dim -d 'Dim text'

--- a/share/completions/set_color.fish
+++ b/share/completions/set_color.fish
@@ -5,5 +5,6 @@ complete -c set_color -s i -l italics -d Italicise
 complete -c set_color -s d -l dim -d 'Dim text'
 complete -c set_color -s r -l reverse -d 'Reverse color text'
 complete -c set_color -s u -l underline -d 'Underline text'
+complete -c set_color -l curly-underline -d 'Curly underline'
 complete -c set_color -s h -l help -d 'Display help and exit'
 complete -c set_color -s c -l print-colors -d 'Print a list of all accepted color names'

--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -40,7 +40,7 @@ end" >$__fish_config_dir/config.fish
         __init_uvar fish_color_param cyan
         __init_uvar fish_color_redirection cyan --bold
         __init_uvar fish_color_comment red
-        __init_uvar fish_color_error brred
+        __init_uvar fish_color_error brred --curly-underline
         __init_uvar fish_color_escape brcyan
         __init_uvar fish_color_operator brcyan
         __init_uvar fish_color_end green

--- a/share/tools/web_config/fishconfig.css
+++ b/share/tools/web_config/fishconfig.css
@@ -153,6 +153,7 @@ body {
 }
 .detail_function .fish_color_error {
     color: #ff0000;
+    text-decoration-style: wavy;
 }
 .detail_function .fish_color_escape {
     color: #00a6b2;

--- a/share/tools/web_config/themes/Base16 Default Dark.theme
+++ b/share/tools/web_config/themes/Base16 Default Dark.theme
@@ -7,7 +7,7 @@ fish_color_command a1b56c
 fish_color_quote f7ca88
 fish_color_redirection d8d8d8
 fish_color_end ba8baf
-fish_color_error ab4642
+fish_color_error ab4642 --curly-underline
 fish_color_param d8d8d8
 fish_color_comment f7ca88
 fish_color_match 7cafc2

--- a/share/tools/web_config/themes/Base16 Default Light.theme
+++ b/share/tools/web_config/themes/Base16 Default Light.theme
@@ -7,7 +7,7 @@ fish_color_command a1b56c
 fish_color_quote f7ca88
 fish_color_redirection 383838
 fish_color_end ba8baf
-fish_color_error ab4642
+fish_color_error ab4642 --curly-underline
 fish_color_param 383838
 fish_color_comment f7ca88
 fish_color_match 7cafc2

--- a/share/tools/web_config/themes/Base16 Eighties.theme
+++ b/share/tools/web_config/themes/Base16 Eighties.theme
@@ -7,7 +7,7 @@ fish_color_command 99cc99
 fish_color_quote ffcc66
 fish_color_redirection d3d0c8
 fish_color_end cc99cc
-fish_color_error f2777a
+fish_color_error f2777a --curly-underline
 fish_color_param d3d0c8
 fish_color_comment ffcc66
 fish_color_match 6699cc

--- a/share/tools/web_config/themes/Bay Cruise.theme
+++ b/share/tools/web_config/themes/Bay Cruise.theme
@@ -6,7 +6,7 @@ fish_color_command 009999
 fish_color_quote 5CCCCC
 fish_color_redirection BF7130
 fish_color_end FFB273
-fish_color_error FF7400
+fish_color_error FF7400 --curly-underline
 fish_color_param 33CCCC
 fish_color_comment FF9640
 fish_color_match --background=brblue

--- a/share/tools/web_config/themes/Dracula.theme
+++ b/share/tools/web_config/themes/Dracula.theme
@@ -18,7 +18,7 @@ fish_color_command 8be9fd
 fish_color_quote f1fa8c
 fish_color_redirection f8f8f2
 fish_color_end ffb86c
-fish_color_error ff5555
+fish_color_error ff5555 --curly-underline
 fish_color_param bd93f9
 fish_color_comment 6272a4
 fish_color_match --background=brblue

--- a/share/tools/web_config/themes/Fairground.theme
+++ b/share/tools/web_config/themes/Fairground.theme
@@ -6,7 +6,7 @@ fish_color_command 0772A1
 fish_color_quote 024A68
 fish_color_redirection 63AFD0
 fish_color_end 8D003B
-fish_color_error EC3B86
+fish_color_error EC3B86 --curly-underline
 fish_color_param 225E79
 fish_color_comment FFE100
 fish_color_match --background=brblue

--- a/share/tools/web_config/themes/Just a Touch.theme
+++ b/share/tools/web_config/themes/Just a Touch.theme
@@ -6,7 +6,7 @@ fish_color_command F4F4F4
 fish_color_quote 666A80
 fish_color_redirection FAFAFA
 fish_color_end 969696
-fish_color_error FFA779
+fish_color_error FFA779 --curly-underline
 fish_color_param A0A0F0
 fish_color_comment B0B0B0
 fish_color_match --background=brblue

--- a/share/tools/web_config/themes/Lava.theme
+++ b/share/tools/web_config/themes/Lava.theme
@@ -6,7 +6,7 @@ fish_color_command FF9400
 fish_color_quote BF9C30
 fish_color_redirection BF5B30
 fish_color_end FF4C00
-fish_color_error FFDD73
+fish_color_error FFDD73 --curly-underline
 fish_color_param FFC000
 fish_color_comment A63100
 fish_color_match --background=brblue

--- a/share/tools/web_config/themes/Mono Lace.theme
+++ b/share/tools/web_config/themes/Mono Lace.theme
@@ -6,7 +6,7 @@ fish_color_command 000000
 fish_color_quote 626262
 fish_color_redirection 8a8a8a
 fish_color_end 767676
-fish_color_error b2b2b2
+fish_color_error b2b2b2 --curly-underline
 fish_color_param 303030
 fish_color_comment 4e4e4e
 fish_color_match --background=brblue

--- a/share/tools/web_config/themes/Mono Smoke.theme
+++ b/share/tools/web_config/themes/Mono Smoke.theme
@@ -6,7 +6,7 @@ fish_color_command ffffff
 fish_color_quote a8a8a8
 fish_color_redirection 808080
 fish_color_end 949494
-fish_color_error 585858
+fish_color_error 585858 --curly-underline
 fish_color_param d7d7d7
 fish_color_comment bcbcbc
 fish_color_match --background=brblue

--- a/share/tools/web_config/themes/None.theme
+++ b/share/tools/web_config/themes/None.theme
@@ -8,7 +8,7 @@ fish_color_comment
 fish_color_cwd normal
 fish_color_cwd_root normal
 fish_color_end
-fish_color_error
+fish_color_error --curly-underline
 fish_color_escape
 fish_color_history_current
 fish_color_host normal

--- a/share/tools/web_config/themes/Nord.theme
+++ b/share/tools/web_config/themes/Nord.theme
@@ -9,7 +9,7 @@ fish_color_keyword 81a1c1
 fish_color_quote a3be8c
 fish_color_redirection b48ead --bold
 fish_color_end 81a1c1
-fish_color_error bf616a
+fish_color_error bf616a --curly-underline
 fish_color_param d8dee9
 fish_color_valid_path --underline
 fish_color_option 8fbcbb

--- a/share/tools/web_config/themes/Old School.theme
+++ b/share/tools/web_config/themes/Old School.theme
@@ -6,7 +6,7 @@ fish_color_command 00FF00
 fish_color_quote 44FF44
 fish_color_redirection 7BFF7B
 fish_color_end FF7B7B
-fish_color_error A40000
+fish_color_error A40000 --curly-underline
 fish_color_param 30BE30
 fish_color_comment 30BE30
 fish_color_match --background=brblue

--- a/share/tools/web_config/themes/Seaweed.theme
+++ b/share/tools/web_config/themes/Seaweed.theme
@@ -6,7 +6,7 @@ fish_color_command 00BF32
 fish_color_quote 206676
 fish_color_redirection 7CB02C
 fish_color_end 8EEB00
-fish_color_error 60B9CE
+fish_color_error 60B9CE --curly-underline
 fish_color_param 04819E
 fish_color_comment 5C9900
 fish_color_match --background=brblue

--- a/share/tools/web_config/themes/Snow Day.theme
+++ b/share/tools/web_config/themes/Snow Day.theme
@@ -6,7 +6,7 @@ fish_color_command 164CC9
 fish_color_quote 4C3499
 fish_color_redirection 248E8E
 fish_color_end 02BDBD
-fish_color_error 9177E5
+fish_color_error 9177E5 --curly-underline
 fish_color_param 4319CC
 fish_color_comment 007B7B
 fish_color_match --background=brblue

--- a/share/tools/web_config/themes/Solarized Dark.theme
+++ b/share/tools/web_config/themes/Solarized Dark.theme
@@ -7,7 +7,7 @@ fish_color_command 93a1a1
 fish_color_quote 657b83
 fish_color_redirection 6c71c4
 fish_color_end 268bd2
-fish_color_error dc322f
+fish_color_error dc322f --curly-underline
 fish_color_param 839496
 fish_color_comment 586e75
 fish_color_match --background=brblue

--- a/share/tools/web_config/themes/Solarized Light.theme
+++ b/share/tools/web_config/themes/Solarized Light.theme
@@ -7,7 +7,7 @@ fish_color_command 586e75
 fish_color_quote 839496
 fish_color_redirection 6c71c4
 fish_color_end 268bd2
-fish_color_error dc322f
+fish_color_error dc322f --curly-underline
 fish_color_param 657b83
 fish_color_comment 93a1a1
 fish_color_match --background=brblue

--- a/share/tools/web_config/themes/Tomorrow Night Bright.theme
+++ b/share/tools/web_config/themes/Tomorrow Night Bright.theme
@@ -7,7 +7,7 @@ fish_color_command c397d8
 fish_color_quote b9ca4a
 fish_color_redirection 70c0b1
 fish_color_end c397d8
-fish_color_error d54e53
+fish_color_error d54e53 --curly-underline
 fish_color_param 7aa6da
 fish_color_comment e7c547
 fish_color_match --background=brblue

--- a/share/tools/web_config/themes/Tomorrow Night.theme
+++ b/share/tools/web_config/themes/Tomorrow Night.theme
@@ -7,7 +7,7 @@ fish_color_command b294bb
 fish_color_quote b5bd68
 fish_color_redirection 8abeb7
 fish_color_end b294bb
-fish_color_error cc6666
+fish_color_error cc6666 --curly-underline
 fish_color_param 81a2be
 fish_color_comment f0c674
 fish_color_match --background=brblue

--- a/share/tools/web_config/themes/Tomorrow.theme
+++ b/share/tools/web_config/themes/Tomorrow.theme
@@ -7,7 +7,7 @@ fish_color_command 8959a8
 fish_color_quote 718c00
 fish_color_redirection 3e999f
 fish_color_end 8959a8
-fish_color_error c82829
+fish_color_error c82829 --curly-underline
 fish_color_param 4271ae
 fish_color_comment eab700
 fish_color_match --background=brblue

--- a/share/tools/web_config/themes/ayu Dark.theme
+++ b/share/tools/web_config/themes/ayu Dark.theme
@@ -7,7 +7,7 @@ fish_color_command 39BAE6
 fish_color_quote C2D94C
 fish_color_redirection FFEE99
 fish_color_end F29668
-fish_color_error FF3333
+fish_color_error FF3333 --curly-underline
 fish_color_param B3B1AD
 fish_color_comment 626A73
 fish_color_match F07178

--- a/share/tools/web_config/themes/ayu Light.theme
+++ b/share/tools/web_config/themes/ayu Light.theme
@@ -7,7 +7,7 @@ fish_color_command 55B4D4
 fish_color_quote 86B300
 fish_color_redirection A37ACC
 fish_color_end ED9366
-fish_color_error F51818
+fish_color_error F51818 --curly-underline
 fish_color_param 575F66
 fish_color_comment ABB0B6
 fish_color_match F07171

--- a/share/tools/web_config/themes/ayu Mirage.theme
+++ b/share/tools/web_config/themes/ayu Mirage.theme
@@ -7,7 +7,7 @@ fish_color_command 5CCFE6
 fish_color_quote BAE67E
 fish_color_redirection D4BFFF
 fish_color_end F29E74
-fish_color_error FF3333
+fish_color_error FF3333 --curly-underline
 fish_color_param CBCCC6
 fish_color_comment 5C6773
 fish_color_match F28779

--- a/share/tools/web_config/themes/coolbeans.theme
+++ b/share/tools/web_config/themes/coolbeans.theme
@@ -8,7 +8,7 @@ fish_color_comment '888'  '--italics'
 fish_color_cwd 0A0
 fish_color_cwd_root A00
 fish_color_end 009900
-fish_color_error F22
+fish_color_error F22 --curly-underline
 fish_color_escape 0AA
 fish_color_history_current 0AA
 fish_color_host normal

--- a/share/tools/web_config/themes/fish default.theme
+++ b/share/tools/web_config/themes/fish default.theme
@@ -8,7 +8,7 @@ fish_color_command normal
 fish_color_quote yellow
 fish_color_redirection cyan --bold
 fish_color_end green
-fish_color_error brred
+fish_color_error brred --curly-underline
 fish_color_param cyan
 fish_color_comment red
 fish_color_match --background=brblue

--- a/share/tools/web_config/webconfig.py
+++ b/share/tools/web_config/webconfig.py
@@ -252,7 +252,7 @@ def parse_color(color_str):
         elif comp.startswith("-b"):
             # Background color in short.
             skip = len("-b")
-            if comp[len("-b=")] in ["=", " "]:
+            if comp[skip] in ["=", " "]:
                 skip += 1
             c = comp[skip:]
             parsed_c = parse_one_color(c)

--- a/share/tools/web_config/webconfig.py
+++ b/share/tools/web_config/webconfig.py
@@ -227,7 +227,12 @@ def parse_color(color_str):
     comps = color_str.split(" ")
     color = ""
     background_color = ""
-    bold, underline, italics, dim, reverse = False, False, False, False, False
+    bold = False
+    underline = False
+    italics = False
+    dim = False
+    reverse = False
+    curly_underline = False
     for comp in comps:
         # Remove quotes
         comp = comp.strip("'\" ")
@@ -241,6 +246,8 @@ def parse_color(color_str):
             dim = True
         elif comp == "--reverse" or comp == "-r":
             reverse = True
+        elif comp == "--curly-underline":
+            curly_underline = True
         elif comp.startswith("--background"):
             # Background color
             c = comp[len("--background=") :]
@@ -292,6 +299,8 @@ def unparse_color(col):
         ret += " --dim"
     if col["reverse"]:
         ret += " --reverse"
+    if col["curly-underline"]:
+        ret += " --curly-underline"
     if col["background"]:
         ret += " --background=" + col["background"]
     return ret

--- a/src/builtins/set_color.rs
+++ b/src/builtins/set_color.rs
@@ -112,6 +112,10 @@ pub fn set_color(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
 
     let mut outp = Outputter::new_buffering();
     outp.set_text_face(TextFace::new(Color::None, Color::None, style));
+
+    // Here's some automagic behavior: if either of foreground or background are "normal",
+    // reset all colors/attributes. Same if foreground is "reset" (undocumented).
+    // Note that either overwrite the attributes printed above! For "normal", this is probably wrong?
     if bg.is_normal() {
         outp.reset_text_face(false);
     }

--- a/src/builtins/set_color.rs
+++ b/src/builtins/set_color.rs
@@ -78,7 +78,7 @@ fn print_colors(
             }
         }
         outp.write_wstr(color_name);
-        if !bg.is_none() {
+        if streams.out_is_terminal() && !bg.is_none() {
             // If we have a background, stop it after the color
             // or it goes to the end of the line and looks ugly.
             outp.write_command(ExitAttributeMode);

--- a/src/builtins/set_color.rs
+++ b/src/builtins/set_color.rs
@@ -111,7 +111,7 @@ pub fn set_color(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
     // #1323: We may have multiple foreground colors. Choose the best one.
     let fg = best_color(fgcolors.into_iter(), get_color_support());
 
-    let outp = &mut Outputter::new_buffering();
+    let mut outp = Outputter::new_buffering();
     outp.set_text_face(TextFace::new(Color::None, Color::None, style));
     if bgcolor.is_some() && bg.is_normal() {
         outp.write_command(ExitAttributeMode);

--- a/src/builtins/set_color.rs
+++ b/src/builtins/set_color.rs
@@ -174,7 +174,7 @@ pub fn set_color(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
         // for --print-colors. Because it's not interesting in terms of display,
         // just skip it.
         if bgcolor.is_some() && bg.is_special() {
-            bg = Color::from_wstr(L!("")).unwrap_or(Color::NONE);
+            bg = Color::NONE;
         }
         let args = &argv[wopt_index..argc];
         print_colors(streams, args, bold, underline, italics, dim, reverse, bg);

--- a/src/builtins/set_color.rs
+++ b/src/builtins/set_color.rs
@@ -90,18 +90,12 @@ pub fn set_color(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
         })
     };
 
-    let mut bg = Color::None;
-    if let Some(bgcolor) = bgcolor {
-        bg = parse_color(bgcolor)?;
-    }
+    let bg = match bgcolor {
+        Some(s) => parse_color(s)?,
+        None => Color::None,
+    };
 
     if print_color_mode {
-        // Hack: Explicitly setting a background of "normal" crashes
-        // for --print-colors. Because it's not interesting in terms of display,
-        // just skip it.
-        if bgcolor.is_some() && bg.is_special() {
-            bg = Color::None;
-        }
         let args = &argv[wopt_index..argc];
         print_colors(streams, args, style, bg);
         return Ok(SUCCESS);

--- a/src/builtins/set_color.rs
+++ b/src/builtins/set_color.rs
@@ -3,8 +3,7 @@
 use super::prelude::*;
 use crate::color::Color;
 use crate::common::str2wcstring;
-use crate::terminal::TerminalCommand::ExitAttributeMode;
-use crate::terminal::{best_color, get_color_support, Output, Outputter};
+use crate::terminal::{best_color, get_color_support, Outputter};
 use crate::text_face::{
     parse_text_face_and_options, TextFace, TextFaceArgsAndOptions, TextFaceArgsAndOptionsResult,
     TextStyling,
@@ -114,12 +113,12 @@ pub fn set_color(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
     let mut outp = Outputter::new_buffering();
     outp.set_text_face(TextFace::new(Color::None, Color::None, style));
     if bg.is_normal() {
-        outp.write_command(ExitAttributeMode);
+        outp.reset_text_face(false);
     }
 
     if let Some(fg) = fg {
         if fg.is_normal() || fg.is_reset() {
-            outp.write_command(ExitAttributeMode);
+            outp.reset_text_face(false);
         } else if !outp.write_color(fg, true /* is_fg */) {
             // We need to do *something* or the lack of any output messes up
             // when the cartesian product here would make "foo" disappear:

--- a/src/builtins/set_color.rs
+++ b/src/builtins/set_color.rs
@@ -113,7 +113,7 @@ pub fn set_color(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
 
     let mut outp = Outputter::new_buffering();
     outp.set_text_face(TextFace::new(Color::None, Color::None, style));
-    if bgcolor.is_some() && bg.is_normal() {
+    if bg.is_normal() {
         outp.write_command(ExitAttributeMode);
     }
 

--- a/src/builtins/set_color.rs
+++ b/src/builtins/set_color.rs
@@ -127,8 +127,7 @@ pub fn set_color(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
     // Remaining arguments are foreground color.
     let mut fgcolors = Vec::new();
     while wopt_index < argc {
-        let fg = Color::from_wstr(argv[wopt_index]).unwrap_or(Color::None);
-        if fg.is_none() {
+        let Some(fg) = Color::from_wstr(argv[wopt_index]) else {
             streams.err.append(wgettext_fmt!(
                 "%ls: Unknown color '%ls'\n",
                 argv[0],

--- a/src/builtins/set_color.rs
+++ b/src/builtins/set_color.rs
@@ -9,7 +9,7 @@ use crate::text_face::{
     TextStyling,
 };
 
-fn print_colors(streams: &mut IoStreams, args: &[&wstr], style: TextStyling, bg: Color) {
+fn print_colors(streams: &mut IoStreams, args: &[&wstr], style: TextStyling, bg: Option<Color>) {
     let outp = &mut Outputter::new_buffering();
 
     // Rebind args to named_colors if there are no args.
@@ -24,10 +24,10 @@ fn print_colors(streams: &mut IoStreams, args: &[&wstr], style: TextStyling, bg:
     for color_name in args {
         if streams.out_is_terminal() {
             let fg = Color::from_wstr(color_name).unwrap_or(Color::None);
-            outp.set_text_face(TextFace::new(fg, bg, style));
+            outp.set_text_face(TextFace::new(fg, bg.unwrap_or(Color::None), style));
         }
         outp.write_wstr(color_name);
-        if streams.out_is_terminal() && !bg.is_none() {
+        if streams.out_is_terminal() && bg.is_some() {
             // If we have a background, stop it after the color
             // or it goes to the end of the line and looks ugly.
             outp.reset_text_face(true);
@@ -51,7 +51,7 @@ pub fn set_color(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
     }
 
     let TextFaceArgsAndOptions {
-        mut wopt_index,
+        wopt_index,
         bgcolor,
         style,
         print_color_mode,
@@ -90,8 +90,8 @@ pub fn set_color(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
     };
 
     let bg = match bgcolor {
-        Some(s) => parse_color(s)?,
-        None => Color::None,
+        Some(s) => Some(parse_color(s)?),
+        None => None,
     };
 
     if print_color_mode {
@@ -102,36 +102,42 @@ pub fn set_color(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
 
     // Remaining arguments are foreground color.
     let mut fgcolors = Vec::new();
-    while wopt_index < argc {
-        fgcolors.push(parse_color(argv[wopt_index])?);
-        wopt_index += 1;
+    let mut is_reset = false;
+    for (i, arg) in argv.iter().skip(wopt_index).enumerate() {
+        if arg == "reset" {
+            // Historical behavior: reset only applies if it's the first argument.
+            if i == 0 {
+                is_reset = true;
+                break;
+            }
+        } else {
+            fgcolors.push(parse_color(arg)?);
+        }
     }
 
     // #1323: We may have multiple foreground colors. Choose the best one.
     let fg = best_color(fgcolors.into_iter(), get_color_support());
 
     let mut outp = Outputter::new_buffering();
-    outp.set_text_face(TextFace::new(Color::None, Color::None, style));
 
     // Here's some automagic behavior: if either of foreground or background are "normal",
     // reset all colors/attributes. Same if foreground is "reset" (undocumented).
     // Note that either overwrite the attributes printed above! For "normal", this is probably wrong?
-    if bg.is_normal() {
+    if is_reset || [fg, bg].iter().any(|c| c.is_some_and(|c| c.is_normal())) {
         outp.reset_text_face(false);
-    }
-
-    if let Some(fg) = fg {
-        if fg.is_normal() || fg.is_reset() {
-            outp.reset_text_face(false);
-        } else if !outp.write_color(fg, true /* is_fg */) {
-            // We need to do *something* or the lack of any output messes up
-            // when the cartesian product here would make "foo" disappear:
-            //  $ echo (set_color foo)bar
-            outp.reset_text_face(true);
+    } else {
+        outp.set_text_face(TextFace::new(Color::None, Color::None, style));
+        if let Some(fg) = fg {
+            if !outp.write_color(fg, true /* is_fg */) {
+                // We need to do *something* or the lack of any output messes up
+                // when the cartesian product here would make "foo" disappear:
+                //  $ echo (set_color foo)bar
+                outp.reset_text_face(true);
+            }
         }
-    }
-    if bgcolor.is_some() && !bg.is_normal() && !bg.is_reset() {
-        outp.write_color(bg, false /* is_fg */);
+        if let Some(bg) = bg {
+            outp.write_color(bg, false /* is_fg */);
+        }
     }
 
     // Output the collected string.

--- a/src/builtins/set_color.rs
+++ b/src/builtins/set_color.rs
@@ -3,60 +3,11 @@
 use super::prelude::*;
 use crate::color::Color;
 use crate::common::str2wcstring;
-use crate::terminal::TerminalCommand::{
-    EnterBoldMode, EnterDimMode, EnterItalicsMode, EnterReverseMode, EnterStandoutMode,
-    EnterUnderlineMode, ExitAttributeMode,
-};
+use crate::terminal::TerminalCommand::ExitAttributeMode;
 use crate::terminal::{best_color, get_color_support, Output, Outputter};
+use crate::text_face::{TextFace, TextStyling};
 
-#[allow(clippy::too_many_arguments)]
-fn print_modifiers(
-    outp: &mut Outputter,
-    bold: bool,
-    underline: bool,
-    italics: bool,
-    dim: bool,
-    reverse: bool,
-    bg: Color,
-) {
-    if bold {
-        outp.write_command(EnterBoldMode);
-    }
-
-    if underline {
-        outp.write_command(EnterUnderlineMode);
-    }
-
-    if italics {
-        outp.write_command(EnterItalicsMode);
-    }
-
-    if dim {
-        outp.write_command(EnterDimMode);
-    }
-
-    #[allow(clippy::collapsible_if)]
-    if reverse {
-        if !outp.write_command(EnterReverseMode) {
-            outp.write_command(EnterStandoutMode);
-        }
-    }
-    if !bg.is_none() && bg.is_normal() {
-        outp.write_command(ExitAttributeMode);
-    }
-}
-
-#[allow(clippy::too_many_arguments)]
-fn print_colors(
-    streams: &mut IoStreams,
-    args: &[&wstr],
-    bold: bool,
-    underline: bool,
-    italics: bool,
-    dim: bool,
-    reverse: bool,
-    bg: Color,
-) {
+fn print_colors(streams: &mut IoStreams, args: &[&wstr], style: TextStyling, bg: Color) {
     let outp = &mut Outputter::new_buffering();
 
     // Rebind args to named_colors if there are no args.
@@ -70,18 +21,14 @@ fn print_colors(
 
     for color_name in args {
         if streams.out_is_terminal() {
-            print_modifiers(outp, bold, underline, italics, dim, reverse, bg);
-            let color = Color::from_wstr(color_name).unwrap_or(Color::NONE);
-            outp.set_color(color, Color::NONE);
-            if !bg.is_none() {
-                outp.write_color(bg, false /* not is_fg */);
-            }
+            let fg = Color::from_wstr(color_name).unwrap_or(Color::None);
+            outp.set_text_face(TextFace::new(fg, bg, style));
         }
         outp.write_wstr(color_name);
         if streams.out_is_terminal() && !bg.is_none() {
             // If we have a background, stop it after the color
             // or it goes to the end of the line and looks ugly.
-            outp.write_command(ExitAttributeMode);
+            outp.reset_text_face(true);
         }
         outp.writech('\n');
     } // conveniently, 'normal' is always the last color so we don't need to reset here
@@ -114,11 +61,7 @@ pub fn set_color(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
     }
 
     let mut bgcolor = None;
-    let mut bold = false;
-    let mut underline = false;
-    let mut italics = false;
-    let mut dim = false;
-    let mut reverse = false;
+    let mut style = TextStyling::empty();
     let mut print = false;
 
     let mut w = WGetopter::new(SHORT_OPTIONS, LONG_OPTIONS, argv);
@@ -132,11 +75,11 @@ pub fn set_color(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
                 builtin_print_help(parser, streams, argv[0]);
                 return Ok(SUCCESS);
             }
-            'o' => bold = true,
-            'i' => italics = true,
-            'd' => dim = true,
-            'r' => reverse = true,
-            'u' => underline = true,
+            'o' => style |= TextStyling::BOLD,
+            'i' => style |= TextStyling::ITALICS,
+            'd' => style |= TextStyling::DIM,
+            'r' => style |= TextStyling::REVERSE,
+            'u' => style |= TextStyling::UNDERLINE,
             'c' => print = true,
             ':' => {
                 // We don't error here because "-b" is the only option that requires an argument,
@@ -159,7 +102,7 @@ pub fn set_color(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
     // We want to reclaim argv so grab wopt_index now.
     let mut wopt_index = w.wopt_index;
 
-    let mut bg = Color::from_wstr(bgcolor.unwrap_or(L!(""))).unwrap_or(Color::NONE);
+    let mut bg = bgcolor.and_then(Color::from_wstr).unwrap_or(Color::None);
     if bgcolor.is_some() && bg.is_none() {
         streams.err.append(wgettext_fmt!(
             "%ls: Unknown color '%ls'\n",
@@ -174,17 +117,17 @@ pub fn set_color(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
         // for --print-colors. Because it's not interesting in terms of display,
         // just skip it.
         if bgcolor.is_some() && bg.is_special() {
-            bg = Color::NONE;
+            bg = Color::None;
         }
         let args = &argv[wopt_index..argc];
-        print_colors(streams, args, bold, underline, italics, dim, reverse, bg);
+        print_colors(streams, args, style, bg);
         return Ok(SUCCESS);
     }
 
     // Remaining arguments are foreground color.
     let mut fgcolors = Vec::new();
     while wopt_index < argc {
-        let fg = Color::from_wstr(argv[wopt_index]).unwrap_or(Color::NONE);
+        let fg = Color::from_wstr(argv[wopt_index]).unwrap_or(Color::None);
         if fg.is_none() {
             streams.err.append(wgettext_fmt!(
                 "%ls: Unknown color '%ls'\n",
@@ -203,7 +146,7 @@ pub fn set_color(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
     assert!(fgcolors.is_empty() || !fg.is_none());
 
     let outp = &mut Outputter::new_buffering();
-    print_modifiers(outp, bold, underline, italics, dim, reverse, bg);
+    outp.set_text_face(TextFace::new(Color::None, Color::None, style));
     if bgcolor.is_some() && bg.is_normal() {
         outp.write_command(ExitAttributeMode);
     }
@@ -215,7 +158,7 @@ pub fn set_color(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
             // We need to do *something* or the lack of any output messes up
             // when the cartesian product here would make "foo" disappear:
             //  $ echo (set_color foo)bar
-            outp.set_color(Color::RESET, Color::NONE);
+            outp.reset_text_face(true);
         }
     }
     if bgcolor.is_some() && !bg.is_normal() && !bg.is_reset() {

--- a/src/builtins/set_color.rs
+++ b/src/builtins/set_color.rs
@@ -3,13 +3,19 @@
 use super::prelude::*;
 use crate::color::Color;
 use crate::common::str2wcstring;
-use crate::terminal::{best_color, get_color_support, Outputter};
+use crate::terminal::{best_color, get_color_support, Outputter, Paintee};
 use crate::text_face::{
     parse_text_face_and_options, TextFace, TextFaceArgsAndOptions, TextFaceArgsAndOptionsResult,
     TextStyling,
 };
 
-fn print_colors(streams: &mut IoStreams, args: &[&wstr], style: TextStyling, bg: Option<Color>) {
+fn print_colors(
+    streams: &mut IoStreams,
+    args: &[&wstr],
+    style: TextStyling,
+    bg: Option<Color>,
+    underline_color: Option<Color>,
+) {
     let outp = &mut Outputter::new_buffering();
 
     // Rebind args to named_colors if there are no args.
@@ -24,7 +30,12 @@ fn print_colors(streams: &mut IoStreams, args: &[&wstr], style: TextStyling, bg:
     for color_name in args {
         if streams.out_is_terminal() {
             let fg = Color::from_wstr(color_name).unwrap_or(Color::None);
-            outp.set_text_face(TextFace::new(fg, bg.unwrap_or(Color::None), style));
+            outp.set_text_face(TextFace::new(
+                fg,
+                bg.unwrap_or(Color::None),
+                underline_color.unwrap_or(Color::None),
+                style,
+            ));
         }
         outp.write_wstr(color_name);
         if streams.out_is_terminal() && bg.is_some() {
@@ -53,6 +64,7 @@ pub fn set_color(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
     let TextFaceArgsAndOptions {
         wopt_index,
         bgcolor,
+        underline_color,
         style,
         print_color_mode,
     } = match parse_text_face_and_options(argv, /*is_builtin=*/ true) {
@@ -94,9 +106,14 @@ pub fn set_color(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
         None => None,
     };
 
+    let underline_color = match underline_color {
+        Some(s) => Some(parse_color(s)?),
+        None => None,
+    };
+
     if print_color_mode {
         let args = &argv[wopt_index..argc];
-        print_colors(streams, args, style, bg);
+        print_colors(streams, args, style, bg, underline_color);
         return Ok(SUCCESS);
     }
 
@@ -126,9 +143,9 @@ pub fn set_color(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
     if is_reset || [fg, bg].iter().any(|c| c.is_some_and(|c| c.is_normal())) {
         outp.reset_text_face(false);
     } else {
-        outp.set_text_face(TextFace::new(Color::None, Color::None, style));
+        outp.set_text_face(TextFace::new(Color::None, Color::None, Color::None, style));
         if let Some(fg) = fg {
-            if !outp.write_color(fg, true /* is_fg */) {
+            if !outp.write_color(Paintee::Foreground, fg) {
                 // We need to do *something* or the lack of any output messes up
                 // when the cartesian product here would make "foo" disappear:
                 //  $ echo (set_color foo)bar
@@ -136,7 +153,10 @@ pub fn set_color(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
             }
         }
         if let Some(bg) = bg {
-            outp.write_color(bg, false /* is_fg */);
+            outp.write_color(Paintee::Background, bg);
+        }
+        if let Some(underline_color) = underline_color {
+            outp.write_color(Paintee::Underline, underline_color);
         }
     }
 

--- a/src/color.rs
+++ b/src/color.rs
@@ -46,12 +46,12 @@ bitflags! {
 
 /// A type that represents a color.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct RgbColor {
+pub struct Color {
     pub typ: Type,
     pub flags: Flags,
 }
 
-impl RgbColor {
+impl Color {
     /// The color white
     pub const WHITE: Self = Self {
         typ: Type::Named { idx: 7 },
@@ -293,7 +293,7 @@ impl RgbColor {
         } else {
             return None;
         };
-        Some(RgbColor::from_rgb(r, g, b))
+        Some(Color::from_rgb(r, g, b))
     }
 
     /// Try parsing an explicit color name like "magenta".
@@ -436,37 +436,37 @@ fn term256_color_for_rgb(color: Color24) -> u8 {
 
 #[cfg(test)]
 mod tests {
-    use crate::color::{Color24, Flags, RgbColor, Type};
+    use crate::color::{Color, Color24, Flags, Type};
     use crate::wchar::prelude::*;
 
     #[test]
     fn parse() {
-        assert!(RgbColor::from_wstr(L!("#FF00A0")).unwrap().is_rgb());
-        assert!(RgbColor::from_wstr(L!("FF00A0")).unwrap().is_rgb());
-        assert!(RgbColor::from_wstr(L!("#F30")).unwrap().is_rgb());
-        assert!(RgbColor::from_wstr(L!("F30")).unwrap().is_rgb());
-        assert!(RgbColor::from_wstr(L!("f30")).unwrap().is_rgb());
-        assert!(RgbColor::from_wstr(L!("#FF30a5")).unwrap().is_rgb());
-        assert!(RgbColor::from_wstr(L!("3f30")).is_none());
-        assert!(RgbColor::from_wstr(L!("##f30")).is_none());
-        assert!(RgbColor::from_wstr(L!("magenta")).unwrap().is_named());
-        assert!(RgbColor::from_wstr(L!("MaGeNTa")).unwrap().is_named());
-        assert!(RgbColor::from_wstr(L!("mooganta")).is_none());
+        assert!(Color::from_wstr(L!("#FF00A0")).unwrap().is_rgb());
+        assert!(Color::from_wstr(L!("FF00A0")).unwrap().is_rgb());
+        assert!(Color::from_wstr(L!("#F30")).unwrap().is_rgb());
+        assert!(Color::from_wstr(L!("F30")).unwrap().is_rgb());
+        assert!(Color::from_wstr(L!("f30")).unwrap().is_rgb());
+        assert!(Color::from_wstr(L!("#FF30a5")).unwrap().is_rgb());
+        assert!(Color::from_wstr(L!("3f30")).is_none());
+        assert!(Color::from_wstr(L!("##f30")).is_none());
+        assert!(Color::from_wstr(L!("magenta")).unwrap().is_named());
+        assert!(Color::from_wstr(L!("MaGeNTa")).unwrap().is_named());
+        assert!(Color::from_wstr(L!("mooganta")).is_none());
     }
 
     #[test]
     fn parse_rgb() {
-        assert!(RgbColor::from_wstr(L!("##FF00A0")).is_none());
-        assert!(RgbColor::from_wstr(L!("#FF00A0")) == Some(RgbColor::from_rgb(0xff, 0x00, 0xa0)));
-        assert!(RgbColor::from_wstr(L!("FF00A0")) == Some(RgbColor::from_rgb(0xff, 0x00, 0xa0)));
-        assert!(RgbColor::from_wstr(L!("FAF")) == Some(RgbColor::from_rgb(0xff, 0xaa, 0xff)));
+        assert!(Color::from_wstr(L!("##FF00A0")).is_none());
+        assert!(Color::from_wstr(L!("#FF00A0")) == Some(Color::from_rgb(0xff, 0x00, 0xa0)));
+        assert!(Color::from_wstr(L!("FF00A0")) == Some(Color::from_rgb(0xff, 0x00, 0xa0)));
+        assert!(Color::from_wstr(L!("FAF")) == Some(Color::from_rgb(0xff, 0xaa, 0xff)));
     }
 
     // Regression test for multiplicative overflow in convert_color.
     #[test]
     fn test_term16_color_for_rgb() {
         for c in 0..=u8::MAX {
-            let color = RgbColor {
+            let color = Color {
                 typ: Type::Rgb(Color24 { r: c, g: c, b: c }),
                 flags: Flags::DEFAULT,
             };
@@ -477,52 +477,52 @@ mod tests {
     #[test]
     fn parse_short_hex_with_hash() {
         assert_eq!(
-            RgbColor::try_parse_rgb(L!("#F3A")),
-            Some(RgbColor::from_rgb(0xFF, 0x33, 0xAA))
+            Color::try_parse_rgb(L!("#F3A")),
+            Some(Color::from_rgb(0xFF, 0x33, 0xAA))
         );
     }
 
     #[test]
     fn parse_long_hex_with_hash() {
         assert_eq!(
-            RgbColor::try_parse_rgb(L!("#F3A035")),
-            Some(RgbColor::from_rgb(0xF3, 0xA0, 0x35))
+            Color::try_parse_rgb(L!("#F3A035")),
+            Some(Color::from_rgb(0xF3, 0xA0, 0x35))
         );
     }
 
     #[test]
     fn parse_short_hex_without_hash() {
         assert_eq!(
-            RgbColor::try_parse_rgb(L!("F3A")),
-            Some(RgbColor::from_rgb(0xFF, 0x33, 0xAA))
+            Color::try_parse_rgb(L!("F3A")),
+            Some(Color::from_rgb(0xFF, 0x33, 0xAA))
         );
     }
 
     #[test]
     fn parse_long_hex_without_hash() {
         assert_eq!(
-            RgbColor::try_parse_rgb(L!("F3A035")),
-            Some(RgbColor::from_rgb(0xF3, 0xA0, 0x35))
+            Color::try_parse_rgb(L!("F3A035")),
+            Some(Color::from_rgb(0xF3, 0xA0, 0x35))
         );
     }
 
     #[test]
     fn invalid_hex_length() {
-        assert_eq!(RgbColor::try_parse_rgb(L!("#F3A03")), None);
-        assert_eq!(RgbColor::try_parse_rgb(L!("F3A0")), None);
+        assert_eq!(Color::try_parse_rgb(L!("#F3A03")), None);
+        assert_eq!(Color::try_parse_rgb(L!("F3A0")), None);
     }
 
     #[test]
     fn invalid_hex_character() {
-        assert_eq!(RgbColor::try_parse_rgb(L!("#GFA")), None);
-        assert_eq!(RgbColor::try_parse_rgb(L!("F3G035")), None);
+        assert_eq!(Color::try_parse_rgb(L!("#GFA")), None);
+        assert_eq!(Color::try_parse_rgb(L!("F3G035")), None);
     }
 
     #[test]
     fn invalid_hash_combinations() {
-        assert_eq!(RgbColor::try_parse_rgb(L!("##F3A")), None);
-        assert_eq!(RgbColor::try_parse_rgb(L!("###F3A035")), None);
-        assert_eq!(RgbColor::try_parse_rgb(L!("F3A#")), None);
-        assert_eq!(RgbColor::try_parse_rgb(L!("#F#3A")), None);
+        assert_eq!(Color::try_parse_rgb(L!("##F3A")), None);
+        assert_eq!(Color::try_parse_rgb(L!("###F3A035")), None);
+        assert_eq!(Color::try_parse_rgb(L!("F3A#")), None);
+        assert_eq!(Color::try_parse_rgb(L!("#F#3A")), None);
     }
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -29,7 +29,6 @@ pub enum Color {
     Named { idx: u8 },
     Rgb(Color24),
     Normal,
-    Reset,
 }
 
 impl Color {
@@ -54,11 +53,6 @@ impl Color {
     /// Returns whether the color is the normal special color.
     pub const fn is_normal(self) -> bool {
         matches!(self, Self::Normal)
-    }
-
-    /// Returns whether the color is the reset special color.
-    pub const fn is_reset(self) -> bool {
-        matches!(self, Self::Reset)
     }
 
     /// Returns whether the color is the none special color.
@@ -87,7 +81,6 @@ impl Color {
             Self::Named { idx } => [0, 7, 8, 15, 16].contains(idx) || (232..=255).contains(idx),
             Self::Rgb(rgb) => rgb.r == rgb.g && rgb.r == rgb.b,
             Self::Normal => true,
-            Self::Reset => true,
         }
     }
 
@@ -97,7 +90,7 @@ impl Color {
         match self {
             Self::Named { idx } => idx,
             Self::Rgb(c) => term16_color_for_rgb(c),
-            Self::None | Self::Normal | Self::Reset => {
+            Self::None | Self::Normal => {
                 panic!("to_name_index() called on Color that's not named or RGB")
             }
         }
@@ -144,8 +137,6 @@ impl Color {
     fn try_parse_special(special: &wstr) -> Option<Self> {
         if simple_icase_compare(special, L!("normal")) == Ordering::Equal {
             Some(Self::Normal)
-        } else if simple_icase_compare(special, L!("reset")) == Ordering::Equal {
-            Some(Self::Reset)
         } else {
             None
         }

--- a/src/highlight/highlight.rs
+++ b/src/highlight/highlight.rs
@@ -6,7 +6,7 @@ use crate::ast::{
     VariableAssignment,
 };
 use crate::builtins::shared::builtin_exists;
-use crate::color::RgbColor;
+use crate::color::Color;
 use crate::common::{
     valid_var_name, valid_var_name_char, ASCII_MAX, EXPAND_RESERVED_BASE, EXPAND_RESERVED_END,
 };
@@ -71,12 +71,12 @@ pub fn colorize(text: &wstr, colors: &[HighlightSpec], vars: &dyn Environment) -
     for (i, c) in text.chars().enumerate() {
         let color = colors[i];
         if color != last_color {
-            outp.set_color(rv.resolve_spec(&color, false, vars), RgbColor::NORMAL);
+            outp.set_color(rv.resolve_spec(&color, false, vars), Color::NORMAL);
             last_color = color;
         }
         outp.writech(c);
     }
-    outp.set_color(RgbColor::NORMAL, RgbColor::NORMAL);
+    outp.set_color(Color::NORMAL, Color::NORMAL);
     outp.contents().to_owned()
 }
 
@@ -107,8 +107,8 @@ pub fn highlight_shell(
 /// one screen redraw.
 #[derive(Default)]
 pub struct HighlightColorResolver {
-    fg_cache: HashMap<HighlightSpec, RgbColor>,
-    bg_cache: HashMap<HighlightSpec, RgbColor>,
+    fg_cache: HashMap<HighlightSpec, Color>,
+    bg_cache: HashMap<HighlightSpec, Color>,
 }
 
 /// highlight_color_resolver_t resolves highlight specs (like "a command") to actual RGB colors.
@@ -124,7 +124,7 @@ impl HighlightColorResolver {
         highlight: &HighlightSpec,
         is_background: bool,
         vars: &dyn Environment,
-    ) -> RgbColor {
+    ) -> Color {
         let cache = if is_background {
             &mut self.bg_cache
         } else {
@@ -143,8 +143,8 @@ impl HighlightColorResolver {
         highlight: &HighlightSpec,
         is_background: bool,
         vars: &dyn Environment,
-    ) -> RgbColor {
-        let mut result = RgbColor::NORMAL;
+    ) -> Color {
+        let mut result = Color::NORMAL;
         let role = if is_background {
             highlight.background
         } else {

--- a/src/highlight/highlight.rs
+++ b/src/highlight/highlight.rs
@@ -181,10 +181,17 @@ impl HighlightColorResolver {
 /// Return the internal color code representing the specified color.
 pub(crate) fn parse_text_face_for_highlight(var: &EnvVar) -> TextFace {
     let face = parse_text_face(var.as_list());
-    let fg = face.fg.unwrap_or(Color::Normal);
-    let bg = face.bg.unwrap_or(Color::Normal);
+    let default = TextFace::default();
+    let fg = face.fg.unwrap_or(default.fg);
+    let bg = face.bg.unwrap_or(default.bg);
+    let underline_color = face.underline_color.unwrap_or(default.underline_color);
     let style = face.style;
-    TextFace { fg, bg, style }
+    TextFace {
+        fg,
+        bg,
+        underline_color,
+        style,
+    }
 }
 
 fn command_is_valid(

--- a/src/highlight/highlight.rs
+++ b/src/highlight/highlight.rs
@@ -27,8 +27,8 @@ use crate::parse_util::{
     parse_util_locate_cmdsubst_range, parse_util_slice_length, MaybeParentheses,
 };
 use crate::path::{path_as_implicit_cd, path_get_cdpath, path_get_path, paths_are_same_file};
-use crate::terminal::{parse_text_face, Outputter};
-use crate::text_face::{TextFace, TextStyling};
+use crate::terminal::Outputter;
+use crate::text_face::{parse_text_face, TextFace, TextStyling};
 use crate::threads::assert_is_background_thread;
 use crate::tokenizer::{variable_assignment_equals_pos, PipeOrRedir};
 use crate::wchar::{wstr, WString, L};
@@ -193,7 +193,7 @@ pub(crate) fn parse_text_face_for_highlight(
         let Some(var) = maybe_var else {
             return (Color::Normal, TextStyling::empty());
         };
-        let (mut color, style) = parse_text_face(var, is_background);
+        let (mut color, style) = parse_text_face(var.as_list(), is_background);
         if color.is_none() {
             color = Color::Normal;
         }

--- a/src/highlight/highlight.rs
+++ b/src/highlight/highlight.rs
@@ -156,26 +156,12 @@ impl HighlightColorResolver {
                 if !valid_path_face.fg.is_normal() {
                     result.fg = valid_path_face.fg;
                 }
-                if valid_path_face.is_bold() {
-                    result.set_bold(true);
-                }
-                if valid_path_face.is_underline() {
-                    result.set_underline(true);
-                }
-                if valid_path_face.is_italics() {
-                    result.set_italics(true);
-                }
-                if valid_path_face.is_dim() {
-                    result.set_dim(true);
-                }
-                if valid_path_face.is_reverse() {
-                    result.set_reverse(true);
-                }
+                result.style |= valid_path_face.style;
             }
         }
 
         if highlight.force_underline {
-            result.set_underline(true);
+            result.inject_underline(true);
         }
 
         result

--- a/src/highlight/highlight.rs
+++ b/src/highlight/highlight.rs
@@ -11,7 +11,7 @@ use crate::common::{
     valid_var_name, valid_var_name_char, ASCII_MAX, EXPAND_RESERVED_BASE, EXPAND_RESERVED_END,
 };
 use crate::complete::complete_wrap_map;
-use crate::env::Environment;
+use crate::env::{EnvVar, Environment};
 use crate::expand::{
     expand_one, expand_to_command_and_args, ExpandFlags, ExpandResultCode, PROCESS_EXPAND_SELF_STR,
 };
@@ -27,7 +27,8 @@ use crate::parse_util::{
     parse_util_locate_cmdsubst_range, parse_util_slice_length, MaybeParentheses,
 };
 use crate::path::{path_as_implicit_cd, path_get_cdpath, path_get_path, paths_are_same_file};
-use crate::terminal::{parse_color, Outputter};
+use crate::terminal::{parse_text_face, Outputter};
+use crate::text_face::{TextFace, TextStyling};
 use crate::threads::assert_is_background_thread;
 use crate::tokenizer::{variable_assignment_equals_pos, PipeOrRedir};
 use crate::wchar::{wstr, WString, L};
@@ -71,12 +72,14 @@ pub fn colorize(text: &wstr, colors: &[HighlightSpec], vars: &dyn Environment) -
     for (i, c) in text.chars().enumerate() {
         let color = colors[i];
         if color != last_color {
-            outp.set_color(rv.resolve_spec(&color, false, vars), Color::NORMAL);
+            let mut face = rv.resolve_spec(&color, vars);
+            face.bg = Color::Normal; // Historical behavior.
+            outp.set_text_face(face);
             last_color = color;
         }
         outp.writech(c);
     }
-    outp.set_color(Color::NORMAL, Color::NORMAL);
+    outp.set_text_face(TextFace::default());
     outp.contents().to_owned()
 }
 
@@ -107,8 +110,7 @@ pub fn highlight_shell(
 /// one screen redraw.
 #[derive(Default)]
 pub struct HighlightColorResolver {
-    fg_cache: HashMap<HighlightSpec, Color>,
-    bg_cache: HashMap<HighlightSpec, Color>,
+    cache: HashMap<HighlightSpec, TextFace>,
 }
 
 /// highlight_color_resolver_t resolves highlight specs (like "a command") to actual RGB colors.
@@ -119,86 +121,90 @@ impl HighlightColorResolver {
         Default::default()
     }
     /// Return an RGB color for a given highlight spec.
-    pub fn resolve_spec(
+    pub(crate) fn resolve_spec(
         &mut self,
         highlight: &HighlightSpec,
-        is_background: bool,
         vars: &dyn Environment,
-    ) -> Color {
-        let cache = if is_background {
-            &mut self.bg_cache
-        } else {
-            &mut self.fg_cache
-        };
-        match cache.entry(*highlight) {
+    ) -> TextFace {
+        match self.cache.entry(*highlight) {
             Entry::Occupied(e) => *e.get(),
             Entry::Vacant(e) => {
-                let color = Self::resolve_spec_uncached(highlight, is_background, vars);
-                e.insert(color);
-                color
+                let face = Self::resolve_spec_uncached(highlight, vars);
+                e.insert(face);
+                face
             }
         }
     }
-    pub fn resolve_spec_uncached(
+    pub(crate) fn resolve_spec_uncached(
         highlight: &HighlightSpec,
-        is_background: bool,
         vars: &dyn Environment,
-    ) -> Color {
-        let mut result = Color::NORMAL;
-        let role = if is_background {
-            highlight.background
-        } else {
-            highlight.foreground
+    ) -> TextFace {
+        let resolve_role = |role| {
+            vars.get_unless_empty(get_highlight_var_name(role))
+                .or_else(|| vars.get_unless_empty(get_highlight_var_name(get_fallback(role))))
+                .or_else(|| vars.get(get_highlight_var_name(HighlightRole::normal)))
         };
-
-        let var = vars
-            .get_unless_empty(get_highlight_var_name(role))
-            .or_else(|| vars.get_unless_empty(get_highlight_var_name(get_fallback(role))))
-            .or_else(|| vars.get(get_highlight_var_name(HighlightRole::normal)));
-        if let Some(var) = var {
-            result = parse_color(&var, is_background);
-        }
+        let fg_var = resolve_role(highlight.foreground);
+        let bg_var = resolve_role(highlight.background);
+        let mut result = parse_text_face_for_highlight(fg_var.as_ref(), bg_var.as_ref());
 
         // Handle modifiers.
-        if !is_background && highlight.valid_path {
-            if let Some(var2) = vars.get(L!("fish_color_valid_path")) {
-                let result2 = parse_color(&var2, is_background);
-                if result.is_normal() {
-                    result = result2;
-                } else if !result2.is_normal() {
-                    // Valid path has an actual color, use it and merge the modifiers.
-                    let mut rescol = result2;
-                    rescol.set_bold(result.is_bold() || result2.is_bold());
-                    rescol.set_underline(result.is_underline() || result2.is_underline());
-                    rescol.set_italics(result.is_italics() || result2.is_italics());
-                    rescol.set_dim(result.is_dim() || result2.is_dim());
-                    rescol.set_reverse(result.is_reverse() || result2.is_reverse());
-                    result = rescol;
-                } else {
-                    if result2.is_bold() {
-                        result.set_bold(true)
-                    };
-                    if result2.is_underline() {
-                        result.set_underline(true)
-                    };
-                    if result2.is_italics() {
-                        result.set_italics(true)
-                    };
-                    if result2.is_dim() {
-                        result.set_dim(true)
-                    };
-                    if result2.is_reverse() {
-                        result.set_reverse(true)
-                    };
+        if highlight.valid_path {
+            if let Some(valid_path_var) = vars.get(L!("fish_color_valid_path")) {
+                // Historical behavior is to not apply background.
+                let valid_path_face = parse_text_face_for_highlight(Some(&valid_path_var), None);
+                if !valid_path_face.fg.is_normal() {
+                    result.fg = valid_path_face.fg;
+                }
+                if valid_path_face.is_bold() {
+                    result.set_bold(true);
+                }
+                if valid_path_face.is_underline() {
+                    result.set_underline(true);
+                }
+                if valid_path_face.is_italics() {
+                    result.set_italics(true);
+                }
+                if valid_path_face.is_dim() {
+                    result.set_dim(true);
+                }
+                if valid_path_face.is_reverse() {
+                    result.set_reverse(true);
                 }
             }
         }
 
-        if !is_background && highlight.force_underline {
+        if highlight.force_underline {
             result.set_underline(true);
         }
 
         result
+    }
+}
+
+/// Return the internal color code representing the specified color.
+/// TODO: This code should be refactored to enable sharing with builtin_set_color.
+///       In particular, the argument parsing still isn't fully capable.
+pub(crate) fn parse_text_face_for_highlight(
+    fg_var: Option<&EnvVar>,
+    bg_var: Option<&EnvVar>,
+) -> TextFace {
+    let parse_var = |maybe_var: Option<&EnvVar>, is_background| {
+        let Some(var) = maybe_var else {
+            return (Color::Normal, TextStyling::empty());
+        };
+        let (mut color, style) = parse_text_face(var, is_background);
+        if color.is_none() {
+            color = Color::Normal;
+        }
+        (color, style)
+    };
+    let (fg, fg_style) = parse_var(fg_var, false);
+    let (bg, bg_style) = parse_var(bg_var, true);
+    TextFace {
+        fg,
+        bg,
+        style: fg_style | bg_style,
     }
 }
 
@@ -1279,7 +1285,7 @@ pub enum HighlightRole {
     pager_selected_description,
 }
 
-/// Simply value type describing how a character should be highlighted..
+/// Simple value type describing how a character should be highlighted.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct HighlightSpec {
     pub foreground: HighlightRole,

--- a/src/highlight/highlight.rs
+++ b/src/highlight/highlight.rs
@@ -28,7 +28,7 @@ use crate::parse_util::{
 };
 use crate::path::{path_as_implicit_cd, path_get_cdpath, path_get_path, paths_are_same_file};
 use crate::terminal::Outputter;
-use crate::text_face::{parse_text_face, TextFace};
+use crate::text_face::{parse_text_face, TextFace, UnderlineStyle};
 use crate::threads::assert_is_background_thread;
 use crate::tokenizer::{variable_assignment_equals_pos, PipeOrRedir};
 use crate::wchar::{wstr, WString, L};
@@ -166,12 +166,12 @@ impl HighlightColorResolver {
                 if !valid_path_face.fg.is_normal() {
                     face.fg = valid_path_face.fg;
                 }
-                face.style = face.style.union(valid_path_face.style);
+                face.style = face.style.union_prefer_right(valid_path_face.style);
             }
         }
 
         if highlight.force_underline {
-            face.style.inject_underline(true);
+            face.style.inject_underline(UnderlineStyle::Single);
         }
 
         face

--- a/src/highlight/highlight.rs
+++ b/src/highlight/highlight.rs
@@ -28,7 +28,7 @@ use crate::parse_util::{
 };
 use crate::path::{path_as_implicit_cd, path_get_cdpath, path_get_path, paths_are_same_file};
 use crate::terminal::Outputter;
-use crate::text_face::{parse_text_face, TextFace, TextStyling};
+use crate::text_face::{parse_text_face, SpecifiedTextFace, TextFace, TextStyling};
 use crate::threads::assert_is_background_thread;
 use crate::tokenizer::{variable_assignment_equals_pos, PipeOrRedir};
 use crate::wchar::{wstr, WString, L};
@@ -175,21 +175,22 @@ pub(crate) fn parse_text_face_for_highlight(
 ) -> TextFace {
     let parse_var = |maybe_var: Option<&EnvVar>| {
         let Some(var) = maybe_var else {
-            return (
-                Some(Color::Normal),
-                Some(Color::Normal),
-                TextStyling::default(),
-            );
+            return SpecifiedTextFace {
+                fg: Some(Color::Normal),
+                bg: Some(Color::Normal),
+                style: TextStyling::default(),
+            };
         };
         parse_text_face(var.as_list())
     };
-    let (fg, _bg, mut style) = parse_var(fg_var);
-    let (_fg, bg, bg_style) = parse_var(bg_var);
-    let fg = fg.unwrap_or(Color::Normal);
-    let bg = bg.unwrap_or(Color::Normal);
+    let fg_face = parse_var(fg_var);
+    let bg_face = parse_var(bg_var);
+    let fg = fg_face.fg.unwrap_or(Color::Normal);
+    let bg = bg_face.bg.unwrap_or(Color::Normal);
     // In case the background role is different from the foreground one, we ignore its style
     // except for reverse mode.
-    style.reverse |= bg_style.reverse;
+    let mut style = fg_face.style;
+    style.reverse |= bg_face.style.reverse;
     TextFace { fg, bg, style }
 }
 

--- a/src/highlight/highlight.rs
+++ b/src/highlight/highlight.rs
@@ -156,12 +156,12 @@ impl HighlightColorResolver {
                 if !valid_path_face.fg.is_normal() {
                     result.fg = valid_path_face.fg;
                 }
-                result.style |= valid_path_face.style;
+                result.style = result.style.union(valid_path_face.style);
             }
         }
 
         if highlight.force_underline {
-            result.inject_underline(true);
+            result.style.inject_underline(true);
         }
 
         result
@@ -173,21 +173,24 @@ pub(crate) fn parse_text_face_for_highlight(
     fg_var: Option<&EnvVar>,
     bg_var: Option<&EnvVar>,
 ) -> TextFace {
-    let parse_var = |maybe_var: Option<&EnvVar>, is_background| {
+    let parse_var = |maybe_var: Option<&EnvVar>| {
         let Some(var) = maybe_var else {
-            return (Color::Normal, TextStyling::empty());
+            return (
+                Some(Color::Normal),
+                Some(Color::Normal),
+                TextStyling::default(),
+            );
         };
-        let (color, style) = parse_text_face(var.as_list(), is_background);
-        let color = color.unwrap_or(Color::Normal);
-        (color, style)
+        parse_text_face(var.as_list())
     };
-    let (fg, fg_style) = parse_var(fg_var, false);
-    let (bg, bg_style) = parse_var(bg_var, true);
-    TextFace {
-        fg,
-        bg,
-        style: fg_style | bg_style,
-    }
+    let (fg, _bg, mut style) = parse_var(fg_var);
+    let (_fg, bg, bg_style) = parse_var(bg_var);
+    let fg = fg.unwrap_or(Color::Normal);
+    let bg = bg.unwrap_or(Color::Normal);
+    // In case the background role is different from the foreground one, we ignore its style
+    // except for reverse mode.
+    style.reverse |= bg_style.reverse;
+    TextFace { fg, bg, style }
 }
 
 fn command_is_valid(

--- a/src/highlight/highlight.rs
+++ b/src/highlight/highlight.rs
@@ -183,8 +183,6 @@ impl HighlightColorResolver {
 }
 
 /// Return the internal color code representing the specified color.
-/// TODO: This code should be refactored to enable sharing with builtin_set_color.
-///       In particular, the argument parsing still isn't fully capable.
 pub(crate) fn parse_text_face_for_highlight(
     fg_var: Option<&EnvVar>,
     bg_var: Option<&EnvVar>,
@@ -193,10 +191,8 @@ pub(crate) fn parse_text_face_for_highlight(
         let Some(var) = maybe_var else {
             return (Color::Normal, TextStyling::empty());
         };
-        let (mut color, style) = parse_text_face(var.as_list(), is_background);
-        if color.is_none() {
-            color = Color::Normal;
-        }
+        let (color, style) = parse_text_face(var.as_list(), is_background);
+        let color = color.unwrap_or(Color::Normal);
         (color, style)
     };
     let (fg, fg_style) = parse_var(fg_var, false);

--- a/src/highlight/highlight.rs
+++ b/src/highlight/highlight.rs
@@ -28,7 +28,7 @@ use crate::parse_util::{
 };
 use crate::path::{path_as_implicit_cd, path_get_cdpath, path_get_path, paths_are_same_file};
 use crate::terminal::Outputter;
-use crate::text_face::{parse_text_face, SpecifiedTextFace, TextFace, TextStyling};
+use crate::text_face::{parse_text_face, TextFace};
 use crate::threads::assert_is_background_thread;
 use crate::tokenizer::{variable_assignment_equals_pos, PipeOrRedir};
 use crate::wchar::{wstr, WString, L};
@@ -143,54 +143,47 @@ impl HighlightColorResolver {
             vars.get_unless_empty(get_highlight_var_name(role))
                 .or_else(|| vars.get_unless_empty(get_highlight_var_name(get_fallback(role))))
                 .or_else(|| vars.get(get_highlight_var_name(HighlightRole::normal)))
+                .as_ref()
+                .map(parse_text_face_for_highlight)
+                .unwrap_or_else(TextFace::default)
         };
-        let fg_var = resolve_role(highlight.foreground);
-        let bg_var = resolve_role(highlight.background);
-        let mut result = parse_text_face_for_highlight(fg_var.as_ref(), bg_var.as_ref());
+        let mut face = resolve_role(highlight.foreground);
+
+        // Optimization: no need to parse again if both colors are the same.
+        if highlight.background != highlight.foreground {
+            let bg_face = resolve_role(highlight.background);
+            face.bg = bg_face.bg;
+            // In case the background role is different from the foreground one, we ignore its style
+            // except for reverse mode.
+            face.style.reverse |= bg_face.style.is_reverse();
+        }
 
         // Handle modifiers.
         if highlight.valid_path {
             if let Some(valid_path_var) = vars.get(L!("fish_color_valid_path")) {
                 // Historical behavior is to not apply background.
-                let valid_path_face = parse_text_face_for_highlight(Some(&valid_path_var), None);
+                let valid_path_face = parse_text_face_for_highlight(&valid_path_var);
                 if !valid_path_face.fg.is_normal() {
-                    result.fg = valid_path_face.fg;
+                    face.fg = valid_path_face.fg;
                 }
-                result.style = result.style.union(valid_path_face.style);
+                face.style = face.style.union(valid_path_face.style);
             }
         }
 
         if highlight.force_underline {
-            result.style.inject_underline(true);
+            face.style.inject_underline(true);
         }
 
-        result
+        face
     }
 }
 
 /// Return the internal color code representing the specified color.
-pub(crate) fn parse_text_face_for_highlight(
-    fg_var: Option<&EnvVar>,
-    bg_var: Option<&EnvVar>,
-) -> TextFace {
-    let parse_var = |maybe_var: Option<&EnvVar>| {
-        let Some(var) = maybe_var else {
-            return SpecifiedTextFace {
-                fg: Some(Color::Normal),
-                bg: Some(Color::Normal),
-                style: TextStyling::default(),
-            };
-        };
-        parse_text_face(var.as_list())
-    };
-    let fg_face = parse_var(fg_var);
-    let bg_face = parse_var(bg_var);
-    let fg = fg_face.fg.unwrap_or(Color::Normal);
-    let bg = bg_face.bg.unwrap_or(Color::Normal);
-    // In case the background role is different from the foreground one, we ignore its style
-    // except for reverse mode.
-    let mut style = fg_face.style;
-    style.reverse |= bg_face.style.reverse;
+pub(crate) fn parse_text_face_for_highlight(var: &EnvVar) -> TextFace {
+    let face = parse_text_face(var.as_list());
+    let fg = face.fg.unwrap_or(Color::Normal);
+    let bg = face.bg.unwrap_or(Color::Normal);
+    let style = face.style;
     TextFace { fg, bg, style }
 }
 

--- a/src/highlight/tests.rs
+++ b/src/highlight/tests.rs
@@ -3,6 +3,7 @@ use crate::env::EnvMode;
 use crate::future_feature_flags::{self, FeatureFlag};
 use crate::highlight::HighlightColorResolver;
 use crate::tests::prelude::*;
+use crate::text_face::UnderlineStyle;
 use crate::wchar::prelude::*;
 use crate::{
     env::EnvStack,
@@ -695,8 +696,9 @@ fn test_trailing_spaces_after_command() {
     // Check that 'echo' is underlined
     for i in 0..4 {
         let face = resolver.resolve_spec(&colors[i], vars);
-        assert!(
-            face.is_underline(),
+        assert_eq!(
+            face.style.underline_style(),
+            Some(UnderlineStyle::Single),
             "Character at position {} of 'echo' should be underlined",
             i
         );
@@ -705,8 +707,9 @@ fn test_trailing_spaces_after_command() {
     // Check that trailing spaces are NOT underlined
     for i in 4..text.len() {
         let face = resolver.resolve_spec(&colors[i], vars);
-        assert!(
-            !face.is_underline(),
+        assert_eq!(
+            face.style.underline_style(),
+            None,
             "Trailing space at position {} should NOT be underlined",
             i
         );

--- a/src/highlight/tests.rs
+++ b/src/highlight/tests.rs
@@ -694,9 +694,9 @@ fn test_trailing_spaces_after_command() {
 
     // Check that 'echo' is underlined
     for i in 0..4 {
-        let rgb = resolver.resolve_spec(&colors[i], false, vars);
+        let face = resolver.resolve_spec(&colors[i], vars);
         assert!(
-            rgb.is_underline(),
+            face.is_underline(),
             "Character at position {} of 'echo' should be underlined",
             i
         );
@@ -704,9 +704,9 @@ fn test_trailing_spaces_after_command() {
 
     // Check that trailing spaces are NOT underlined
     for i in 4..text.len() {
-        let rgb = resolver.resolve_spec(&colors[i], false, vars);
+        let face = resolver.resolve_spec(&colors[i], vars);
         assert!(
-            !rgb.is_underline(),
+            !face.is_underline(),
             "Trailing space at position {} should NOT be underlined",
             i
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,7 @@ pub mod screen;
 pub mod signal;
 pub mod terminal;
 pub mod termsize;
+pub mod text_face;
 pub mod threads;
 pub mod timer;
 pub mod tinyexpr;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1660,10 +1660,7 @@ impl<'a> Reader<'a> {
             let explicit_foreground = self
                 .vars()
                 .get_unless_empty(L!("fish_color_search_match"))
-                .is_some_and(|var| {
-                    let (fg, _bg, _style) = parse_text_face(var.as_list());
-                    !fg.is_none()
-                });
+                .is_some_and(|var| parse_text_face(var.as_list()).fg.is_some());
 
             for color in &mut colors[range] {
                 if explicit_foreground {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -123,7 +123,6 @@ use crate::signal::{
     signal_check_cancel, signal_clear_cancel, signal_reset_handlers, signal_set_handlers,
     signal_set_handlers_once,
 };
-use crate::terminal::parse_text_face;
 use crate::terminal::BufferedOutputter;
 use crate::terminal::Output;
 use crate::terminal::Outputter;
@@ -143,6 +142,7 @@ use crate::terminal::{
     SYNCHRONIZED_OUTPUT_SUPPORTED,
 };
 use crate::termsize::{termsize_invalidate_tty, termsize_last, termsize_update};
+use crate::text_face::parse_text_face;
 use crate::text_face::TextFace;
 use crate::threads::{
     assert_is_background_thread, assert_is_main_thread, iothread_service_main_with_timeout,
@@ -1661,7 +1661,7 @@ impl<'a> Reader<'a> {
                 .vars()
                 .get_unless_empty(L!("fish_color_search_match"))
                 .is_some_and(|var| {
-                    let (color, _flags) = parse_text_face(&var, false);
+                    let (color, _flags) = parse_text_face(var.as_list(), false);
                     !color.is_none()
                 });
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1661,8 +1661,8 @@ impl<'a> Reader<'a> {
                 .vars()
                 .get_unless_empty(L!("fish_color_search_match"))
                 .is_some_and(|var| {
-                    let (color, _flags) = parse_text_face(var.as_list(), false);
-                    !color.is_none()
+                    let (fg, _bg, _style) = parse_text_face(var.as_list());
+                    !fg.is_none()
                 });
 
             for color in &mut colors[range] {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -2692,10 +2692,7 @@ impl<'a> Reader<'a> {
 
                     let mut outp = Outputter::stdoutput().borrow_mut();
                     if let Some(fish_color_cancel) = self.vars().get(L!("fish_color_cancel")) {
-                        outp.set_text_face(parse_text_face_for_highlight(
-                            Some(&fish_color_cancel),
-                            Some(&fish_color_cancel),
-                        ));
+                        outp.set_text_face(parse_text_face_for_highlight(&fish_color_cancel));
                     }
                     outp.write_wstr(L!("^C"));
                     outp.reset_text_face(true);

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -46,7 +46,7 @@ use crate::ast::{self, Ast, Category, Traversal};
 use crate::builtins::shared::ErrorCode;
 use crate::builtins::shared::STATUS_CMD_ERROR;
 use crate::builtins::shared::STATUS_CMD_OK;
-use crate::color::RgbColor;
+use crate::color::Color;
 use crate::common::restore_term_foreground_process_group_for_exit;
 use crate::common::{
     escape, escape_string, exit_without_destructors, get_ellipsis_char, get_obfuscation_read_char,
@@ -2292,7 +2292,7 @@ impl<'a> Reader<'a> {
             }
             Outputter::stdoutput()
                 .borrow_mut()
-                .set_color(RgbColor::RESET, RgbColor::RESET);
+                .set_color(Color::RESET, Color::RESET);
         }
         let result = self
             .rls()
@@ -2700,7 +2700,7 @@ impl<'a> Reader<'a> {
                         );
                     }
                     outp.write_wstr(L!("^C"));
-                    outp.set_color(RgbColor::RESET, RgbColor::RESET);
+                    outp.set_color(Color::RESET, Color::RESET);
 
                     // We print a newline last so the prompt_sp hack doesn't get us.
                     outp.push(b'\n');
@@ -4466,7 +4466,7 @@ fn reader_interactive_init(parser: &Parser) {
 fn reader_interactive_destroy() {
     Outputter::stdoutput()
         .borrow_mut()
-        .set_color(RgbColor::RESET, RgbColor::RESET);
+        .set_color(Color::RESET, Color::RESET);
 }
 
 /// Return whether fish is currently unwinding the stack in preparation to exit.
@@ -4530,7 +4530,7 @@ pub fn reader_write_title(
         out.write_command(Osc0WindowTitle(&lst));
     }
 
-    out.set_color(RgbColor::RESET, RgbColor::RESET);
+    out.set_color(Color::RESET, Color::RESET);
     if reset_cursor_position && !lst.is_empty() {
         // Put the cursor back at the beginning of the line (issue #2453).
         out.write_bytes(b"\r");
@@ -5670,7 +5670,7 @@ fn reader_run_command(parser: &Parser, cmd: &wstr) -> EvalRes {
     reader_write_title(cmd, parser, true);
     Outputter::stdoutput()
         .borrow_mut()
-        .set_color(RgbColor::NORMAL, RgbColor::NORMAL);
+        .set_color(Color::NORMAL, Color::NORMAL);
     term_donate(false);
 
     let time_before = Instant::now();

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -46,7 +46,6 @@ use crate::ast::{self, Ast, Category, Traversal};
 use crate::builtins::shared::ErrorCode;
 use crate::builtins::shared::STATUS_CMD_ERROR;
 use crate::builtins::shared::STATUS_CMD_OK;
-use crate::color::Color;
 use crate::common::restore_term_foreground_process_group_for_exit;
 use crate::common::{
     escape, escape_string, exit_without_destructors, get_ellipsis_char, get_obfuscation_read_char,
@@ -71,7 +70,8 @@ use crate::flog::{FLOG, FLOGF};
 use crate::future::IsSomeAnd;
 use crate::global_safety::RelaxedAtomicBool;
 use crate::highlight::{
-    autosuggest_validate_from_history, highlight_shell, HighlightRole, HighlightSpec,
+    autosuggest_validate_from_history, highlight_shell, parse_text_face_for_highlight,
+    HighlightRole, HighlightSpec,
 };
 use crate::history::{
     history_session_id, in_private_mode, History, HistorySearch, PersistenceMode, SearchDirection,
@@ -123,8 +123,7 @@ use crate::signal::{
     signal_check_cancel, signal_clear_cancel, signal_reset_handlers, signal_set_handlers,
     signal_set_handlers_once,
 };
-use crate::terminal::parse_color;
-use crate::terminal::parse_color_maybe_none;
+use crate::terminal::parse_text_face;
 use crate::terminal::BufferedOutputter;
 use crate::terminal::Output;
 use crate::terminal::Outputter;
@@ -144,6 +143,7 @@ use crate::terminal::{
     SYNCHRONIZED_OUTPUT_SUPPORTED,
 };
 use crate::termsize::{termsize_invalidate_tty, termsize_last, termsize_update};
+use crate::text_face::TextFace;
 use crate::threads::{
     assert_is_background_thread, assert_is_main_thread, iothread_service_main_with_timeout,
     Debounce,
@@ -1660,7 +1660,10 @@ impl<'a> Reader<'a> {
             let explicit_foreground = self
                 .vars()
                 .get_unless_empty(L!("fish_color_search_match"))
-                .is_some_and(|var| !parse_color_maybe_none(&var, false).is_none());
+                .is_some_and(|var| {
+                    let (color, _flags) = parse_text_face(&var, false);
+                    !color.is_none()
+                });
 
             for color in &mut colors[range] {
                 if explicit_foreground {
@@ -2290,9 +2293,7 @@ impl<'a> Reader<'a> {
                 }
                 perror("tcsetattr"); // return to previous mode
             }
-            Outputter::stdoutput()
-                .borrow_mut()
-                .set_color(Color::RESET, Color::RESET);
+            Outputter::stdoutput().borrow_mut().reset_text_face(true);
         }
         let result = self
             .rls()
@@ -2694,13 +2695,13 @@ impl<'a> Reader<'a> {
 
                     let mut outp = Outputter::stdoutput().borrow_mut();
                     if let Some(fish_color_cancel) = self.vars().get(L!("fish_color_cancel")) {
-                        outp.set_color(
-                            parse_color(&fish_color_cancel, false),
-                            parse_color(&fish_color_cancel, true),
-                        );
+                        outp.set_text_face(parse_text_face_for_highlight(
+                            Some(&fish_color_cancel),
+                            Some(&fish_color_cancel),
+                        ));
                     }
                     outp.write_wstr(L!("^C"));
-                    outp.set_color(Color::RESET, Color::RESET);
+                    outp.reset_text_face(true);
 
                     // We print a newline last so the prompt_sp hack doesn't get us.
                     outp.push(b'\n');
@@ -4464,9 +4465,7 @@ fn reader_interactive_init(parser: &Parser) {
 
 /// Destroy data for interactive use.
 fn reader_interactive_destroy() {
-    Outputter::stdoutput()
-        .borrow_mut()
-        .set_color(Color::RESET, Color::RESET);
+    Outputter::stdoutput().borrow_mut().reset_text_face(true);
 }
 
 /// Return whether fish is currently unwinding the stack in preparation to exit.
@@ -4530,7 +4529,7 @@ pub fn reader_write_title(
         out.write_command(Osc0WindowTitle(&lst));
     }
 
-    out.set_color(Color::RESET, Color::RESET);
+    out.reset_text_face(true);
     if reset_cursor_position && !lst.is_empty() {
         // Put the cursor back at the beginning of the line (issue #2453).
         out.write_bytes(b"\r");
@@ -5670,7 +5669,7 @@ fn reader_run_command(parser: &Parser, cmd: &wstr) -> EvalRes {
     reader_write_title(cmd, parser, true);
     Outputter::stdoutput()
         .borrow_mut()
-        .set_color(Color::NORMAL, Color::NORMAL);
+        .set_text_face(TextFace::default());
     term_donate(false);
 
     let time_before = Instant::now();

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -1034,9 +1034,9 @@ impl Screen {
         // Helper function to set a resolved color, using the caching resolver.
         let mut color_resolver = HighlightColorResolver::new();
         let mut set_color = |zelf: &mut Self, c| {
-            let fg = color_resolver.resolve_spec(&c, false, vars);
-            let bg = color_resolver.resolve_spec(&c, true, vars);
-            zelf.outp.borrow_mut().set_color(fg, bg);
+            zelf.outp
+                .borrow_mut()
+                .set_text_face(color_resolver.resolve_spec(&c, vars));
         };
 
         let mut cached_layouts = LAYOUT_CACHE_SHARED.lock().unwrap();

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -581,29 +581,29 @@ impl Outputter {
 
         // Lastly, we set bold, underline, italics, dim, and reverse modes correctly.
         if is_bold && !self.last.is_bold() && !bg_set && self.write_command(EnterBoldMode) {
-            self.last.style.set(TextStyling::BOLD, is_bold);
+            self.last.style.set(TextStyling::BOLD, true);
         }
 
         if !self.last.is_underline() && is_underline && self.write_command(EnterUnderlineMode) {
-            self.last.style.set(TextStyling::UNDERLINE, is_underline);
+            self.last.style.set(TextStyling::UNDERLINE, true);
         } else if self.last.is_underline() && !is_underline && self.write_command(ExitUnderlineMode)
         {
-            self.last.style.set(TextStyling::UNDERLINE, is_underline);
+            self.last.style.set(TextStyling::UNDERLINE, false);
         }
 
         if self.last.is_italics() && !is_italics && self.write_command(ExitItalicsMode) {
-            self.last.style.set(TextStyling::ITALICS, is_italics);
+            self.last.style.set(TextStyling::ITALICS, false);
         } else if !self.last.is_italics() && is_italics && self.write_command(EnterItalicsMode) {
-            self.last.style.set(TextStyling::ITALICS, is_italics);
+            self.last.style.set(TextStyling::ITALICS, true);
         }
 
         if is_dim && !self.last.is_dim() && self.write_command(EnterDimMode) {
-            self.last.style.set(TextStyling::DIM, is_dim);
+            self.last.style.set(TextStyling::DIM, true);
         }
 
         if is_reverse && !self.last.is_reverse() {
             if self.write_command(EnterReverseMode) || self.write_command(EnterStandoutMode) {
-                self.last.style.set(TextStyling::REVERSE, is_reverse);
+                self.last.style.set(TextStyling::REVERSE, true);
             }
         }
     }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -579,20 +579,21 @@ impl Outputter {
             }
         }
 
-        if self.last_fg != fg {
+        if !fg.is_none() && self.last_fg != fg {
             if fg.is_normal() {
                 write_foreground_color(self, 0);
                 self.write_command(ExitAttributeMode);
 
                 self.last_bg = Color::NORMAL;
                 self.reset_modes();
-            } else if !fg.is_special() {
+            } else {
+                assert!(!fg.is_special());
                 self.write_color(fg, true /* foreground */);
             }
+            self.last_fg = fg;
         }
-        self.last_fg = fg;
 
-        if self.last_bg != bg {
+        if !bg.is_none() && self.last_bg != bg {
             if bg.is_normal() {
                 write_background_color(self, 0);
 
@@ -601,11 +602,11 @@ impl Outputter {
                     self.write_color(self.last_fg, true /* foreground */);
                 }
                 self.reset_modes();
-                self.last_bg = bg;
-            } else if !bg.is_special() {
+            } else {
+                assert!(!bg.is_special());
                 self.write_color(bg, false /* not foreground */);
-                self.last_bg = bg;
             }
+            self.last_bg = bg;
         }
 
         // Lastly, we set bold, underline, italics, dim, and reverse modes correctly.

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -550,7 +550,7 @@ impl Outputter {
             self.reset_text_face(false);
         }
 
-        if !fg.is_none() && self.last.fg != fg {
+        if !fg.is_none() && fg != self.last.fg {
             if fg.is_normal() {
                 write_foreground_color(self, 0);
                 self.write_command(ExitAttributeMode);
@@ -564,7 +564,7 @@ impl Outputter {
             self.last.fg = fg;
         }
 
-        if !bg.is_none() && self.last.bg != bg {
+        if !bg.is_none() && bg != self.last.bg {
             if bg.is_normal() {
                 write_background_color(self, 0);
 
@@ -590,16 +590,16 @@ impl Outputter {
         }
 
         let was_underline = self.last.style.is_underline();
-        if !was_underline && style.is_underline() && self.write_command(EnterUnderlineMode) {
-            self.last.style.underline = true;
-        } else if was_underline && !style.is_underline() && self.write_command(ExitUnderlineMode) {
+        if !style.is_underline() && was_underline && self.write_command(ExitUnderlineMode) {
             self.last.style.underline = false;
+        } else if style.is_underline() && !was_underline && self.write_command(EnterUnderlineMode) {
+            self.last.style.underline = true;
         }
 
         let was_italics = self.last.style.is_italics();
-        if was_italics && !style.is_italics() && self.write_command(ExitItalicsMode) {
+        if !style.is_italics() && was_italics && self.write_command(ExitItalicsMode) {
             self.last.style.italics = false;
-        } else if !was_italics && style.is_italics() && self.write_command(EnterItalicsMode) {
+        } else if style.is_italics() && !was_italics && self.write_command(EnterItalicsMode) {
             self.last.style.italics = true;
         }
 
@@ -607,10 +607,11 @@ impl Outputter {
             self.last.style.dim = true;
         }
 
-        if style.is_reverse() && !self.last.style.is_reverse() {
-            if self.write_command(EnterReverseMode) || self.write_command(EnterStandoutMode) {
-                self.last.style.reverse = true;
-            }
+        if style.is_reverse()
+            && !self.last.style.is_reverse()
+            && (self.write_command(EnterReverseMode) || self.write_command(EnterStandoutMode))
+        {
+            self.last.style.reverse = true;
         }
     }
 

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -501,10 +501,6 @@ impl Outputter {
         let mut bg_set = false;
         let mut last_bg_set = false;
 
-        if fg.is_reset() || bg.is_reset() {
-            self.reset_text_face(true);
-            return;
-        }
         use TerminalCommand::{
             EnterBoldMode, EnterDimMode, EnterItalicsMode, EnterReverseMode, EnterStandoutMode,
             EnterUnderlineMode, ExitAttributeMode, ExitItalicsMode, ExitUnderlineMode,

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -41,6 +41,13 @@ pub fn set_color_support(val: ColorSupport) {
     COLOR_SUPPORT.store(val.bits(), Ordering::Relaxed);
 }
 
+#[derive(Clone, Copy)]
+pub(crate) enum Paintee {
+    Foreground,
+    Background,
+    Underline,
+}
+
 #[derive(Clone)]
 pub(crate) enum TerminalCommand<'a> {
     // Text attributes
@@ -61,8 +68,8 @@ pub(crate) enum TerminalCommand<'a> {
     ClearToEndOfScreen,
 
     // Colors
-    SelectPaletteColor(/*is_foreground=*/ bool, u8),
-    SelectRgbColor(/*is_foreground=*/ bool, Color24),
+    SelectPaletteColor(Paintee, u8),
+    SelectRgbColor(Paintee, Color24),
 
     // Cursor Movement
     CursorUp,
@@ -153,8 +160,8 @@ pub(crate) trait Output {
             ClearScreen => ti(self, b"\x1b[H\x1b[2J", |term| &term.clear_screen),
             ClearToEndOfLine => ti(self, b"\x1b[K", |term| &term.clr_eol),
             ClearToEndOfScreen => ti(self, b"\x1b[J", |term| &term.clr_eos),
-            SelectPaletteColor(is_foreground, idx) => palette_color(self, is_foreground, idx),
-            SelectRgbColor(is_foreground, rgb) => rgb_color(self, is_foreground, rgb),
+            SelectPaletteColor(paintee, idx) => palette_color(self, paintee, idx),
+            SelectRgbColor(paintee, rgb) => rgb_color(self, paintee, rgb),
             CursorUp => ti(self, b"\x1b[A", |term| &term.cursor_up),
             CursorDown => ti(self, b"\n", |term| &term.cursor_down),
             CursorLeft => ti(self, b"\x08", |term| &term.cursor_left),
@@ -232,20 +239,22 @@ pub(crate) fn use_terminfo() -> bool {
     !future_feature_flags::test(FeatureFlag::ignore_terminfo) && TERM.lock().unwrap().is_some()
 }
 
-fn palette_color(out: &mut impl Output, foreground: bool, mut idx: u8) -> bool {
+fn palette_color(out: &mut impl Output, paintee: Paintee, mut idx: u8) -> bool {
     if only_grayscale() && !(Color::Named { idx }).is_grayscale() {
         return false;
     }
     if use_terminfo() {
         let term = crate::terminal::term();
-        let Some(command) = (if foreground {
-            term.set_a_foreground
+        let Some(command) = (match paintee {
+            Paintee::Foreground => term
+                .set_a_foreground
                 .as_ref()
-                .or(term.set_foreground.as_ref())
-        } else {
-            term.set_a_background
+                .or(term.set_foreground.as_ref()),
+            Paintee::Background => term
+                .set_a_background
                 .as_ref()
-                .or(term.set_background.as_ref())
+                .or(term.set_background.as_ref()),
+            Paintee::Underline => None,
         }) else {
             return false;
         };
@@ -260,11 +269,14 @@ fn palette_color(out: &mut impl Output, foreground: bool, mut idx: u8) -> bool {
             idx -= 8;
         }
     }
-    let bg = if foreground { 0 } else { 10 };
+    let is_underline = matches!(paintee, Paintee::Underline);
+    let is_bg = matches!(paintee, Paintee::Background);
+    let bg = if is_bg { 10 } else { 0 };
+    let ul = if is_underline { 20 } else { 0 };
     match idx {
-        0..=7 => write_to_output!(out, "\x1b[{}m", 30 + bg + idx),
-        8..=15 => write_to_output!(out, "\x1b[{}m", 90 + bg + (idx - 8)),
-        _ => write_to_output!(out, "\x1b[{};5;{}m", 38 + bg, idx),
+        0..=7 if !is_underline => write_to_output!(out, "\x1b[{}m", 30 + bg + idx),
+        8..=15 if !is_underline => write_to_output!(out, "\x1b[{}m", 90 + bg + (idx - 8)),
+        _ => write_to_output!(out, "\x1b[{};5;{}m", 38 + bg + ul, idx),
     };
     true
 }
@@ -279,13 +291,18 @@ fn term_supports_color_natively(term: &Term, c: u8) -> bool {
     }
 }
 
-fn rgb_color(out: &mut impl Output, foreground: bool, rgb: Color24) -> bool {
+fn rgb_color(out: &mut impl Output, paintee: Paintee, rgb: Color24) -> bool {
     // Foreground: ^[38;2;<r>;<g>;<b>m
     // Background: ^[48;2;<r>;<g>;<b>m
+    // Underline: ^[58;2::<r>:<g>:<b>m
     write_to_output!(
         out,
         "\x1b[{};2;{};{};{}m",
-        if foreground { 38 } else { 48 },
+        match paintee {
+            Paintee::Foreground => 38,
+            Paintee::Background => 48,
+            Paintee::Underline => 58,
+        },
         rgb.r,
         rgb.g,
         rgb.b
@@ -399,11 +416,17 @@ fn index_for_color(c: Color) -> u8 {
 }
 
 fn write_foreground_color(outp: &mut Outputter, idx: u8) -> bool {
-    outp.write_command(TerminalCommand::SelectPaletteColor(true, idx))
+    outp.write_command(TerminalCommand::SelectPaletteColor(
+        Paintee::Foreground,
+        idx,
+    ))
 }
 
 fn write_background_color(outp: &mut Outputter, idx: u8) -> bool {
-    outp.write_command(TerminalCommand::SelectPaletteColor(false, idx))
+    outp.write_command(TerminalCommand::SelectPaletteColor(
+        Paintee::Background,
+        idx,
+    ))
 }
 
 pub struct Outputter {
@@ -447,16 +470,12 @@ impl Outputter {
 
     /// Unconditionally write the color string to the output.
     /// Exported for builtin_set_color's usage only.
-    pub fn write_color(&mut self, color: Color, is_fg: bool) -> bool {
+    pub(crate) fn write_color(&mut self, paintee: Paintee, color: Color) -> bool {
         let supports_term24bit = get_color_support().contains(ColorSupport::TERM_24BIT);
         if !supports_term24bit || !color.is_rgb() {
             // Indexed or non-24 bit color.
             let idx = index_for_color(color);
-            if is_fg {
-                return write_foreground_color(self, idx);
-            } else {
-                return write_background_color(self, idx);
-            };
+            return self.write_command(TerminalCommand::SelectPaletteColor(paintee, idx));
         }
 
         if only_grayscale() && color.is_grayscale() {
@@ -464,7 +483,7 @@ impl Outputter {
         }
 
         // 24 bit!
-        self.write_command(TerminalCommand::SelectRgbColor(is_fg, color.to_color24()))
+        self.write_command(TerminalCommand::SelectRgbColor(paintee, color.to_color24()))
     }
 
     /// Unconditionally resets colors and text style.
@@ -499,6 +518,7 @@ impl Outputter {
     pub(crate) fn set_text_face(&mut self, face: TextFace) {
         let mut fg = face.fg;
         let bg = face.bg;
+        let underline_color = face.underline_color;
         let style = face.style;
         let mut bg_set = false;
         let mut last_bg_set = false;
@@ -555,10 +575,11 @@ impl Outputter {
                 self.write_command(ExitAttributeMode);
 
                 self.last.bg = Color::Normal;
+                self.last.underline_color = Color::Normal;
                 self.last.style = TextStyling::default();
             } else {
                 assert!(!fg.is_special());
-                self.write_color(fg, true /* foreground */);
+                self.write_color(Paintee::Foreground, fg);
             }
             self.last.fg = fg;
         }
@@ -569,14 +590,22 @@ impl Outputter {
 
                 self.write_command(ExitAttributeMode);
                 if !self.last.fg.is_normal() {
-                    self.write_color(self.last.fg, true /* foreground */);
+                    self.write_color(Paintee::Foreground, self.last.fg);
+                }
+                if !self.last.underline_color.is_normal() && !self.last.underline_color.is_none() {
+                    self.write_color(Paintee::Underline, self.last.underline_color);
                 }
                 self.last.style = TextStyling::default();
             } else {
                 assert!(!bg.is_special());
-                self.write_color(bg, false /* not foreground */);
+                self.write_color(Paintee::Background, bg);
             }
             self.last.bg = bg;
+        }
+
+        if !underline_color.is_none() && underline_color != self.last.underline_color {
+            self.write_color(Paintee::Underline, bg);
+            self.last.underline_color = underline_color;
         }
 
         // Lastly, we set bold, underline, italics, dim, and reverse modes correctly.

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -5,7 +5,7 @@ use crate::common::{self, escape_string, wcs2string, wcs2string_appending, Escap
 use crate::future_feature_flags::{self, FeatureFlag};
 use crate::global_safety::RelaxedAtomicBool;
 use crate::screen::{is_dumb, only_grayscale};
-use crate::text_face::{TextFace, TextStyling};
+use crate::text_face::{TextFace, TextStyling, UnderlineStyle};
 use crate::threads::MainThread;
 use crate::wchar::prelude::*;
 use crate::FLOGF;
@@ -53,6 +53,7 @@ pub(crate) enum TerminalCommand<'a> {
     EnterStandoutMode,
     ExitItalicsMode,
     ExitUnderlineMode,
+    EnterCurlyUnderlineMode,
 
     // Screen clearing
     ClearScreen,
@@ -148,6 +149,7 @@ pub(crate) trait Output {
             EnterStandoutMode => ti(self, b"\x1b[7m", |t| &t.enter_standout_mode),
             ExitItalicsMode => ti(self, b"\x1b[23m", |t| &t.exit_italics_mode),
             ExitUnderlineMode => ti(self, b"\x1b[24m", |t| &t.exit_underline_mode),
+            EnterCurlyUnderlineMode => write(self, b"\x1b[4:3m"),
             ClearScreen => ti(self, b"\x1b[H\x1b[2J", |term| &term.clear_screen),
             ClearToEndOfLine => ti(self, b"\x1b[K", |term| &term.clr_eol),
             ClearToEndOfScreen => ti(self, b"\x1b[J", |term| &term.clr_eos),
@@ -502,18 +504,19 @@ impl Outputter {
         let mut last_bg_set = false;
 
         use TerminalCommand::{
-            EnterBoldMode, EnterDimMode, EnterItalicsMode, EnterReverseMode, EnterStandoutMode,
-            EnterUnderlineMode, ExitAttributeMode, ExitItalicsMode, ExitUnderlineMode,
+            EnterBoldMode, EnterCurlyUnderlineMode, EnterDimMode, EnterItalicsMode,
+            EnterReverseMode, EnterStandoutMode, EnterUnderlineMode, ExitAttributeMode,
+            ExitItalicsMode, ExitUnderlineMode,
         };
 
         // Removes all styles that are individually resettable.
         let non_resettable = |mut style: TextStyling| {
             style.italics = false;
-            style.underline = false;
+            style.underline_style = None;
             style
         };
         let non_resettable_attributes_to_unset =
-            non_resettable(self.last.style).difference(non_resettable(style));
+            non_resettable(self.last.style).difference_prefer_empty(non_resettable(style));
         if !non_resettable_attributes_to_unset.is_empty() {
             // Only way to exit non-resettable ones is a reset of all attributes.
             self.reset_text_face(false);
@@ -585,11 +588,22 @@ impl Outputter {
             self.last.style.bold = true;
         }
 
-        let was_underline = self.last.style.is_underline();
-        if !style.is_underline() && was_underline && self.write_command(ExitUnderlineMode) {
-            self.last.style.underline = false;
-        } else if style.is_underline() && !was_underline && self.write_command(EnterUnderlineMode) {
-            self.last.style.underline = true;
+        if style.underline_style != self.last.style.underline_style {
+            match style.underline_style {
+                None => {
+                    if self.write_command(ExitUnderlineMode) {
+                        self.last.style.underline_style = None;
+                    }
+                }
+                Some(underline) => {
+                    if self.write_command(match underline {
+                        UnderlineStyle::Single => EnterUnderlineMode,
+                        UnderlineStyle::Curly => EnterCurlyUnderlineMode,
+                    }) {
+                        self.last.style.underline_style = Some(underline);
+                    }
+                }
+            }
         }
 
         let was_italics = self.last.style.is_italics();

--- a/src/text_face.rs
+++ b/src/text_face.rs
@@ -96,9 +96,13 @@ impl TextFace {
     }
 }
 
-pub(crate) fn parse_text_face(
-    arguments: &[WString],
-) -> (Option<Color>, Option<Color>, TextStyling) {
+pub(crate) struct SpecifiedTextFace {
+    pub(crate) fg: Option<Color>,
+    pub(crate) bg: Option<Color>,
+    pub(crate) style: TextStyling,
+}
+
+pub(crate) fn parse_text_face(arguments: &[WString]) -> SpecifiedTextFace {
     let mut argv: Vec<&wstr> = Some(L!(""))
         .into_iter()
         .chain(arguments.iter().map(|s| s.as_utfstr()))
@@ -124,7 +128,7 @@ pub(crate) fn parse_text_face(
     let bg = bgcolor.and_then(Color::from_wstr);
     assert!(fg.map_or(true, |fg| !fg.is_none()));
     assert!(bg.map_or(true, |bg| !bg.is_none()));
-    (fg, bg, style)
+    SpecifiedTextFace { fg, bg, style }
 }
 
 pub(crate) struct TextFaceArgsAndOptions<'a> {

--- a/src/text_face.rs
+++ b/src/text_face.rs
@@ -23,17 +23,15 @@ pub(crate) struct TextFace {
     pub(crate) style: TextStyling,
 }
 
-impl Default for TextFace {
-    fn default() -> Self {
+impl TextFace {
+    pub const fn default() -> Self {
         Self {
             fg: Color::Normal,
             bg: Color::Normal,
             style: TextStyling::empty(),
         }
     }
-}
 
-impl TextFace {
     pub fn new(fg: Color, bg: Color, style: TextStyling) -> Self {
         Self { fg, bg, style }
     }
@@ -42,18 +40,13 @@ impl TextFace {
         self.style.contains(TextStyling::BOLD)
     }
 
-    /// Set whether the text face is bold.
-    pub fn set_bold(&mut self, bold: bool) {
-        self.style.set(TextStyling::BOLD, bold)
-    }
-
     /// Returns whether the text face is underlined.
     pub const fn is_underline(self) -> bool {
         self.style.contains(TextStyling::UNDERLINE)
     }
 
     /// Set whether the text face is underline.
-    pub fn set_underline(&mut self, underline: bool) {
+    pub fn inject_underline(&mut self, underline: bool) {
         self.style.set(TextStyling::UNDERLINE, underline)
     }
 
@@ -62,29 +55,14 @@ impl TextFace {
         self.style.contains(TextStyling::ITALICS)
     }
 
-    /// Set whether the text face is italics.
-    pub fn set_italics(&mut self, italics: bool) {
-        self.style.set(TextStyling::ITALICS, italics)
-    }
-
     /// Returns whether the text face is dim.
     pub const fn is_dim(self) -> bool {
         self.style.contains(TextStyling::DIM)
     }
 
-    /// Set whether the text face is dim.
-    pub fn set_dim(&mut self, dim: bool) {
-        self.style.set(TextStyling::DIM, dim)
-    }
-
     /// Returns whether the text face has reverse foreground/background colors.
     pub const fn is_reverse(self) -> bool {
         self.style.contains(TextStyling::REVERSE)
-    }
-
-    /// Set whether the text face has reverse foreground/background colors.
-    pub fn set_reverse(&mut self, reverse: bool) {
-        self.style.set(TextStyling::REVERSE, reverse)
     }
 }
 

--- a/src/text_face.rs
+++ b/src/text_face.rs
@@ -1,0 +1,86 @@
+use bitflags::bitflags;
+
+use crate::color::Color;
+
+bitflags! {
+    #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+    pub struct TextStyling: u8 {
+        const BOLD = 1<<0;
+        const UNDERLINE = 1<<1;
+        const ITALICS = 1<<2;
+        const DIM = 1<<3;
+        const REVERSE = 1<<4;
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct TextFace {
+    pub(crate) fg: Color,
+    pub(crate) bg: Color,
+    pub(crate) style: TextStyling,
+}
+
+impl Default for TextFace {
+    fn default() -> Self {
+        Self {
+            fg: Color::Normal,
+            bg: Color::Normal,
+            style: TextStyling::empty(),
+        }
+    }
+}
+
+impl TextFace {
+    pub fn new(fg: Color, bg: Color, style: TextStyling) -> Self {
+        Self { fg, bg, style }
+    }
+    /// Returns whether the text face is bold.
+    pub const fn is_bold(self) -> bool {
+        self.style.contains(TextStyling::BOLD)
+    }
+
+    /// Set whether the text face is bold.
+    pub fn set_bold(&mut self, bold: bool) {
+        self.style.set(TextStyling::BOLD, bold)
+    }
+
+    /// Returns whether the text face is underlined.
+    pub const fn is_underline(self) -> bool {
+        self.style.contains(TextStyling::UNDERLINE)
+    }
+
+    /// Set whether the text face is underline.
+    pub fn set_underline(&mut self, underline: bool) {
+        self.style.set(TextStyling::UNDERLINE, underline)
+    }
+
+    /// Returns whether the text face is italics.
+    pub const fn is_italics(self) -> bool {
+        self.style.contains(TextStyling::ITALICS)
+    }
+
+    /// Set whether the text face is italics.
+    pub fn set_italics(&mut self, italics: bool) {
+        self.style.set(TextStyling::ITALICS, italics)
+    }
+
+    /// Returns whether the text face is dim.
+    pub const fn is_dim(self) -> bool {
+        self.style.contains(TextStyling::DIM)
+    }
+
+    /// Set whether the text face is dim.
+    pub fn set_dim(&mut self, dim: bool) {
+        self.style.set(TextStyling::DIM, dim)
+    }
+
+    /// Returns whether the text face has reverse foreground/background colors.
+    pub const fn is_reverse(self) -> bool {
+        self.style.contains(TextStyling::REVERSE)
+    }
+
+    /// Set whether the text face has reverse foreground/background colors.
+    pub fn set_reverse(&mut self, reverse: bool) {
+        self.style.set(TextStyling::REVERSE, reverse)
+    }
+}

--- a/src/text_face.rs
+++ b/src/text_face.rs
@@ -3,10 +3,34 @@ use crate::terminal::{best_color, get_color_support};
 use crate::wchar::prelude::*;
 use crate::wgetopt::{wopt, ArgType, WGetopter, WOption};
 
+trait StyleSet {
+    fn union_prefer_right(self, other: Self) -> Self;
+    fn difference_prefer_empty(self, other: Self) -> Self;
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(crate) enum UnderlineStyle {
+    Single,
+    Curly,
+}
+
+impl StyleSet for Option<UnderlineStyle> {
+    fn union_prefer_right(self, other: Self) -> Self {
+        other.or(self)
+    }
+
+    fn difference_prefer_empty(self, other: Self) -> Self {
+        if other.is_some() {
+            return None;
+        }
+        self
+    }
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub(crate) struct TextStyling {
     pub(crate) bold: bool,
-    pub(crate) underline: bool,
+    pub(crate) underline_style: Option<UnderlineStyle>,
     pub(crate) italics: bool,
     pub(crate) dim: bool,
     pub(crate) reverse: bool,
@@ -16,7 +40,7 @@ impl TextStyling {
     pub(crate) const fn default() -> Self {
         Self {
             bold: false,
-            underline: false,
+            underline_style: None,
             italics: false,
             dim: false,
             reverse: false,
@@ -25,19 +49,23 @@ impl TextStyling {
     pub(crate) fn is_empty(&self) -> bool {
         *self == Self::default()
     }
-    pub(crate) fn union(self, other: Self) -> Self {
+    pub(crate) fn union_prefer_right(self, other: Self) -> Self {
         Self {
             bold: self.is_bold() || other.is_bold(),
-            underline: self.is_underline() || other.is_underline(),
+            underline_style: self
+                .underline_style
+                .union_prefer_right(other.underline_style),
             italics: self.is_italics() || other.is_italics(),
             dim: self.is_dim() || other.is_dim(),
             reverse: self.is_reverse() || other.is_reverse(),
         }
     }
-    pub(crate) fn difference(self, other: Self) -> Self {
+    pub(crate) fn difference_prefer_empty(self, other: Self) -> Self {
         Self {
             bold: self.is_bold() && !other.is_bold(),
-            underline: self.is_underline() && !other.is_underline(),
+            underline_style: self
+                .underline_style
+                .difference_prefer_empty(other.underline_style),
             italics: self.is_italics() && !other.is_italics(),
             dim: self.is_dim() && !other.is_dim(),
             reverse: self.is_reverse() && !other.is_reverse(),
@@ -49,14 +77,14 @@ impl TextStyling {
         self.bold
     }
 
-    /// Returns whether the text face is underlined.
-    pub const fn is_underline(self) -> bool {
-        self.underline
+    #[cfg(test)]
+    pub const fn underline_style(self) -> Option<UnderlineStyle> {
+        self.underline_style
     }
 
-    /// Set whether the text face is underline.
-    pub fn inject_underline(&mut self, underline: bool) {
-        self.underline = underline;
+    /// Set the given underline style.
+    pub fn inject_underline(&mut self, underline: UnderlineStyle) {
+        self.underline_style = Some(underline);
     }
 
     /// Returns whether the text face is italics.
@@ -156,6 +184,7 @@ pub(crate) fn parse_text_face_and_options<'a>(
         wopt(L!("background"), ArgType::RequiredArgument, 'b'),
         wopt(L!("bold"), ArgType::NoArgument, 'o'),
         wopt(L!("underline"), ArgType::NoArgument, 'u'),
+        wopt(L!("curly-underline"), ArgType::NoArgument, '\x01'),
         wopt(L!("italics"), ArgType::NoArgument, 'i'),
         wopt(L!("dim"), ArgType::NoArgument, 'd'),
         wopt(L!("reverse"), ArgType::NoArgument, 'r'),
@@ -184,7 +213,8 @@ pub(crate) fn parse_text_face_and_options<'a>(
             'i' => style.italics = true,
             'd' => style.dim = true,
             'r' => style.reverse = true,
-            'u' => style.underline = true,
+            'u' => style.underline_style = Some(UnderlineStyle::Single),
+            '\x01' => style.underline_style = Some(UnderlineStyle::Curly),
             'c' => print_color_mode = true,
             ':' => {
                 if is_builtin {

--- a/src/text_face.rs
+++ b/src/text_face.rs
@@ -107,6 +107,7 @@ impl TextStyling {
 pub(crate) struct TextFace {
     pub(crate) fg: Color,
     pub(crate) bg: Color,
+    pub(crate) underline_color: Color,
     pub(crate) style: TextStyling,
 }
 
@@ -115,18 +116,25 @@ impl TextFace {
         Self {
             fg: Color::Normal,
             bg: Color::Normal,
+            underline_color: Color::None,
             style: TextStyling::default(),
         }
     }
 
-    pub fn new(fg: Color, bg: Color, style: TextStyling) -> Self {
-        Self { fg, bg, style }
+    pub fn new(fg: Color, bg: Color, underline_color: Color, style: TextStyling) -> Self {
+        Self {
+            fg,
+            bg,
+            underline_color,
+            style,
+        }
     }
 }
 
 pub(crate) struct SpecifiedTextFace {
     pub(crate) fg: Option<Color>,
     pub(crate) bg: Option<Color>,
+    pub(crate) underline_color: Option<Color>,
     pub(crate) style: TextStyling,
 }
 
@@ -138,6 +146,7 @@ pub(crate) fn parse_text_face(arguments: &[WString]) -> SpecifiedTextFace {
     let TextFaceArgsAndOptions {
         wopt_index,
         bgcolor,
+        underline_color,
         style,
         print_color_mode,
     } = match parse_text_face_and_options(&mut argv, /*is_builtin=*/ false) {
@@ -154,14 +163,21 @@ pub(crate) fn parse_text_face(arguments: &[WString]) -> SpecifiedTextFace {
         get_color_support(),
     );
     let bg = bgcolor.and_then(Color::from_wstr);
+    let underline_color = underline_color.and_then(Color::from_wstr);
     assert!(fg.map_or(true, |fg| !fg.is_none()));
     assert!(bg.map_or(true, |bg| !bg.is_none()));
-    SpecifiedTextFace { fg, bg, style }
+    SpecifiedTextFace {
+        fg,
+        bg,
+        underline_color,
+        style,
+    }
 }
 
 pub(crate) struct TextFaceArgsAndOptions<'a> {
     pub(crate) wopt_index: usize,
     pub(crate) bgcolor: Option<&'a wstr>,
+    pub(crate) underline_color: Option<&'a wstr>,
     pub(crate) style: TextStyling,
     pub(crate) print_color_mode: bool,
 }
@@ -182,6 +198,7 @@ pub(crate) fn parse_text_face_and_options<'a>(
     let short_options = &short_options[..short_options.len() - builtin_extra_args];
     let long_options: &[WOption] = &[
         wopt(L!("background"), ArgType::RequiredArgument, 'b'),
+        wopt(L!("underline-color"), ArgType::RequiredArgument, '\x02'),
         wopt(L!("bold"), ArgType::NoArgument, 'o'),
         wopt(L!("underline"), ArgType::NoArgument, 'u'),
         wopt(L!("curly-underline"), ArgType::NoArgument, '\x01'),
@@ -194,6 +211,7 @@ pub(crate) fn parse_text_face_and_options<'a>(
     let long_options = &long_options[..long_options.len() - builtin_extra_args];
 
     let mut bgcolor = None;
+    let mut underline_color = None;
     let mut style = TextStyling::default();
     let mut print_color_mode = false;
 
@@ -203,6 +221,10 @@ pub(crate) fn parse_text_face_and_options<'a>(
             'b' => {
                 assert!(w.woptarg.is_some(), "Arg should have been set");
                 bgcolor = w.woptarg;
+            }
+            '\x02' => {
+                assert!(w.woptarg.is_some(), "Arg should have been set");
+                underline_color = w.woptarg;
             }
             'h' => {
                 if is_builtin {
@@ -232,6 +254,7 @@ pub(crate) fn parse_text_face_and_options<'a>(
     TextFaceArgsAndOptionsResult::Ok(TextFaceArgsAndOptions {
         wopt_index: w.wopt_index,
         bgcolor,
+        underline_color,
         style,
         print_color_mode,
     })

--- a/tests/checks/set_color.fish
+++ b/tests/checks/set_color.fish
@@ -1,0 +1,14 @@
+#RUN: %fish %s
+
+string escape (set_color normal)
+# CHECK: \e\[m
+string escape (set_color reset)
+# CHECK: \e\[m
+
+string escape (set_color red yellow)
+# CHECK: \e\[31m
+string escape (set_color red reset yellow)
+# CHECK: \e\[31m
+
+string escape (set_color --background=reset)
+# CHECKERR: set_color: Unknown color 'reset'

--- a/tests/pexpects/set_color.py
+++ b/tests/pexpects/set_color.py
@@ -89,3 +89,7 @@ sendline("set_color --print-colors ff0 red")
 expect_str("\x1b[38;2;255;255;0mff0")
 expect_str("\x1b[31mred")
 expect_prompt()
+
+sendline("set_color --underline-color red --curly-underline; echo red undercurl")
+expect_str("\x1b[4:3m" "\x1b[58;5;1m" "red undercurl")
+expect_prompt()


### PR DESCRIPTION
Consider reviewing the last three commits.

Add curly and colored underlines, and use curly underlines for errors.

Add a new `--underline-color`` option to set_color (instead of adding an optional
color argument to --underline); this allows to set the underline color
independently of underline style (line, curly, etc.). I don't think this
flexibility is very important but this approach is probably the least hacky.

Closes #7619
