### PR TITLE
Make printf Unicode-aware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,8 @@ name = "fish-printf"
 version = "0.2.1"
 dependencies = [
  "libc",
+ "unicode-segmentation",
+ "unicode-width",
  "widestring",
 ]
 
@@ -545,6 +547,18 @@ name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unix_path"

--- a/printf/Cargo.toml
+++ b/printf/Cargo.toml
@@ -10,6 +10,8 @@ license = "MIT"
 [dependencies]
 libc = "0.2.155"
 widestring = { version = "1.0.2", optional = true }
+unicode-segmentation = "1.12.0"
+unicode-width = "0.2.0"
 
 [lints]
 workspace = true

--- a/printf/src/lib.rs
+++ b/printf/src/lib.rs
@@ -71,7 +71,7 @@ macro_rules! sprintf {
 /// - `args`: Iterator over the arguments to format.
 ///
 /// # Returns
-/// A `Result` which is `Ok` containing the number of characters written on success, or an `Error`.
+/// A `Result` which is `Ok` containing the width of the string written on success, or an `Error`.
 ///
 /// # Example
 ///

--- a/tests/checks/printf.fish
+++ b/tests/checks/printf.fish
@@ -154,3 +154,21 @@ printf '%b\n' '\0057foo\0057bar\0057'
 
 printf %18446744073709551616s
 # CHECKERR: Number out of range
+
+# Test non-ASCII behavior
+printf '|%3s|\n' 'ö'
+# CHECK: |  ö|
+printf '|%3s|\n' '🇺🇳'
+#CHECK: | 🇺🇳|
+printf '|%.3s|\n' '🇺🇳🇺🇳'
+#CHECK: |🇺🇳|
+printf '|%.3s|\n' 'a🇺🇳'
+#CHECK: |a🇺🇳|
+printf '|%.3s|\n' 'aa🇺🇳'
+#CHECK: |aa|
+printf '|%3.3s|\n' 'aa🇺🇳'
+#CHECK: | aa|
+printf '|%.1s|\n' '𒈙a'
+#CHECK: |𒈙|
+printf '|%3.3s|\n' '👨‍👨‍👧‍👧'
+#CHECK: | 👨‍👨‍👧‍👧|


### PR DESCRIPTION
Specifically, the width and precision format specifiers are interpreted as referring to the width of the grapheme clusters rather than the byte count of the string. Note that grapheme clusters can differ in width.

If a precision is specified for a string, meaning its "maximum number of characters", we consider this to limit the width displayed. If there is a grapheme cluster whose width is greater than 1, it might not be possible to get precisely the desired width. In such cases, this last grapheme cluster is excluded from the output.

Note that the definitions used here are not consistent with the `string length` builtin at the moment, but this has already been the case.

Fixes issue #11412