### PR TITLE
Remove source locations from translations

### DIFF
--- a/build_tools/fish_xgettext.fish
+++ b/build_tools/fish_xgettext.fish
@@ -69,7 +69,7 @@ end
 
 # This regex handles descriptions for `complete` and `function` statements. These messages are not
 # particularly important to translate. Hence the "implicit" label.
-set -l implicit_regex '(?:^| +)(?:complete|function).*? (?:-d|--description) (([\'"]).+?(?<!\\\\)\\2).*'
+set -l implicit_regex '^(?:\s|and |or )*(?:complete|function).*? (?:-d|--description) (([\'"]).+?(?<!\\\\)\\2).*'
 extract_fish_script_messages implicit $implicit_regex
 
 # This regex handles explicit requests to translate a message. These are more important to translate


### PR DESCRIPTION
Source locations (file name and line number) where a string originates is not required by gettext tooling. It can help translators to identify context, but the value of this is reduced by our lack of context support, meaning that all occurrences of a string will receive the same translation. Translators can use `rg` or similar tools to find the source locations. For further details see this thread:
https://github.com/fish-shell/fish-shell/pull/11463#discussion_r2079378627

The main advantage is that updates to the PO files are now only necessary when the source strings change, which greatly reduces the diff noise.

A secondary benefit is that the string extraction logic is simplified. We can now directly extract the strings from fish scripts, and several issues are fixed alongside, mostly related to quoting. The regex for extracting implicit messages from fish scripts has been tweaked to ignore commented-out lines, and properly support lines starting with `and`/`or`.

## TODOs:
- [ ] Do we want alphabetically sorted messages? At the moment, there are 3 sections (Rust strings, explicit fish strings, implicit fish strings) which get sorted individually. I think it's useful to have the most important messages at the start of the file, but I'm not sure if alphabetic sorting is desirable.