### PR TITLE
Use separate lock file for history file accesses

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -1025,8 +1025,8 @@ msgid "Error reading script file '%s':"
 msgstr "Die Script-Datei '%s' kann nicht gelesen werden:"
 
 #, c-format
-msgid "Error when renaming history file: %s"
-msgstr "Fehler beim Umbenennen der Verlaufsdatei: %s"
+msgid "Error when renaming file: %s"
+msgstr ""
 
 #, c-format
 msgid "Error while reading file %ls\n"
@@ -1248,14 +1248,6 @@ msgstr ""
 
 msgid "List or remove functions"
 msgstr "Funktionen auflisten oder entfernen"
-
-#, c-format
-msgid "Locking the history file took too long (%.3f seconds)."
-msgstr "Sperren der Geschichts-Datei dauerte zu lang (%.3f Sekunden)."
-
-#, c-format
-msgid "Locking the universal var file took too long (%.3f seconds)."
-msgstr "Die Datei für universelle Variablen zu sperren dauerte zu lange (%.3f Sekunden)"
 
 msgid "Logical operations are not supported, use `test` instead"
 msgstr "Logikoperationen werden nicht unterstützt, nimm stattdessen `test`"
@@ -1519,6 +1511,10 @@ msgstr "Derzeit ausgewertete Funktion stoppen"
 msgid "Stop the innermost loop"
 msgstr "Innerste Schleife beenden"
 
+#
+msgid "Synchronized file access"
+msgstr ""
+
 msgid "Temporarily block delivery of events"
 msgstr "Ereignisweitergabe vorübergehend blockieren"
 
@@ -1624,20 +1620,8 @@ msgid "Unable to locate the %ls directory."
 msgstr ""
 
 #, c-format
-msgid "Unable to open universal variable file '%s': %s"
-msgstr "Die Universal-Variablen-Datei '%s' kann nicht geöffnet werden: %s"
-
-#, c-format
 msgid "Unable to read input file: %s"
 msgstr ""
-
-#, c-format
-msgid "Unable to rename file from '%ls' to '%ls': %s"
-msgstr "Konnte Datei '%ls' nicht zu '%ls' umbenennen: %s"
-
-#, c-format
-msgid "Unable to write to universal variables file '%ls': %s"
-msgstr "Die Universal-Variablen-Datei '%ls' kann nicht geschrieben werden: %s"
 
 msgid "Unexpected ')' for unopened parenthesis"
 msgstr ""
@@ -79191,6 +79175,30 @@ msgstr ""
 
 msgid "~ expansion"
 msgstr ""
+
+#, c-format
+#~ msgid "Error when renaming history file: %s"
+#~ msgstr "Fehler beim Umbenennen der Verlaufsdatei: %s"
+
+#, c-format
+#~ msgid "Locking the history file took too long (%.3f seconds)."
+#~ msgstr "Sperren der Geschichts-Datei dauerte zu lang (%.3f Sekunden)."
+
+#, c-format
+#~ msgid "Locking the universal var file took too long (%.3f seconds)."
+#~ msgstr "Die Datei für universelle Variablen zu sperren dauerte zu lange (%.3f Sekunden)"
+
+#, c-format
+#~ msgid "Unable to open universal variable file '%s': %s"
+#~ msgstr "Die Universal-Variablen-Datei '%s' kann nicht geöffnet werden: %s"
+
+#, c-format
+#~ msgid "Unable to rename file from '%ls' to '%ls': %s"
+#~ msgstr "Konnte Datei '%ls' nicht zu '%ls' umbenennen: %s"
+
+#, c-format
+#~ msgid "Unable to write to universal variables file '%ls': %s"
+#~ msgstr "Die Universal-Variablen-Datei '%ls' kann nicht geschrieben werden: %s"
 
 #~ msgid "builtin\n"
 #~ msgstr "Eingebauter Befehl\n"

--- a/po/en.po
+++ b/po/en.po
@@ -1023,7 +1023,7 @@ msgid "Error reading script file '%s':"
 msgstr ""
 
 #, c-format
-msgid "Error when renaming history file: %s"
+msgid "Error when renaming file: %s"
 msgstr ""
 
 #, c-format
@@ -1245,14 +1245,6 @@ msgstr ""
 
 msgid "List or remove functions"
 msgstr "List or remove functions"
-
-#, c-format
-msgid "Locking the history file took too long (%.3f seconds)."
-msgstr ""
-
-#, c-format
-msgid "Locking the universal var file took too long (%.3f seconds)."
-msgstr ""
 
 msgid "Logical operations are not supported, use `test` instead"
 msgstr ""
@@ -1516,6 +1508,10 @@ msgstr "Stop the currently evaluated function"
 msgid "Stop the innermost loop"
 msgstr "Stop the innermost loop"
 
+#
+msgid "Synchronized file access"
+msgstr ""
+
 msgid "Temporarily block delivery of events"
 msgstr "Temporarily block delivery of events"
 
@@ -1621,20 +1617,8 @@ msgid "Unable to locate the %ls directory."
 msgstr "Unable to locate the %ls directory."
 
 #, c-format
-msgid "Unable to open universal variable file '%s': %s"
-msgstr ""
-
-#, c-format
 msgid "Unable to read input file: %s"
 msgstr ""
-
-#, c-format
-msgid "Unable to rename file from '%ls' to '%ls': %s"
-msgstr ""
-
-#, c-format
-msgid "Unable to write to universal variables file '%ls': %s"
-msgstr "Unable to write to universal variables file '%ls': %s"
 
 msgid "Unexpected ')' for unopened parenthesis"
 msgstr ""
@@ -79187,6 +79171,10 @@ msgstr ""
 
 msgid "~ expansion"
 msgstr ""
+
+#, c-format
+#~ msgid "Unable to write to universal variables file '%ls': %s"
+#~ msgstr "Unable to write to universal variables file '%ls': %s"
 
 #~ msgid "empty"
 #~ msgstr "empty"

--- a/po/fr.po
+++ b/po/fr.po
@@ -1124,7 +1124,7 @@ msgid "Error reading script file '%s':"
 msgstr ""
 
 #, c-format
-msgid "Error when renaming history file: %s"
+msgid "Error when renaming file: %s"
 msgstr ""
 
 #, c-format
@@ -1346,14 +1346,6 @@ msgstr ""
 
 msgid "List or remove functions"
 msgstr "Lister ou supprimer des fonctions"
-
-#, c-format
-msgid "Locking the history file took too long (%.3f seconds)."
-msgstr "Le verrouillage du fichier d’historique a pris trop de temps (%.3f secondes)."
-
-#, c-format
-msgid "Locking the universal var file took too long (%.3f seconds)."
-msgstr "Le verrouillage du fichier des variables universel a pris trop de temps (%.3f secondes)."
 
 msgid "Logical operations are not supported, use `test` instead"
 msgstr ""
@@ -1617,6 +1609,10 @@ msgstr "Arrêter la fonction actuellement en évaluation"
 msgid "Stop the innermost loop"
 msgstr "Arrêter la boucle interne"
 
+#
+msgid "Synchronized file access"
+msgstr ""
+
 msgid "Temporarily block delivery of events"
 msgstr "Bloquer temporairement la distribution des événements"
 
@@ -1722,20 +1718,8 @@ msgid "Unable to locate the %ls directory."
 msgstr "Impossible de localiser le dossier %ls."
 
 #, c-format
-msgid "Unable to open universal variable file '%s': %s"
-msgstr ""
-
-#, c-format
 msgid "Unable to read input file: %s"
 msgstr ""
-
-#, c-format
-msgid "Unable to rename file from '%ls' to '%ls': %s"
-msgstr "Impossible de renommer le fichier '%ls' en '%ls': %s"
-
-#, c-format
-msgid "Unable to write to universal variables file '%ls': %s"
-msgstr "Impossible d’écrire dans le fichier de variables universelles '%ls': %s"
 
 msgid "Unexpected ')' for unopened parenthesis"
 msgstr ""
@@ -79288,6 +79272,22 @@ msgstr ""
 
 msgid "~ expansion"
 msgstr ""
+
+#, c-format
+#~ msgid "Locking the history file took too long (%.3f seconds)."
+#~ msgstr "Le verrouillage du fichier d’historique a pris trop de temps (%.3f secondes)."
+
+#, c-format
+#~ msgid "Locking the universal var file took too long (%.3f seconds)."
+#~ msgstr "Le verrouillage du fichier des variables universel a pris trop de temps (%.3f secondes)."
+
+#, c-format
+#~ msgid "Unable to rename file from '%ls' to '%ls': %s"
+#~ msgstr "Impossible de renommer le fichier '%ls' en '%ls': %s"
+
+#, c-format
+#~ msgid "Unable to write to universal variables file '%ls': %s"
+#~ msgstr "Impossible d’écrire dans le fichier de variables universelles '%ls': %s"
 
 #~ msgid "Check that this terminal type is supported on this system."
 #~ msgstr "Vérifiez que votre type de terminal est supporté sur ce système"

--- a/po/pl.po
+++ b/po/pl.po
@@ -1019,7 +1019,7 @@ msgid "Error reading script file '%s':"
 msgstr ""
 
 #, c-format
-msgid "Error when renaming history file: %s"
+msgid "Error when renaming file: %s"
 msgstr ""
 
 #, c-format
@@ -1241,14 +1241,6 @@ msgstr ""
 
 msgid "List or remove functions"
 msgstr "Wypisz lub usuń funkcje"
-
-#, c-format
-msgid "Locking the history file took too long (%.3f seconds)."
-msgstr ""
-
-#, c-format
-msgid "Locking the universal var file took too long (%.3f seconds)."
-msgstr ""
 
 msgid "Logical operations are not supported, use `test` instead"
 msgstr ""
@@ -1512,6 +1504,10 @@ msgstr "Zatrzymaj obecnie używaną funkcję"
 msgid "Stop the innermost loop"
 msgstr ""
 
+#
+msgid "Synchronized file access"
+msgstr ""
+
 msgid "Temporarily block delivery of events"
 msgstr ""
 
@@ -1617,19 +1613,7 @@ msgid "Unable to locate the %ls directory."
 msgstr ""
 
 #, c-format
-msgid "Unable to open universal variable file '%s': %s"
-msgstr ""
-
-#, c-format
 msgid "Unable to read input file: %s"
