### PR TITLE
Update nix to 0.30.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,9 +175,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "lock_api"
@@ -218,9 +218,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "nix"
-version = "0.29.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ libc = "0.2"
 # disabling default features uses the stdlib instead, but it doubles the time to rewrite the history
 # files as of 22 April 2024.
 lru = "0.13.0"
-nix = { version = "0.29.0", default-features = false, features = [
+nix = { version = "0.30.1", default-features = false, features = [
     "event",
     "inotify",
     "resource",

--- a/src/common.rs
+++ b/src/common.rs
@@ -1340,7 +1340,7 @@ fn can_be_encoded(wc: char) -> bool {
 /// Return the number of bytes read, or 0 on EOF, or an error.
 pub fn read_blocked(fd: RawFd, buf: &mut [u8]) -> nix::Result<usize> {
     loop {
-        let res = nix::unistd::read(fd, buf);
+        let res = nix::unistd::read(unsafe { BorrowedFd::borrow_raw(fd) }, buf);
         if let Err(nix::Error::EINTR) = res {
             continue;
         }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -32,6 +32,7 @@ use std::io::BufReader;
 use std::num::NonZeroUsize;
 use std::ops::ControlFlow;
 use std::ops::Range;
+use std::os::fd::BorrowedFd;
 use std::os::fd::RawFd;
 use std::pin::Pin;
 use std::rc::Rc;
@@ -797,7 +798,7 @@ fn read_ni(parser: &Parser, fd: RawFd, io: &IoChain) -> Result<(), ErrorCode> {
     loop {
         let mut buff = [0_u8; 4096];
 
-        match nix::unistd::read(fd, &mut buff) {
+        match nix::unistd::read(unsafe { BorrowedFd::borrow_raw(fd) }, &mut buff) {
             Ok(0) => {
                 // EOF.
                 break;

--- a/src/tests/fd_monitor.rs
+++ b/src/tests/fd_monitor.rs
@@ -61,7 +61,7 @@ impl ItemMaker {
 
     fn callback(&self, fd: &mut AutoCloseFd) {
         let mut buf = [0u8; 1024];
-        let res = nix::unistd::read(fd.as_raw_fd(), &mut buf);
+        let res = nix::unistd::read(&fd, &mut buf);
         let amt = res.expect("read error!");
         self.length_read.fetch_add(amt as usize, Ordering::Relaxed);
         let was_closed = amt == 0;

--- a/src/topic_monitor.rs
+++ b/src/topic_monitor.rs
@@ -243,7 +243,7 @@ impl BinarySemaphore {
                         let _ = FdReadableSet::is_fd_readable(fd, Timeout::Forever);
                     }
                     let mut ignored: u8 = 0;
-                    match unistd::read(fd, std::slice::from_mut(&mut ignored)) {
+                    match unistd::read(&pipes.read, std::slice::from_mut(&mut ignored)) {
                         Ok(1) => break,
                         Ok(_) => continue,
                         // EAGAIN should only be possible if TSAN workarounds have been applied

--- a/src/universal_notifier/notifyd.rs
+++ b/src/universal_notifier/notifyd.rs
@@ -5,7 +5,7 @@ use crate::universal_notifier::UniversalNotifier;
 use crate::wchar::prelude::*;
 use libc::{c_char, c_int};
 use std::ffi::CString;
-use std::os::fd::RawFd;
+use std::os::fd::{BorrowedFd, RawFd};
 
 extern "C" {
     fn notify_register_file_descriptor(
@@ -114,7 +114,8 @@ impl UniversalNotifier for NotifydNotifier {
         let mut read_something = false;
         let mut buff: [u8; 64] = [0; 64];
         loop {
-            let res = nix::unistd::read(self.notify_fd, &mut buff);
+            let res =
+                nix::unistd::read(unsafe { BorrowedFd::borrow_raw(self.notify_fd) }, &mut buff);
 
             if let Ok(amt_read) = res {
                 read_something |= amt_read > 0;


### PR DESCRIPTION
## Description

After `nix` updated to 0.30, all functions related to file descriptor accepts `impl AsFd`, e.g., `BorrowedFd`. This PR is a minimal update. It tries to use `impl AsFd` as long as possible, but uses `BorrowedFd` in some places. Yes it introduces `unsafe`, but doesn't introduce *new* unsafe code.

This PR also enables the code to compile directly on cygwin:)

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
