### PR TITLE
Mark format strings in po files

### DIFF
--- a/build_tools/fish_xgettext.fish
+++ b/build_tools/fish_xgettext.fish
@@ -44,9 +44,14 @@ begin
     rm $cargo_expanded_file
 
     # Sort the extracted strings and remove duplicates.
-    # Then, transform them into the po format
+    # Then, transform them into the po format.
+    # If a string contains a '%' it is considered a format string and marked with a '#, c-format'.
+    # This allows msgfmt to identify issues with translations whose format string does not match the
+    # original.
     sort -u $rust_string_file |
-        sed -E 's/^(.*)$/msgid "\1"\nmsgstr ""\n/'
+        sed -E -e '/%/ i\
+#, c-format
+' -e 's/^(.*)$/msgid "\1"\nmsgstr ""\n/'
 
     rm $rust_string_file
 


### PR DESCRIPTION
This allows msgfmt to detect issues with translations of format strings. The detection used here is very simple. It just checks if a string contains '%', and if it does, the entry in the po file is preceded by '#, c-format'. Any entries with this marker are checked by msgfmt in our tests, so if an issue arises, we will notice before it is merged.