### PR TITLE
Update completion for tmutil

### DIFF
--- a/share/completions/tmutil.fish
+++ b/share/completions/tmutil.fish
@@ -5,7 +5,6 @@ function __destination_ids
         if string match -q '*===*' -- $line
             # New section so clear out variables
             set -f name ''
-            set -f ID ''
             set -f kind ''
             continue
         end

--- a/share/completions/tmutil.fish
+++ b/share/completions/tmutil.fish
@@ -30,13 +30,12 @@ function __destination_ids
     end
 end
 
-complete -c tmutil -f
-complete -c tmutil -n '__fish_seen_subcommand_from status' -f
 complete -c tmutil -n __fish_use_subcommand -a status -d 'Display Time Machine status'
+complete -c tmutil -f -n '__fish_seen_subcommand_from status'
 
-complete -c tmutil -F -n __fish_use_subcommand -a addexclusion -d 'Add an exclusion not to back up a file'
-complete -c tmutil -F -n '__fish_seen_subcommand_from addexclusion' -s v -d 'Volume exclusion'
-complete -c tmutil -F -n '__fish_seen_subcommand_from addexclusion' -s p -d 'Path exclusion'
+complete -c tmutil -f -n __fish_use_subcommand -a addexclusion -d 'Add an exclusion not to back up a file'
+complete -c tmutil -r -n '__fish_seen_subcommand_from addexclusion' -s v -d 'Volume exclusion'
+complete -c tmutil -r -n '__fish_seen_subcommand_from addexclusion' -s p -d 'Path exclusion'
 
 complete -c tmutil -r -n __fish_use_subcommand -a associatedisk -d 'Bind a snapshot volume directory to the specified local disk'
 
@@ -62,7 +61,7 @@ complete -c tmutil -f -n '__fish_seen_subcommand_from compare' -s U -d 'Ignore l
 
 complete -c tmutil -r -n __fish_use_subcommand -a delete -d 'Delete one or more snapshots'
 complete -c tmutil -r -n '__fish_seen_subcommand_from delete' -s d -d 'Backup mount point'
-complete -c tmutil -r -n '__fish_seen_subcommand_from delete' -s t -d 'Timestamp'
+complete -c tmutil -r -f -n '__fish_seen_subcommand_from delete' -s t -d 'Timestamp'
 complete -c tmutil -r -n '__fish_seen_subcommand_from delete' -s p -d 'Path'
 
 complete -c tmutil -r -n __fish_use_subcommand -a deletelocalsnapshots -d 'Delete all local Time Machine snapshots for the specified date (formatted YYYY-MM-DD-HHMMSS)'
@@ -81,9 +80,9 @@ complete -c tmutil -f -n __fish_use_subcommand -a enablelocal -d 'Turn on local 
 
 complete -c tmutil -r -n __fish_use_subcommand -a inheritbackup -d 'Claim a machine directory or sparsebundle for use by the current machine'
 
-complete -c tmutil -F -n __fish_use_subcommand -a isexcluded -d 'Determine if a file, directory, or volume are excluded from backups'
+complete -c tmutil -r -n __fish_use_subcommand -a isexcluded -d 'Determine if a file, directory, or volume are excluded from backups'
 
-complete -c tmutil -r -n __fish_use_subcommand -a latestbackup -d 'Print the path to the latest snapshot'
+complete -c tmutil -f -n __fish_use_subcommand -a latestbackup -d 'Print the path to the latest snapshot'
 
 complete -c tmutil -f -n __fish_use_subcommand -a listlocalsnapshotdates -d 'List the creation dates of all local Time Machine snapshots'
 
