### PR TITLE
Completion cache

### DIFF
--- a/share/completions/flatpak.fish
+++ b/share/completions/flatpak.fish
@@ -58,22 +58,12 @@ function __fish_flatpak
     flatpak $argv | string replace -rf '^([^A-Z].*?)(?: +|\t)(.*?)\s*$' '$1\t$2'
 end
 
-function __fish_print_flatpak_packages
-    set -l xdg_cache_home (__fish_make_cache_dir)
-    or return
-    set -l cache_file $xdg_cache_home/flatpak
-    __fish_cache_read $cache_file 250 && return
-    __fish_cache_put $cache_file
-    __fish_flatpak remote-ls --columns=application,name >$cache_file &
-    return 0
-end
-
 complete -f -c flatpak -n "__fish_seen_subcommand_from run" -a "(__fish_flatpak list --app --columns=application,name)"
 complete -f -c flatpak -n "__fish_seen_subcommand_from info uninstall" -a "(__fish_flatpak list --columns=application,name)"
 complete -f -c flatpak -n "__fish_seen_subcommand_from enter kill" -a "(__fish_flatpak ps --columns=instance,application)"
 complete -f -c flatpak -n "__fish_seen_subcommand_from remote-info remote-ls remote-modify remote-delete" -a "(__fish_flatpak remotes --columns=name,title)"
 
-complete -c flatpak -n '__fish_seen_subcommand_from install' -xa "(__fish_print_flatpak_packages)"
+complete -c flatpak -n '__fish_seen_subcommand_from install' -xa "(__fish_cached -t 250 __fish_flatpak remote-ls --columns=application,name)"
 
 # Plenty of the other stuff is too free-form to complete (e.g. remote-add).
 complete -f -c flatpak -s h -l help

--- a/share/completions/flatpak.fish
+++ b/share/completions/flatpak.fish
@@ -62,14 +62,7 @@ function __fish_print_flatpak_packages
     set -l xdg_cache_home (__fish_make_cache_dir)
     or return
     set -l cache_file $xdg_cache_home/flatpak
-    if test -f $cache_file
-        cat $cache_file
-        set -l age (path mtime -R -- $cache_file)
-        set -l max_age 250
-        if test $age -lt $max_age
-            return
-        end
-    end
+    __fish_cache_read $cache_file 250 && return
     __fish_cache_put $cache_file
     __fish_flatpak remote-ls --columns=application,name >$cache_file &
     return 0

--- a/share/functions/__fish_cache_read.fish
+++ b/share/functions/__fish_cache_read.fish
@@ -1,0 +1,10 @@
+function __fish_cache_read -a cache_file max_age
+    if not test -f $cache_file
+        return 1
+    end
+    set -l age (path mtime --relative $cache_file)
+    if test -n "$max_age" && test $age -gt $max_age
+        return 1
+    end
+    cat $cache_file
+end

--- a/share/functions/__fish_cached.fish
+++ b/share/functions/__fish_cached.fish
@@ -1,0 +1,21 @@
+function __fish_cached --description "Cache the command output for a given amount of time"
+
+    argparse --stop-nonopt 't/max_age=' 'k/cache_key=' -- $argv
+
+    if set -q _flag_cache_key
+        set cache_key $_flag_cache_key
+    else
+        set cache_key (string split ' ' "$argv" | head -1)
+    end
+    set cache_dir (__fish_make_cache_dir)
+    set cache_file (path normalize $cache_dir/$cache_key)
+    set cache_age (path mtime --relative $cache_file)
+
+    if not test -f $cache_file
+        or test $cache_age -gt $_flag_max_age
+
+        eval "$argv" >$cache_file
+        __fish_cache_put $cache_file
+    end
+    cat $cache_file
+end

--- a/share/functions/__fish_print_eopkg_packages.fish
+++ b/share/functions/__fish_print_eopkg_packages.fish
@@ -4,26 +4,11 @@ function __fish_print_eopkg_packages
     argparse i/installed -- $argv
     or return 1
 
-    set -l xdg_cache_home (__fish_make_cache_dir)
-    or return
-
-    # If the cache is less than max_age, we do not recalculate it
-    # Determine whether to print installed/available packages
-
     if set -q _flag_installed
-        set -l cache_file $xdg_cache_home/eopkg-installed
-        __fish_cache_read $cache_file 500 && return
-        __fish_cache_put $cache_file
-        # Remove package version information from output and pipe into cache file
-        eopkg list-installed -N | cut -d ' ' -f 1 >$cache_file &
+        __fish_cached -t 500 -k eopkg-installed -- eopkg list-installed -N \| cut -d ' ' -f 1
         return 0
     else
