### PR TITLE
Fix translation file generation

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -304,7 +304,7 @@ To update a translation:
   ``build_tools/fish_xgettext.fish`` from the source tree
 
 * update the existing translation by running
-  ``msgmerge --update --no-fuzzy-matching po/LANG.po messages.pot``
+  ``msgmerge --update --no-fuzzy-matching --no-wrap po/LANG.po messages.pot``
 
 The ``--no-fuzzy-matching`` is important as we have had terrible experiences with gettext's "fuzzy" translations in the past.
 

--- a/build_tools/fish_xgettext.fish
+++ b/build_tools/fish_xgettext.fish
@@ -30,7 +30,7 @@ for str in $strs
     # grep -P needed for string escape to be compatible (PCRE-style),
     # -H gives the filename, -n the line number.
     # If you want to run this on non-GNU grep: Don't.
-    echo "#:" (grep -PHn -r -- (string escape --style=regex -- $str) src/ |
+    echo "#:" (grep -PHn -r -- \"(string escape --style=regex -- $str)\" src/ |
     head -n1 | string replace -r ':\s.*' '')
     echo "msgid \"$str\""
     echo 'msgstr ""'


### PR DESCRIPTION
The previous version generates files which do not preserve the line number from the original fish script file, resulting in translation not working.

The new approach is quite ugly, and might have some issues, but at least it seems to work in some cases

For extracting gettext strings from rust code, I also added quotes around the string such that grep only looks for the string when it appears in quotes. This prevents scenarios where the string content also appears outside of a string unquoted from producing garbage.