@@ -133,3 +132,4 @@ complete -c tmutil -f -n '__fish_seen_subcommand_from setquota' -r -a '$(__desti
 complete -c tmutil -f -n '__fish_seen_subcommand_from destinationinfo isexcluded compare status' -s X -d 'Print as XML'
 complete -c tmutil -f -n '__fish_seen_subcommand_from latestbackup listbackups' -s m -d 'Destination volume to list backups from'
 complete -c tmutil -f -n '__fish_seen_subcommand_from latestbackup listbackups' -s t -d 'Attempt to mount the backups and list their mounted paths'
+complete -c tmutil -f -n '__fish_seen_subcommand_from latestbackup listbackups' -s d -d 'Backup mount point'

--- a/share/completions/tmutil.fish
+++ b/share/completions/tmutil.fish
@@ -1,61 +1,136 @@
 # completion for tmutil (macOS)
 
-complete -f -c tmutil -n __fish_use_subcommand -a addexclusion -d 'Add an exclusion not to back up a file'
-complete -f -c tmutil -n '__fish_seen_subcommand_from addexclusion' -s v -d 'Volume exclusion'
-complete -f -c tmutil -n '__fish_seen_subcommand_from addexclusion' -s p -d 'Path exclusion'
-complete -r -c tmutil -n __fish_use_subcommand -a associatedisk -d 'Bind a snapshot volume directory to the specified local disk'
-complete -r -c tmutil -n __fish_use_subcommand -a calculatedrift -d 'Determine the amount of change between snapshots'
-complete -r -c tmutil -n __fish_use_subcommand -a compare -d 'Perform a backup diff'
-complete -f -c tmutil -n '__fish_seen_subcommand_from compare' -s a -d 'Compare all supported metadata'
-complete -f -c tmutil -n '__fish_seen_subcommand_from compare' -s n -d 'No metadata comparison'
-complete -f -c tmutil -n '__fish_seen_subcommand_from compare' -s @ -d 'Compare extended attributes'
-complete -f -c tmutil -n '__fish_seen_subcommand_from compare' -s c -d 'Compare creation times'
-complete -f -c tmutil -n '__fish_seen_subcommand_from compare' -s d -d 'Compare file data forks'
-complete -f -c tmutil -n '__fish_seen_subcommand_from compare' -s e -d 'Compare ACLs'
-complete -f -c tmutil -n '__fish_seen_subcommand_from compare' -s f -d 'Compare file flags'
-complete -f -c tmutil -n '__fish_seen_subcommand_from compare' -s g -d 'Compare GIDs'
-complete -f -c tmutil -n '__fish_seen_subcommand_from compare' -s m -d 'Compare file modes'
-complete -f -c tmutil -n '__fish_seen_subcommand_from compare' -s s -d 'Compare sizes'
-complete -f -c tmutil -n '__fish_seen_subcommand_from compare' -s t -d 'Compare modification times'
-complete -f -c tmutil -n '__fish_seen_subcommand_from compare' -s u -d 'Compare UIDs'
-complete -r -c tmutil -n '__fish_seen_subcommand_from compare' -s D -d 'Limit traversal depth to depth levels from the beginning of iteration'
-complete -f -c tmutil -n '__fish_seen_subcommand_from compare' -s E -d 'Dont take exclusions into account'
-complete -r -c tmutil -n '__fish_seen_subcommand_from compare' -s I -d 'Ignore path'
-complete -f -c tmutil -n '__fish_seen_subcommand_from compare' -s U -d 'Ignore logical volume identity'
-complete -r -c tmutil -n __fish_use_subcommand -a delete -d 'Delete one or more snapshots'
-complete -r -c tmutil -n __fish_use_subcommand -a deletelocalsnapshots -d 'Delete all local Time Machine snapshots for the specified date (formatted YYYY-MM-DD-HHMMSS)'
-complete -f -c tmutil -n __fish_use_subcommand -a destinationinfo -d 'Print information about destinations'
-complete -f -c tmutil -n __fish_use_subcommand -a disable -d 'Turn off automatic backups'
-complete -f -c tmutil -n __fish_use_subcommand -a disablelocal -d 'Turn off local Time Machine snapshots'
-complete -f -c tmutil -n __fish_use_subcommand -a enable -d 'Turn on automatic backups'
-complete -f -c tmutil -n __fish_use_subcommand -a enablelocal -d 'Turn on local Time Machine snapshots'
-complete -r -c tmutil -n __fish_use_subcommand -a inheritbackup -d 'Claim a machine directory or sparsebundle for use by the current machine'
-complete -f -c tmutil -n __fish_use_subcommand -a isexcluded -d 'Determine if a file, directory, or volume are excluded from backups'
-complete -f -c tmutil -n __fish_use_subcommand -a latestbackup -d 'Print the path to the latest snapshot'
-complete -c tmutil -n __fish_use_subcommand -a listlocalsnapshotdates -d 'List the creation dates of all local Time Machine snapshots'
-complete -r -c tmutil -n __fish_use_subcommand -a listlocalsnapshots -d 'List local Time Machine snapshots of the specified volume'
-complete -f -c tmutil -n __fish_use_subcommand -a listbackups -d 'Print paths for all snapshots'
-complete -f -c tmutil -n __fish_use_subcommand -a localsnapshot -d 'Create new local Time Machine snapshot of APFS volume in TM backup'
-complete -f -c tmutil -n __fish_use_subcommand -a machinedirectory -d 'Print the path to the current machine directory'
-complete -f -c tmutil -n __fish_use_subcommand -a removedestination -d 'Removes a backup destination'
-complete -f -c tmutil -n __fish_use_subcommand -a removeexclusion -d 'Remove an exclusion'
-complete -f -c tmutil -n '__fish_seen_subcommand_from removeexclusion' -s v -d 'Volume exclusion'
-complete -f -c tmutil -n '__fish_seen_subcommand_from removeexclusion' -s p -d 'Path exclusion'
-complete -f -c tmutil -n __fish_use_subcommand -a restore -d 'Restore an item'
-complete -r -c tmutil -n '__fish_seen_subcommand_from restore' -s v
-complete -r -c tmutil -n __fish_use_subcommand -a setdestination -d 'Set a backup destination'
-complete -f -c tmutil -n '__fish_seen_subcommand_from setdestination' -s a -d 'Add to the list of destinations'
-complete -f -c tmutil -n '__fish_seen_subcommand_from setdestination' -s p -d 'Enter the password at a non-echoing interactive prompt'
-complete -f -c tmutil -n __fish_use_subcommand -a snapshot -d 'Create new local Time Machine snapshot'
-complete -f -c tmutil -n __fish_use_subcommand -a startbackup -d 'Begin a backup if one is not already running'
-complete -f -c tmutil -n '__fish_seen_subcommand_from startbackup' -s a -l auto -d 'Automatic mode'
-complete -f -c tmutil -n '__fish_seen_subcommand_from startbackup' -s b -l block -d 'Block until finished'
-complete -f -c tmutil -n '__fish_seen_subcommand_from startbackup' -s r -l rotation -d 'Automatic rotation'
-complete -r -c tmutil -n '__fish_seen_subcommand_from startbackup' -s d -l destination -d 'Backup destination'
-complete -f -c tmutil -n __fish_use_subcommand -a stopbackup -d 'Cancel a backup currently in progress'
-complete -r -c tmutil -n __fish_use_subcommand -a thinlocalsnapshots -d 'Thin local Time Machine snapshots for the specified volume'
-complete -r -c tmutil -n __fish_use_subcommand -a uniquesize -d 'Analyze the specified path and determine its unique size'
-complete -r -c tmutil -n __fish_use_subcommand -a verifychecksums -d 'Verify snapshot'
-complete -f -c tmutil -n __fish_use_subcommand -a version -d 'Print version'
+function __destination_ids
+    for line in $(tmutil destinationinfo)
+        if test -n "$(string match '*===*' $line)"
+            # New section so clear out variables
+            set -f name ''
+            set -f ID ''
+            set -f kind ''
+            continue
+        end
 
