### PR TITLE
Fix build.rs to support cross-compiling to cygwin

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -143,9 +143,9 @@ fn detect_apple(_: &Target) -> Result<bool, Box<dyn Error>> {
     Ok(cfg!(any(target_os = "ios", target_os = "macos")))
 }
 
-#[allow(unexpected_cfgs)]
 fn detect_cygwin(_: &Target) -> Result<bool, Box<dyn Error>> {
-    Ok(cfg!(target_os = "cygwin"))
+    // Cygwin target is usually cross-compiled.
+    Ok(std::env::var("CARGO_CFG_TARGET_OS").unwrap() == "cygwin")
 }
 
 /// Detect if we're being compiled for a BSD-derived OS, allowing targeting code conditionally with


### PR DESCRIPTION
## Description

https://github.com/fish-shell/fish-shell/commit/2719ae443b8f908cc7e83d9475d8c8ddda8973fa adds a special cfg for cygwin to avoid annoying warnings. As cygwin target is usually cross-compiled, `cfg!` is not enough to detect the correct target. This PR uses `CARGO_CFG_TARGET_OS` env var instead.

