### PR TITLE
completion(winetricks): redirect winetricks list-all sderr to /dev/null

### DIFF
--- a/share/completions/winetricks.fish
+++ b/share/completions/winetricks.fish
@@ -1,5 +1,5 @@
 function __fish_winetricks__complete_verbs
-    winetricks list-all |
+    winetricks list-all 2>/dev/null |
         string match --invert --regex '^==' |
         string match --invert --regex '^(apps|dlls|fonts|games|settings)$' |
         string replace --regex '(\S+)\s+(.+)' '$1\t$2'


### PR DESCRIPTION
## Description

The command `winetricks list-all` used to generate completions is kind of slow, and hitting Ctrl + C while fish is calling it generates an excessive verbose output that comes from winetricks.

Fixes this by redirection stderr to /dev/null.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
