### PR TITLE
Add more completions to aptitude

### DIFF
--- a/share/completions/aptitude.fish
+++ b/share/completions/aptitude.fish
@@ -11,7 +11,7 @@ end
 
 function __fish_apt_use_package -d 'Test if aptitude command should have packages as potential completion'
     for i in (commandline -xpc)
-        if contains -- $i changelog full-upgrade download forbid-version hold install keep-all markauto purge reinstall remove show unhold unmarkauto
+        if contains -- $i changelog full-upgrade download forbid-version hold install keep-all markauto purge reinstall remove show showrc unhold unmarkauto why why-not versions
             return 0
         end
     end
@@ -38,15 +38,19 @@ complete -f -n __fish_apt_no_subcommand -c aptitude -a markauto -d 'Mark package
 complete -f -n __fish_apt_no_subcommand -c aptitude -a purge -d 'Remove and delete all associated configuration and data files'
 complete -f -n __fish_apt_no_subcommand -c aptitude -a reinstall -d 'Reinstall the packages'
 complete -f -n __fish_apt_no_subcommand -c aptitude -a remove -d 'Remove the packages'
+complete -f -n __fish_apt_no_subcommand -c aptitude -a showsrc -d 'Display detailed information about the source packages (apt wrapper)'
 complete -f -n __fish_apt_no_subcommand -c aptitude -a show -d 'Display detailed information about the packages'
 complete -f -n __fish_apt_no_subcommand -c aptitude -a unhold -d 'Consider the packages by future upgrade commands'
 complete -f -n __fish_apt_no_subcommand -c aptitude -a unmarkauto -d 'Mark packages as manually installed'
 complete -f -n __fish_apt_no_subcommand -c aptitude -a search -d 'Search for packages matching one of the patterns'
 complete -f -n __fish_apt_no_subcommand -c aptitude -a help -d 'Display brief summary of the available commands and options'
+complete -f -n __fish_apt_no_subcommand -c aptitude -a why -d 'Explain why a particular package should be installed'
+complete -f -n __fish_apt_no_subcommand -c aptitude -a why-not -d 'Explain why a particular package cannot be installed'
+complete -f -n __fish_apt_no_subcommand -c aptitude -a versions -d 'Displays the versions of specified packages'
 
 complete -c aptitude -s D -l show-deps -d 'Show explanations of automatic installations and removals'
-complete -c aptitude -s d -l download-only -d 'Download Only'
-complete -c aptitude -s f -l fix-broken -d 'Correct broken dependencies'
+complete -c aptitude -s d -l download-only -d 'Download only'
+complete -c aptitude -s f -l fix-broken -d 'Aggressively try to fix broken packages'
 complete -c aptitude -l purge-unused -d 'Purge packages that are not required by any installed package'
 complete -c aptitude -s P -l prompt -d 'Always display a prompt'
 complete -c aptitude -s R -l without-recommends -d 'Do not treat recommendations as dependencies'
@@ -60,6 +64,7 @@ complete -c aptitude -l version -d 'Display the version of aptitude and compile 
 complete -c aptitude -l visual-preview -d 'Start up the visual interface and display its preview screen'
 complete -c aptitude -s y -l assume-yes -d 'Assume the answer yes for all question prompts'
 complete -c aptitude -s Z -d 'Show how much disk space will be used or freed'
+complete -c aptitude -s u -d 'Download new package lists on startup (terminal interface only)'
 complete -r -c aptitude -s F -l display-format -d 'Specify the format to be used by the search command'
 complete -r -c aptitude -s t -l target-release -d 'Set the release from which packages should be installed'
 complete -r -c aptitude -s O -l sort -d 'Specify the order for the output from the search command'


### PR DESCRIPTION
## Description

Talk about your changes here.

Adds the following subcommands completions:
- showrc
- why
- why-not
- versions
They all take a package as an argument, thus the function __fish_apt_use_package was changed accordingly.

Adds the following option completion:
- -u

All of these subcommands and option above are documented in `aptitude --help`, descriptions for all of them were also added based upon the description given by `aptitude --help`.

Fixed small typo in the description of the -d option, and changed the description of the -f option to better reflect that it is not going to magically fix broken dependencies (the new description is copied from `aptitude --help`).

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
