### PR TITLE
Unset SYSTEMD_COLORS for systemd completion

### DIFF
--- a/share/functions/__fish_systemctl.fish
+++ b/share/functions/__fish_systemctl.fish
@@ -1,4 +1,7 @@
 function __fish_systemctl --description 'Call systemctl with some options from the current commandline'
+    # We don't want to complete with ANSI color codes
+    set -lu SYSTEMD_COLORS
+
     # These options are all global - before or after subcommand/arguments.
     # There's a bunch of long-only options in here, so we need to be creative with the mandatory short version.
     set -l opts t/type= s-state= p/property= a/all

--- a/share/functions/__fish_systemctl_services.fish
+++ b/share/functions/__fish_systemctl_services.fish
@@ -1,4 +1,7 @@
 function __fish_systemctl_services
+    # We don't want to complete with ANSI color codes
+    set -lu SYSTEMD_COLORS
+
     if type -q systemctl
         if __fish_contains_opt user
             systemctl --user list-unit-files --full --no-legend --no-pager --plain --type=service 2>/dev/null $argv | string split -f 1 ' '

--- a/share/functions/__fish_systemd_machine_images.fish
+++ b/share/functions/__fish_systemd_machine_images.fish
@@ -1,6 +1,9 @@
 # Like for running machines, I'm assuming machinectl doesn't allow spaces in image names
 # This does not include the special image ".host" since it isn't valid for most operations
 function __fish_systemd_machine_images
+    # We don't want to complete with ANSI color codes
+    set -lu SYSTEMD_COLORS
+
     machinectl --no-legend --no-pager list-images | while read -l a b
         echo $a
     end

--- a/share/functions/__fish_systemd_machines.fish
+++ b/share/functions/__fish_systemd_machines.fish
@@ -1,5 +1,8 @@
 # It seems machinectl will eliminate spaces from machine names so we don't need to handle that
 function __fish_systemd_machines
+    # We don't want to complete with ANSI color codes
+    set -lu SYSTEMD_COLORS
+
     machinectl --no-legend --no-pager list --all | while read -l a b
         echo $a
     end


### PR DESCRIPTION
## Description
Fixes an issue where systemctl and other systemd commands completions are prefixed by ANSI color escape codes

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->

## Notes:
Since dependencies has changed an Nix is a bit finicky with cargoHashes and stuff I cloned 4.0.2 which I'm currently using and applied this patch which i then cherry picked to master, but considering the change is only in fish code it should be irrelevant.

It was a bit unclear from the documentation if ```set -lu``` would work without unexporting the variable for the running shell but tests on my machine keeps SYSTEMD_COLORS=true in my shell.

Last minute thing: Should i use set -lu or set -fu?