-complete -f -c tmutil -n '__fish_seen_subcommand_from destinationinfo isexcluded compare' -s X -d 'Print as XML'
+        if test -n "$(string match -r '^Name' $line)"
+            # Got the destination name
+            set -f name "$(string match -r -g '^Name\s+:\s+(.*)$' $line | string trim)"
+            continue
+        end
+
+        if test -n "$(string match -r '^Kind' $line)"
+            # Got the destination name
+            set -f kind "$(string match -r -g '^Kind\s+:\s+(\w+)' $line | string trim)"
+            continue
+        end
+
+        if test -n "$(string match -r '^ID' $line)"
+            # Got the destination ID
+            set -f ID "$(string match -r -g '^ID\s+:\s+(.*)$' $line | string trim)"
+            echo "$ID\t'$name $kind'"
+            continue
+        end
+    end
+end
+
+complete -c tmutil -f
+complete -c tmutil -n '__fish_seen_subcommand_from status' -f
+complete -c tmutil -n __fish_use_subcommand -a status -d 'Display Time Machine status'
+
+complete -c tmutil -F -n __fish_use_subcommand -a addexclusion -d 'Add an exclusion not to back up a file'
+complete -c tmutil -F -n '__fish_seen_subcommand_from addexclusion' -s v -d 'Volume exclusion'
+complete -c tmutil -F -n '__fish_seen_subcommand_from addexclusion' -s p -d 'Path exclusion'
+
+complete -c tmutil -r -n __fish_use_subcommand -a associatedisk -d 'Bind a snapshot volume directory to the specified local disk'
+
+complete -c tmutil -r -n __fish_use_subcommand -a calculatedrift -d 'Determine the amount of change between snapshots'
+
+complete -c tmutil -r -n __fish_use_subcommand -a compare -d 'Perform a backup diff'
+complete -c tmutil -f -n '__fish_seen_subcommand_from compare' -s a -d 'Compare all supported metadata'
+complete -c tmutil -f -n '__fish_seen_subcommand_from compare' -s n -d 'No metadata comparison'
+complete -c tmutil -f -n '__fish_seen_subcommand_from compare' -s @ -d 'Compare extended attributes'
+complete -c tmutil -f -n '__fish_seen_subcommand_from compare' -s c -d 'Compare creation times'
+complete -c tmutil -f -n '__fish_seen_subcommand_from compare' -s d -d 'Compare file data forks'
+complete -c tmutil -f -n '__fish_seen_subcommand_from compare' -s e -d 'Compare ACLs'
+complete -c tmutil -f -n '__fish_seen_subcommand_from compare' -s f -d 'Compare file flags'
+complete -c tmutil -f -n '__fish_seen_subcommand_from compare' -s g -d 'Compare GIDs'
+complete -c tmutil -f -n '__fish_seen_subcommand_from compare' -s m -d 'Compare file modes'
+complete -c tmutil -f -n '__fish_seen_subcommand_from compare' -s s -d 'Compare sizes'
+complete -c tmutil -f -n '__fish_seen_subcommand_from compare' -s t -d 'Compare modification times'
+complete -c tmutil -f -n '__fish_seen_subcommand_from compare' -s u -d 'Compare UIDs'
+complete -c tmutil -r -n '__fish_seen_subcommand_from compare' -s D -d 'Limit traversal depth to depth levels from the beginning of iteration'
+complete -c tmutil -f -n '__fish_seen_subcommand_from compare' -s E -d 'Dont take exclusions into account'
+complete -c tmutil -r -n '__fish_seen_subcommand_from compare' -s I -d 'Ignore path'
+complete -c tmutil -f -n '__fish_seen_subcommand_from compare' -s U -d 'Ignore logical volume identity'
+
+complete -c tmutil -r -n __fish_use_subcommand -a delete -d 'Delete one or more snapshots'
+complete -c tmutil -r -n '__fish_seen_subcommand_from delete' -s d -d 'Backup mount point'
+complete -c tmutil -r -n '__fish_seen_subcommand_from delete' -s t -d 'Timestamp'
+complete -c tmutil -r -n '__fish_seen_subcommand_from delete' -s p -d 'Path'
+
+complete -c tmutil -r -n __fish_use_subcommand -a deletelocalsnapshots -d 'Delete all local Time Machine snapshots for the specified date (formatted YYYY-MM-DD-HHMMSS)'
+
+complete -c tmutil -r -n __fish_use_subcommand -a deleteinprogress -d 'Delete all in-progress backups for a machine directory'
+
+complete -c tmutil -f -n __fish_use_subcommand -a destinationinfo -d 'Print information about destinations'
+
+complete -c tmutil -f -n __fish_use_subcommand -a disable -d 'Turn off automatic backups'
+
+complete -c tmutil -f -n __fish_use_subcommand -a disablelocal -d 'Turn off local Time Machine snapshots'
+
+complete -c tmutil -f -n __fish_use_subcommand -a enable -d 'Turn on automatic backups'
+
+complete -c tmutil -f -n __fish_use_subcommand -a enablelocal -d 'Turn on local Time Machine snapshots'
+
+complete -c tmutil -r -n __fish_use_subcommand -a inheritbackup -d 'Claim a machine directory or sparsebundle for use by the current machine'
+
+complete -c tmutil -F -n __fish_use_subcommand -a isexcluded -d 'Determine if a file, directory, or volume are excluded from backups'
+
+complete -c tmutil -r -n __fish_use_subcommand -a latestbackup -d 'Print the path to the latest snapshot'
+
+complete -c tmutil -f -n __fish_use_subcommand -a listlocalsnapshotdates -d 'List the creation dates of all local Time Machine snapshots'
+
+complete -c tmutil -r -n __fish_use_subcommand -a listlocalsnapshots -d 'List local Time Machine snapshots of the specified volume'
+
+complete -c tmutil -f -n __fish_use_subcommand -a listbackups -d 'Print paths for all snapshots'
+
+complete -c tmutil -f -n __fish_use_subcommand -a localsnapshot -d 'Create new local Time Machine snapshot of APFS volume in TM backup'
+
+complete -c tmutil -f -n __fish_use_subcommand -a machinedirectory -d 'Print the path to the current machine directory'
+
+complete -c tmutil -f -n __fish_use_subcommand -a removedestination -d 'Removes a backup destination'
+complete -c tmutil -f -n '__fish_seen_subcommand_from removedestination' -d "$(__destination_ids)"
+
+complete -c tmutil -f -n __fish_use_subcommand -a removeexclusion -d 'Remove an exclusion'
+complete -c tmutil -f -n '__fish_seen_subcommand_from removeexclusion' -s v -d 'Volume exclusion'
+complete -c tmutil -f -n '__fish_seen_subcommand_from removeexclusion' -s p -d 'Path exclusion'
+
+complete -c tmutil -f -n __fish_use_subcommand -a restore -d 'Restore an item'
+complete -c tmutil -r -n '__fish_seen_subcommand_from restore' -s v
+
+complete -c tmutil -r -n __fish_use_subcommand -a setdestination -d 'Set a backup destination'
+complete -c tmutil -f -n '__fish_seen_subcommand_from setdestination' -s a -d 'Add to the list of destinations'
+complete -c tmutil -f -n '__fish_seen_subcommand_from setdestination' -s p -d 'Enter the password at a non-echoing interactive prompt'
+
+complete -c tmutil -f -n __fish_use_subcommand -a snapshot -f -d 'Create new local Time Machine snapshot'
+
+complete -c tmutil -f -n __fish_use_subcommand -a startbackup -d 'Begin a backup if one is not already running'
+complete -c tmutil -f -n '__fish_seen_subcommand_from startbackup' -s a -l auto -d 'Automatic mode'
+complete -c tmutil -f -n '__fish_seen_subcommand_from startbackup' -s b -l block -d 'Block until finished'
+complete -c tmutil -f -n '__fish_seen_subcommand_from startbackup' -s r -l rotation -d 'Automatic rotation'
+complete -c tmutil -f -n '__fish_seen_subcommand_from startbackup' -s d -l destination -r -a "$(__destination_ids)" -d 'Backup destination'
+
+complete -c tmutil -f -n __fish_use_subcommand -a stopbackup -d 'Cancel a backup currently in progress'
+
+complete -c tmutil -r -n __fish_use_subcommand -a thinlocalsnapshots -d 'Thin local Time Machine snapshots for the specified volume'
+
+complete -c tmutil -r -n __fish_use_subcommand -a uniquesize -d 'Analyze the specified path and determine its unique size'
+
+complete -c tmutil -r -n __fish_use_subcommand -a verifychecksums -d 'Verify snapshot'
+
+complete -c tmutil -f -n __fish_use_subcommand -a version -d 'Print version'
+
+complete -c tmutil -f -n __fish_use_subcommand -a setquota -d 'Set the quota for the destination in gigabytes'
+complete -c tmutil -f -n '__fish_seen_subcommand_from setquota' -r -a "$(__destination_ids)"
+
+complete -c tmutil -f -n '__fish_seen_subcommand_from destinationinfo isexcluded compare status' -s X -d 'Print as XML'
+complete -c tmutil -f -n '__fish_seen_subcommand_from latestbackup listbackups' -s m -d 'Destination volume to list backups from'
+complete -c tmutil -f -n '__fish_seen_subcommand_from latestbackup listbackups' -s t -d 'Attempt to mount the backups and list their mounted paths'

