### PR TITLE
Add completions for `iconutil` (macOS)

### DIFF
--- a/share/completions/iconutil.fish
+++ b/share/completions/iconutil.fish
@@ -1,0 +1,3 @@
+complete -c iconutil -s c -l "convert" -r -f --arguments "icns iconset" -d "Convert to the specified type."
+complete -c iconutil -s o -l "output" -r -F --description "Overrides the default output file name."
+complete -c iconutil -r -F -d "Source file"


### PR DESCRIPTION
## Description

This adds completions for the `iconutil` command (included at `/usr/bin/iconutil`) on macOS.

The command is very simple, as shown by the `man` page synopsis:

```
iconutil -c {icns | iconset} [-o file] file [icon-name]
```

Ideally:

- The completions should be limited to a single positional file argument,
- the optional second positional argument should not use file completions.

However, I don't know of a particularly simple way to do this, and I do not recall ever seeing a single use of the `icon-name` argument.[^1] So I've kept the completions as simple as possible for  now.

[^1]: I still can't find any uses of it on the internet. [Apple's documentation](https://developer.apple.com/library/archive/documentation/GraphicsAnimation/Conceptual/HighResolutionOSX/Optimizing/Optimizing.html#//apple_ref/doc/uid/TP40012302-CH7-SW2) does not include such an example. The [Wikipedia article for `.icns`](https://en.wikipedia.org/wiki/Apple_Icon_Image_format) refers to a `'name'` field in the data structure, but it is described as "Usage unknown". I can't find any example uses on GitHub, Stack Overflow, or Reddit.)