### PR TITLE
wpctl: add completion for settings option

### DIFF
--- a/share/completions/wpctl.fish
+++ b/share/completions/wpctl.fish
@@ -1,5 +1,9 @@
 set -l commands status get-volume inspect set-default set-volume set-mute set-profile clear-default
 
+if wpctl settings &> /dev/null;
+    set --append commands settings
+end
+
 function __wpctl_get_nodes -a section -a type
     set -l havesection
     set -l havetype
@@ -38,6 +42,10 @@ function __wpctl_command_shape
     end
 end
 
+function __wpctl_get_settings
+    wpctl settings | string match --regex --groups-only -- '- Name: (.*)'
+end
+
 complete -c wpctl -f
 
 complete -c wpctl -s h -l help -d "Show help options"
@@ -48,6 +56,9 @@ complete -c wpctl -n "__fish_seen_subcommand_from inspect" -s a -l associated -d
 complete -c wpctl -n "__fish_seen_subcommand_from set-volume" -s p -l pid -d "Selects all nodes associated to the given PID"
 complete -c wpctl -n "__fish_seen_subcommand_from set-volume" -s l -l limit -d "Limit volume to below this value"
 complete -c wpctl -n "__fish_seen_subcommand_from set-mute" -s p -l pid -d "Selects all nodes associated to the given PID"
+complete -c wpctl -n "__fish_seen_subcommand_from settings" -s d -l delete -d "Deletes the saved setting value"
+complete -c wpctl -n "__fish_seen_subcommand_from settings" -s s -l save -d "Saves the setting value"
+complete -c wpctl -n "__fish_seen_subcommand_from settings" -s r -l reset -d "Resets the saved setting to its default value"
 
 complete -c wpctl -n __wpctl_command_shape -a "$commands"
 complete -c wpctl -n '__wpctl_command_shape "*"' -n "__fish_seen_subcommand_from get-volume inspect set-volume set-mute set-profile" -a "@DEFAULT_AUDIO_SOURCE@" -d "Default Microphone"
@@ -56,3 +67,4 @@ complete -c wpctl -n '__wpctl_command_shape "*"' -n "__fish_seen_subcommand_from
 complete -c wpctl -n '__wpctl_command_shape "*"' -n "__fish_seen_subcommand_from get-volume inspect set-volume set-mute set-profile" -a "(__wpctl_get_nodes Audio Sources) (__wpctl_get_nodes Audio Sinks)"
 complete -c wpctl -n '__wpctl_command_shape "*"' -n "__fish_seen_subcommand_from inspect set-profile" -a "(__wpctl_get_nodes Audio Sources) (__wpctl_get_nodes Audio Sinks) (__wpctl_get_nodes Video Source)"
 complete -c wpctl -n '__wpctl_command_shape set-mute "*"' -a "0 1 toggle"
+complete -c wpctl -n '__wpctl_command_shape settings' -a "(__wpctl_get_settings)"

--- a/share/completions/wpctl.fish
+++ b/share/completions/wpctl.fish
@@ -1,6 +1,6 @@
 set -l commands status get-volume inspect set-default set-volume set-mute set-profile clear-default
 
-if wpctl settings &> /dev/null;
+if wpctl settings &>/dev/null
     set --append commands settings
 end
 
@@ -43,7 +43,15 @@ function __wpctl_command_shape
 end
 
 function __wpctl_get_settings
-    wpctl settings | string match --regex --groups-only -- '- Name: (.*)'
+    set -l wpctl_settings (wpctl settings | string collect)
+    
+    string match --regex --all --quiet '\- Name: (?<wpctl_settings_name>.*)\n  Desc: (?<wpctl_settings_desc>.*)' $wpctl_settings
+
+    for i in (seq 1 (count $wpctl_settings_name))
+        set -l name $wpctl_settings_name[$i]
+        set -l desc (string shorten --max 60 $wpctl_settings_desc[$i])
+        echo $name\t$desc
+    end
 end
 
 complete -c wpctl -f


### PR DESCRIPTION
## Description

Add completion for the `wpctl settings` CLI option, added on [wireplumber 0.4.90](https://gitlab.freedesktop.org/pipewire/wireplumber/-/releases/0.4.90). The completion will be conditionally available on wpctl versions that contain this option.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