--- a/share/completions/tmutil.fish
+++ b/share/completions/tmutil.fish
@@ -97,7 +97,7 @@ complete -c tmutil -f -n __fish_use_subcommand -a localsnapshot -d 'Create new l
 complete -c tmutil -f -n __fish_use_subcommand -a machinedirectory -d 'Print the path to the current machine directory'
 
 complete -c tmutil -f -n __fish_use_subcommand -a removedestination -d 'Removes a backup destination'
-complete -c tmutil -f -n '__fish_seen_subcommand_from removedestination' -d "$(__destination_ids)"
+complete -c tmutil -f -n '__fish_seen_subcommand_from removedestination' -a "$(__destination_ids)"
 
 complete -c tmutil -f -n __fish_use_subcommand -a removeexclusion -d 'Remove an exclusion'
 complete -c tmutil -f -n '__fish_seen_subcommand_from removeexclusion' -s v -d 'Volume exclusion'

--- a/share/completions/tmutil.fish
+++ b/share/completions/tmutil.fish
@@ -2,7 +2,7 @@
 
 function __destination_ids
     for line in $(tmutil destinationinfo)
-        if test -n "$(string match '*===*' $line)"
+        if string match -q '*===*' -- $line
             # New section so clear out variables
             set -f name ''
             set -f ID ''