-msgstr ""
-
-#, c-format
-msgid "Unable to rename file from '%ls' to '%ls': %s"
-msgstr ""
-
-#, c-format
-msgid "Unable to write to universal variables file '%ls': %s"
 msgstr ""
 
 msgid "Unexpected ')' for unopened parenthesis"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1024,7 +1024,7 @@ msgid "Error reading script file '%s':"
 msgstr ""
 
 #, c-format
-msgid "Error when renaming history file: %s"
+msgid "Error when renaming file: %s"
 msgstr ""
 
 #, c-format
@@ -1246,14 +1246,6 @@ msgstr ""
 
 msgid "List or remove functions"
 msgstr "Lista ou remove funções"
-
-#, c-format
-msgid "Locking the history file took too long (%.3f seconds)."
-msgstr ""
-
-#, c-format
-msgid "Locking the universal var file took too long (%.3f seconds)."
-msgstr ""
 
 msgid "Logical operations are not supported, use `test` instead"
 msgstr ""
@@ -1517,6 +1509,10 @@ msgstr "Pára a função em execução"
 msgid "Stop the innermost loop"
 msgstr "Pára o laço mais interno"
 
+#
+msgid "Synchronized file access"
+msgstr ""
+
 msgid "Temporarily block delivery of events"
 msgstr "Bloqueia temporariamente a entrega de eventos"
 
@@ -1622,19 +1618,7 @@ msgid "Unable to locate the %ls directory."
 msgstr ""
 
 #, c-format
-msgid "Unable to open universal variable file '%s': %s"
-msgstr ""
-
-#, c-format
 msgid "Unable to read input file: %s"
-msgstr ""
-
-#, c-format
-msgid "Unable to rename file from '%ls' to '%ls': %s"
-msgstr ""
-
-#, c-format
-msgid "Unable to write to universal variables file '%ls': %s"
 msgstr ""
 
 msgid "Unexpected ')' for unopened parenthesis"

--- a/po/sv.po
+++ b/po/sv.po
@@ -1020,7 +1020,7 @@ msgid "Error reading script file '%s':"
 msgstr ""
 
 #, c-format
-msgid "Error when renaming history file: %s"
+msgid "Error when renaming file: %s"
 msgstr ""
 
 #, c-format
@@ -1242,14 +1242,6 @@ msgstr ""
 
 msgid "List or remove functions"
 msgstr "Visa eller ta bort funktioner"
-
-#, c-format
-msgid "Locking the history file took too long (%.3f seconds)."
-msgstr ""
-
-#, c-format
-msgid "Locking the universal var file took too long (%.3f seconds)."
-msgstr ""
 
 msgid "Logical operations are not supported, use `test` instead"
 msgstr ""
@@ -1513,6 +1505,10 @@ msgstr "Avbryt den nuvarande funktionen"
 msgid "Stop the innermost loop"
 msgstr "Avbryt den innersta loopen"
 
+#
+msgid "Synchronized file access"
+msgstr ""
+
 msgid "Temporarily block delivery of events"
 msgstr "Blockera tillfälligt leverans av händelser"
 
@@ -1618,19 +1614,7 @@ msgid "Unable to locate the %ls directory."
 msgstr ""
 
 #, c-format
-msgid "Unable to open universal variable file '%s': %s"
-msgstr ""
-
-#, c-format
 msgid "Unable to read input file: %s"
-msgstr ""
-
-#, c-format
-msgid "Unable to rename file from '%ls' to '%ls': %s"
-msgstr ""
-
-#, c-format
-msgid "Unable to write to universal variables file '%ls': %s"
 msgstr ""
 
 msgid "Unexpected ')' for unopened parenthesis"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1017,8 +1017,8 @@ msgid "Error reading script file '%s':"
 msgstr "读取脚本文件 '%s'出错: "
 
 #, c-format
-msgid "Error when renaming history file: %s"
-msgstr "重命名历史文件时出错:%s"
+msgid "Error when renaming file: %s"
+msgstr ""
 
 #, c-format
 msgid "Error while reading file %ls\n"
@@ -1240,14 +1240,6 @@ msgstr ""
 
 msgid "List or remove functions"
 msgstr "列出或移除函数"
-
-#, c-format
-msgid "Locking the history file took too long (%.3f seconds)."
-msgstr "锁定历史文件花费了太长时间(%.3f 秒)."
-
-#, c-format
-msgid "Locking the universal var file took too long (%.3f seconds)."
-msgstr "锁定 通用 var 文件花费了太长时间 (%.3f 秒) ."
 
 msgid "Logical operations are not supported, use `test` instead"
 msgstr "不支持逻辑操作,使用`test`替代"
@@ -1511,6 +1503,10 @@ msgstr "停止当前求值的函数"
 msgid "Stop the innermost loop"
 msgstr "停止最内层的循环"
 
+#
+msgid "Synchronized file access"
+msgstr ""
+
 msgid "Temporarily block delivery of events"
 msgstr "Temporarily block delivery of events"
 
@@ -1616,20 +1612,8 @@ msgid "Unable to locate the %ls directory."
 msgstr "无法找到 %ls 目录 ."
 
 #, c-format
-msgid "Unable to open universal variable file '%s': %s"
-msgstr "无法打开通用变量文件'%s': %s"
-
-#, c-format
 msgid "Unable to read input file: %s"
 msgstr "无法读取输入文件:%s"
-
-#, c-format
-msgid "Unable to rename file from '%ls' to '%ls': %s"
-msgstr "无法将文件从 '%ls' 重命名为 '%ls':%s"
-
-#, c-format
-msgid "Unable to write to universal variables file '%ls': %s"
-msgstr "无法写入通用变量文件 '%ls':%s"
 
 msgid "Unexpected ')' for unopened parenthesis"
 msgstr "未打开的括号' ' "
@@ -79186,6 +79170,30 @@ msgstr "缩放"
 
 msgid "~ expansion"
 msgstr "~ 扩大"
+
+#, c-format
+#~ msgid "Error when renaming history file: %s"
+#~ msgstr "重命名历史文件时出错:%s"
+
+#, c-format
+#~ msgid "Locking the history file took too long (%.3f seconds)."
+#~ msgstr "锁定历史文件花费了太长时间(%.3f 秒)."
+
+#, c-format
+#~ msgid "Locking the universal var file took too long (%.3f seconds)."
+#~ msgstr "锁定 通用 var 文件花费了太长时间 (%.3f 秒) ."
+
+#, c-format
+#~ msgid "Unable to open universal variable file '%s': %s"
+#~ msgstr "无法打开通用变量文件'%s': %s"
+
+#, c-format
+#~ msgid "Unable to rename file from '%ls' to '%ls': %s"
+#~ msgstr "无法将文件从 '%ls' 重命名为 '%ls':%s"
+
+#, c-format
+#~ msgid "Unable to write to universal variables file '%ls': %s"
+#~ msgstr "无法写入通用变量文件 '%ls':%s"
 
 #~ msgid "builtin\n"
 #~ msgstr "内建\n"

--- a/src/env_universal_common.rs
+++ b/src/env_universal_common.rs
@@ -407,7 +407,9 @@ impl EnvUniversal {
             let callbacks = self.generate_callbacks_and_update_exports(&new_vars);
 
             // Acquire the new variables.
-            self.acquire_variables(new_vars);
+            self.acquire_variables(&mut new_vars);
+            // We have constructed all the callbacks and updated vars_to_acquire. Acquire it!
+            self.vars = new_vars;
             self.last_read_file_id = current_file_id;
             Some(callbacks)
         }
@@ -613,9 +615,8 @@ impl EnvUniversal {
         callbacks
     }
 
