### PR TITLE
`__fish_complete_man`: cope with gzipped man pages

### DIFF
--- a/share/functions/__fish_complete_man.fish
+++ b/share/functions/__fish_complete_man.fish
@@ -69,8 +69,8 @@ function __fish_complete_man
 
         # Fish commands are not given by apropos
         if not set -ql exclude_fish_commands
-            set -l files $__fish_data_dir/man/man1/*.1
-            string replace -r '.*/([^/]+)\.1$' '$1\t1: fish command' -- $files (status list-files man/man1/ 2>/dev/null)
+            set -l files $__fish_data_dir/man/man1/*.1*
+            string replace -r '.*/([^/]+)\.1(\.gz)?$' '$1\t1: fish command' -- $files (status list-files man/man1/ 2>/dev/null)
         end
     else
         return 1


### PR DESCRIPTION
## Description

On my system (Fedora 42) the man pages in `$__fish_data_dir/man/man1/` are gzipped and end in `.1.gz`.
Therefore, completions for `man` currently do not show the fish commands for me.
This commit makes `__fish_complete_man` cope with gzipped man pages.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