@@ -10,19 +10,19 @@ function __destination_ids
             continue
         end
 
-        if test -n "$(string match -r '^Name' $line)"
+        if string match -q -r '^Name' -- $line
             # Got the destination name
             set -f name "$(string match -r -g '^Name\s+:\s+(.*)$' $line | string trim)"
             continue
         end
 
-        if test -n "$(string match -r '^Kind' $line)"
+        if string match -q -r '^Kind' -- $line
             # Got the destination name
             set -f kind "$(string match -r -g '^Kind\s+:\s+(\w+)' $line | string trim)"
             continue
         end
 
-        if test -n "$(string match -r '^ID' $line)"
+        if string match -q -r '^ID' -- $line
             # Got the destination ID
             set -f ID "$(string match -r -g '^ID\s+:\s+(.*)$' $line | string trim)"
             echo "$ID\t'$name $kind'"

--- a/share/completions/tmutil.fish
+++ b/share/completions/tmutil.fish
@@ -24,7 +24,7 @@ function __destination_ids
         if string match -q -r '^ID' -- $line
             # Got the destination ID
             set -f ID "$(string match -r -g '^ID\s+:\s+(.*)$' $line | string trim)"
-            echo "$ID\t'$name $kind'"
+            echo $ID\t$name $kind
             continue
         end
     end