-        set -l cache_file $xdg_cache_home/eopkg-available
-        __fish_cache_read $cache_file 500 && return
-        __fish_cache_put $cache_file
-        # Remove package version information from output and pipe into cache file
-        eopkg list-available -N | cut -d ' ' -f 1 >$cache_file &
+        __fish_cached -t 500 -k eopkg-available -- eopkg list-available -N \| cut -d ' ' -f 1
         return 0
     end
-    return 1
 end

--- a/share/functions/__fish_print_eopkg_packages.fish
+++ b/share/functions/__fish_print_eopkg_packages.fish
@@ -12,30 +12,14 @@ function __fish_print_eopkg_packages
 
     if set -q _flag_installed
         set -l cache_file $xdg_cache_home/eopkg-installed
-        if test -f $cache_file
-            cat $cache_file
-            set -l age (path mtime -R -- $cache_file)
-            set -l max_age 500
-            if test $age -lt $max_age
-                return 0
-            end
-        end
-
+        __fish_cache_read $cache_file 500 && return
         __fish_cache_put $cache_file
         # Remove package version information from output and pipe into cache file
         eopkg list-installed -N | cut -d ' ' -f 1 >$cache_file &
         return 0
     else
         set -l cache_file $xdg_cache_home/eopkg-available
-        if test -f $cache_file
-            cat $cache_file
-            set -l age (path mtime -R -- $cache_file)
-            set -l max_age 500
-            if test $age -lt $max_age
-                return 0
-            end
-        end
-
+        __fish_cache_read $cache_file 500 && return
         __fish_cache_put $cache_file
         # Remove package version information from output and pipe into cache file
         eopkg list-available -N | cut -d ' ' -f 1 >$cache_file &

--- a/share/functions/__fish_print_pacman_packages.fish
+++ b/share/functions/__fish_print_pacman_packages.fish
@@ -5,15 +5,8 @@ function __fish_print_pacman_packages
     argparse i/installed -- $argv
     or return 1
 
-    set -l xdg_cache_home (__fish_make_cache_dir)
-    or return
-
     if not set -q _flag_installed
-        set -l cache_file $xdg_cache_home/pacman
-        __fish_cache_read $cache_file 250 && return
-        __fish_cache_put $cache_file
-        # prints: <package name>	Package
-        pacman -Ssq | sed -e 's/$/\t'Package'/' | tee $cache_file
+        __fish_cached -t 250 -- pacman -Ssq \| sed 's/\$/\tPackage/'
         return 0
     else
         pacman -Q | string replace ' ' \t

--- a/share/functions/__fish_print_pacman_packages.fish
+++ b/share/functions/__fish_print_pacman_packages.fish
@@ -13,7 +13,7 @@ function __fish_print_pacman_packages
         __fish_cache_read $cache_file 250 && return
         __fish_cache_put $cache_file
         # prints: <package name>	Package
-        pacman -Ssq | sed -e 's/$/\t'Package'/' >$cache_file &
+        pacman -Ssq | sed -e 's/$/\t'Package'/' | tee $cache_file
         return 0
     else
         pacman -Q | string replace ' ' \t

--- a/share/functions/__fish_print_pacman_packages.fish
+++ b/share/functions/__fish_print_pacman_packages.fish
@@ -10,14 +10,7 @@ function __fish_print_pacman_packages
 
     if not set -q _flag_installed
         set -l cache_file $xdg_cache_home/pacman
-        if test -f $cache_file
-            cat $cache_file
-            set -l age (path mtime -R -- $cache_file)
-            set -l max_age 250
-            if test $age -lt $max_age
-                return
-            end
-        end
+        __fish_cache_read $cache_file 250 && return
         __fish_cache_put $cache_file
         # prints: <package name>	Package
         pacman -Ssq | sed -e 's/$/\t'Package'/' >$cache_file &

--- a/share/functions/__fish_print_port_packages.fish
+++ b/share/functions/__fish_print_port_packages.fish
@@ -6,15 +6,7 @@ function __fish_print_port_packages
     or return
 
     set -l cache_file $xdg_cache_home/port
-    if test -f $cache_file
-        cat $cache_file
-        set -l age (path mtime -R -- $cache_file)
-        set -l max_age 250
-        if test $age -lt $max_age
-            return
-        end
-    end
-
+    __fish_cache_read $cache_file 250 && return
     __fish_cache_put $cache_file
     # Remove trailing whitespace and pipe into cache file
     printf "all\ncurrent\nactive\ninactive\ninstalled\nuninstalled\noutdated" >$cache_file

--- a/share/functions/__fish_print_rpm_packages.fish
+++ b/share/functions/__fish_print_rpm_packages.fish
@@ -5,29 +5,14 @@ function __fish_print_rpm_packages
     argparse i/installed -- $argv
     or return 1
 
-    set -l xdg_cache_home (__fish_make_cache_dir)
-    or return
-
     if type -q -f /usr/share/yum-cli/completion-helper.py
         # If the cache is less than six hours old, we do not recalculate it
