### PR TITLE
Use workspace config in packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ embed-data = ["dep:rust-embed"]
 asan = []
 tsan = []
 
-[lints]
+[workspace.lints]
 rust.non_camel_case_types = "allow"
 rust.non_upper_case_globals = "allow"
 rust.unknown_lints = "allow"
@@ -113,3 +113,6 @@ clippy.needless_lifetimes = "allow"
 # In the future, they might change to flag other methods of printing.
 clippy.print_stdout = "deny"
 clippy.print_stderr = "deny"
+
+[lints]
+workspace = true

--- a/printf/Cargo.toml
+++ b/printf/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "fish-printf"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 version = "0.2.1"
 repository = "https://github.com/fish-shell/fish-shell"
 description = "printf implementation, based on musl"
@@ -9,3 +10,6 @@ license = "MIT"
 [dependencies]
 libc = "0.2.155"
 widestring = { version = "1.0.2", optional = true }
+
+[lints]
+workspace = true

--- a/printf/clippy.toml
+++ b/printf/clippy.toml
@@ -1,0 +1,1 @@
+allow-print-in-tests = true


### PR DESCRIPTION
- Apply lint config to entire workspace

- Inherit workspace config for fish-printf

- Allow stdlib printing in fish-printf tests

The current problem which is addressed by this is that warnings about C-String literals are generated by clippy for code in fish-printf. These literals are not available with the current MSRV 1.70, but previously the MSRV setting was not inherited by fish-printf, causing the warning to appear.

# TODOs
- [ ] Do we want to allow stdlib printing in tests? If so, just in the fish-printf tests as currently implemented or for all tests?