### PR TITLE
feat: Add `pager-show-search` readline command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 fish 4.1.0 (released ???)
 =========================
 
-.. ignore for 4.1: 10929 10940 10948 10955 10965 10975 10989 10990 10998 11028 11052 11055 11069 11071 11079 11092 11098 11104 11106 11110 11140 11146 11148 11150 11214 11218 11259 11288 11299 11328 11350 11373 11395 11417 11419  
+.. ignore for 4.1: 10929 10940 10948 10955 10965 10975 10989 10990 10998 11028 11052 11055 11069 11071 11079 11092 11098 11104 11106 11110 11140 11146 11148 11150 11214 11218 11259 11288 11299 11328 11350 11373 11395 11417 11419
 
 Notable improvements and fixes
 ------------------------------
@@ -18,6 +18,7 @@ Notable improvements and fixes
   use `status get-file` or find alternatives (like loading completions for "foo" via `complete -C"foo "`).
 
   We're considering making data embedding mandatory in future releases because it has a few advantages even for installation from a package (like making file conflicts with other packages impossible). (:issue:`11143`)
+- Added an readline command, `pager-show-search`, which shows the search field in pager (:issue:`11450`).
 
 Deprecations and removed features
 ---------------------------------
@@ -97,7 +98,7 @@ This release of fish fixes a number of issues identified in fish 4.0.1:
 - The warning when the terminfo database can't be found has been downgraded to a log message. fish will act as if the terminal behaves like xterm-256color, which is correct for the vast majority of cases (:issue:`11277`, :issue:`11290`).
 - Key combinations using the super (Windows/command) key can now (actually) be bound using the :kbd:`super-` prefix (:issue:`11217`). This was listed in the release notes for 4.0.1 but did not work correctly.
 - :doc:`function <cmds/function>` is stricter about argument parsing, rather than allowing additional parameters to be silently ignored (:issue:`11295`).
-- Using parentheses in the :doc:`test <cmds/test>` builtin works correctly, following a regression in 4.0.0 where they were not recognized (:issue:`11387`). 
+- Using parentheses in the :doc:`test <cmds/test>` builtin works correctly, following a regression in 4.0.0 where they were not recognized (:issue:`11387`).
 - :kbd:`delete` in Vi mode when Num Lock is active will work correctly (:issue:`11303`).
 - Abbreviations cannot alter the command-line contents, preventing a crash (:issue:`11324`).
 - Improvements to various completions, including new completions for ``wl-randr`` (:issue:`11301`), performance improvements for ``cargo`` completions by avoiding network requests (:issue:`11347`), and other improvements for  ``btrfs`` (:issue:`11320`), ``cryptsetup`` (:issue:`11315`), ``git`` (:issue:`11319`, :issue:`11322`, :issue:`11323`), ``jj`` (:issue:`11046`), and ``systemd-analyze`` (:issue:`11314`).
@@ -300,7 +301,7 @@ Interactive improvements
 New or improved bindings
 ^^^^^^^^^^^^^^^^^^^^^^^^
 - When the cursor is on a command that resolves to an executable script, :kbd:`alt-o` will now open that script in your editor (:issue:`10266`).
-- During up-arrow history search, :kbd:`shift-delete` will delete the current search item and move to the next older item. Previously this was only supported in the history pager. 
+- During up-arrow history search, :kbd:`shift-delete` will delete the current search item and move to the next older item. Previously this was only supported in the history pager.
 - :kbd:`shift-delete` will also remove the currently-displayed autosuggestion from history, and remove it as a suggestion.
 - :kbd:`ctrl-Z` (also known as :kbd:`ctrl-shift-z`) is now bound to redo.
 - Some improvements to the :kbd:`alt-e` binding which edits the command line in an external editor:

--- a/doc_src/cmds/bind.rst
+++ b/doc_src/cmds/bind.rst
@@ -326,6 +326,9 @@ The following special input functions are available:
 ``or``
     only execute the next function if the previous did not succeed (note: only some functions report failure)
 
+``pager-show-search``
+    shows the search field if the completions pager is visible.
+
 ``pager-toggle-search``
     toggles the search field if the completions pager is visible; or if used after ``history-pager``, search forwards in time.
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -186,6 +186,7 @@ const INPUT_FUNCTION_METADATA: &[InputFunctionMetadata] = &[
     make_md(L!("kill-word"), ReadlineCmd::KillWord),
     make_md(L!("nextd-or-forward-word"), ReadlineCmd::NextdOrForwardWord),
     make_md(L!("or"), ReadlineCmd::FuncOr),
+    make_md(L!("pager-show-search"), ReadlineCmd::PagerShowSearch),
     make_md(L!("pager-toggle-search"), ReadlineCmd::PagerToggleSearch),
     make_md(L!("prevd-or-backward-word"), ReadlineCmd::PrevdOrBackwardWord),
     make_md(L!("redo"), ReadlineCmd::Redo),

--- a/src/input_common.rs
+++ b/src/input_common.rs
@@ -82,6 +82,7 @@ pub enum ReadlineCmd {
     YankPop,
     Complete,
     CompleteAndSearch,
+    PagerShowSearch,
     PagerToggleSearch,
     BeginningOfHistory,
     EndOfHistory,

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -2787,6 +2787,24 @@ impl<'a> Reader<'a> {
                     self.compute_and_apply_completions(c);
                 }
             }
+            rl::PagerShowSearch => {
+                if let Some(history_pager) = &self.history_pager {
+                    if history_pager.start == 0 {
+                        self.flash(0..self.command_line.len())
+                    }
+                    return;
+                }
+                if !self.pager.is_empty() {
+                    let sfs = self.pager.is_search_field_shown();
+                    self.pager.set_search_field_shown(true);
+                    self.pager.set_fully_disclosed();
+
+                    // Begin navigating if we were not searching previously.
+                    if !sfs && !self.is_navigating_pager_contents() {
+                        self.select_completion_in_direction(SelectionMotion::South, false);
+                    }
+                }
+            }
             rl::PagerToggleSearch => {
                 if let Some(history_pager) = &self.history_pager {
                     if history_pager.start == 0 {


### PR DESCRIPTION
## Description

Adds a readline command `pager-show-search` that shows the search when a pager is visible.

Differences with existing commands:

- `complete-and-search`: it does not select the last item in pager.
- `pager-toggle-search`: it always shows rather than toggling show/hide; it does not select the next item if search is already shown.

Primarily intended to be called after `complete`.

Fixes issue #11449.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
