### PR TITLE
Use standard library formatting and printing functions

### DIFF
--- a/src/autoload.rs
+++ b/src/autoload.rs
@@ -189,7 +189,7 @@ impl Autoload {
                 widename.push_str(name);
                 let ret = parser.eval_file_wstr(src, Arc::new(widename), &IoChain::new(), None);
                 if let Err(msg) = ret {
-                    eprintf!("%ls", msg);
+                    eprint!("{msg}");
                 }
             }
         }

--- a/src/bin/fish.rs
+++ b/src/bin/fish.rs
@@ -38,10 +38,9 @@ use fish::{
         environment::{env_init, EnvStack, Environment},
         ConfigPaths, EnvMode, Statuses, CONFIG_PATHS,
     },
-    eprintf,
     event::{self, Event},
     flog::{self, activate_flog_categories_by_pattern, set_flog_file_fd, FLOG, FLOGF},
-    fprintf, function, future_feature_flags as features,
+    function, future_feature_flags as features,
     history::{self, start_private_mode},
     io::IoChain,
     nix::{getpid, getrusage, isatty, RUsage},
@@ -181,7 +180,7 @@ fn read_init(parser: &Parser, paths: &ConfigPaths) {
         let ret = parser.eval_file_wstr(src, fname, &IoChain::new(), None);
         parser.libdata_mut().within_fish_init = false;
         if let Err(msg) = ret {
-            eprintf!("%ls", msg);
+            eprint!("{msg}");
         }
     }
     #[cfg(not(feature = "embed-data"))]
@@ -238,7 +237,7 @@ fn run_command_list(parser: &Parser, cmds: &[OsString]) -> Result<(), libc::c_in
             retval = Ok(());
         } else {
             let backtrace = parser.get_backtrace(&cmd_wcs, &errors);
-            eprintf!("%s", backtrace);
+            eprint!("{backtrace}");
             // XXX: Why is this the return for "unknown command"?
             retval = Err(STATUS_CMD_UNKNOWN);
         }

--- a/src/bin/fish.rs
+++ b/src/bin/fish.rs
@@ -50,7 +50,6 @@ use fish::{
     parse_util::parse_util_detect_errors_in_ast,
     parser::{BlockType, CancelBehavior, Parser},
     path::path_get_config,
-    printf,
     proc::{
         get_login, is_interactive_session, mark_login, mark_no_exec, proc_init,
         set_interactive_session, Pid,
@@ -336,8 +335,8 @@ fn fish_parse_opt(args: &mut [WString], opts: &mut FishCmdOpts) -> ControlFlow<i
             }
             'P' => opts.enable_private_mode = true,
             'v' => {
-                printf!(
-                    "%s",
+                print!(
+                    "{}",
                     wgettext_fmt!("%s, version %s\n", PACKAGE_NAME, fish::BUILD_VERSION)
                 );
                 return ControlFlow::Break(0);

--- a/src/builtins/fg.rs
+++ b/src/builtins/fg.rs
@@ -126,7 +126,7 @@ pub fn fg(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Built
     } else {
         // If we aren't redirecting, send output to real stderr, since stuff in sb_err won't get
         // printed until the command finishes.
-        eprintf!("%s", wgettext_fmt!(FG_MSG, job.job_id(), job.command()));
+        eprint!("{}", wgettext_fmt!(FG_MSG, job.job_id(), job.command()));
     }
 
     let ft = tok_command(job.command());

--- a/src/io.rs
+++ b/src/io.rs
@@ -205,7 +205,7 @@ impl IoData for IoClose {
         -1
     }
     fn print(&self) {
-        eprintf!("close %d\n", self.fd)
+        eprintln!("close {}", self.fd)
     }
 }
 
@@ -231,7 +231,7 @@ impl IoData for IoFd {
         self.source_fd
     }
     fn print(&self) {
-        eprintf!("FD map %d -> %d\n", self.source_fd, self.fd)
+        eprintln!("FD map {} -> {}", self.source_fd, self.fd)
     }
 }
 
@@ -260,7 +260,7 @@ impl IoData for IoFile {
         self.file.as_raw_fd()
     }
     fn print(&self) {
-        eprintf!("file %d -> %d\n", self.file.as_raw_fd(), self.fd)
+        eprintln!("file {} -> {}", self.file.as_raw_fd(), self.fd)
     }
 }
 
