### PR TITLE
Move and rename messages template file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ Desktop.ini
 Thumbs.db
 ehthumbs.db
 
-messages.pot
+po/template.po
 *.mo
 .directory
 .fuse_hidden*

--- a/build_tools/update_translations.fish
+++ b/build_tools/update_translations.fish
@@ -23,7 +23,7 @@
 set -gx LC_ALL C.UTF-8
 
 set -l build_tools (status dirname)
-set -l template_file $build_tools/../messages.pot
+set -l template_file $build_tools/../po/template.po
 set -l po_dir $build_tools/../po
 
 set -l extract


### PR DESCRIPTION
There is no reason to have this file clutter the repo root. Move it into the `po` directory, and give it a more descriptive name.

Inspired by this discussion:
https://github.com/fish-shell/fish-shell/pull/11463#discussion_r2083453275

I use `template.po` instead of `message.po-template` to be more compatible with automatic filetype detection. (e.g. vim/nvim detect the former as a po file, but the latter as a conf file)