### PR TITLE
Builtin XTGETTCAP support, use curly underlines for errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -69,6 +69,9 @@ Improved terminal support
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 - Support for curly underlines in `fish_color_*` variables and :doc:`set_color <cmds/set_color>` (:issue:`10957`).
 - Underlines can now be colored independent of text (:issue:`7619`).
+- Errors are now highlighted with curly underlines in the default themes.
+  For compatibility with terminals that interpret the curly-underline escape sequence in an unexpected way,
+  the default themes enable this only if the terminal advertises support for the ``Su`` capability via XTGETTCAP.
 - New documentation page `Terminal Compatibility <terminal-compatibility.html>`_ (also accessible via ``man fish-terminal-compatibility``) lists required and optional terminal control sequences used by fish.
 - :doc:`status <cmds/status>` learned the ``xtgettcap`` subcommand, to query terminfo capabilities via XTGETTCAP commands.
 - :doc:`status <cmds/status>` learned the ``xtversion`` subcommand, to show the terminal's name and version (as reported by via the XTVERSION command).

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -70,6 +70,8 @@ Improved terminal support
 - Support for curly underlines in `fish_color_*` variables and :doc:`set_color <cmds/set_color>` (:issue:`10957`).
 - Underlines can now be colored independent of text (:issue:`7619`).
 - New documentation page `Terminal Compatibility <terminal-compatibility.html>`_ (also accessible via ``man fish-terminal-compatibility``) lists required and optional terminal control sequences used by fish.
+- :doc:`status <cmds/status>` learned the ``xtgettcap`` subcommand, to query terminfo capabilities via XTGETTCAP commands.
+- :doc:`status <cmds/status>` learned the ``xtversion`` subcommand, to show the terminal's name and version (as reported by via the XTVERSION command).
 
 Other improvements
 ------------------

--- a/doc_src/cmds/status.rst
+++ b/doc_src/cmds/status.rst
@@ -33,6 +33,8 @@ Synopsis
     status buildinfo
     status get-file FILE
     status list-files [PATH]
+    status xtgettcap TERMINFO-CAPABILITY
+    status xtversion
 
 Description
 -----------
@@ -116,6 +118,13 @@ The following operations (subcommands) are available:
 **list-files** *FILE*
     This lists the files embedded in the fish binary at compile time. Only files where the path starts with the optional *FILE* argument are shown.
     Returns 0 if something was printed, 1 otherwise.
+
+**xtgettcap** *TERMINFO-CAPABILITY*
+    Query the terminal for a terminfo capability via XTGETTCAP.
+    Returns 0 if the capability is present and 1 otherwise.
+
+**xtversion**
+    Show the terminal name and version (XTVERSION).
 
 Notes
 -----

--- a/doc_src/terminal-compatibility.rst
+++ b/doc_src/terminal-compatibility.rst
@@ -177,7 +177,9 @@ Optional Commands
      - Su
      - Reset underline color to the default (follow the foreground color).
      - kitty