@@ -96,7 +96,7 @@ complete -c tmutil -f -n __fish_use_subcommand -a localsnapshot -d 'Create new l
 complete -c tmutil -f -n __fish_use_subcommand -a machinedirectory -d 'Print the path to the current machine directory'
 
 complete -c tmutil -f -n __fish_use_subcommand -a removedestination -d 'Removes a backup destination'
-complete -c tmutil -f -n '__fish_seen_subcommand_from removedestination' -a "$(__destination_ids)"
+complete -c tmutil -f -n '__fish_seen_subcommand_from removedestination' -a '$(__destination_ids)'
 
 complete -c tmutil -f -n __fish_use_subcommand -a removeexclusion -d 'Remove an exclusion'
 complete -c tmutil -f -n '__fish_seen_subcommand_from removeexclusion' -s v -d 'Volume exclusion'
@@ -115,7 +115,7 @@ complete -c tmutil -f -n __fish_use_subcommand -a startbackup -d 'Begin a backup
 complete -c tmutil -f -n '__fish_seen_subcommand_from startbackup' -s a -l auto -d 'Automatic mode'
 complete -c tmutil -f -n '__fish_seen_subcommand_from startbackup' -s b -l block -d 'Block until finished'
 complete -c tmutil -f -n '__fish_seen_subcommand_from startbackup' -s r -l rotation -d 'Automatic rotation'
