### PR TITLE
Add openssf scorecard lint/check and workflow

### DIFF
--- a/.github/workflows/openssfscorecard.yml
+++ b/.github/workflows/openssfscorecard.yml
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2025 fish-shell/fish-shell
+#
+# SPDX-License-Identifier: CC0-1.0
+#
+# Description:
+# This workflow runs OpenSSF Scorecard to analyze your repository for security best practices.
+# It runs on push to main branch and weekly on Saturdays at 01:30 UTC.
+# It uploads the results as artifacts and integrates with GitHub's code scanning dashboard.
+---
+name: OpenSSF Scorecard analysis
+
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    # Weekly on Saturdays at 01:30 UTC
+    - cron: "30 1 * * 6"
+
+permissions:
+  contents: read
+
+jobs:
+  scorecard-analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Needed for Code scanning upload
+      security-events: write
+      # Needed for GitHub OIDC token for publishing results
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186 # v2.4.1
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable
+      # uploads of run results in SARIF format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard (optional).
+      # Commenting out will disable upload of results to your repo's Code Scanning dashboard
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@fc7e4a0fa01c3cca5fd6a1fddec5c0740c977aa2 # v3.28.14
+        with:
+          sarif_file: results.sarif

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,14 @@
+`fish <https://fishshell.com/>`__ - the friendly interactive shell
+=============================================================================================
+
+|Build Status| |Cirrus CI| |OpenSSF Scorecard|
+
 .. |Cirrus CI| image:: https://api.cirrus-ci.com/github/fish-shell/fish-shell.svg?branch=master
       :target: https://cirrus-ci.com/github/fish-shell/fish-shell
       :alt: Cirrus CI Build Status
-
-`fish <https://fishshell.com/>`__ - the friendly interactive shell |Build Status| |Cirrus CI|
-=============================================================================================
+.. |OpenSSF Scorecard| image:: https://api.scorecard.dev/projects/github.com/janderssonse/fish-shell/badge
+   :target: https://scorecard.dev/viewer/?uri=github.com/janderssonse/fish-shell
+   :alt: OpenSSF Scorecard
 
 fish is a smart and user-friendly command line shell for macOS, Linux,
 and the rest of the family. fish includes features like syntax


### PR DESCRIPTION
## Description

This small (in size) PR adds an openssf scorecard workflow and badge to the project. Openssf scorecard is a standard https://scorecard.dev/ for security health metrics in a lightweight way, used by quite a few prominent projects, example https://github.com/renovatebot/renovate, https://github.com/prometheus/prometheus and so on. Openssf is backed by OWASP, Linux foundation etc, so it should be long term and no fad. It dynamically updates the score as the workflow runs on different occasions.

**What does it do:**

It runs add bunch of predefined health security checks (see l) on the repo on schedule (or push to main) and gives a report and suggestions for improvements. It adds the score to a badge, scoring the project, and to the security tab in github, as improvements issues, and gives a report (clicking on the badge)..

To see results and ran for the fish-shell project, and how it would work, click the badge in the README.rst in my fork, to see a report of imports. I'm not sure you can see the top GH-security tab in my fork, but if you can click tab. 


**Why,What would the benefits be for fish-shell?:**

**A fancy badge with a score on it** - yeah, no :),.. to be more serious - it would serve three important purposes:

1) It would show end user of how fish is doing regarding health security metrics 
2) More importantly, It would serve as dynamic motivator/linter for fish-shell itself to fix those things and raise the score a bit over time. 
3) It would, as it runs on schedule, help the project keep the good practices over time and helping keeping a good security baseline..


Notes:

Many projects will get a low score at first,- that is expected, and nothing to be disappointed about,  as many of the fixes are quite easy to do. So starting at 3, and over time getting up to something like 7 is quite easy. I have never seen a project with a 10 out in the wild, ever. Everything over 5-6 is good.
I would help with ones I can as a contributor, in future PR's, like pinning the GitHub-actions etc to raise it. While some actions can  only be done by a project owner, (branch protection etc should it complain) other can be handled by contributors like.

Note2: 

Should you like the addition, and card after reading up on it, considering merge, you MUST change the url in the README-badge, as it points to my repo currently for demo-purposes.
Also, you might  want to consider changing the schedule for the cron job (once every night, if not running on master push, or remove the master push), things only you could decide. 

Examples:

The scorecard badge:

![Skärmbild från 2025-05-15 05-56-19](https://github.com/user-attachments/assets/2a2b302b-383e-4133-9ce2-27ea8962fb79)

The report on badge click:
![Skärmbild från 2025-05-15 05-56-42](https://github.com/user-attachments/assets/db1b8dac-de37-4b57-830d-b81cbf7a52ad)


The Security Issues Tab on GH
![Skärmbild från 2025-05-15 05-57-04](https://github.com/user-attachments/assets/bf0428aa-eb29-4d7f-9a76-0dbd811bfb10)

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [N/A] Changes to fish usage are reflected in user documentation/manpages.
- [N/A] Tests have been added for regressions fixed
- [N/A] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
