### PR TITLE
Fix `diff_profiles.fish`

### DIFF
--- a/build_tools/diff_profiles.fish
+++ b/build_tools/diff_profiles.fish
@@ -5,6 +5,12 @@
 #
 # Usage: ./diff_profiles.fish profile1.log profile2.log > profile_diff.log
 
+if test (count $argv) -ne 2;
+    echo "Incorrect number of arguments."
+    echo "Usage: "(status filename)" profile1.log profile2.log"
+    exit 1
+end
+
 set -l profile1 (cat $argv[1])
 set -l profile2 (cat $argv[2])
 
@@ -15,13 +21,13 @@ while set -l next_line_no (math $line_no + 1) && set -q profile1[$next_line_no] 
     set -l line1 $profile1[$line_no]
     set -l line2 $profile2[$line_no]
 
-    if not string match -qr '^\d+\t\d+' $line1
+    if not string match -qr '^\s*\d+\s+\d+' $line1
         echo $line1
         continue
     end
 
-    set -l results1 (string match -r '^(\d+)\t(\d+)\s+(.*)' $line1)
-    set -l results2 (string match -r '^(\d+)\t(\d+)\s+(.*)' $line2)
+    set -l results1 (string match -r '^\s*(\d+)\s+(\d+)\s+(.*)' $line1)
+    set -l results2 (string match -r '^\s*(\d+)\s+(\d+)\s+(.*)' $line2)
 
     # times from both files
     set -l time1 $results1[2..3]
@@ -42,5 +48,5 @@ while set -l next_line_no (math $line_no + 1) && set -q profile1[$next_line_no] 
     set diff[1] (math $time1[1] - $time2[1])
     set diff[2] (math $time1[2] - $time2[2])
 
-    echo $diff[1] $diff[2] $remainder1
+    printf '%10d %10d %s\n' $diff[1] $diff[2] $remainder1
 end


### PR DESCRIPTION
This script was broken by the changes to profiling output in 9d904e111345a64eb4ff05ecd8d7737f22cfc762.

The new version works with both the old and new profiling output, even when mixed. The script output has been adjusted to match the new profiling style better.

This also adds basic error handling for situations where the script is invoked incorrectly and makes the file executable.
