### PR TITLE
Optimize xgettext performance

### DIFF
--- a/build_tools/fish_xgettext.fish
+++ b/build_tools/fish_xgettext.fish
@@ -15,37 +15,40 @@ begin
     echo ""
 end >$output_file
 
-set -l tmpfile (mktemp)
+set -l cargo_expanded_file (mktemp)
 # This is a gigantic crime.
 # We use cargo-expand to get all our wgettext invocations.
 # This might be replaced once we have a tool which properly handles macro expansions.
-begin cargo expand --lib; for f in fish fish_indent fish_key_reader; cargo expand --bin $f; end; end >$tmpfile
+begin
+    cargo expand --lib
+    for f in fish fish_indent fish_key_reader
+        cargo expand --bin $f
+    end
+end >$cargo_expanded_file
+
+set -l rust_string_file (mktemp)
 
 # Extract any gettext call
-set -l strs (grep -A1 wgettext_static_str <$tmpfile |
-             grep 'widestring::internals::core::primitive::str =' |
-             string match -rg '"(.*)"' | string match -rv '^%ls$|^$' |
-             # escaping difference between gettext and cargo-expand: single-quotes
-             string replace -a "\'" "'")
+grep -A1 wgettext_static_str <$cargo_expanded_file |
+    grep 'widestring::internals::core::primitive::str =' |
+    string match -rg '"(.*)"' |
+    string match -rv '^%ls$|^$' |
+    # escaping difference between gettext and cargo-expand: single-quotes
+    string replace -a "\'" "'" >$rust_string_file
 
 # Extract any constants
-set -a strs (grep -Ev 'BUILD_VERSION:|PACKAGE_NAME' <$tmpfile |
-             grep -E 'const [A-Z_]*: &str = "(.*)"' |
-             sed -E -e 's/^.*const [A-Z_]*: &str = "(.*)".*$/\1/' -e "s_\\\'_'_g")
+grep -Ev 'BUILD_VERSION:|PACKAGE_NAME' <$cargo_expanded_file |
+    grep -E 'const [A-Z_]*: &str = "(.*)"' |
+    sed -E -e 's/^.*const [A-Z_]*: &str = "(.*)".*$/\1/' -e "s_\\\'_'_g" >>$rust_string_file
 
-rm $tmpfile
+rm $cargo_expanded_file
 
 # Sort the extracted strings and remove duplicates.
-# This is optional.
-set -l strs (string join \n -- $strs | sort -u)
+# Then, transform them into the po format
+sort -u $rust_string_file |
+    sed -E 's/^(.*)$/msgid "\1"\nmsgstr ""\n/' >>$output_file
 
-# We construct messages.pot ourselves instead of forcing this into msgmerge or whatever.
-# The escaping so far works out okay.
-for str in $strs
-    echo "msgid \"$str\""
-    echo 'msgstr ""'
-    echo ""
-end >>$output_file
+rm $rust_string_file
 
 function extract_fish_script_messages --argument-names regex
 
@@ -72,7 +75,9 @@ function extract_fish_script_messages --argument-names regex
             string unescape |
             string replace --all '\\' '\\\\' |
             string replace --all '"' '\\"'
-    end | sort -u | string replace --regex '^(.*)$' 'msgid "$1"'\n'msgstr ""'\n >>$output_file
+    end |
+        sort -u |
+        sed -E 's/^(.*)$/msgid "\1"\nmsgstr ""\n/' >>$output_file
 end
 
 # This regex handles explicit requests to translate a message. These are more important to translate

--- a/build_tools/fish_xgettext.fish
+++ b/build_tools/fish_xgettext.fish
@@ -58,26 +58,23 @@ function extract_fish_script_messages --argument-names regex
     # We work around this issue by manually writing the file content.
 
     # Steps:
-    # 1. We extract strings to be translated from the file f and drop the rest. This step
+    # 1. We extract strings to be translated from the relevant files and drop the rest. This step
     #    depends on the regex matching the entire line, and the first capture group matching the
     #    string.
     # 2. We unescape. This gets rid of some escaping necessary in fish strings.
-    # 3. Single backslashes are replaced by double backslashes. This results in the backslashes
-    #    being interpreted as literal backslashes by gettext tooling.
-    # 4. Double quotes are escaped, such that they are not interpreted as the start or end of
-    #    a msgid.
-    # 5. The resulting strings are sorted alphabetically. This step is optional. Not sorting would
+    # 3. The resulting strings are sorted alphabetically. This step is optional. Not sorting would
     #    result in strings from the same file appearing together. Removing duplicates is also
     #    optional, since msguniq takes care of that later on as well.
+    # 4. Single backslashes are replaced by double backslashes. This results in the backslashes
+    #    being interpreted as literal backslashes by gettext tooling.
+    # 5. Double quotes are escaped, such that they are not interpreted as the start or end of
+    #    a msgid.
     # 6. We transform the string into the format expected in a PO file.
-    for f in share/config.fish share/completions/*.fish share/functions/*.fish
-        string replace --filter --regex $regex '$1' <$f |
-            string unescape |
-            string replace --all '\\' '\\\\' |
-            string replace --all '"' '\\"'
-    end |
+    cat share/config.fish share/completions/*.fish share/functions/*.fish |
+        string replace --filter --regex $regex '$1' |
+        string unescape |
         sort -u |
-        sed -E 's/^(.*)$/msgid "\1"\nmsgstr ""\n/' >>$output_file
+        sed -E -e 's_\\\\_\\\\\\\\_g' -e 's_"_\\\\"_g' -e 's_^(.*)$_msgid "\1"\nmsgstr ""\n_' >>$output_file
 end
 
 # This regex handles explicit requests to translate a message. These are more important to translate

--- a/build_tools/fish_xgettext.fish
+++ b/build_tools/fish_xgettext.fish
@@ -29,8 +29,9 @@ set -l strs (grep -A1 wgettext_static_str <$tmpfile |
              string replace -a "\'" "'")
 
 # Extract any constants
-set -a strs (string match -rv 'BUILD_VERSION:|PACKAGE_NAME' <$tmpfile |
-             string match -rg 'const [A-Z_]*: &str = "(.*)"' | string replace -a "\'" "'")
+set -a strs (grep -Ev 'BUILD_VERSION:|PACKAGE_NAME' <$tmpfile |
+             grep -E 'const [A-Z_]*: &str = "(.*)"' |
+             sed -E -e 's/^.*const [A-Z_]*: &str = "(.*)".*$/\1/' -e "s_\\\'_'_g")
 
 rm $tmpfile
 


### PR DESCRIPTION
This should not result in any external behavioral difference. The goal is just to speed up the  `fish_xgettext.fish` script, and to clean it up a bit.

It takes my machine currently about 7 seconds to run the version of the script on master, and about 5.5 seconds on this branch. (Assuming cargo does not have to compile anything.) This is an absolute speedup of 1.5 seconds, or a relative one of 1.27.

If excluding the time it takes to run cargo-expand (about 4.5 seconds) it takes the rest of the script from 2.5 seconds to 1 second (relative speedup 2.5).

The `messages.pot` file produced by the script is unchanged.