### PR TITLE
Add clippy lints about using stdlib print macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,3 +107,9 @@ rust.unstable_name_collisions = "allow"
 clippy.manual_range_contains = "allow"
 clippy.needless_return = "allow"
 clippy.needless_lifetimes = "allow"
+
+# We do not want to use the e?print(ln)?! macros.
+# These lints flag their use.
+# In the future, they might change to flag other methods of printing.
+clippy.print_stdout = "deny"
+clippy.print_stderr = "deny"


### PR DESCRIPTION
Context why we do not want to use these macros:
- https://github.com/fish-shell/fish-shell/pull/11397#discussion_r2050759690
- https://github.com/fish-shell/fish-shell/pull/11397#discussion_r2050759693
- https://github.com/fish-shell/fish-shell/pull/11397#discussion_r2050759696

These lints are not strictly about the macros, but at the moment they are implemented to flag `print!`, `println!`, `eprint!`, and `eptintln!`.

- https://rust-lang.github.io/rust-clippy/master/#print_stdout
- https://rust-lang.github.io/rust-clippy/master/#print_stderr
- https://doc.rust-lang.org/stable/clippy/lint_configuration.html#allow-print-in-tests

# TODO

- [ ] At the moment, there are a few uses of these macros in the code.
- [ ] For some reason, detection seems a bit flaky. Using rust-analyzer in my editor seems to work fine, but running `cargo clippy` manually does not find all problematic macro uses. (e.g. when adding a test containing `print!` and setting `allow-print-in-tests = false`, the `print!` usage is flagged by rust-analyzer in my editor but not by `cargo clippy`. I have no idea why.
- [ ] Which level do we want for the lint? (`warn`/`deny`)