-complete -c tmutil -f -n '__fish_seen_subcommand_from startbackup' -s d -l destination -r -a "$(__destination_ids)" -d 'Backup destination'
+complete -c tmutil -f -n '__fish_seen_subcommand_from startbackup' -s d -l destination -r -a '$(__destination_ids)' -d 'Backup destination'
 
 complete -c tmutil -f -n __fish_use_subcommand -a stopbackup -d 'Cancel a backup currently in progress'
 
@@ -128,7 +128,7 @@ complete -c tmutil -r -n __fish_use_subcommand -a verifychecksums -d 'Verify sna
 complete -c tmutil -f -n __fish_use_subcommand -a version -d 'Print version'
 
 complete -c tmutil -f -n __fish_use_subcommand -a setquota -d 'Set the quota for the destination in gigabytes'
-complete -c tmutil -f -n '__fish_seen_subcommand_from setquota' -r -a "$(__destination_ids)"
+complete -c tmutil -f -n '__fish_seen_subcommand_from setquota' -r -a '$(__destination_ids)'
 
 complete -c tmutil -f -n '__fish_seen_subcommand_from destinationinfo isexcluded compare status' -s X -d 'Print as XML'
 complete -c tmutil -f -n '__fish_seen_subcommand_from latestbackup listbackups' -s m -d 'Destination volume to list backups from'


### PR DESCRIPTION
## Description

- Reorganize completions and options so they are easier to read.
- Add destination UUIDs to completetions as well as descriptions
- Add a few missing sub commands

The biggest change is adding the destination UUIDs to the completion. This is very helpful with `tmutil startbackup -d [destination ID]` or `tmutil setquota [destination ID]`.

I used the neat feature of `fish` to dynamically populate the completion description as well as the value.

One thing I could use help with is how to make the completion values update dynamically when destinations are added/removed. Currently I have to source the completions again to update the destination IDs. I know there is a way to do this but I couldn't quite figure it out. Thanks!

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