-    // Given a variable table, copy unmodified values into self.
-    fn acquire_variables(&mut self, mut vars_to_acquire: VarTable) {
-        // Copy modified values from existing vars to vars_to_acquire.
+    /// Copy modified values from existing vars to `vars_to_acquire`.
+    fn acquire_variables(&mut self, vars_to_acquire: &mut VarTable) {
         for key in &self.modified {
             match self.vars.get(key) {
                 None => {
@@ -628,9 +629,6 @@ impl EnvUniversal {
                 }
             }
         }
-
-        // We have constructed all the callbacks and updated vars_to_acquire. Acquire it!
-        self.vars = vars_to_acquire;
     }
 
     fn populate_1_variable(

--- a/src/flog.rs
+++ b/src/flog.rs
@@ -124,6 +124,8 @@ pub mod categories {
 
         (profile_history, "profile-history", "History performance measurements");
 
+        (synced_file_access, "synced-file-access", "Synchronized file access");
+
         (iothread, "iothread", "Background IO thread events");
         (fd_monitor, "fd-monitor", "FD monitor events");
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,0 +1,58 @@
+use crate::{
+    common::{str2wcstring, wcs2zstring},
+    wchar::prelude::*,
+    FLOG,
+};
+use errno::errno;
+use std::{ffi::CString, fs::File, os::fd::FromRawFd};
+
+// Replacement for mkostemp(str, O_CLOEXEC)
+// This uses mkostemp if available,
+// otherwise it uses mkstemp followed by fcntl
+fn fish_mkstemp_cloexec(name_template: CString) -> std::io::Result<(File, CString)> {
+    let name = name_template.into_raw();
+    #[cfg(not(apple))]
+    let fd = {
+        use libc::O_CLOEXEC;
+        unsafe { libc::mkostemp(name, O_CLOEXEC) }
+    };
+    #[cfg(apple)]
+    let fd = {
+        use libc::{FD_CLOEXEC, F_SETFD};
+        let fd = unsafe { libc::mkstemp(name) };
+        if fd != -1 {
+            unsafe { libc::fcntl(fd, F_SETFD, FD_CLOEXEC) };
+        }
+        fd
+    };
+    if fd == -1 {
+        Err(std::io::Error::from(errno()))
+    } else {
+        unsafe { Ok((File::from_raw_fd(fd), CString::from_raw(name))) }
+    }
+}
+
+/// Creates a temporary file created according to the template and its name if successful.
+pub fn create_temporary_file(name_template: &wstr) -> std::io::Result<(File, WString)> {
+    let (fd, c_string_template) = loop {
+        match fish_mkstemp_cloexec(wcs2zstring(name_template)) {
+            Ok(tmp_file_data) => break tmp_file_data,
+            Err(e) => match e.kind() {
+                std::io::ErrorKind::Interrupted => {}
+                _ => {
+                    FLOG!(
+                        error,
+                        wgettext_fmt!(
+                            "Unable to create temporary file '%ls': %s",
+                            name_template,
+                            e
+                        )
+                    );
+
+                    return Err(e);
+                }
+            },
+        }
+    };
+    Ok((fd, str2wcstring(c_string_template.to_bytes())))
+}

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,10 +1,26 @@
 use crate::{
-    common::{str2wcstring, wcs2zstring},
+    common::{str2wcstring, wcs2zstring, ScopeGuard},
+    fds::wopen_cloexec,
+    global_safety::RelaxedAtomicBool,
+    path::{path_remoteness, DirRemoteness},
     wchar::prelude::*,
-    FLOG,
+    wutil::{
+        file_id_for_file, file_id_for_path, wdirname, wrename, wunlink, FileId, INVALID_FILE_ID,
+    },
+    FLOG, FLOGF,
 };
 use errno::errno;
-use std::{ffi::CString, fs::File, os::fd::FromRawFd};
+use libc::{c_int, fchown, flock, LOCK_EX, LOCK_SH};
+use nix::{fcntl::OFlag, sys::stat::Mode};
+use std::{
+    ffi::CString,
+    fs::File,
+    io::Seek,
+    os::{
+        fd::{AsRawFd, FromRawFd},
+        unix::fs::MetadataExt,
+    },
+};
 
 // Replacement for mkostemp(str, O_CLOEXEC)
 // This uses mkostemp if available,
@@ -55,4 +71,379 @@ pub fn create_temporary_file(name_template: &wstr) -> std::io::Result<(File, WSt
         }
     };
     Ok((fd, str2wcstring(c_string_template.to_bytes())))
+}
+
+/// Use this struct for all accesses to file which need mutual exclusion.
+/// Otherwise, races on the file are possible.
+/// The lock is released when this struct is dropped.
+pub struct LockedFile {
+    /// This is the file which requires mutual exclusion.
+    /// It should only be accessed through this struct,
+    /// because the locks used here do not protect from other accesses to the file.
+    data_file: File,
+    /// The file descriptor of the parent directory, used for locking.
+    /// The lock is not placed on the data file directly due to issues with renaming.
+    /// If the data file is renamed after opening and before locking it,
+    /// There are two independent files around, whose locks do not interact.
+    /// In some cases this can be identified by checking file identifiers and timestamps,
+    /// but even with such checks races and corresponding file corruption can occur.
+    /// It is simpler to lock a different path, which does not change.
+    ///
+    /// We may fail to lock (e.g. on lockless NFS - see issue #685.
+    /// In that case, we proceed as if locking succeeded.
+    /// This might result in corruption,
+    /// but the alternative of not being able to access the file at all is not desirable either.
+    _locked_fd: File,
+}
+
+pub const LOCKED_FILE_MODE: Mode = Mode::from_bits_truncate(0o600);
+
+pub enum LockingMode {
+    Shared,
+    Exclusive(WriteMethod),
+}
+pub enum WriteMethod {
+    Append,
+    RenameIntoPlace,
+}
+
+impl LockingMode {
+    pub fn flock_op(&self) -> c_int {
+        match self {
+            Self::Shared => LOCK_SH,
+            Self::Exclusive(_) => LOCK_EX,
+        }
+    }
+
+    pub fn file_flags(&self) -> OFlag {
+        match self {
+            Self::Shared => OFlag::O_RDONLY,
+            Self::Exclusive(WriteMethod::Append) => {
+                OFlag::O_WRONLY | OFlag::O_APPEND | OFlag::O_CREAT
+            }
+            Self::Exclusive(WriteMethod::RenameIntoPlace) => OFlag::O_RDONLY | OFlag::O_CREAT,
+        }
+    }
+}
+
+impl LockedFile {
+    /// Creates a [`LockedFile`].
+    /// Use this for any access to a which requires mutual exclusion, as it ensures correct locking.
+    /// Use [`LockingMode::Exclusive`] if you want to modify the file in any way.
+    /// Otherwise you should use [`LockingMode::Shared`].
+    /// Two modes of modification are supported:
+    /// - Appending
+    /// - Writing to a temporary file which is then renamed into place.
+    /// File flags are derived from the [`LockingMode`].
+    /// `file_name` should just be a name, not a full path.
+    pub fn new(locking_mode: LockingMode, file_path: &wstr) -> std::io::Result<Self> {
+        let dir_path = wdirname(file_path);
+
+        if path_remoteness(dir_path) == DirRemoteness::remote {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "Directory considered remote. Locking is disabled on remote file systems.",
+            ));
+        }
+
+        // We start by locking the directory.
+        // This is required to avoid racing modifications by other threads/processes.
+        let dir_fd = wopen_cloexec(dir_path, OFlag::O_RDONLY, Mode::empty())?;
+
+        // Try locking the directory. Retry if locking was interrupted.
+        while unsafe { flock(dir_fd.as_raw_fd(), locking_mode.flock_op()) } == -1 {
+            let err = std::io::Error::last_os_error();
+            if err.kind() != std::io::ErrorKind::Interrupted {
+                return Err(err);
+            }
+        }
+
+        // Open the data file
+        let data_file = wopen_cloexec(file_path, locking_mode.file_flags(), LOCKED_FILE_MODE)?;
+
+        Ok(Self {
+            data_file,
+            _locked_fd: dir_fd,
+        })
+    }
+
+    pub fn get(&self) -> &File {
+        &self.data_file
+    }
+
+    pub fn get_mut(&mut self) -> &mut File {
+        &mut self.data_file
+    }
+}
+
+/// Runs the `load` function, which should see a consistent state of the file at `path`.
+/// To ensure a consistent state, we use locks to prevent modifications by others.
+/// If locking is unavailable, the `load` function might be executed multiple times,
+/// until it manages a run without the file being modified in the meantime, or until the maximum
+/// number of allowed attempts is reached.
+/// If the file does not exist this function will return an error.
+pub fn lock_and_load<F, UserData>(
+    path: &wstr,
+    locking_enabled: &RelaxedAtomicBool,
+    load: F,
+) -> std::io::Result<(FileId, UserData)>
+where
+    F: Fn(&File) -> std::io::Result<UserData>,
+{
+    if locking_enabled.load() {
+        match LockedFile::new(LockingMode::Shared, path) {
+            Ok(locked_file) => {
+                return Ok((
+                    file_id_for_file(locked_file.get()),
+                    load(locked_file.get())?,
+                ));
+            }
+            Err(e) => {
+                FLOGF!(
+                    synced_file_access,
+                    "Error acquiring shared lock on the directory of '%s': %s",
+                    path,
+                    e,
+                );
+                // This function might be called when the file does not exist.
+                // Do not abandon locking is such cases.
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    // There is no point in continuing in this function if the file does not
+                    // exist.
+                    return Err(e);
+                } else {
+                    FLOG!(synced_file_access, "Disabling locking.");
+                    locking_enabled.store(false);
+                }
+            }
+        }
+    }
+
+    FLOG!(
+        synced_file_access,
+        "flock-based locking is disabled. Using fallback implementation."
+    );
+
+    // Fallback implementation for situations where locking is unavailable.
+    let max_attempts = 1000;
+    for _ in 0..max_attempts {
+        let initial_file_id = file_id_for_path(path);
+        // If we cannot open the file, there is nothing we can do,
+        // so just return immediately.
+        let file = wopen_cloexec(path, OFlag::O_RDONLY, Mode::empty())?;
+        let loaded_data = match load(&file) {
+            Ok(update_data) => update_data,
+            Err(_) => {
+                // Retry if load function failed. Because we do not hold a lock, this might be
+                // caused by concurrent modifications.
+                continue;
+            }
+        };
+
+        let final_file_id = file_id_for_path(path);
+        if initial_file_id != final_file_id {
+            continue;
+        }
+        // If the file id did not change, we assume that we loaded a consistent state.
+        return Ok((final_file_id, loaded_data));
+    }
+    Err(std::io::Error::new(std::io::ErrorKind::Other, "Failed to update the file. Locking is disabled, and the fallback code did not succeed within the permissible number of attempts."))
+}
+
+pub struct PotentialUpdate<UserData> {
+    pub do_save: bool,
+    pub data: UserData,
+}
+
+/// Use this function for updating a file based on its current content,
+/// for files which might be accessed at the same time by other threads/processes.
+/// The basic principle is to create a temporary file, take a lock on the file to be rewritten,
+/// do the rewrite (which might involve reading the old file contents),
+/// and finally release the lock.
+/// Error handling (especially the case where locking is not possible) makes the implementation
+/// non-straightforward.
+///
+/// # Arguments
+///
+/// - `path`: The path to the file which should be updated.
+/// - `locking_enabled`: To indicate whether locking should be attempted. This function might
+/// update the value stored in `locking_enabled`.
+/// - `rewrite`: The function which handles reading from the file and writing to a temporary file.
+/// The first argument is for the file to read from, the second for the temporary file to write to.
+/// On success, the value returned by `rewrite` is included in this functions return value. Be
+/// careful about side effects of `rewrite`. It might get executed multiple times. Try to avoid
+/// side effects and instead extract any data you might need and return them on success.
+/// Then, apply the desired side effects once this function has returned successfully.
+///
+/// # Return value
+///
+/// On success, the [`FileId`] of the rewritten file is returned, alongside the value returned by
+/// `rewrite`. Note that if locking is unavailable, the [`FileId`] might be the id of a different
+/// version of the file, which was written after this function renamed the temporary file to `path`
+/// but before we obtained the [`FileId`] from `path`. This is a race condition we do not detect.
+pub fn rewrite_via_temporary_file<F, UserData>(
+    path: &wstr,
+    locking_enabled: &RelaxedAtomicBool,
+    rewrite: F,
+) -> std::io::Result<(FileId, PotentialUpdate<UserData>)>
+where
+    F: Fn(&File, &mut File) -> std::io::Result<PotentialUpdate<UserData>>,
+{
+    /// Updates the metadata of the `new_file` to match the `old_file`.
+    /// Also updates the mtime of the `new_file` to the current time manually, to work around
+    /// operating systems which do not update the internal time used for such time stamps
+    /// frequently enough. This is important for [`FileId`] comparisons.
+    fn update_metadata(old_file: &File, new_file: &File) {
+        // Ensure we maintain the ownership and permissions of the original (#2355). If the
+        // stat fails, we assume (hope) our default permissions are correct. This
+        // corresponds to e.g. someone running sudo -E as the very first command. If they
+        // did, it would be tricky to set the permissions correctly. (bash doesn't get this
+        // case right either).
+        if let Ok(md) = old_file.metadata() {
+            // TODO(MSRV): Consider replacing with std::os::unix::fs::fchown when MSRV >= 1.73
+            if unsafe { fchown(new_file.as_raw_fd(), md.uid(), md.gid()) } == -1 {
+                FLOG!(
+                    synced_file_access,
+                    "Error when changing ownership of file:",
+                    errno::errno()
+                );
+            }
+            if let Err(e) = new_file.set_permissions(md.permissions()) {
+                FLOG!(synced_file_access, "Error when changing mode of file:", e);
+            }
+        } else {
+            FLOG!(synced_file_access, "Could not get metadata for file");
+        }
+        // Linux by default stores the mtime with low precision, low enough that updates that occur
+        // in quick succession may result in the same mtime (even the nanoseconds field). So
+        // manually set the mtime of the new file to a high-precision clock. Note that this is only
+        // necessary because Linux aggressively reuses inodes, causing the ABA problem; on other
+        // platforms we tend to notice the file has changed due to a different inode.
+        //
+        // The current time within the Linux kernel is cached, and generally only updated on a timer
+        // interrupt. So if the timer interrupt is running at 10 milliseconds, the cached time will
+        // only be updated once every 10 milliseconds.
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        {
+            let mut times: [libc::timespec; 2] = unsafe { std::mem::zeroed() };
+            times[0].tv_nsec = libc::UTIME_OMIT; // don't change atime
+            if unsafe { libc::clock_gettime(libc::CLOCK_REALTIME, &mut times[1]) } == 0 {
+                unsafe {
+                    // This accesses both times[0] and times[1]. Check `utimensat(2)` for details.
+                    libc::futimens(new_file.as_raw_fd(), &times[0]);
+                }
+            }
+        }
+    }
+
+    /// Renames a file from `old_name` to `new_name`.
+    fn rename(old_name: &wstr, new_name: &wstr) -> std::io::Result<()> {
+        if wrename(old_name, new_name) == -1 {
+            let error_number = errno::errno();
+            FLOG!(
+                error,
+                wgettext_fmt!("Error when renaming file: %s", error_number.to_string())
+            );
+            return Err(std::io::Error::from(error_number));
+        }
+        Ok(())
+    }
+
+    const TMP_FILE_SUFFIX: &wstr = L!(".XXXXXX");
+    let tmp_file_template = path.to_owned() + TMP_FILE_SUFFIX;
+    let (tmp_file, tmp_name) = create_temporary_file(&tmp_file_template)?;
+    // Ensure that the temporary file is unlinked when this function returns.
+    let mut tmp_file = ScopeGuard::new(tmp_file, |_| {
+        wunlink(&tmp_name);
+    });
+
+    // We want to rewrite the file.
+    // To avoid issues with crashes during writing,
+    // we write to a temporary file and once we are done, this file is renamed such that it
+    // replaces the original file.
+    if locking_enabled.load() {
+        // To avoid races, we need to have exclusive access to the file for the entire
+        // duration, which we get via an exclusive lock on the parent directory.
+        // Taking a shared lock first and later upgrading to an exclusive one could result in a
+        // deadlock, so we take an exclusive one immediately.
+        match LockedFile::new(LockingMode::Exclusive(WriteMethod::RenameIntoPlace), path) {
+            Ok(locked_file) => {
+                let potential_update = rewrite(locked_file.get(), &mut tmp_file)?;
+                if potential_update.do_save {
+                    update_metadata(locked_file.get(), &tmp_file);
+                    rename(&tmp_name, path)?;
+                }
+                return Ok((file_id_for_path(path), potential_update));
+            }
+            Err(e) => {
+                FLOGF!(
+                    synced_file_access,
+                    "Error acquiring exclusive lock on the directory of '%s': %s",
+                    path,
+                    e,
+                );
+                locking_enabled.store(false);
+            }
+        }
+    }
+
+    // If this is reached, we assume that locking is not available so we use a fallback
+    // implementation which tries to avoid race conditions, but in the case of contention it is
+    // possible that some writes are lost.
+
+    FLOG!(
+        synced_file_access,
+        "flock-based locking is disabled. Using fallback implementation."
+    );
+
+    // Give up after this many unsuccessful attempts.
+    // TODO: which value, should this be a constant shared with other retrying logic?
+    let max_attempts = 1000;
+    for _ in 0..max_attempts {
+        // Truncate tmp_file for the next attempt to get rid of data potentially written in the
+        // previous iteration.
+        tmp_file.set_len(0)?;
+        tmp_file.seek(std::io::SeekFrom::Start(0)).unwrap();
+
+        // If the file does not exist yet, this will be `INVALID_FILE_ID`.
+        let initial_file_id = file_id_for_path(path);
+        // If we cannot open the file, there is nothing we can do,
+        // so just return immediately.
+        let old_file = wopen_cloexec(path, OFlag::O_RDONLY | OFlag::O_CREAT, LOCKED_FILE_MODE)?;
+        let opened_file_id = file_id_for_file(&old_file);
+        if initial_file_id != INVALID_FILE_ID && initial_file_id != opened_file_id {
+            // File ID changed (and not just because the file was created by us).
+            continue;
+        }
+        let Ok(potential_update) = rewrite(&old_file, &mut tmp_file) else {
+            // Retry if rewrite function failed. Because we do not hold a lock, this might be
+            // caused by concurrent modifications.
+            continue;
+        };
+
+        if potential_update.do_save {
+            update_metadata(&old_file, &tmp_file);
+        }
+
+        let mut final_file_id = file_id_for_path(path);
+        if opened_file_id != final_file_id {
+            continue;
+        }
+
+        // If we reach this point, the file ID did not change while we read the old file and wrote
+        // to `tmp_file`. Now we replace the old file with the `tmp_file`.
+        // Note that we cannot prevent races here.
+        // If the file is modified by someone else between the syscall for determining the [`FileId`]
+        // and the rename syscall, these modifications will be lost.
+
+        if potential_update.do_save {
+            // Do not retry on rename failures, as it is unlikely that these will disappear if we retry.
+            rename(&tmp_name, path)?;
+            final_file_id = file_id_for_path(path);
+        }
+        // Note that this might not match the version of the file we just wrote.
+        // (If we did write.)
+        return Ok((final_file_id, potential_update));
+    }
+    Err(std::io::Error::new(std::io::ErrorKind::Other, "Failed to update the file. Locking is disabled, and the fallback code did not succeed within the permissible number of attempts."))
 }