-        set -l cache_file $xdg_cache_home/yum
-        __fish_cache_read $cache_file 21600 && return
-        __fish_cache_put $cache_file
-        # Remove package version information from output and pipe into cache file
-        /usr/share/yum-cli/completion-helper.py list all -d 0 -C | sed "s/\..*/\tPackage/" >$cache_file &
+        __fish_cached -t 21600 -k yum -- '/usr/share/yum-cli/completion-helper.py list -C | sed "s/\..*/\tPackage/"'
         return
     end
 
-    # Rpm is too slow for this job, so we set it up to do completions
-    # as a background job and cache the results.
     if type -q -f rpm
-        # If the cache is less than five minutes old, we do not recalculate it
-        set -l cache_file $xdg_cache_home/rpm
-        __fish_cache_read $cache_file 250 && return
-
-        # Remove package version information from output and pipe into cache file
-        __fish_cache_put $cache_file
-        rpm -qa | sed -e 's/-[^-]*-[^-]*$/\t'Package'/' >$cache_file &
+        __fish_cached -t 250 -- rpm -qa | sed -e 's/-[^-]*-[^-]*$/\tPackage/'
         return
     end
 end

--- a/share/functions/__fish_print_rpm_packages.fish
+++ b/share/functions/__fish_print_rpm_packages.fish
@@ -11,15 +11,7 @@ function __fish_print_rpm_packages
     if type -q -f /usr/share/yum-cli/completion-helper.py
         # If the cache is less than six hours old, we do not recalculate it
         set -l cache_file $xdg_cache_home/yum
-        if test -f $cache_file
-            cat $cache_file
-            set -l age (path mtime -R -- $cache_file)
-            set -l max_age 21600
-            if test $age -lt $max_age
-                return
-            end
-        end
-
+        __fish_cache_read $cache_file 21600 && return
         __fish_cache_put $cache_file
         # Remove package version information from output and pipe into cache file
         /usr/share/yum-cli/completion-helper.py list all -d 0 -C | sed "s/\..*/\tPackage/" >$cache_file &
@@ -31,14 +23,7 @@ function __fish_print_rpm_packages
     if type -q -f rpm
         # If the cache is less than five minutes old, we do not recalculate it
         set -l cache_file $xdg_cache_home/rpm
-        if test -f $cache_file
-            cat $cache_file
-            set -l age (path mtime -R -- $cache_file)
-            set -l max_age 250
-            if test $age -lt $max_age
-                return
-            end
-        end
+        __fish_cache_read $cache_file 250 && return
 
         # Remove package version information from output and pipe into cache file
         __fish_cache_put $cache_file

--- a/share/functions/__fish_print_xbps_packages.fish
+++ b/share/functions/__fish_print_xbps_packages.fish
@@ -10,14 +10,7 @@ function __fish_print_xbps_packages
 
     if not set -q _flag_installed
         set -l cache_file $xdg_cache_home/xbps
-        if test -f $cache_file
-            set -l age (path mtime -R -- $cache_file)
-            set -l max_age 300
-            if test $age -lt $max_age
-                cat $cache_file
-                return
-            end
-        end
+        __fish_cache_read $cache_file 300 && return
         __fish_cache_put $cache_file
         # prints: <package name>	Package
         xbps-query -Rs "" | sed 's/^... \([^ ]*\)-.* .*/\1/; s/$/\t'Package'/' | tee $cache_file

--- a/share/functions/__fish_print_xbps_packages.fish
+++ b/share/functions/__fish_print_xbps_packages.fish
@@ -5,15 +5,8 @@ function __fish_print_xbps_packages
     argparse i/installed -- $argv
     or return 1
 
-    set -l xdg_cache_home (__fish_make_cache_dir)
-    or return
-
     if not set -q _flag_installed
-        set -l cache_file $xdg_cache_home/xbps
-        __fish_cache_read $cache_file 300 && return
-        __fish_cache_put $cache_file
-        # prints: <package name>	Package
-        xbps-query -Rs "" | sed 's/^... \([^ ]*\)-.* .*/\1/; s/$/\t'Package'/' | tee $cache_file
+        __fish_cached -t 300 -- "xbps-query -Rs '' | sed 's/^... \([^ ]*\)-.* .*/\1/; s/\$/\tPackage/'"
         return 0
     else
         xbps-query -l | sed 's/^.. \([^ ]*\)-.* .*/\1/' # TODO: actually put package versions in tab for locally installed packages


### PR DESCRIPTION
## Description

Add `__fish_cache_read` and`__fish_cached` functions and replace cache implementations with the new cache functions.

## Tests

- [x] completion cache for `pacman` command
- [x] completion cache for `flatpak` command
- [ ] completion cache for `yum` command
- [ ] completion cache for `rpm` command
- [ ] completion cache for `xbps` command
