### PR TITLE
Use stdlib functions to show profiling info

### DIFF
--- a/tests/checks/invocation.fish
+++ b/tests/checks/invocation.fish
@@ -62,7 +62,7 @@ $fish --profile $tmp/normal.prof --profile-startup $tmp/startup.prof -ic exit
 
 # This should be the full file - just the one command we gave explicitly!
 cat $tmp/normal.prof
-# CHECK: Time{{\s+}}Sum{{\s+}}Command
+# CHECK: Time (μs){{\s+}}Sum (μs){{\s+}}Command
 # CHECK: {{\d+\s+\d+\s+>}} exit
 
 string match -rq "builtin source " < $tmp/startup.prof


### PR DESCRIPTION
## Description

Refactor `print_profile` to use Rust's standard formatting and writing functionality.

## TODOs:
- [x] Ensure that UTF32 in `item.cmd` is converted correctly.
- [x] Ensure that scripts do not rely on exact formatting of profiling output.
- [x] Error handling: Do we want to do anything about errors if they occur during writing?
- [x] Style: `write!` could be used instead of `write_all` + `format!` + `as_bytes`, which would be a bit more concise, but does not retry when interrupted.