--- a/src/history.rs
+++ b/src/history.rs
@@ -516,7 +516,7 @@ impl HistoryImpl {
             // as if it did not fail. The risk is that we may get an incomplete history item; this
             // is unlikely because we only treat an item as valid if it has a terminating newline.
             let locked = unsafe { Self::maybe_lock_file(&mut file, LOCK_SH) };
-            self.file_contents = HistoryFileContents::create(&mut file);
+            self.file_contents = HistoryFileContents::create(&mut file).ok();
             self.history_file_id = if self.file_contents.is_some() {
                 file_id_for_file(&file)
             } else {
@@ -592,7 +592,7 @@ impl HistoryImpl {
         // Read in existing items (which may have changed out from underneath us, so don't trust our
         // old file contents).
         if let Some(existing_file) = existing_file {
-            if let Some(local_file) = HistoryFileContents::create(existing_file) {
+            if let Ok(local_file) = HistoryFileContents::create(existing_file) {
                 let mut cursor = 0;
                 while let Some(offset) = local_file.offset_of_next_item(&mut cursor, None) {
                     // Try decoding an old item.

--- a/src/history.rs
+++ b/src/history.rs
@@ -516,7 +516,7 @@ impl HistoryImpl {
             // as if it did not fail. The risk is that we may get an incomplete history item; this
             // is unlikely because we only treat an item as valid if it has a terminating newline.
             let locked = unsafe { Self::maybe_lock_file(&mut file, LOCK_SH) };
-            self.file_contents = HistoryFileContents::create(&mut file).ok();
+            self.file_contents = HistoryFileContents::create(&file).ok();
             self.history_file_id = if self.file_contents.is_some() {
                 file_id_for_file(&file)
             } else {

--- a/src/history.rs
+++ b/src/history.rs
@@ -1360,9 +1360,6 @@ impl HistoryImpl {
         if ABANDONED_LOCKING.load() {
             return false;
         }
-        if CHAOS_MODE.load() {
-            return false;
-        }
         if path_get_data_remoteness() == DirRemoteness::remote {
             return false;
         }
@@ -2084,7 +2081,3 @@ pub fn in_private_mode(vars: &dyn Environment) -> bool {
 
 /// Whether to force the read path instead of mmap. This is useful for testing.
 static NEVER_MMAP: RelaxedAtomicBool = RelaxedAtomicBool::new(false);
-
-/// Whether we're in maximum chaos mode, useful for testing.
-/// This causes things like locks to fail.
-pub static CHAOS_MODE: RelaxedAtomicBool = RelaxedAtomicBool::new(false);

--- a/src/history.rs
+++ b/src/history.rs
@@ -395,12 +395,7 @@ impl HistoryImpl {
     /// `item_at_index()` until a call to `resolve_pending()`. Pending items are tracked with an
     /// offset into the array of new items, so adding a non-pending item has the effect of resolving
     /// all pending items.
-    fn add(
-        &mut self,
-        item: HistoryItem,
-        pending: bool, /*=false*/
-        do_save: bool, /*=true*/
-    ) {
+    fn add(&mut self, item: HistoryItem, pending: bool, do_save: bool) {
         // We use empty items as sentinels to indicate the end of history.
         // Do not allow them to be added (#6032).
         if item.contents.is_empty() {
@@ -1283,7 +1278,7 @@ impl History {
     /// Privately add an item. If pending, the item will not be returned by history searches until a
     /// call to resolve_pending. Any trailing ephemeral items are dropped.
     /// Exposed for testing.
-    pub fn add(&self, item: HistoryItem, pending: bool /*=false*/) {
+    pub fn add(&self, item: HistoryItem, pending: bool) {
         self.imp().add(item, pending, true)
     }
 

--- a/src/history.rs
+++ b/src/history.rs
@@ -2,47 +2,41 @@
 //!
 //! 1. All history files are append-only. Data, once written, is never modified.
 //!
-//! 2. A history file may be re-written ("vacuumed"). This involves reading in the file and writing a
-//! new one, while performing maintenance tasks: discarding items in an LRU fashion until we reach
-//! the desired maximum count, removing duplicates, and sorting them by timestamp (eventually, not
-//! implemented yet). The new file is atomically moved into place via rename().
+//! 2. A history file may be re-written ("vacuumed"). This involves reading in the file and writing
+//!    a new one, while performing maintenance tasks: discarding items in an LRU fashion until we
+//!    reach the desired maximum count, removing duplicates, and sorting them by timestamp
+//!    (eventually, not implemented yet). The new file is atomically moved into place via `rename()`.
 //!
-//! 3. History files are mapped in via mmap(). Before the file is mapped, the file takes a fcntl read
-//! lock. The purpose of this lock is to avoid seeing a transient state where partial data has been
-//! written to the file.
+//! 3. History files are mapped in via `mmap()`. This allows only storing one `usize` per item (its
+//!    offset), and lazily loading items on demand, which reduces memory consumption.
 //!
-//! 4. History is appended to under a fcntl write lock.
-//!
-//! 5. The chaos_mode boolean can be set to true to do things like lower buffer sizes which can
-//! trigger race conditions. This is useful for testing.
-//!
-//! Locking on remote filesystems may hang for an unacceptably long time. For that reason, fish
-//! does not take locks on the file if it believes the history file is on a remote filesystem,
-//! or if the mmap fails with ENODEV, or if the first lock attempt takes excessively long.
-//! Eliding locks means that two concurrent shell sessions with a remote history file may, in
-//! rare cases with multiple simultaneous shell sessions, lose a history item; this is
-//! considered preferable to hanging the the shell waiting for a lock.
+//! 4. Accesses to the history file need to be synchronized. This is achieved by functionality in
+//!    `src/fs.rs`. By default, `flock()` is used for locking. If that is unavailable, an imperfect
+//!    fallback solution attempts to detect races and retries if a race is detected.
 
 use crate::{
-    common::cstr2wcstring, env::EnvVar, fs::create_temporary_file, wcstringutil::trim,
-    wutil::fileid::file_id_for_path_or_error,
+    common::cstr2wcstring,
+    env::EnvVar,
+    fs::{
+        lock_and_load, rewrite_via_temporary_file, LockedFile, LockingMode, PotentialUpdate,
+        WriteMethod, LOCKED_FILE_MODE,
+    },
+    wcstringutil::trim,
 };
 use std::{
     borrow::Cow,
     collections::{BTreeMap, HashMap, HashSet},
     ffi::CString,
     fs::File,
-    io::{BufRead, Read, Seek, SeekFrom, Write},
+    io::{BufRead, Read, Write},
     mem::MaybeUninit,
     num::NonZeroUsize,
     ops::ControlFlow,
-    os::{fd::AsRawFd, unix::fs::MetadataExt},
     sync::{Arc, Mutex, MutexGuard},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use bitflags::bitflags;
-use libc::{fchown, flock, EINTR, LOCK_EX, LOCK_SH, LOCK_UN};
 use lru::LruCache;
 use nix::{fcntl::OFlag, sys::stat::Mode};
 use rand::Rng;
@@ -60,18 +54,13 @@ use crate::{
     operation_context::{OperationContext, EXPANSION_LIMIT_BACKGROUND},
     parse_constants::{ParseTreeFlags, StatementDecoration},
     parse_util::{parse_util_detect_errors, parse_util_unescape_wildcards},
-    path::{
-        path_get_config, path_get_data, path_get_data_remoteness, path_is_valid, DirRemoteness,
-    },
+    path::{path_get_config, path_get_data, path_is_valid},
     threads::{assert_is_background_thread, iothread_perform},
     util::{find_subslice, get_rng},
     wchar::prelude::*,
     wcstringutil::subsequence_in_string,
     wildcard::{wildcard_match, ANY_STRING},
-    wutil::{
-        file_id_for_file, file_id_for_path, wgettext_fmt, wrealpath, wrename, wstat, wunlink,
-        FileId, INVALID_FILE_ID,
-    },
+    wutil::{file_id_for_file, wgettext_fmt, wrealpath, wstat, wunlink, FileId, INVALID_FILE_ID},
 };
 
 mod file;
@@ -134,14 +123,6 @@ const HISTORY_SAVE_MAX: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(1024
 
 /// Default buffer size for flushing to the history file.
 const HISTORY_OUTPUT_BUFFER_SIZE: usize = 64 * 1024;
-
-/// The file access mode we use for creating history files
-const HISTORY_FILE_MODE: Mode = Mode::from_bits_truncate(0o600);
-
-/// How many times we retry to save
-/// Saving may fail if the file is modified in between our opening
-/// the file and taking the lock
-const MAX_SAVE_TRIES: usize = 1024;
 
 pub const VACUUM_FREQUENCY: usize = 25;
 
@@ -213,29 +194,6 @@ impl LruCacheExt for LruCache<WString, HistoryItem> {
             self.put(key.to_owned(), item);
         }
     }
-}
-
-/// Returns the path for the history file for the given `session_id`
-/// if `session_id` is non-empty.
-/// If it is empty, `Ok(None)` will be returned.
-/// An error is returned if obtaining the data directory failed.
-/// Because the `path_get_data` function does not return error information,
-/// we cannot provide more detail about the reason for the failure here.
-/// If `suffix` is provided, append that suffix to the path; this is used for temporary files.
-fn history_filename(session_id: &wstr, suffix: &wstr) -> std::io::Result<Option<WString>> {
-    if session_id.is_empty() {
-        return Ok(None);
-    }
-
-    let Some(mut result) = path_get_data() else {
-        return Err(std::io::Error::new(std::io::ErrorKind::NotFound, "Error obtaining data directory. This is a manually constructed error which does not indicate why this happened."));
-    };
-
-    result.push('/');
-    result.push_utfstr(session_id);
-    result.push_utfstr(L!("_history"));
-    result.push_utfstr(suffix);
-    Ok(Some(result))
 }
 
 pub type PathList = Vec<WString>;
@@ -406,11 +364,33 @@ struct HistoryImpl {
     old_item_offsets: Vec<usize>,
 }
 
-/// If set, we gave up on file locking because it took too long.
-/// Note this is shared among all history instances.
-static ABANDONED_LOCKING: RelaxedAtomicBool = RelaxedAtomicBool::new(false);
-
 impl HistoryImpl {
+    /// Returns the canonical path for the history file, or `Ok(None)` in private mode.
+    /// An error is returned if obtaining the data directory fails.
+    /// Because the `path_get_data` function does not return error information,
+    /// we cannot provide more detail about the reason for the failure here.
+    fn history_file_path(&self) -> std::io::Result<Option<WString>> {
+        if self.name.is_empty() {
+            return Ok(None);
+        }
+
+        let Some(mut path) = path_get_data() else {
+            return Err(std::io::Error::new(std::io::ErrorKind::NotFound, "Error obtaining data directory. This is a manually constructed error which does not indicate why this happened."));
+        };
+
+        path.push('/');
+        path.push_utfstr(&self.name);
+        path.push_utfstr(L!("_history"));
+        if let Some(canonicalized_path) = wrealpath(&path) {
+            Ok(Some(canonicalized_path))
+        } else {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("wrealpath failed to produce a canonical version of '{path}'."),
+            ))
+        }
+    }
+
     /// Add a new history item to the end. If `pending` is set, the item will not be returned by
     /// `item_at_index()` until a call to `resolve_pending()`. Pending items are tracked with an
     /// offset into the array of new items, so adding a non-pending item has the effect of resolving
@@ -502,34 +482,22 @@ impl HistoryImpl {
         self.loaded_old = true;
 
         let _profiler = TimeProfiler::new("load_old");
-        if let Ok(Some(history_path)) = history_filename(&self.name, L!("")) {
-            let Ok(mut file) = wopen_cloexec(&history_path, OFlag::O_RDONLY, Mode::empty()) else {
-                return;
-            };
-
-            // Take a read lock to guard against someone else appending. This is released after
-            // getting the file's length. We will read the file after releasing the lock, but that's
-            // not a problem, because we never modify already written data. In short, the purpose of
-            // this lock is to ensure we don't see the file size change mid-update.
-            //
-            // We may fail to lock (e.g. on lockless NFS - see issue #685. In that case, we proceed
-            // as if it did not fail. The risk is that we may get an incomplete history item; this
-            // is unlikely because we only treat an item as valid if it has a terminating newline.
-            let locked = unsafe { Self::maybe_lock_file(&mut file, LOCK_SH) };
-            self.file_contents = HistoryFileContents::create(&file).ok();
-            self.history_file_id = if self.file_contents.is_some() {
-                file_id_for_file(&file)
-            } else {
-                INVALID_FILE_ID
-            };
-            if locked {
-                unsafe {
-                    Self::unlock_file(&mut file);
+        if let Ok(Some(history_path)) = self.history_file_path() {
+            match lock_and_load(
+                &history_path,
+                &LOCK_HISTORY_FILE,
+                HistoryFileContents::create,
+            ) {
+                Ok((file_id, file_contents)) => {
+                    self.file_contents = Some(file_contents);
+                    self.history_file_id = file_id;
+                    let _profiler = TimeProfiler::new("populate_from_file_contents");
+                    self.populate_from_file_contents();
+                }
+                Err(e) => {
+                    FLOG!(history_file, "Error reading from history file:", e);
                 }
             }
-
-            let _profiler = TimeProfiler::new("populate_from_file_contents");
-            self.populate_from_file_contents();
         }
     }
 
@@ -578,10 +546,9 @@ impl HistoryImpl {
     }
 
     /// Given an existing history file, write a new history file to `dst`.
-    /// Returns false on error, true on success
     fn rewrite_to_temporary_file(
         &self,
-        existing_file: Option<&mut File>,
+        existing_file: &File,
         dst: &mut File,
     ) -> std::io::Result<()> {
         // We are reading FROM existing_file and writing TO dst
@@ -591,32 +558,29 @@ impl HistoryImpl {
 
         // Read in existing items (which may have changed out from underneath us, so don't trust our
         // old file contents).
-        if let Some(existing_file) = existing_file {
-            if let Ok(local_file) = HistoryFileContents::create(existing_file) {
-                let mut cursor = 0;
-                while let Some(offset) = local_file.offset_of_next_item(&mut cursor, None) {
-                    // Try decoding an old item.
-                    let Some(old_item) = local_file.decode_item(offset) else {
-                        continue;
-                    };
+        if let Ok(local_file) = HistoryFileContents::create(existing_file) {
+            let mut cursor = 0;
+            while let Some(offset) = local_file.offset_of_next_item(&mut cursor, None) {
+                // Try decoding an old item.
+                let Some(old_item) = local_file.decode_item(offset) else {
+                    continue;
+                };
 
-                    // If old item is newer than session always erase if in deleted.
-                    if old_item.timestamp() > self.boundary_timestamp {
-                        if old_item.is_empty() || self.deleted_items.contains_key(old_item.str()) {
-                            continue;
-                        }
-                        lru.add_item(old_item);
-                    } else {
-                        // If old item is older and in deleted items don't erase if added by
-                        // clear_session.
-                        if old_item.is_empty()
-                            || self.deleted_items.get(old_item.str()) == Some(&false)
-                        {
-                            continue;
-                        }
-                        // Add this old item.
-                        lru.add_item(old_item);
+                // If old item is newer than session always erase if in deleted.
+                if old_item.timestamp() > self.boundary_timestamp {
+                    if old_item.is_empty() || self.deleted_items.contains_key(old_item.str()) {
+                        continue;
                     }
+                    lru.add_item(old_item);
+                } else {
+                    // If old item is older and in deleted items don't erase if added by
+                    // clear_session.
+                    if old_item.is_empty() || self.deleted_items.get(old_item.str()) == Some(&false)
+                    {
+                        continue;
+                    }
+                    // Add this old item.
+                    lru.add_item(old_item);
                 }
             }
         }
@@ -669,13 +633,9 @@ impl HistoryImpl {
 
     /// Saves history by rewriting the file.
     fn save_internal_via_rewrite(&mut self) -> std::io::Result<()> {
-        // We want to rewrite the file, while holding the lock for as briefly as possible
-        // To do this, we speculatively write a file, and then lock and see if our original file changed
-        // Repeat until we succeed or give up
-        let Some(possibly_indirect_target_name) = history_filename(&self.name, L!(""))? else {
+        let Some(history_path) = self.history_file_path()? else {
             return Ok(());
         };
-        let tmp_name_template = history_filename(&self.name, L!(".XXXXXX"))?.unwrap();
 
         FLOGF!(
             history,
@@ -683,150 +643,43 @@ impl HistoryImpl {
             self.new_items.len() - self.first_unwritten_new_item_index
         );
 
-        // If the history file is a symlink, we want to rewrite the real file so long as we can find it.
-        let target_name =
-            wrealpath(&possibly_indirect_target_name).unwrap_or(possibly_indirect_target_name);
+        let rewrite =
+            |old_file: &File, tmp_file: &mut File| -> std::io::Result<PotentialUpdate<()>> {
+                self.rewrite_to_temporary_file(old_file, tmp_file)?;
+                Ok(PotentialUpdate {
+                    do_save: true,
+                    data: (),
+                })
+            };
 
-        // Make our temporary file
-        let (mut tmp_file, tmp_name) = create_temporary_file(&tmp_name_template)?;
-        let mut done = false;
-        for _i in 0..MAX_SAVE_TRIES {
-            if done {
-                break;
-            }
+        let (file_id, _) = rewrite_via_temporary_file(&history_path, &LOCK_HISTORY_FILE, rewrite)?;
+        self.history_file_id = file_id;
 
-            let target_file_before = wopen_cloexec(
-                &target_name,
-                OFlag::O_RDONLY | OFlag::O_CREAT,
-                HISTORY_FILE_MODE,
-            );
-            if let Err(err) = target_file_before {
-                FLOG!(history_file, "Error opening history file:", err);
-            }
+        // We've saved everything, so we have no more unsaved items.
+        self.first_unwritten_new_item_index = self.new_items.len();
 
-            let orig_file_id = target_file_before
-                .as_ref()
-                .map(file_id_for_file)
-                .unwrap_or(INVALID_FILE_ID);
+        // We deleted our deleted items.
+        self.deleted_items.clear();
 
-            // Open any target file, but do not lock it right away
-            if let Err(err) =
-                self.rewrite_to_temporary_file(target_file_before.ok().as_mut(), &mut tmp_file)
-            {
-                // Failed to write, no good
-                FLOG!(history_file, "Error writing to temporary file:", err);
-                break;
-            }
+        // Our history has been written to the file, so clear our state so we can re-reference the
+        // file.
+        self.clear_file_state();
 
-            // The crux! We rewrote the history file; see if the history file changed while we
-            // were rewriting it. Make an effort to take the lock before checking, to avoid racing.
-            // If the open fails, then proceed; this may be because there is no current history
-            let mut new_file_id = INVALID_FILE_ID;
-
-            let mut target_file_after = wopen_cloexec(&target_name, OFlag::O_RDONLY, Mode::empty());
-            if let Ok(target_file_after) = target_file_after.as_mut() {
-                // critical to take the lock before checking file IDs,
-                // and hold it until after we are done replacing.
-                // Also critical to check the file at the path, NOT based on our fd.
-                // It's only OK to replace the file while holding the lock.
-                // Note any lock is released when target_file_after is closed.
-                unsafe {
-                    Self::maybe_lock_file(target_file_after, LOCK_EX);
-                }
-                new_file_id = match file_id_for_path_or_error(&target_name) {
-                    Ok(file_id) => file_id,
-                    Err(err) => {
-                        if err.kind() != std::io::ErrorKind::NotFound {
-                            FLOG!(history_file, "Error re-opening history file:", err);
-                        }
-                        INVALID_FILE_ID
-                    }
-                }
-            }
-
-            let can_replace_file = new_file_id == orig_file_id || new_file_id == INVALID_FILE_ID;
-            if !can_replace_file {
-                // The file has changed, so we're going to re-read it
-                // Truncate our tmp_file so we can reuse it
-                if let Err(err) = tmp_file.set_len(0) {
-                    FLOG!(
-                        history_file,
-                        "Error when truncating temporary history file:",
-                        err
-                    );
-                }
-                if let Err(err) = tmp_file.seek(SeekFrom::Start(0)) {
-                    FLOG!(
-                        history_file,
-                        "Error resetting cursor in temporary history file:",
-                        err
-                    );
-                }
-            } else {
-                // The file is unchanged, or the new file doesn't exist or we can't read it
-                // We also attempted to take the lock, so we feel confident in replacing it
-
-                // Ensure we maintain the ownership and permissions of the original (#2355). If the
-                // stat fails, we assume (hope) our default permissions are correct. This
-                // corresponds to e.g. someone running sudo -E as the very first command. If they
-                // did, it would be tricky to set the permissions correctly. (bash doesn't get this
-                // case right either).
-                if let Ok(target_file_after) = target_file_after.as_ref() {
-                    if let Ok(md) = target_file_after.metadata() {
-                        // TODO(MSRV): Consider replacing with std::os::unix::fs::fchown when MSRV >= 1.73
-                        if unsafe { fchown(tmp_file.as_raw_fd(), md.uid(), md.gid()) } == -1 {
-                            FLOG!(
-                                history_file,
-                                "Error when changing ownership of history file:",
-                                errno::errno()
-                            );
-                        }
-                        if let Err(e) = tmp_file.set_permissions(md.permissions()) {
-                            FLOG!(history_file, "Error when changing mode of history file:", e);
-                        }
-                    }
-                }
-
-                // Slide it into place
-                if wrename(&tmp_name, &target_name) == -1 {
-                    FLOG!(
-                        error,
-                        wgettext_fmt!(
-                            "Error when renaming history file: %s",
-                            errno::errno().to_string()
-                        )
-                    );
-                }
-
-                // We did it
-                done = true;
-            }
-        }
-
-        // Ensure we never leave the old file around
-        let _ = wunlink(&tmp_name);
-
-        if done {
-            // We've saved everything, so we have no more unsaved items.
-            self.first_unwritten_new_item_index = self.new_items.len();
-
-            // We deleted our deleted items.
-            self.deleted_items.clear();
-
-            // Our history has been written to the file, so clear our state so we can re-reference the
-            // file.
-            self.clear_file_state();
-        }
         Ok(())
     }
 
     /// Saves history by appending to the file.
     fn save_internal_via_appending(&mut self) -> std::io::Result<()> {
-        // Get the path to the real history file.
-        let Some(history_path) = history_filename(&self.name, L!(""))? else {
+        let Some(history_path) = self.history_file_path()? else {
             return Ok(());
         };
-        let history_path = wrealpath(&history_path).unwrap_or(history_path);
+
+        if !LOCK_HISTORY_FILE.load() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "Appending is not supported when locking is disabled.",
+            ));
+        }
 
         FLOGF!(
             history,
@@ -836,57 +689,19 @@ impl HistoryImpl {
         // No deleting allowed.
         assert!(self.deleted_items.is_empty());
 
-        // If the file is different (someone vacuumed it) then we need to update our mmap.
-        let mut file_changed = false;
+        let mut locked_history_file =
+            LockedFile::new(LockingMode::Exclusive(WriteMethod::Append), &history_path)?;
 
-        // We are going to open the file, lock it, append to it, and then close it
-        // After locking it, we need to stat the file at the path; if there is a new file there, it
-        // means the file was replaced and we have to try again.
-        // Limit our max tries so we don't do this forever.
-        let mut num_attempts = 0;
-        let mut history_file = loop {
-            if num_attempts == MAX_SAVE_TRIES {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "Number of unsuccessful attempts to open history file exceeds maximum.",
-                ));
-            }
-            // Return immediately if an error occurs here.
-            let mut file = wopen_cloexec(
-                &history_path,
-                OFlag::O_WRONLY | OFlag::O_APPEND,
-                Mode::empty(),
-            )?;
+        // Check if the file was modified since it was last read.
+        let file_id = file_id_for_file(locked_history_file.get());
+        let file_changed = file_id != self.history_file_id;
 
-            // Exclusive lock on the entire file. This is released when we close the file (below). This
-            // may fail on (e.g.) lockless NFS. If so, proceed as if it did not fail; the risk is that
-            // we may get interleaved history items, which is considered better than no history, or
-            // forcing everything through the slow copy-move mode. We try to minimize this possibility
-            // by writing with O_APPEND.
-            unsafe {
-                Self::maybe_lock_file(&mut file, LOCK_EX);
-            }
-            let file_id = file_id_for_file(&file);
-            if file_id_for_path(&history_path) == file_id {
-                // File IDs match, so the file we opened is still at that path
-                // We're going to use this fd
-                if file_id != self.history_file_id {
-                    file_changed = true;
-                }
-                break file;
-            }
-            num_attempts += 1;
-        };
-
-        // We (hopefully successfully) took the exclusive lock. Append to the file.
+        // We took the exclusive lock. Append to the file.
         // Note that this is sketchy for a few reasons:
         //   - Another shell may have appended its own items with a later timestamp, so our file may
         // no longer be sorted by timestamp.
         //   - Another shell may have appended the same items, so our file may now contain
         // duplicates.
-        //
-        // We cannot modify any previous parts of our file, because other instances may be reading
-        // those portions. We can only append.
         //
         // Originally we always rewrote the file on saving, which avoided both of these problems.
         // However, appending allows us to save history after every command, which is nice!
@@ -911,7 +726,8 @@ impl HistoryImpl {
                 // the file system.
                 // Flushing and syncing each iteration adds overhead,
                 // but hopefully there are not that many items to write when appending.
-                res = drain_buffer_into_file_and_flush(&mut buffer, &mut history_file);
+                res = drain_buffer_into_file_and_flush(&mut buffer, locked_history_file.get_mut());
+
                 if res.is_err() {
                     break;
                 }
@@ -923,11 +739,11 @@ impl HistoryImpl {
         // Since we just modified the file, update our history_file_id to match its current state
         // Otherwise we'll think the file has been changed by someone else the next time we go to
         // write.
-        // We don't update the mapping since we only appended to the file, and everything we
+        // We don't update `self.file_contents` since we only appended to the file, and everything we
         // appended remains in our new_items
-        self.history_file_id = file_id_for_file(&history_file);
+        self.history_file_id = file_id;
 
-        drop(history_file);
+        drop(locked_history_file);
 
         // If someone has replaced the file, forget our file state.
         if file_changed {
@@ -946,6 +762,9 @@ impl HistoryImpl {
             return;
         }
 
+        // Compact our new items so we don't have duplicates.
+        self.compact_new_items();
+
         if self.name.is_empty() {
             // We're in the "incognito" mode. Pretend we've saved the history.
             self.first_unwritten_new_item_index = self.new_items.len();
@@ -953,16 +772,13 @@ impl HistoryImpl {
             self.clear_file_state();
         }
 
-        // Compact our new items so we don't have duplicates.
-        self.compact_new_items();
-
         // Try saving. If we have items to delete, we have to rewrite the file. If we do not, we can
         // append to it.
         let mut ok = false;
         if !vacuum && self.deleted_items.is_empty() {
             // Try doing a fast append.
             if let Err(e) = self.save_internal_via_appending() {
-                FLOG!(history, "Appending to history failed", e);
+                FLOG!(history, "Appending to history failed:", e);
             } else {
                 ok = true;
             }
@@ -1048,7 +864,7 @@ impl HistoryImpl {
             // If we have not loaded old items, don't actually load them (which may be expensive); just
             // stat the file and see if it exists and is nonempty.
 
-            let Ok(Some(where_)) = history_filename(&self.name, L!("")) else {
+            let Ok(Some(where_)) = self.history_file_path() else {
                 return true;
             };
 
@@ -1104,7 +920,7 @@ impl HistoryImpl {
         self.deleted_items.clear();
         self.first_unwritten_new_item_index = 0;
         self.old_item_offsets.clear();
-        if let Ok(Some(filename)) = history_filename(&self.name, L!("")) {
+        if let Ok(Some(filename)) = self.history_file_path() {
             wunlink(&filename);
         }
         self.clear_file_state();
@@ -1125,7 +941,7 @@ impl HistoryImpl {
     /// file to the new history file.
     /// The new contents will automatically be re-mapped later.
     fn populate_from_config_path(&mut self) {
-        let Ok(Some(new_file)) = history_filename(&self.name, L!("")) else {
+        let Ok(Some(new_file)) = self.history_file_path() else {
             return;
         };
 
@@ -1148,7 +964,7 @@ impl HistoryImpl {
         let mut dst_file = match wopen_cloexec(
             &new_file,
             OFlag::O_WRONLY | OFlag::O_CREAT,
-            HISTORY_FILE_MODE,
+            LOCKED_FILE_MODE,
         ) {
             Ok(file) => file,
             Err(err) => {
@@ -1344,57 +1160,6 @@ impl HistoryImpl {
         self.load_old_if_needed();
         let old_item_count = self.old_item_offsets.len();
         return new_item_count + old_item_count;
-    }
-
-    /// Maybe lock a history file.
-    /// Returns `true` if successful, `false` if locking was skipped.
-    ///
-    /// # Safety
-    ///
-    /// `fd` and `lock_type` must be valid arguments to `flock(2)`.
-    unsafe fn maybe_lock_file(file: &mut File, lock_type: libc::c_int) -> bool {
-        assert!(lock_type & LOCK_UN == 0, "Do not use lock_file to unlock");
-
-        // Don't lock if it took too long before, if we are simulating a failing lock, or if our history
-        // is on a remote filesystem.
-        if ABANDONED_LOCKING.load() {
-            return false;
-        }
-        if path_get_data_remoteness() == DirRemoteness::remote {
-            return false;
-        }
-
-        let (ok, start_time) = loop {
-            let start_time = SystemTime::now();
-            if unsafe { flock(file.as_raw_fd(), lock_type) } != -1 {
-                break (true, start_time);
-            }
-            if errno::errno().0 != EINTR {
-                break (false, start_time);
-            }
-        };
-        if let Ok(duration) = start_time.elapsed() {
-            if duration > Duration::from_millis(250) {
-                FLOG!(
-                    warning,
-                    wgettext_fmt!(
-                        "Locking the history file took too long (%.3f seconds).",
-                        duration.as_secs_f64()
-                    )
-                );
-                ABANDONED_LOCKING.store(true);
-            }
-        }
-        ok
-    }
-
-    /// Unlock a history file.
-    ///
-    /// # Safety
-    ///
-    /// `fd` must be a valid argument to `flock(2)` with `LOCK_UN`.
-    unsafe fn unlock_file(file: &mut File) {
-        libc::flock(file.as_raw_fd(), LOCK_UN);
     }
 }
 
@@ -2081,3 +1846,5 @@ pub fn in_private_mode(vars: &dyn Environment) -> bool {
 
 /// Whether to force the read path instead of mmap. This is useful for testing.
 static NEVER_MMAP: RelaxedAtomicBool = RelaxedAtomicBool::new(false);
+
+static LOCK_HISTORY_FILE: RelaxedAtomicBool = RelaxedAtomicBool::new(true);

--- a/src/history/file.rs
+++ b/src/history/file.rs
@@ -5,7 +5,7 @@ use std::{
     fs::File,
     io::{Read, Seek, SeekFrom, Write},
     ops::{Deref, DerefMut},
-    os::fd::{AsRawFd, RawFd},
+    os::fd::AsRawFd,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -43,11 +43,19 @@ impl MmapRegion {
         Self { ptr, len }
     }
 
-    /// Map a region `[0, len)` from an `fd`.
-    /// Returns [`None`] on failure.
-    pub fn map_file(fd: RawFd, len: usize) -> std::io::Result<Self> {
-        assert!(len != 0);
-        let ptr = unsafe { mmap(std::ptr::null_mut(), len, PROT_READ, MAP_PRIVATE, fd, 0) };
+    /// Map a region `[0, len)` from a locked file.
+    pub fn map_file(file: &File, len: usize) -> std::io::Result<Self> {
+        let ptr = unsafe {
+            mmap(
+                std::ptr::null_mut(),
+                len,
+                PROT_READ,
+                MAP_PRIVATE,
+                file.as_raw_fd(),
+                0,
+            )
+        };
+
         if ptr == MAP_FAILED {
             return Err(std::io::Error::last_os_error());
         }
@@ -57,12 +65,7 @@ impl MmapRegion {
     }
 
     /// Map anonymous memory of a given length.
-    /// Returns [`None`] on failure.
-    pub fn map_anon(len: usize) -> Option<Self> {
-        if len == 0 {
-            return None;
-        }
-
+    pub fn map_anon(len: usize) -> std::io::Result<Self> {
         let ptr = unsafe {
             mmap(
                 std::ptr::null_mut(),
@@ -74,11 +77,11 @@ impl MmapRegion {
             )
         };
         if ptr == MAP_FAILED {
-            return None;
+            return Err(std::io::Error::last_os_error());
         }
 
         // SAFETY: mmap of `len` was successful and returned `ptr`
-        Some(unsafe { Self::new(ptr.cast(), len) })
+        Ok(unsafe { Self::new(ptr.cast(), len) })
     }
 }
 
@@ -113,39 +116,47 @@ pub struct HistoryFileContents {
 }
 
 impl HistoryFileContents {
-    /// Construct a history file contents from a File reference.
-    pub fn create(file: &mut File) -> Option<Self> {
+    /// Construct a history file contents from a [`File`] reference.
+    pub fn create(history_file: &mut File) -> std::io::Result<Self> {
         // Check that the file is seekable, and its size.
-        let len: usize = file.seek(SeekFrom::End(0)).ok()?.try_into().ok()?;
-        if len == 0 {
-            return None;
-        }
-        let map_anon = |file: &mut File, len: usize| {
+        let len: usize = match history_file.seek(SeekFrom::End(0))?.try_into() {
+            Ok(len) => len,
+            Err(err) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Unsupported,
+                    format!("Cannot convert u64 to usize: {err}"),
+                ))
+            }
+        };
+        let map_anon = |file: &mut File, len: usize| -> std::io::Result<MmapRegion> {
             let mut region = MmapRegion::map_anon(len)?;
             // If we mapped anonymous memory, we have to read from the file.
-            file.seek(SeekFrom::Start(0)).ok()?;
-            read_zero_padded(&mut *file, region.as_mut()).ok()?;
-            Some(region)
+            file.seek(SeekFrom::Start(0))?;
+            read_zero_padded(&mut *file, region.as_mut())?;
+            Ok(region)
         };
         let region = if should_mmap() {
-            match MmapRegion::map_file(file.as_raw_fd(), len) {
+            match MmapRegion::map_file(history_file, len) {
                 Ok(region) => region,
-                Err(err) if err.raw_os_error() == Some(ENODEV) => {
-                    // Our mmap failed with ENODEV, which means the underlying
-                    // filesystem does not support mapping. Treat this as a hint
-                    // that the filesystem is remote, and so disable locks for
-                    // the history file.
-                    super::ABANDONED_LOCKING.store(true);
-                    // Create an anonymous mapping and read() the file into it.
-                    map_anon(file, len)?
+                Err(err) => {
+                    if err.raw_os_error() == Some(ENODEV) {
+                        // Our mmap failed with ENODEV, which means the underlying
+                        // filesystem does not support mapping. Treat this as a hint
+                        // that the filesystem is remote, and so disable locks for
+                        // the history file.
+                        super::ABANDONED_LOCKING.store(true);
+                        // Create an anonymous mapping and read() the file into it.
+                        map_anon(history_file, len)?
+                    } else {
+                        return Err(err);
+                    }
                 }
-                Err(_err) => return None,
             }
         } else {
-            map_anon(file, len)?
+            map_anon(history_file, len)?
         };
 
-        region.try_into().ok()
+        region.try_into()
     }
 
     /// Decode an item at a given offset.
@@ -184,13 +195,17 @@ fn infer_file_type(contents: &[u8]) -> HistoryFileType {
 }
 
 impl TryFrom<MmapRegion> for HistoryFileContents {
-    type Error = ();
+    type Error = std::io::Error;
 
-    fn try_from(region: MmapRegion) -> Result<Self, Self::Error> {
+    fn try_from(region: MmapRegion) -> std::io::Result<Self> {
         let type_ = infer_file_type(&region);
         if type_ == HistoryFileType::Fish1_x {
-            FLOG!(error, "unsupported history file format 1.x");
-            return Err(());
+            let error_message = "unsupported history file format 1.x";
+            FLOG!(error, error_message);
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                error_message,
+            ));
         }
         Ok(Self { region })
     }
@@ -220,7 +235,7 @@ pub fn append_history_item_to_buffer(item: &HistoryItem, buffer: &mut Vec<u8>) {
     }
 }
 
-/// Check if we should mmap the fd.
+/// Check if we should mmap the file.
 /// Don't try mmap() on non-local filesystems.
 fn should_mmap() -> bool {
     if super::NEVER_MMAP.load() {
@@ -231,7 +246,7 @@ fn should_mmap() -> bool {
     path_get_config_remoteness() != DirRemoteness::remote
 }
 
-/// Read from `fd` to fill `dest`, zeroing any unused space.
+/// Read from `file` to fill `dest`, zeroing any unused space.
 fn read_zero_padded(file: &mut File, mut dest: &mut [u8]) -> std::io::Result<()> {
     while !dest.is_empty() {
         match file.read(dest) {

--- a/src/history/file.rs
+++ b/src/history/file.rs
@@ -15,7 +15,7 @@ use super::{HistoryItem, PersistenceMode};
 use crate::{
     common::{str2wcstring, subslice_position, wcs2string},
     flog::FLOG,
-    path::{path_get_config_remoteness, DirRemoteness},
+    path::{path_get_data_remoteness, DirRemoteness},
 };
 
 /// History file types.
@@ -243,7 +243,7 @@ fn should_mmap() -> bool {
     }
 
     // mmap only if we are known not-remote.
-    path_get_config_remoteness() != DirRemoteness::remote
+    path_get_data_remoteness() != DirRemoteness::remote
 }
 
 fn replace_all(s: &mut Vec<u8>, needle: &[u8], replacement: &[u8]) {

--- a/src/history/file.rs
+++ b/src/history/file.rs
@@ -141,14 +141,7 @@ impl HistoryFileContents {
                 Err(err) => {
                     if err.raw_os_error() == Some(ENODEV) {
                         // Our mmap failed with ENODEV, which means the underlying
-                        // filesystem does not support mapping. Treat this as a hint
-                        // that the filesystem is remote, and so disable locks for
-                        // the history file.
-                        FLOG!(
-                            history_file,
-                            "Remote file system detected. Disabling history file locking.",
-                        );
-                        super::LOCK_HISTORY_FILE.store(false);
+                        // filesystem does not support mapping.
                         // Create an anonymous mapping and read() the file into it.
                         map_anon(history_file, len)?
                     } else {

--- a/src/history/file.rs
+++ b/src/history/file.rs
@@ -144,7 +144,11 @@ impl HistoryFileContents {
                         // filesystem does not support mapping. Treat this as a hint
                         // that the filesystem is remote, and so disable locks for
                         // the history file.
-                        super::ABANDONED_LOCKING.store(true);
+                        FLOG!(
+                            history_file,
+                            "Remote file system detected. Disabling history file locking.",
+                        );
+                        super::LOCK_HISTORY_FILE.store(false);
                         // Create an anonymous mapping and read() the file into it.
                         map_anon(history_file, len)?
                     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ pub mod fd_readable_set;
 pub mod fds;
 pub mod flog;
 pub mod fork_exec;
+pub mod fs;
 pub mod function;
 pub mod future;
 pub mod future_feature_flags;

--- a/src/path.rs
+++ b/src/path.rs
@@ -667,7 +667,7 @@ fn create_dir_all_with_mode<P: AsRef<std::path::Path>>(path: P, mode: u32) -> st
 }
 
 /// Return whether the given path is on a remote filesystem.
-fn path_remoteness(path: &wstr) -> DirRemoteness {
+pub fn path_remoteness(path: &wstr) -> DirRemoteness {
     let narrow = wcs2zstring(path);
     #[cfg(target_os = "linux")]
     {

--- a/src/tests/history.rs
+++ b/src/tests/history.rs
@@ -272,8 +272,6 @@ fn test_history_races() {
     // Ensure history is clear.
     History::new(L!("race_test")).clear();
 
-    // history::CHAOS_MODE.store(true);
-
     let mut children = Vec::with_capacity(RACE_COUNT);
     for i in 0..RACE_COUNT {
         children.push(std::thread::spawn(move || {
@@ -295,7 +293,6 @@ fn test_history_races() {
 
     // Ensure that we got sane, sorted results.
     let hist = History::new(L!("race_test"));
-    history::CHAOS_MODE.store(false);
 
     // History is enumerated from most recent to least
     // Every item should be the last item in some array

--- a/src/wutil/tests.rs
+++ b/src/wutil/tests.rs
@@ -1,11 +1,10 @@
-use crate::fds::AutoCloseFd;
 use crate::tests::prelude::*;
 use crate::util::get_rng;
+use crate::{fds::AutoCloseFd, fs::create_temporary_file};
 use libc::{c_void, O_CREAT, O_RDWR, O_TRUNC, SEEK_SET};
 use rand::Rng;
-use std::{ffi::CString, ptr};
-
-use crate::fallback::fish_mkstemp_cloexec;
+use std::ffi::CString;
+use std::ptr;
 
 use super::*;
 
@@ -62,8 +61,8 @@ fn test_wdirname_wbasename() {
 #[serial]
 fn test_wwrite_to_fd() {
     let _cleanup = test_init();
-    let (_fd, filename) =
-        fish_mkstemp_cloexec(CString::new("/tmp/fish_test_wwrite.XXXXXX").unwrap()).unwrap();
+    let (_fd, filename) = create_temporary_file(L!("/tmp/fish_test_wwrite.XXXXXX")).unwrap();
+    let filename = CString::new(filename.to_string()).unwrap();
     let mut rng = get_rng();
     let sizes = [1, 2, 3, 5, 13, 23, 64, 128, 255, 4096, 4096 * 2];
     for &size in &sizes {

--- a/src/wutil/tests.rs
+++ b/src/wutil/tests.rs
@@ -61,7 +61,7 @@ fn test_wdirname_wbasename() {
 #[serial]
 fn test_wwrite_to_fd() {
     let _cleanup = test_init();
-    let (_fd, filename) = create_temporary_file(L!("/tmp/fish_test_wwrite.XXXXXX")).unwrap();
+    let (_file, filename) = create_temporary_file(L!("/tmp/fish_test_wwrite.XXXXXX")).unwrap();
     let filename = CString::new(filename.to_string()).unwrap();
     let mut rng = get_rng();
     let sizes = [1, 2, 3, 5, 13, 23, 64, 128, 255, 4096, 4096 * 2];


### PR DESCRIPTION
Locking on the history file itself comes with several problems related to the
file being renamed in the `save_internal_via_rewrite` function.
Specifically, before locking a file, it needs to be opened.
It is possible that the file gets replaced after opening but before locking.
The code had checks for this using the inode number and timestamps, but even
with these present, races could occur.

The simpler approach is to use a separate file for locking. This file never
needs to be replaced, so the aforementioned problem does not occur.

This version of the code provides a struct whose constructor allows opening the
history file while holding a lock on it. This lock can be either exclusive or
shared.
The constructor opens (and possibly creates) the lock file and locks it.
Once the lock is held, the history file is also opened.
A struct holding both files is returned.
At the moment, the encapsulation is weak, since both files are accessible to the
caller of the constructor, even though there is no need to access the lock file.
The lock on it is released when the `File` is dropped. (Because then, the file
descriptor is closed.)
Directly exposing the history file is also questionable, but convenient for
keeping compatibility with existing code.

For now, HistoryImpl::{populate_from_config_path, clear} access the history file
without locking. This is unchanged from the previous behavior.

One important additional change is that the rewrite path for updating the
history file now takes the lock before reading the history file, which is done
before populating the temporary file. This is necessary and not doing so
introduced a race condition in the old code.


Fixes issue #10300

## TODOs:
- [x] Should the lockfile be cleared on`HistoryImpl::clear`? (no: https://github.com/fish-shell/fish-shell/pull/11492#issuecomment-2953775952)
