### PR TITLE
Remove `libc::sem_t` completely on non-linux

### DIFF
--- a/src/tests/topic_monitor.rs
+++ b/src/tests/topic_monitor.rs
@@ -36,9 +36,6 @@ fn test_topic_monitor() {
 }
 
 #[test]
-// FIXME: Does not compile on NetBSD & Cygwin
-// "`*mut sem` cannot be sent between threads safely"
-#[cfg(not(any(target_os = "netbsd", cygwin)))]
 #[serial]
 fn test_topic_monitor_torture() {
     let _cleanup = test_init();


### PR DESCRIPTION
## Description

As it's only used on Linux, we can cfg it out completely on other platforms. It also enables `test_topic_monitor_torture` on NetBSD & Cygwin.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
