### PR TITLE
completions/cargo: strip ansi color codes

### DIFF
--- a/share/completions/cargo.fish
+++ b/share/completions/cargo.fish
@@ -1,20 +1,25 @@
 # Tab completion for cargo (https://github.com/rust-lang/cargo).
 
 ## --- WRITTEN MANUALLY ---
-set -l __fish_cargo_subcommands (cargo --list 2>&1 | string replace -rf '^\s+([^\s]+)\s*(.*)' '$1\t$2' | string escape)
+
+function __fish_cargo
+    cargo --color=never $argv
+end
+
+set -l __fish_cargo_subcommands (__fish_cargo --list 2>&1 | string replace -rf '^\s+([^\s]+)\s*(.*)' '$1\t$2' | string escape)
 
 complete -c cargo -f -c cargo -n __fish_use_subcommand -a "$__fish_cargo_subcommands"
 complete -c cargo -x -c cargo -n '__fish_seen_subcommand_from help' -a "$__fish_cargo_subcommands"
 
 for x in bench b build c check rustc t test
-    complete -c cargo -x -n "__fish_seen_subcommand_from $x" -l bench -a "(cargo bench --bench 2>&1 | string replace -rf '^\s+' '')"
+    complete -c cargo -x -n "__fish_seen_subcommand_from $x" -l bench -a "(__fish_cargo bench --bench 2>&1 | string replace -rf '^\s+' '')"
     complete -c cargo -n "__fish_seen_subcommand_from $x" -l lib -d 'Only this package\'s library'
-    complete -c cargo -x -n "__fish_seen_subcommand_from $x" -l test -a "(cargo test --test 2>&1 | string replace -rf '^\s+' '')"
+    complete -c cargo -x -n "__fish_seen_subcommand_from $x" -l test -a "(__fish_cargo test --test 2>&1 | string replace -rf '^\s+' '')"
 end
 
 for x in bench b build c check r run rustc t test
-    complete -c cargo -x -n "__fish_seen_subcommand_from $x" -l bin -a "(cargo run --bin 2>&1 | string replace -rf '^\s+' '')"
-    complete -c cargo -x -n "__fish_seen_subcommand_from $x" -l example -a "(cargo run --example 2>&1 | string replace -rf '^\s+' '')"
+    complete -c cargo -x -n "__fish_seen_subcommand_from $x" -l bin -a "(__fish_cargo run --bin 2>&1 | string replace -rf '^\s+' '')"
+    complete -c cargo -x -n "__fish_seen_subcommand_from $x" -l example -a "(__fish_cargo run --example 2>&1 | string replace -rf '^\s+' '')"
 end
 
 # If using rustup, get the list of installed targets from there. Otherwise print all targets.
@@ -38,18 +43,18 @@ end
 
 function __fish_cargo_features
     if command -q jq
-        cargo read-manifest | jq -r '.features | keys | .[]' | __fish_concat_completions
+        __fish_cargo read-manifest | jq -r '.features | keys | .[]' | __fish_concat_completions
     else if set -l python (__fish_anypython)
-        cargo read-manifest | command $python -Sc "import sys, json"\n"print(*json.load(sys.stdin)['features'].keys(), sep='\n')" | __fish_concat_completions
+        __fish_cargo read-manifest | command $python -Sc "import sys, json"\n"print(*json.load(sys.stdin)['features'].keys(), sep='\n')" | __fish_concat_completions
     end
 end
 
 function __fish_cargo_packages
     if command -q jq
-        cargo metadata --no-deps --format-version 1 | jq -r '.packages | .[] | .name' | __fish_concat_completions
+        __fish_cargo metadata --no-deps --format-version 1 | jq -r '.packages | .[] | .name' | __fish_concat_completions
     else if set -l python (__fish_anypython)
-        cargo metadata --no-deps --format-version 1 |
-        command $python -Sc "import sys, json"\n"print(*[x['name'] for x in json.load(sys.stdin)['packages']], sep='\n')"
+        __fish_cargo metadata --no-deps --format-version 1 |
+            command $python -Sc "import sys, json"\n"print(*[x['name'] for x in json.load(sys.stdin)['packages']], sep='\n')"
     end
 end
 complete -c cargo -n '__fish_seen_subcommand_from run test build debug check clippy' -s p -l package \
@@ -60,7 +65,7 @@ complete -c cargo -n '__fish_seen_subcommand_from run test build debug check cli
 complete -c cargo -n __fish_use_subcommand -l explain -d 'Run `rustc --explain CODE`'
 complete -c cargo -n __fish_use_subcommand -l color -d 'Coloring: auto, always, never'
 complete -c cargo -n __fish_use_subcommand -l config -d 'Override a configuration value (unstable)'
-complete -c cargo -n __fish_use_subcommand -s Z -d 'Unstable (nightly-only) flags to Cargo, see \'cargo -Z help\' for details' -xa '(cargo -Z help | string replace -rf \'^\s*-Z (\S+)\s+(.*)\' \'$1\t$2\')'
+complete -c cargo -n __fish_use_subcommand -s Z -d 'Unstable (nightly-only) flags to Cargo, see \'cargo -Z help\' for details' -xa '(__fish_cargo -Z help | string replace -rf \'^\s*-Z (\S+)\s+(.*)\' \'$1\t$2\')'
 complete -c cargo -n __fish_use_subcommand -s V -l version -d 'Print version info and exit'
 complete -c cargo -n __fish_use_subcommand -l list -d 'List installed commands'
 complete -c cargo -n __fish_use_subcommand -s v -l verbose -d 'Use verbose output (-vv very verbose/build.rs output)'
@@ -841,8 +846,8 @@ if command -q cargo-asm
     # Warning: this will build the project and can take time! We make sure to only call it if it's not a switch so completions
     # for --foo will always be fast.
     if command -q timeout
-        complete -c cargo -n "__fish_seen_subcommand_from asm; and not __fish_is_switch" -xa "(timeout 1 cargo asm)"
+        complete -c cargo -n "__fish_seen_subcommand_from asm; and not __fish_is_switch" -xa "(timeout 1 __fish_cargo asm)"
     else
-        complete -c cargo -n "__fish_seen_subcommand_from asm; and not __fish_is_switch" -xa "(cargo asm)"
+        complete -c cargo -n "__fish_seen_subcommand_from asm; and not __fish_is_switch" -xa "(__fish_cargo asm)"
     end
 end


### PR DESCRIPTION
## Description

On my current setup, cargo completions contain ANSI colour codes. The very first `cargo --list` command outputs coloured text, and nothing ever cleans it up.

![20250506-130124](https://github.com/user-attachments/assets/119b4fab-0b52-4f57-a180-c58d77e624cf)

I'm not sure if it's a quirk on my setup specifically. I can't find any environment variable or config file that enforces coloured output even though the stdout/stderr of that command is sent to a pipe.

Regardless, adding that `--color never` flag ensures that we work on colourless text, and that the completion is what we expect.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