-   * - ``\e[ Ps S``
+   * - .. _indn:
+
+       ``\e[ Ps S``
      - indn
      - Scroll forward Ps lines.
      -
@@ -269,6 +271,12 @@ Optional Commands
      - FinalTerm
    * - ``\eP+q Pt \e\\``
      -
-     - Request terminfo capability (XTGETTCAP). The parameter is the capability's hex-encoded terminfo code.
-       Specifically, fish asks for the ``indn`` string capability. At the time of writing string capabilities are supported by kitty and foot.
-     - XTerm, kitty, foot
+     - Request terminfo capability (XTGETTCAP).
+       The parameter is the capability's hex-encoded terminfo code.
+       To advertise a capability, the response must of the form
+       ``\eP1+q Pt \e\\`` or ``\eP1+q Pt = Pt \e\\``.
+       In either variant the first parameter must be the hex-encoded terminfo code.
+       In the second variant, fish ignores the part after the equals sign.
+
+       At startup, fish checks for the presence of the `indn <#indn>`_ string capability.
+     - XTerm, kitty, foot, wezterm, contour

--- a/share/completions/status.fish
+++ b/share/completions/status.fish
@@ -27,7 +27,9 @@ set -l __fish_status_all_commands \
     list-files \
     print-stack-trace \
     stack-trace \
-    test-feature
+    test-feature \
+    xtgettcap \
+    xtversion
 
 # These are the recognized flags.
 complete -c status -s h -l help -d "Display help and exit"
@@ -64,6 +66,8 @@ complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_com
 complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a get-file -d "Print an embedded file from the fish binary"
 complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a list-files -d "List embedded files contained in the fish binary"
 complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a fish-path -d "Print the path to the current instance of fish"
+complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a xtgettcap -d "Query the terminal for a terminfo capability"
+complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a xtversion -d "Show terminal name and version"
 
 # The job-control command changes fish state.
 complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a job-control -d "Set which jobs are under job control"

--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -30,7 +30,7 @@ if status is-interactive
     # Commands to run in interactive sessions can go here
 end" >$__fish_config_dir/config.fish
 
-        echo yes | fish_config theme save "fish default" --track
+        fish_config theme save "fish default" --yes --track
         set -Ue fish_color_keyword fish_color_option
     end
     if test $__fish_initialized -lt 3800 && test "$fish_color_search_match[1]" = bryellow

--- a/share/functions/__fish_in_gnu_screen.fish
+++ b/share/functions/__fish_in_gnu_screen.fish
@@ -1,0 +1,3 @@
+function __fish_in_gnu_screen
+    test -n "$STY" || contains -- $TERM screen screen-256color
+end

--- a/share/functions/__fish_in_terminal_multiplexer.fish
+++ b/share/functions/__fish_in_terminal_multiplexer.fish
@@ -1,0 +1,9 @@
+function __fish_in_terminal_multiplexer
+    set -l terminal_name "(status xtversion | string match -r '^\S*')"
+    string match -q -- tmux $terminal_name ||
+        __fish_in_gnu_screen ||
+        # Emacs does probably not support multiplexing between multiple parent
+        # terminals, but it is affected by the same issues.  Same for Vim's
+        # :terminal TODO detect that before they implement XTGETTCAP.
+        contains -- $TERM dvtm-256color eterm eterm-color
+end

--- a/share/functions/__fish_shared_key_bindings.fish
+++ b/share/functions/__fish_shared_key_bindings.fish
@@ -77,7 +77,13 @@ function __fish_shared_key_bindings -d "Bindings shared between emacs and vi mod
     bind --preset $argv alt-l __fish_list_current_token
     bind --preset $argv alt-o __fish_preview_current_file
     bind --preset $argv alt-w __fish_whatis_current_token
-    bind --preset $argv ctrl-l scrollback-push clear-screen
+    bind --preset $argv ctrl-l (
+        if test -z "$STY"
+            and not string match -qr -- '^(screen|screen-256color)$' $TERM
+            and __fish_xtgettcap indn
+            echo scrollback-push
+        end
+    ) clear-screen
     bind --preset $argv ctrl-c clear-commandline
     bind --preset $argv ctrl-u backward-kill-line
     bind --preset $argv ctrl-k kill-line

--- a/share/functions/__fish_shared_key_bindings.fish
+++ b/share/functions/__fish_shared_key_bindings.fish
@@ -78,9 +78,7 @@ function __fish_shared_key_bindings -d "Bindings shared between emacs and vi mod
     bind --preset $argv alt-o __fish_preview_current_file
     bind --preset $argv alt-w __fish_whatis_current_token
     bind --preset $argv ctrl-l (
-        if test -z "$STY"
-            and not string match -qr -- '^(screen|screen-256color)$' $TERM
-            and __fish_xtgettcap indn
+        if not __fish_in_gnu_screen && and __fish_xtgettcap indn
             echo scrollback-push
         end
     ) clear-screen

--- a/share/functions/__fish_xtgettcap.fish
+++ b/share/functions/__fish_xtgettcap.fish
@@ -1,0 +1,12 @@
+function __fish_xtgettcap --argument-names terminfo_code
+    if test $FISH_UNIT_TESTS_RUNNING = 1
+        return 1
+    end
+    set -l varname __fish_tcap_$terminfo_code
+    if not set -q $varname\[0\]
+        set --global $varname (
+            status xtgettcap $terminfo_code && echo true || echo false
+        )
+    end
+    test "$$varname" = true
+end

--- a/share/tools/web_config/themes/Base16 Default Dark.theme
+++ b/share/tools/web_config/themes/Base16 Default Dark.theme
@@ -10,7 +10,7 @@ fish_color_comment f7ca88
 fish_color_cwd green
 fish_color_cwd_root red
 fish_color_end ba8baf
-fish_color_error ab4642
+fish_color_error ab4642 --underline=curly
 fish_color_escape 86c1b9
 fish_color_history_current --bold
 fish_color_host normal

--- a/share/tools/web_config/themes/Base16 Default Light.theme
+++ b/share/tools/web_config/themes/Base16 Default Light.theme
@@ -10,7 +10,7 @@ fish_color_comment f7ca88
 fish_color_cwd green
 fish_color_cwd_root red
 fish_color_end ba8baf
-fish_color_error ab4642
+fish_color_error ab4642 --underline=curly
 fish_color_escape 86c1b9
 fish_color_history_current --bold
 fish_color_host normal

--- a/share/tools/web_config/themes/Base16 Eighties.theme
+++ b/share/tools/web_config/themes/Base16 Eighties.theme
@@ -10,7 +10,7 @@ fish_color_comment ffcc66
 fish_color_cwd green
 fish_color_cwd_root red
 fish_color_end cc99cc
-fish_color_error f2777a
+fish_color_error f2777a --underline=curly
 fish_color_escape 66cccc
 fish_color_history_current --bold
 fish_color_host normal

--- a/share/tools/web_config/themes/Bay Cruise.theme
+++ b/share/tools/web_config/themes/Bay Cruise.theme
@@ -9,7 +9,7 @@ fish_color_comment FF9640
 fish_color_cwd green
 fish_color_cwd_root red
 fish_color_end FFB273
-fish_color_error FF7400
+fish_color_error FF7400 --underline=curly
 fish_color_escape 00a6b2
 fish_color_history_current --bold
 fish_color_host normal

--- a/share/tools/web_config/themes/Dracula.theme
+++ b/share/tools/web_config/themes/Dracula.theme
@@ -21,7 +21,7 @@ fish_color_comment 6272a4
 fish_color_cwd 50fa7b
 fish_color_cwd_root red
 fish_color_end ffb86c
-fish_color_error ff5555
+fish_color_error ff5555 --underline=curly
 fish_color_escape ff79c6
 fish_color_history_current --bold
 fish_color_host bd93f9

--- a/share/tools/web_config/themes/Fairground.theme
+++ b/share/tools/web_config/themes/Fairground.theme
@@ -9,7 +9,7 @@ fish_color_comment FFE100
 fish_color_cwd green
 fish_color_cwd_root red
 fish_color_end 8D003B
-fish_color_error EC3B86
+fish_color_error EC3B86 --underline=curly
 fish_color_escape 00a6b2
 fish_color_history_current --bold
 fish_color_host normal

--- a/share/tools/web_config/themes/Just a Touch.theme
+++ b/share/tools/web_config/themes/Just a Touch.theme
@@ -9,7 +9,7 @@ fish_color_comment B0B0B0
 fish_color_cwd green
 fish_color_cwd_root red
 fish_color_end 969696
-fish_color_error FFA779
+fish_color_error FFA779 --underline=curly
 fish_color_escape 00a6b2
 fish_color_history_current --bold
 fish_color_host normal

--- a/share/tools/web_config/themes/Lava.theme
+++ b/share/tools/web_config/themes/Lava.theme
@@ -6,7 +6,7 @@ fish_color_command FF9400
 fish_color_quote BF9C30
 fish_color_redirection BF5B30
 fish_color_end FF4C00
-fish_color_error FFDD73
+fish_color_error FFDD73 --underline=curly
 fish_color_param FFC000
 fish_color_comment A63100
 fish_color_selection white --background=brblack --bold

--- a/share/tools/web_config/themes/Mono Lace.theme
+++ b/share/tools/web_config/themes/Mono Lace.theme
@@ -9,7 +9,7 @@ fish_color_comment 4e4e4e
 fish_color_cwd green
 fish_color_cwd_root red
 fish_color_end 767676
-fish_color_error b2b2b2
+fish_color_error b2b2b2 --underline=curly
 fish_color_escape 00a6b2
 fish_color_history_current --bold
 fish_color_host normal

--- a/share/tools/web_config/themes/Mono Smoke.theme
+++ b/share/tools/web_config/themes/Mono Smoke.theme
@@ -6,7 +6,7 @@ fish_color_command ffffff
 fish_color_quote a8a8a8
 fish_color_redirection 808080
 fish_color_end 949494
-fish_color_error 585858
+fish_color_error 585858 --underline=curly
 fish_color_param d7d7d7
 fish_color_comment bcbcbc
 fish_color_selection white --background=brblack --bold

--- a/share/tools/web_config/themes/None.theme
+++ b/share/tools/web_config/themes/None.theme
@@ -9,7 +9,7 @@ fish_color_comment
 fish_color_cwd normal
 fish_color_cwd_root normal
 fish_color_end
-fish_color_error
+fish_color_error --underline=curly
 fish_color_escape
 fish_color_history_current
 fish_color_host normal

--- a/share/tools/web_config/themes/Nord.theme
+++ b/share/tools/web_config/themes/Nord.theme
@@ -11,7 +11,7 @@ fish_color_comment 4c566a --italics
 fish_color_cwd 5e81ac
 fish_color_cwd_root bf616a
 fish_color_end 81a1c1
-fish_color_error bf616a
+fish_color_error bf616a --underline=curly
 fish_color_escape ebcb8b
 fish_color_history_current e5e9f0 --bold
 fish_color_host a3be8c

--- a/share/tools/web_config/themes/Old School.theme
+++ b/share/tools/web_config/themes/Old School.theme
@@ -9,7 +9,7 @@ fish_color_comment 30BE30
 fish_color_cwd green
 fish_color_cwd_root red
 fish_color_end FF7B7B
-fish_color_error A40000
+fish_color_error A40000 --underline=curly
 fish_color_escape 00a6b2
 fish_color_history_current --bold
 fish_color_host normal

--- a/share/tools/web_config/themes/Seaweed.theme
+++ b/share/tools/web_config/themes/Seaweed.theme
@@ -9,7 +9,7 @@ fish_color_comment 5C9900
 fish_color_cwd green
 fish_color_cwd_root red
 fish_color_end 8EEB00
-fish_color_error 60B9CE
+fish_color_error 60B9CE --underline=curly
 fish_color_escape 00a6b2
 fish_color_history_current --bold
 fish_color_host normal

--- a/share/tools/web_config/themes/Snow Day.theme
+++ b/share/tools/web_config/themes/Snow Day.theme
@@ -6,7 +6,7 @@ fish_color_command 164CC9
 fish_color_quote 4C3499
 fish_color_redirection 248E8E
 fish_color_end 02BDBD
-fish_color_error 9177E5
+fish_color_error 9177E5 --underline=curly
 fish_color_param 4319CC
 fish_color_comment 007B7B
 fish_color_selection white --background=brblack --bold

--- a/share/tools/web_config/themes/Solarized Dark.theme
+++ b/share/tools/web_config/themes/Solarized Dark.theme
@@ -10,7 +10,7 @@ fish_color_comment 586e75
 fish_color_cwd green
 fish_color_cwd_root red
 fish_color_end 268bd2
-fish_color_error dc322f
+fish_color_error dc322f --underline=curly
 fish_color_escape 00a6b2
 fish_color_history_current --bold
 fish_color_host normal

--- a/share/tools/web_config/themes/Solarized Light.theme
+++ b/share/tools/web_config/themes/Solarized Light.theme
@@ -7,7 +7,7 @@ fish_color_command 586e75
 fish_color_quote 839496
 fish_color_redirection 6c71c4
 fish_color_end 268bd2
-fish_color_error dc322f
+fish_color_error dc322f --underline=curly
 fish_color_param 657b83
 fish_color_comment 93a1a1
 fish_color_selection white --background=brblack --bold

--- a/share/tools/web_config/themes/Tomorrow Night Bright.theme
+++ b/share/tools/web_config/themes/Tomorrow Night Bright.theme
@@ -10,7 +10,7 @@ fish_color_comment e7c547
 fish_color_cwd green
 fish_color_cwd_root red
 fish_color_end c397d8
-fish_color_error d54e53
+fish_color_error d54e53 --underline=curly
 fish_color_escape 00a6b2
 fish_color_history_current --bold
 fish_color_host normal

--- a/share/tools/web_config/themes/Tomorrow Night.theme
+++ b/share/tools/web_config/themes/Tomorrow Night.theme
@@ -7,7 +7,7 @@ fish_color_command b294bb
 fish_color_quote b5bd68
 fish_color_redirection 8abeb7
 fish_color_end b294bb
-fish_color_error cc6666
+fish_color_error cc6666 --underline=curly
 fish_color_param 81a2be
 fish_color_comment f0c674
 fish_color_selection white --background=brblack --bold

--- a/share/tools/web_config/themes/Tomorrow.theme
+++ b/share/tools/web_config/themes/Tomorrow.theme
@@ -10,7 +10,7 @@ fish_color_comment eab700
 fish_color_cwd green
 fish_color_cwd_root red
 fish_color_end 8959a8
-fish_color_error c82829
+fish_color_error c82829 --underline=curly
 fish_color_escape 00a6b2
 fish_color_history_current --bold
 fish_color_host normal

--- a/share/tools/web_config/themes/ayu Dark.theme
+++ b/share/tools/web_config/themes/ayu Dark.theme
@@ -7,7 +7,7 @@ fish_color_command 39BAE6
 fish_color_quote C2D94C
 fish_color_redirection FFEE99
 fish_color_end F29668
-fish_color_error FF3333
+fish_color_error FF3333 --underline=curly
 fish_color_param B3B1AD
 fish_color_comment 626A73
 fish_color_selection --background=E6B450 --bold

--- a/share/tools/web_config/themes/ayu Light.theme
+++ b/share/tools/web_config/themes/ayu Light.theme
@@ -10,7 +10,7 @@ fish_color_comment ABB0B6
 fish_color_cwd 399EE6
 fish_color_cwd_root red
 fish_color_end ED9366
-fish_color_error F51818
+fish_color_error F51818 --underline=curly
 fish_color_escape 4CBF99
 fish_color_history_current --bold
 fish_color_host normal

--- a/share/tools/web_config/themes/ayu Mirage.theme
+++ b/share/tools/web_config/themes/ayu Mirage.theme
@@ -10,7 +10,7 @@ fish_color_comment 5C6773
 fish_color_cwd 73D0FF
 fish_color_cwd_root red
 fish_color_end F29E74
-fish_color_error FF3333
+fish_color_error FF3333 --underline=curly
 fish_color_escape 95E6CB
 fish_color_history_current --bold
 fish_color_host normal

--- a/share/tools/web_config/themes/coolbeans.theme
+++ b/share/tools/web_config/themes/coolbeans.theme
@@ -9,7 +9,7 @@ fish_color_comment '888'  '--italics'
 fish_color_cwd 0A0
 fish_color_cwd_root A00
 fish_color_end 009900
-fish_color_error F22
+fish_color_error F22 --underline=curly
 fish_color_escape 0AA
 fish_color_history_current 0AA
 fish_color_host normal

--- a/share/tools/web_config/themes/fish default.theme
+++ b/share/tools/web_config/themes/fish default.theme
@@ -11,7 +11,7 @@ fish_color_comment red
 fish_color_cwd green
 fish_color_cwd_root red
 fish_color_end green
-fish_color_error brred
+fish_color_error brred --underline=curly
 fish_color_escape brcyan
 fish_color_history_current --bold
 fish_color_host normal

--- a/src/builtins/fish_key_reader.rs
+++ b/src/builtins/fish_key_reader.rs
@@ -153,7 +153,7 @@ fn setup_and_process_keys(
     unsafe { libc::tcsetattr(0, TCSANOW, &*shell_modes()) };
     terminal_protocol_hacks();
     let blocking_query: OnceCell<RefCell<Option<TerminalQuery>>> = OnceCell::new();
-    initial_query(&blocking_query, streams.out, None);
+    initial_query(&blocking_query, streams.out);
 
     if continuous_mode {
         streams.err.append(L!("\n"));

--- a/src/builtins/read.rs
+++ b/src/builtins/read.rs
@@ -28,6 +28,7 @@ use crate::wutil;
 use crate::wutil::encoding::zero_mbstate;
 use crate::wutil::perror;
 use libc::SEEK_CUR;
+use std::num::NonZeroUsize;
 use std::os::fd::RawFd;
 use std::sync::atomic::Ordering;
 
@@ -219,12 +220,14 @@ fn read_interactive(
     conf.complete_ok = shell;
     conf.highlight_ok = shell;
     conf.syntax_check_ok = shell;
+    conf.prompt_ok = true;
 
     // No autosuggestions or abbreviations in builtin_read.
     conf.autosuggest_ok = false;
     conf.expand_abbrev_ok = false;
 
     conf.exit_on_interrupt = true;
+    conf.in_builtin_read = true;
     conf.in_silent_mode = silent;
 
     conf.left_prompt_cmd = prompt.to_owned();
@@ -244,7 +247,7 @@ fn read_interactive(
 
     let mline = {
         let _interactive = parser.push_scope(|s| s.is_interactive = true);
-        reader_readline(parser, nchars)
+        reader_readline(parser, NonZeroUsize::try_from(nchars).ok())
     };
     terminal_protocols_disable_ifn();
     if let Some(line) = mline {

--- a/src/builtins/status/query.rs
+++ b/src/builtins/status/query.rs
@@ -1,0 +1,166 @@
+use std::ops::ControlFlow;
+use std::rc::Rc;
+
+use crate::builtins::prelude::*;
+
+use crate::common::wcs2string;
+use crate::global_safety::RelaxedAtomicBool;
+use crate::input_common::{
+    terminal_protocols_disable_ifn, InputEventQueuer, TerminalQuery, XtgettcapQuery,
+};
+use crate::nix::isatty;
+use crate::reader::{
+    query_xtgettcap, querying_allowed, reader_pop, reader_push, reader_readline, ReaderConfig,
+    UserQuery,
+};
+use crate::terminal::TerminalCommand::QueryPrimaryDeviceAttribute;
+use crate::terminal::{Output, Outputter, XTVERSION};
+use libc::STDOUT_FILENO;
+
+use super::StatusCmd;
+
+pub(crate) fn status_xtversion(
+    parser: &Parser,
+    streams: &mut IoStreams,
+    cmd: &wstr,
+    args: &[&wstr],
+) -> BuiltinResult {
+    use super::StatusCmd::STATUS_XTVERSION;
+    if !args.is_empty() {
+        streams.err.append(wgettext_fmt!(
+            BUILTIN_ERR_ARG_COUNT2,
+            cmd,
+            STATUS_XTVERSION.to_wstr(),
+            0,
+            args.len()
+        ));
+        return Err(STATUS_INVALID_ARGS);
+    }
+
+    let run_query = { move |_query: &mut Option<TerminalQuery>| ControlFlow::Break(()) };
+    synchronous_query(parser, streams, cmd, &STATUS_XTVERSION, Box::new(run_query))?;
+
+    let Some(xtversion) = XTVERSION.get() else {
+        return Err(STATUS_CMD_ERROR);
+    };
+
+    streams.out.appendln(xtversion);
+
+    Ok(SUCCESS)
+}
+
+pub(crate) fn status_xtgettcap(
+    parser: &Parser,
+    streams: &mut IoStreams,
+    cmd: &wstr,
+    args: &[&wstr],
+) -> BuiltinResult {
+    use super::StatusCmd::STATUS_XTGETTCAP;
+    if !querying_allowed() {
+        return Err(STATUS_CMD_ERROR);
+    }
+    if args.len() != 1 {
+        streams.err.append(wgettext_fmt!(
+            BUILTIN_ERR_ARG_COUNT2,
+            cmd,
+            STATUS_XTGETTCAP.to_wstr(),
+            1,
+            args.len()
+        ));
+        return Err(STATUS_INVALID_ARGS);
+    }
+    let result = Rc::new(RelaxedAtomicBool::new(false));
+    let run_query = {
+        let terminfo_code = wcs2string(args[0]);
+        let result = Rc::clone(&result);
+        move |query: &mut Option<TerminalQuery>| {
+            assert!(matches!(
+                *query,
+                None | Some(TerminalQuery::PrimaryDeviceAttribute(None))
+            ));
+            let mut output = Outputter::stdoutput().borrow_mut();
+            output.begin_buffering();
+            query_xtgettcap(output.by_ref(), &terminfo_code);
+            output.write_command(QueryPrimaryDeviceAttribute);
+            output.end_buffering();
+            *query = Some(TerminalQuery::PrimaryDeviceAttribute(Some(
+                XtgettcapQuery {
+                    terminfo_code,
+                    result,
+                },
+            )));
+            ControlFlow::Continue(())
+        }
+    };
+    synchronous_query(parser, streams, cmd, &STATUS_XTGETTCAP, Box::new(run_query))?;
+    if !result.load() {
+        return Err(STATUS_CMD_ERROR);
+    }
+    Ok(SUCCESS)
+}
+
+fn synchronous_query(
+    parser: &Parser,
+    streams: &mut IoStreams,
+    cmd: &wstr,
+    subcmd: &StatusCmd,
+    run_query: UserQuery,
+) -> Result<(), ErrorCode> {
+    if !isatty(streams.stdin_fd) {
+        streams.err.append(wgettext_fmt!(
+            "%s %s: stdin is not a TTY",
+            cmd,
+            subcmd.to_wstr(),
+        ));
+        return Err(STATUS_INVALID_ARGS);
+    };
+    let out_fd = STDOUT_FILENO;
+    if !isatty(out_fd) {
+        streams.err.append(wgettext_fmt!(
+            "%s %s: stdout is not a TTY",
+            cmd,
+            subcmd.to_wstr(),
+        ));
+        return Err(STATUS_INVALID_ARGS);
+    };
+
+    if let Some(query_state) = parser.blocking_query.get() {
+        if (run_query)(&mut query_state.borrow_mut()).is_break() {
+            return Ok(());
+        }
+    } else {
+        // We are the first reader.
+        let empty_spot = parser.pending_user_query.replace(Some(run_query));
+        assert!(empty_spot.is_none());
+    }
+
+    let mut conf = ReaderConfig::default();
+    conf.inputfd = streams.stdin_fd;
+    conf.prompt_ok = false;
+    conf.exit_on_interrupt = true;
+
+    let pending_keys = {
+        let mut reader = reader_push(parser, L!(""), conf);
+        {
+            let _interactive = parser.push_scope(|s| s.is_interactive = true);
+            let no_line = reader_readline(parser, None);
+            assert!(no_line.is_none());
+        }
+        terminal_protocols_disable_ifn();
+        let input_data = reader.get_input_data_mut();
+        let pending_keys = std::mem::take(&mut input_data.queue);
+        // We blocked code and mapping execution so input function args must be empty.
+        assert!(input_data.input_function_args.is_empty());
+        if input_data.paste_buffer.is_some() {
+            FLOG!(
+                reader,
+                "Bracketed paste was interrupted; dropping uncommitted paste buffer"
+            )
+        }
+        reader_pop();
+        pending_keys
+    };
+    FLOGF!(reader, "Adding %lu pending keys", pending_keys.len());
+    parser.pending_keys.borrow_mut().extend(pending_keys);
+    Ok(())
+}

--- a/src/io.rs
+++ b/src/io.rs
@@ -772,6 +772,10 @@ impl FdOutputStream {
         }
     }
 
+    pub fn as_raw_fd(&self) -> RawFd {
+        self.fd
+    }
+
     fn append(&mut self, s: &wstr) -> bool {
         if self.errored {
             return false;

--- a/tests/checks/fish_config.fish
+++ b/tests/checks/fish_config.fish
@@ -1,7 +1,10 @@
 #RUN: %fish %s
 
 mkdir $__fish_config_dir/themes
-echo >$__fish_config_dir/themes/foo.theme 'fish_color_normal cyan'
+echo >$__fish_config_dir/themes/foo.theme '
+fish_color_normal cyan
+fish_color_error brred --underline=curly
+'
 
 set -g fish_pager_color_secondary_background custom-value
 fish_config theme choose foo
@@ -11,6 +14,14 @@ set -S fish_color_normal
 # CHECK: $fish_color_normal[1]: |cyan|
 set -S fish_pager_color_secondary_background
 # CHECK: $fish_pager_color_secondary_background: set in global scope, unexported, with 0 elements
+
+# Not a default theme, so we allow --underline=curly even if we don't run inside a terminal that
+# advertises support via XTGETTCAP.
+set -S fish_color_error
+# CHECK: $fish_color_error: set in global scope, unexported, with 2 elements
+# CHECK: $fish_color_error[1]: |brred|
+# CHECK: $fish_color_error[2]: |--underline=curly|
+
 
 function change-theme
     echo >$__fish_config_dir/themes/fake-default.theme 'fish_color_command' $argv

--- a/tests/pexpect_helper.py
+++ b/tests/pexpect_helper.py
@@ -180,7 +180,10 @@ class SpawnedProc(object):
         self.spawn.delaybeforesend = None
         self.prompt_counter = 0
         if env.get("TERM") != "dumb":
-            self.spawn.send("\x1b[?123c")  # Primary Device Attribute
+            self.send_primary_device_attribute()
+
+    def send_primary_device_attribute(self):
+        self.spawn.send("\x1b[?123c")
 
     def time_since_first_message(self):
         """Return a delta in seconds since the first message, or 0 if this is the first."""

--- a/tests/pexpects/query.py
+++ b/tests/pexpects/query.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+from pexpect_helper import SpawnedProc
+
+import os
+
+env = os.environ.copy()
+env["TERM"] = "foot"
+
+sp = SpawnedProc(env=env)
+send, sendline, sleep, expect_prompt, expect_re, expect_str = (
+    sp.send,
+    sp.sendline,
+    sp.sleep,
+    sp.expect_prompt,
+    sp.expect_re,
+    sp.expect_str,
+)
+expect_prompt()
+
+sendline("function check; and echo true; or echo false; end")
+
+sendline("status xtgettcap am; check")
+expect_str("\x1bP+q616d\x1b\\") # 616d is "am" in hex
+send("\x1bP1+r616d\x1b\\") # success
+sp.send_primary_device_attribute()
+expect_str("true")
+
+sendline("status xtgettcap an; check")
+expect_str("\x1bP+q616e\x1b\\") # 616e is "an" in hex
+send("\x1bP0+r616e\x1b\\") # failure
+sp.send_primary_device_attribute()
+expect_str("false")


### PR DESCRIPTION
<details>

<summary>
Builtin for querying terminal capabilities/name/version
</summary>

The next commit wants to add a conditional default for styled underlines.
Due to various incompatibilities in terminals, our best option seems to ask
the terminal.

Today we can make XTGETTCAP queries using something like

	printf '\eP+q5373\e\\' # Su
	printf '\e[0c'
	while read -n 1
	    ...
	end

This doesn't seem safe because builtin read might consume other data written
by the terminal such as keyboard input.

Avoid this problem by providing it as a builtin that can enqueue unrelated
input and process it after the query has been answered.

For the same reason, add a builtin to query for XTVERSION; this allows us
to add workarounds for specific terminals (example in the next commit).

TODO: naming -- maybe add a level of nesting:

	status query-terminal xtgettcap
	status query-terminal xtversion
	# Possible future additions:
	status query-terminal os-name
	status query-terminal cursor-position

or "status query-xtgettcap".
We could also hide the exact protocol by saying
"status query terminfo-capability".

Note that xtgettcap, xtversion and os-name are expected to always give the
same results throughout the lifetime of the fish process.  Keep caching
XTVERSION as before, though that's probably not needed.

Future work:

XTGETTCAP potentially supports all of terminfo: boolean, numeric and string
capabilities. Today we have no use beyond checking for presence/absence of
a capabilty. If we ever need more, we can use stdout.

</details>

<details>

<summary>
Use curly underlines for errors in default themes
</summary>

Given that this curly underline will also be red, it should be widely
understood as error.

Since fish always renders immediately (and synchronously), typing "echo"
will briefly show an intermediate curly line.  Maybe fish should redraw
after a timer elapses? This is probably unrelated to this patch.

As mentioned in cc9849c279d (Curly underlines in set_color and fish_color_*,
2025-04-13), there are still some terminals that interpret "\e[4:3m" as
something other than curly underline.

Some of them interpret it as background/foreground color, and some terminal
multiplexers downgrade it to straight underlines (which often happens due
to a false positive).  I want to change this in multiplexers where possible
(see https://github.com/orgs/tmux/discussions/4477) but for now, disable
this feature in multiplexers (there are just a handful).

In a few years, those terminals will maybe agree with XTerm.  Until then,
use XTGETTCAP as a temporary stepping stone. We could also read the terminfo
database but that will give only very few true positives, and lots of false
negatives.  Better implement XTGETTCAP in the relevant terminals.

Note that if the universal variables use the "--track" flag (from https://github.com/fish-shell/fish-shell/pull/11435), then

	rm -rf /tmp/newhome
	foot -e env $HOME=/tmp/newhome fish
	xterm -e env $HOME=/tmp/newhome fish

will "magically work". For foot, $fish_color_error will have --underline=curly.
For xterm, it will not, due to the call to "fish_config theme update".
But of course since it's a universal variable, running fish in xterm
would also downgrade the fish running in other terminals.

Add a "fish_config theme save --yes" flag because "status xtgettcap"
requires stdin to be a terminal.  I'd probably drop this requirement, and
make "status xtgettcap" always use fish's stdin and not its own.  That'd be
cheating because an external command can't do that but I don't think this
change would be hurting anyone.

</details>