@@ -292,8 +292,8 @@ impl IoData for IoPipe {
         self.pipe_fd.as_raw_fd()
     }
     fn print(&self) {
-        eprintf!(
-            "pipe {%d} (input: %s) -> %d\n",
+        eprintln!(
+            "pipe {{{}}} (input: {}) -> {}",
             self.source_fd(),
             if self.is_input { "yes" } else { "no" },
             self.fd
@@ -376,11 +376,7 @@ impl IoData for IoBufferfill {
         self.write_fd.as_raw_fd()
     }
     fn print(&self) {
-        eprintf!(
-            "bufferfill %d -> %d\n",
-            self.write_fd.as_raw_fd(),
-            self.fd()
-        )
+        eprintln!("bufferfill {} -> {}", self.write_fd.as_raw_fd(), self.fd())
     }
     fn as_bufferfill(&self) -> Option<&IoBufferfill> {
         Some(self)
@@ -623,20 +619,17 @@ impl IoChain {
     /// Output debugging information to stderr.
     pub fn print(&self) {
         if self.0.is_empty() {
-            eprintf!(
-                "Empty chain %s\n",
-                format!("{:p}", std::ptr::addr_of!(self))
-            );
+            eprintln!("Empty chain {:p}", std::ptr::addr_of!(self));
             return;
         }
 
-        eprintf!(
-            "Chain %s (%ld items):\n",
-            format!("{:p}", std::ptr::addr_of!(self)),
+        eprintln!(
+            "Chain {:p} ({} items):",
+            std::ptr::addr_of!(self),
             self.0.len()
         );
         for (i, io) in self.0.iter().enumerate() {
-            eprintf!("\t%lu: fd:%d, ", i, io.fd());
+            eprint!("\t{}: fd:{}, ", i, io.fd());
             io.print();
         }
     }

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -34,21 +34,21 @@ pub fn panic_handler(main: impl FnOnce() -> i32 + UnwindSafe) -> ! {
             if let Some(at_exit) = AT_EXIT.get() {
                 (at_exit)(false);
             }
-            eprintf!(
-                "%s crashed, please report a bug.",
-                PROGRAM_NAME.get().unwrap(),
+            eprint!(
+                "{} crashed, please report a bug.",
+                PROGRAM_NAME.get().unwrap()
             );
             if !is_main_thread() {
-                eprintf!("\n");
+                eprintln!();
                 std::thread::sleep(Duration::from_secs(1));
             } else {
-                eprintf!(" Debug PID %d or press Enter to exit\n", unsafe {
+                eprintln!(" Debug PID {} or press Enter to exit", unsafe {
                     libc::getpid()
                 });
                 let mut buf = [0_u8; 1];
                 while let Ok(n) = read_blocked(STDIN_FILENO, &mut buf) {
                     if n == 0 || matches!(buf[0], b'q' | b'\n' | b'\r') {
-                        eprintf!("\n");
+                        eprintln!();
                         break;
                     }
                 }

--- a/src/parse_execution.rs
+++ b/src/parse_execution.rs
@@ -257,7 +257,7 @@ impl<'a> ExecutionContext<'a> {
 
             // Print it.
             if !should_suppress_stderr_for_tests() {
-                eprintf!("%s", backtrace_and_desc);
+                eprint!("{backtrace_and_desc}");
             }
 
             // Mark status.
@@ -1499,7 +1499,7 @@ impl<'a> ExecutionContext<'a> {
                             _ => false,
                         }
                 } {
-                    eprintf!("If you wish to use process substitution, consider the psub command, see: `help psub`\n");
+                    eprintln!("If you wish to use process substitution, consider the psub command, see: `help psub`");
                 }
                 return error_ret;
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -528,7 +528,7 @@ impl Parser {
         let backtrace_and_desc = self.get_backtrace(cmd, &error_list);
 
         // Print it.
-        eprintf!("%s\n", backtrace_and_desc);
+        eprintln!("{backtrace_and_desc}");
 
         // Set a valid status.
         self.set_last_statuses(Statuses::just(STATUS_ILLEGAL_CMD));

--- a/src/path.rs
+++ b/src/path.rs
@@ -183,7 +183,7 @@ fn maybe_issue_path_warning(
             )
         );
     }
-    eprintf!("\n");
+    eprintln!();
 }
 
 /// Finds the path of an executable named `cmd`, by looking in $PATH taken from `vars`.

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -1240,24 +1240,24 @@ pub fn jobs_requiring_warning_on_exit(parser: &Parser) -> JobList {
 /// Print the exit warning for the given jobs, which should have been obtained via
 /// jobs_requiring_warning_on_exit().
 pub fn print_exit_warning_for_jobs(jobs: &JobList) {
-    printf!("%s", wgettext!("There are still jobs active:\n"));
-    printf!("%s", wgettext!("\n   PID  Command\n"));
+    print!("{}", wgettext!("There are still jobs active:\n"));
+    print!("{}", wgettext!("\n   PID  Command\n"));
     for j in jobs {
         // Unwrap safety: we can't have a background job that doesn't have an external process and
         // external processes always have a pid set.
-        printf!(
-            "%6d  %ls\n",
+        println!(
+            "{:>6}  {}",
             j.external_procs().next().and_then(|p| p.pid()).unwrap(),
             j.command()
         );
     }
-    printf!("\n");
-    printf!(
-        "%s",
+    println!();
+    print!(
+        "{}",
         wgettext!("A second attempt to exit will terminate them.\n"),
     );
-    printf!(
-        "%s",
+    print!(
+        "{}",
         wgettext!("Use 'disown PID' to remove jobs from the list without terminating them.\n"),
     );
     reader_schedule_prompt_repaint();

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -823,7 +823,7 @@ fn read_ni(parser: &Parser, fd: RawFd, io: &IoChain) -> Result<(), ErrorCode> {
     match parser.eval_wstr(s, io, None, BlockType::top) {
         Ok(_) => Ok(()),
         Err(msg) => {
-            eprintf!("%ls", msg);
+            eprint!("{msg}");
             Err(STATUS_CMD_ERROR)
         }
     }
@@ -5721,7 +5721,7 @@ fn reader_shell_test(parser: &Parser, bstr: &wstr) -> Result<(), ParserTestError
         if !error_desc.ends_with('\n') {
             error_desc.push('\n');
         }
-        eprintf!("\n%s", error_desc);
+        eprint!("\n{error_desc}");
         reader_schedule_prompt_repaint();
     }
     res

--- a/src/tests/history.rs
+++ b/src/tests/history.rs
@@ -328,7 +328,7 @@ fn test_history_races() {
             );
             for list in &expected_lines {
                 if !list.is_empty() {
-                    printf!("\tRemaining: %ls\n", list.last().unwrap())
+                    println!("\tRemaining: {}", list.last().unwrap())
                 }
             }
         }

--- a/src/wchar.rs
+++ b/src/wchar.rs
@@ -14,7 +14,7 @@ pub mod prelude {
     pub use crate::{
         wchar::{wstr, IntoCharIter, WString, L},
         wchar_ext::{ToWString, WExt},
-        wutil::{eprintf, sprintf, wgettext, wgettext_fmt, wgettext_maybe_fmt, wgettext_str},
+        wutil::{sprintf, wgettext, wgettext_fmt, wgettext_maybe_fmt, wgettext_str},
     };
 }
 

--- a/src/wutil/mod.rs
+++ b/src/wutil/mod.rs
@@ -26,7 +26,7 @@ use std::fs::{self, canonicalize};
 use std::io::{self, Write};
 use std::os::unix::prelude::*;
 
-pub use crate::wutil::printf::{fprintf, printf, sprintf};
+pub use crate::wutil::printf::{fprintf, sprintf};
 
 pub use fileid::{
     file_id_for_fd, file_id_for_path, file_id_for_path_narrow, DevInode, FileId, INVALID_FILE_ID,

--- a/src/wutil/mod.rs
+++ b/src/wutil/mod.rs
@@ -26,7 +26,7 @@ use std::fs::{self, canonicalize};
 use std::io::{self, Write};
 use std::os::unix::prelude::*;
 
-pub use crate::wutil::printf::{eprintf, fprintf, printf, sprintf};
+pub use crate::wutil::printf::{fprintf, printf, sprintf};
 
 pub use fileid::{
     file_id_for_fd, file_id_for_path, file_id_for_path_narrow, DevInode, FileId, INVALID_FILE_ID,

--- a/src/wutil/printf.rs
+++ b/src/wutil/printf.rs
@@ -39,15 +39,7 @@ macro_rules! printf {
     }
 }
 
-#[macro_export]
-macro_rules! eprintf {
-    // Allow a `&str` or `&Utf32Str` as a format, and write to stderr.
-    ($fmt:expr $(, $arg:expr)* $(,)?) => {
-        fprintf!(libc::STDERR_FILENO, $fmt $(, $arg)*)
-    }
-}
-
-pub use {eprintf, fprintf, printf, sprintf};
+pub use {fprintf, printf, sprintf};
 
 #[cfg(test)]
 mod tests {

--- a/src/wutil/printf.rs
+++ b/src/wutil/printf.rs
@@ -31,15 +31,7 @@ macro_rules! fprintf {
     }
 }
 
-#[macro_export]
-macro_rules! printf {
-    // Allow a `&str` or `&Utf32Str` as a format, and write to stdout.
-    ($fmt:expr $(, $arg:expr)* $(,)?) => {
-        $crate::fprintf!(libc::STDOUT_FILENO, $fmt $(, $arg)*)
-    }
-}
-
-pub use {fprintf, printf, sprintf};
+pub use {fprintf, sprintf};
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Description

This replaces the `printf!` and `eprintf!` macros by `print!` and `eprint!`, respectively. The `fprintf!` macro can also be removed once #11396 is merged. This would then only leave the `sprintf!` macro, which is also used by some `wgettext` macros, making it more annoying to replace due to having to adjust the translations accordingly.