### PR TITLE
preciser wording for builtin crossmode alt+p binding

### DIFF
--- a/doc_src/interactive.rst
+++ b/doc_src/interactive.rst
@@ -354,7 +354,7 @@ Some bindings are common across Emacs and vi mode, because they aren't text edit
 
 - :kbd:`alt-o` opens the file at the cursor in a pager. If the cursor is in command position and the command is a script, it will instead open that script in your editor. The editor is chosen from the first available of the ``$VISUAL`` or ``$EDITOR`` variables.
 
-- :kbd:`alt-p` adds the string ``&| less;`` to the end of the job under the cursor. The result is that the output of the command will be paged.
+- :kbd:`alt-p` adds the string ``&| less;`` to the end of the job under the cursor. The result is that the output of the command will be paged. If you set the `$PAGER` environment variable, its value is used instead of `less`.
 
 - :kbd:`alt-w` prints a short description of the command under the cursor.
 

--- a/doc_src/interactive.rst
+++ b/doc_src/interactive.rst
@@ -354,7 +354,7 @@ Some bindings are common across Emacs and vi mode, because they aren't text edit
 
 - :kbd:`alt-o` opens the file at the cursor in a pager. If the cursor is in command position and the command is a script, it will instead open that script in your editor. The editor is chosen from the first available of the ``$VISUAL`` or ``$EDITOR`` variables.
 
-- :kbd:`alt-p` adds the string ``&| less;`` to the end of the job under the cursor. The result is that the output of the command will be paged. If you set the `$PAGER` environment variable, its value is used instead of `less`.
+- :kbd:`alt-p` adds the string ``&| less;`` to the end of the job under the cursor. The result is that the output of the command will be paged. If you set the ``PAGER`` variable, its value is used instead of ``less``.
 
 - :kbd:`alt-w` prints a short description of the command under the cursor.
 


### PR DESCRIPTION
## Description

First time I saw that description, I was under the impression that specifically `less` is hardcoded. As I use a different `$PAGER`, I piped up to go fix this via a pr. It took me to look at the source of the function that's called to realize that no, actually this hotkey *does* respect your `$PAGER` variable. \
So, this pr makes the wording in the description of that <kbd>alt+p</kbd> mapping more precise, pointing out that it respects the `$PAGER` variable.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
