### PR TITLE
builtin set_color: stop resetting unrelated attributes on --background=normal

### DIFF
--- a/doc_src/terminal-compatibility.rst
+++ b/doc_src/terminal-compatibility.rst
@@ -165,13 +165,17 @@ Optional Commands
      -
      - Select background color from 24-bit RGB colors.
      -
+   * - ``\e[49m``
+     -
+     - Reset background color to the terminal's default.
+     -
    * - ``\e[58:2:: Ps : Ps : Ps m`` (note: colons not semicolons)
      - Su
      - Select underline color from 24-bit RGB colors.
      - kitty
    * - ``\e[59m``
      - Su
-     - Reset underline color (follow foreground color).
+     - Reset underline color to the default (follow the foreground color).
      - kitty
    * - ``\e[ Ps S``
      - indn

--- a/src/builtins/set_color.rs
+++ b/src/builtins/set_color.rs
@@ -3,7 +3,7 @@
 use super::prelude::*;
 use crate::color::Color;
 use crate::common::str2wcstring;
-use crate::terminal::TerminalCommand::DefaultUnderlineColor;
+use crate::terminal::TerminalCommand::{DefaultBackgroundColor, DefaultUnderlineColor};
 use crate::terminal::{best_color, get_color_support, Output, Outputter, Paintable};
 use crate::text_face::{
     parse_text_face_and_options, TextFace, TextFaceArgsAndOptions, TextFaceArgsAndOptionsResult,
@@ -148,7 +148,7 @@ pub fn set_color(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
 
     // Here's some automagic behavior: if either of foreground or background are "normal",
     // reset all colors/attributes. Same if foreground is "reset" (undocumented).
-    if is_reset || [fg, bg].iter().any(|c| c.is_some_and(|c| c.is_normal())) {
+    if is_reset || fg.is_some_and(|fg| fg.is_normal()) {
         outp.reset_text_face();
     }
 
@@ -167,7 +167,9 @@ pub fn set_color(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
         }
     }
     if let Some(bg) = bg {
-        if !bg.is_normal() {
+        if bg.is_normal() {
+            outp.write_command(DefaultBackgroundColor);
+        } else {
             outp.write_color(Paintable::Background, bg);
         }
     }

--- a/tests/checks/set_color.fish
+++ b/tests/checks/set_color.fish
@@ -14,7 +14,7 @@ string escape (set_color --background=reset)
 # CHECKERR: set_color: Unknown color 'reset'
 
 string escape (set_color --bold red --background=normal)
-# CHECK: \e\[m\e\[1m\e\[31m
+# CHECK: \e\[1m\e\[31m\e\[49m
 string escape (set_color --bold red --background=blue)
 # CHECK: \e\[1m\e\[31m\e\[44m
 


### PR DESCRIPTION
I don't expect anyone relied on this behavior. Let's remove it, to reduce surprise.
This improves consistency with "set_color --underline-color=normal".

"set_color normal" still resets everything though.

As suggested in
https://github.com/fish-shell/fish-shell/issues/11417#issuecomment-2825023522
