### PR TITLE
Use proc macro for gettext extraction

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,11 +32,8 @@ jobs:
     - name: make fish_run_tests
       run: |
         make -C build VERBOSE=1 fish_run_tests
-    - uses: dtolnay/rust-toolchain@stable
     - name: translation updates
       run: |
-        # Required for our custom xgettext implementation.
-        cargo install --locked --version 1.0.106 cargo-expand
         # Generate PO files. This should not result it a change in the repo if all translations are
         # up to date.
         # Ensure that fish is available as an executable.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -297,12 +297,6 @@ Adding translations for a new language
 Creating new translations requires the Gettext tools.
 More specifically, you will need ``msguniq`` and ``msgmerge`` for creating translations for a new
 language.
-In addition, the ``cargo-expand`` tool is required.
-If you have ``cargo`` installed, run::
-
-  cargo install --locked --version 1.0.106 cargo-expand
-
-to install ``cargo-expand`` (Note that other versions might not work correctly with our scripts).
 To create a new translation, run::
 
     build_tools/update_translations.fish po/LANG.po

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,7 @@ dependencies = [
  "bitflags",
  "cc",
  "errno",
+ "fish-gettext-extraction",
  "fish-printf",
  "libc",
  "lru",
@@ -119,6 +120,13 @@ dependencies = [
  "terminfo",
  "unix_path",
  "widestring",
+]
+
+[[package]]
+name = "fish-gettext-extraction"
+version = "0.0.1"
+dependencies = [
+ "proc-macro2",
 ]
 
 [[package]]
@@ -348,18 +356,18 @@ checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,12 @@
 [workspace]
 resolver = "2"
-members = ["printf"]
+members = ["printf", "gettext-extraction"]
 
 [workspace.package]
 # To build revisions that use Corrosion (those before 2024-01), use CMake 3.19, Rustc 1.78 and Rustup 1.27.
 rust-version = "1.70"
 edition = "2021"
+repository = "https://github.com/fish-shell/fish-shell"
 
 [profile.release]
 overflow-checks = true
@@ -24,7 +25,6 @@ default-run = "fish"
 # see doc_src/license.rst for details
 # don't forget to update COPYING and debian/copyright too
 license = "GPL-2.0-only AND LGPL-2.0-or-later AND MIT AND PSF-2.0"
-repository = "https://github.com/fish-shell/fish-shell"
 homepage = "https://fishshell.com"
 readme = "README.rst"
 
@@ -49,6 +49,7 @@ nix = { version = "0.30.1", default-features = false, features = [
 num-traits = "0.2.19"
 once_cell = "1.19.0"
 fish-printf = { path = "./printf", features = ["widestring"] }
+fish-gettext-extraction = { path = "./gettext-extraction" }
 
 # Don't use the "getrandom" feature as it requires "getentropy" which was not
 # available on macOS < 10.12. We can enable "getrandom" when we raise the

--- a/build.rs
+++ b/build.rs
@@ -63,6 +63,8 @@ fn main() {
     #[cfg(not(debug_assertions))]
     rsconf::rebuild_if_paths_changed(&["doc_src", "share"]);
 
+    rsconf::rebuild_if_env_changed("FISH_GETTEXT_EXTRACTION_DIR");
+
     cc::Build::new()
         .file("src/libc.c")
         .include(build_dir)

--- a/build_tools/fish_xgettext.fish
+++ b/build_tools/fish_xgettext.fish
@@ -3,6 +3,7 @@
 # Tool to generate gettext messages template file.
 # Writes to stdout.
 
+
 begin
     # Write header. This is required by msguniq.
     # Note that this results in the file being overwritten.
@@ -15,45 +16,66 @@ begin
         echo ""
     end
 
-    set -l cargo_expanded_file (mktemp)
-    # This is a gigantic crime.
-    # We use cargo-expand to get all our wgettext invocations.
-    # This might be replaced once we have a tool which properly handles macro expansions.
-    begin
-        cargo expand --lib
-        for f in fish fish_indent fish_key_reader
-            cargo expand --bin $f
-        end
-    end >$cargo_expanded_file
+    set -l extraction_dir (mktemp -d)
 
-    set -l rust_string_file (mktemp)
+    # We need to build to ensure that the proc macro for extracting strings runs.
+    FISH_GETTEXT_EXTRACTION_DIR=$extraction_dir cargo check
+    or exit 1
 
-    # Extract any gettext call
-    grep -A1 wgettext_static_str <$cargo_expanded_file |
-        grep 'widestring::internals::core::primitive::str =' |
-        string match -rg '"(.*)"' |
-        string match -rv '^%ls$|^$' |
-        # escaping difference between gettext and cargo-expand: single-quotes
-        string replace -a "\'" "'" >$rust_string_file
+    set -l rust_string_file $extraction_dir/literals
 
-    # Extract any constants
-    grep -Ev 'BUILD_VERSION:|PACKAGE_NAME' <$cargo_expanded_file |
-        grep -E 'const [A-Z_]*: &str = "(.*)"' |
-        sed -E -e 's/^.*const [A-Z_]*: &str = "(.*)".*$/\1/' -e "s_\\\'_'_g" >>$rust_string_file
+    # Extract constants which get passed to gettext
+    #
+    # The input file contains the name of one constant per line.
+    # Each of these constants is passed to gettext, so we want to extract the corresponding string.
+    # This is not possible in a proc macro, because such a macro just sees the name of the constant,
+    # without having a way to get the corresponding literal.
+    # Therefore, it writes the names of these constants to a file,
+    # and we use these names to extract the corresponding literals from the source files using find+sed.
 
-    rm $cargo_expanded_file
+    # We create a pattern which matches all of our constant names.
+    # This is done by joining the lines of the source file with '|', to create regex alternatives.
+    set -l consts (string join '|' <$extraction_dir/consts)
+    # This is used to identify the first line of constant definitions spanning two lines.
+    set -l const_pattern_first_line '^.*const ('$consts'): &str ='
+    # The pattern for identifying constant definitions.
+    # The first group is required to enclose the '|' separated constant names.
+    # The second group is for the string literal we want to extract.
+    set -l const_pattern $const_pattern_first_line'\s*(".*");'
+
+    # This is the directory we want to search in.
+    # At the time of writing, gettext calls are only present in this directory.
+    # If gettext calls are added in sub-crates, this needs to be modified.
+    set -l src_dir (status dirname)/../src
+
+    # `find` is used to pass the paths of all relevant files to sed.
+    # `sed` is used to find the definitions of the constants and to extract the string literals.
+    # Explanation of the sed command:
+    # 1. sed is line-based, which is a problem if there is a line break after the '=' in the
+    #    definition. (Line breaks at other locations are not handled and would break this.)
+    #    Therefore, if we find a constant definition whose line ends on '=', we add the next line to
+    #    the pattern space. This line should contain the string literal.
+    #    This leaves us with a pattern space containing the entire constant definition.
+    # 2. With the pattern space prepared, we check if it matches our constant definition pattern.
+    #    The remaining commands are only executed if we find a match.
+    # 3. If this step is reached, we have found a pattern definition,
+    #    so extract the string literal and print it.
+    find $src_dir -type f -name '*.rs' -exec sed -nE -e '/'$const_pattern_first_line'$/N; /'$const_pattern'/ { s/'$const_pattern'/\2/; p }' {} '+' >>$rust_string_file
 
     # Sort the extracted strings and remove duplicates.
-    # Then, transform them into the po format.
+    # Double quotes are removed for sorting, because they can result in a string being placed before
+    # a proper prefix of that string.
+    # Once sorted, transform the strings into the po format.
     # If a string contains a '%' it is considered a format string and marked with a '#, c-format'.
     # This allows msgfmt to identify issues with translations whose format string does not match the
     # original.
-    sort -u $rust_string_file |
+    sed -E 's/^"(.*)"$/\1/' $rust_string_file |
+        sort -u  |
         sed -E -e '/%/ i\
 #, c-format
 ' -e 's/^(.*)$/msgid "\1"\nmsgstr ""\n/'
 
-    rm $rust_string_file
+    rm -r $extraction_dir
 
     function extract_fish_script_messages --argument-names regex
 

--- a/gettext-extraction/Cargo.toml
+++ b/gettext-extraction/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "fish-gettext-extraction"
+edition.workspace = true
+rust-version.workspace = true
+version = "0.0.1"
+repository.workspace = true
+description = "proc-macro for extracting strings for gettext translation"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0"
+
+[lints]
+workspace = true

--- a/gettext-extraction/src/lib.rs
+++ b/gettext-extraction/src/lib.rs
@@ -1,0 +1,79 @@
+extern crate proc_macro;
+use proc_macro::TokenStream;
+use std::{fs::OpenOptions, io::Write};
+
+fn append_line_to_file(message: &TokenStream, file_name: &str) {
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(file_name)
+        .unwrap();
+    let mut message_string = message.to_string();
+    if message_string.contains('\n') {
+        panic!("Gettext strings may not contain unescaped newlines. Unescaped newline found in '{message_string}'")
+    }
+    message_string.push('\n');
+    file.write_all(message_string.as_bytes()).unwrap();
+}
+
+/// The `message` is passed through unmodified.
+/// If `FISH_GETTEXT_EXTRACTION_DIR` is defined in the environment,
+/// this directory is used to write the message,
+/// so that it can then be used for generating gettext PO files.
+/// The `message` can be a string literal, in which case it is appended to the `literals` file
+/// in the directory. Literals are written enclosed in double quotes and with a trailing newline.
+/// Alternatively, the name of a constant can be passed as the `message`.
+/// In this case, the macro cannot obtain the corresponding string literal.
+/// (at least not without using unstable features/external commands)
+/// The names of such constants are written to the `consts` file.
+/// This file can then be used as a starting point for extracting the constant strings from the
+/// source files with external tooling.
+///
+/// # Panics
+///
+/// This macro panics if the `FISH_GETTEXT_EXTRACTION_DIR` variable is set and `message` has an
+/// unexpected format.
+/// Note that for example `concat!(...)` cannot be passed to this macro, because expansion works
+/// outside in, meaning this macro would still see the `concat!` macro invocation, instead of a
+/// string literal.
+#[proc_macro]
+pub fn gettext_extract(message: TokenStream) -> TokenStream {
+    if let Ok(dir) = std::env::var("FISH_GETTEXT_EXTRACTION_DIR") {
+        let pm2_message = proc_macro2::TokenStream::from(message.clone());
+        let mut token_trees = pm2_message.into_iter();
+        let first_token = token_trees
+            .next()
+            .expect("gettext_extract got empty token stream. Expected one token.");
+        if token_trees.next().is_some() {
+            panic!("Invalid number of tokens passed to gettext_extract. Expected one token, but got more.")
+        }
+        match first_token {
+            proc_macro2::TokenTree::Group(group) => {
+                let mut group_tokens = group.stream().into_iter();
+                let first_group_token = group_tokens
+                    .next()
+                    .expect("gettext_extract expected one group token but got none.");
+                if group_tokens.next().is_some() {
+                    panic!("Invalid number of tokens in group passed to gettext_extract. Expected one token, but got more.")
+                }
+                match first_group_token {
+                    proc_macro2::TokenTree::Literal(_) => {
+                        append_line_to_file(&message, &format!("{dir}/literals"));
+                    }
+                    proc_macro2::TokenTree::Ident(_) => {
+                        append_line_to_file(&message, &format!("{dir}/consts"));
+                    }
+                    other => {
+                        panic!(
+                            "Expected literal or constant in gettext_extract, but got: {other:?}"
+                        );
+                    }
+                }
+            }
+            other => {
+                panic!("Expected group in gettext_extract, but got: {other:?}");
+            }
+        }
+    }
+    message
+}

--- a/po/de.po
+++ b/po/de.po
@@ -42,6 +42,10 @@ msgid "$$ is not the pid. In fish, please use $fish_pid."
 msgstr ""
 
 #, c-format
+msgid "$%lc is not a valid variable in fish."
+msgstr ""
+
+#, c-format
 msgid "$%ls: originally inherited as |%ls|\n"
 msgstr "$%ls: Ursprünglich geerbt als |%ls|\n"
 
@@ -64,6 +68,10 @@ msgstr "$status ist kein gültiger Befehl. Siehe `help conditions`"
 #, c-format
 msgid "%.*ls: invalid conversion specification"
 msgstr "%.*ls: Ungültige Umwandlungsspezifikation"
+
+#, c-format
+msgid "%ls"
+msgstr ""
 
 #, c-format
 msgid "%ls %ls: Abbreviation %ls already exists, cannot rename %ls\n"
@@ -136,6 +144,10 @@ msgstr ""
 #, c-format
 msgid "%ls: %ls: contains a syntax error\n"
 msgstr "%ls: %ls: enthält einen Syntaxfehler\n"
+
+#, c-format
+msgid "%ls: %ls: expected %d arguments; got %d\n"
+msgstr ""
 
 #, c-format
 msgid "%ls: %ls: invalid base value\n"
@@ -666,6 +678,18 @@ msgid "%ls: exclusive flag string '%ls' is not valid\n"
 msgstr "%ls: Exklusive option '%ls' ist ungültig\n"
 
 #, c-format
+msgid "%ls: expected %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: expected <= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: expected >= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
 msgid "%ls: expected a numeric value"
 msgstr "%ls: Erwartete numerischen Wert"
 
@@ -675,6 +699,10 @@ msgstr "%ls: Brauche Funktionsnamen"
 
 #, c-format
 msgid "%ls: given %d indexes but %d values\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: invalid option combination, %ls\n"
 msgstr ""
 
 #, c-format
@@ -691,6 +719,10 @@ msgstr ""
 
 #, c-format
 msgid "%ls: line/column index starts at 1"
+msgstr ""
+
+#, c-format
+msgid "%ls: missing argument\n"
 msgstr ""
 
 #, c-format
@@ -825,18 +857,6 @@ msgid "--query and --names are mutually exclusive"
 msgstr ""
 
 msgid "--tokens options are mutually exclusive"
-msgstr ""
-
-msgid ".local/bin/"
-msgstr ""
-
-msgid ".local/share/"
-msgstr ""
-
-msgid ".local/share/doc/fish"
-msgstr ""
-
-msgid "/etc/"
 msgstr ""
 
 msgid "A second attempt to exit will terminate them.\n"
@@ -1500,6 +1520,14 @@ msgstr ""
 msgid "Variable: %ls"
 msgstr "Variable: %ls"
 
+#, c-format
+msgid "Variables cannot be bracketed. In fish, please use \"$%ls\"."
+msgstr ""
+
+#, c-format
+msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
+msgstr ""
+
 msgid "Wait for background processes completed"
 msgstr "Auf den Abschluss von Hintergrundprozessen warten"
 
@@ -1573,9 +1601,6 @@ msgstr "exportiert"
 
 msgid "file"
 msgstr "Datei"
-
-msgid "fish/install"
-msgstr ""
 
 #, c-format
 msgid ""

--- a/po/en.po
+++ b/po/en.po
@@ -42,6 +42,10 @@ msgid "$$ is not the pid. In fish, please use $fish_pid."
 msgstr ""
 
 #, c-format
+msgid "$%lc is not a valid variable in fish."
+msgstr "$%lc is not a valid variable in fish."
+
+#, c-format
 msgid "$%ls: originally inherited as |%ls|\n"
 msgstr ""
 
@@ -64,6 +68,10 @@ msgstr ""
 #, c-format
 msgid "%.*ls: invalid conversion specification"
 msgstr "%.*ls: invalid conversion specification"
+
+#, c-format
+msgid "%ls"
+msgstr ""
 
 #, c-format
 msgid "%ls %ls: Abbreviation %ls already exists, cannot rename %ls\n"
@@ -135,6 +143,10 @@ msgstr ""
 
 #, c-format
 msgid "%ls: %ls: contains a syntax error\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: %ls: expected %d arguments; got %d\n"
 msgstr ""
 
 #, c-format
@@ -666,6 +678,18 @@ msgid "%ls: exclusive flag string '%ls' is not valid\n"
 msgstr ""
 
 #, c-format
+msgid "%ls: expected %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: expected <= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: expected >= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
 msgid "%ls: expected a numeric value"
 msgstr "%ls: expected a numeric value"
 
@@ -675,6 +699,10 @@ msgstr ""
 
 #, c-format
 msgid "%ls: given %d indexes but %d values\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: invalid option combination, %ls\n"
 msgstr ""
 
 #, c-format
@@ -691,6 +719,10 @@ msgstr ""
 
 #, c-format
 msgid "%ls: line/column index starts at 1"
+msgstr ""
+
+#, c-format
+msgid "%ls: missing argument\n"
 msgstr ""
 
 #, c-format
@@ -825,18 +857,6 @@ msgid "--query and --names are mutually exclusive"
 msgstr ""
 
 msgid "--tokens options are mutually exclusive"
-msgstr ""
-
-msgid ".local/bin/"
-msgstr ""
-
-msgid ".local/share/"
-msgstr ""
-
-msgid ".local/share/doc/fish"
-msgstr ""
-
-msgid "/etc/"
 msgstr ""
 
 msgid "A second attempt to exit will terminate them.\n"
@@ -1500,6 +1520,14 @@ msgstr ""
 msgid "Variable: %ls"
 msgstr "Variable: %ls"
 
+#, c-format
+msgid "Variables cannot be bracketed. In fish, please use \"$%ls\"."
+msgstr ""
+
+#, c-format
+msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
+msgstr ""
+
 msgid "Wait for background processes completed"
 msgstr ""
 
@@ -1571,9 +1599,6 @@ msgstr ""
 
 msgid "file"
 msgstr "file"
-
-msgid "fish/install"
-msgstr ""
 
 #, c-format
 msgid ""
@@ -79261,10 +79286,6 @@ msgstr ""
 
 #~ msgid "Unused signal"
 #~ msgstr "Unused signal"
-
-#, c-format
-#~ msgid "$%lc is not a valid variable in fish."
-#~ msgstr "$%lc is not a valid variable in fish."
 
 #~ msgid "Process file after the compiler reads in the standard specs file, in order to override the defaults that the gcc driver program uses when determining what switches to pass to cc1, cc1plus, as, ld, etc"
 #~ msgstr "Process file after the compiler reads in the standard specs file, in order to override the defaults that the gcc driver program uses when determining what switches to pass to cc1, cc1plus, as, ld, etc"

--- a/po/fr.po
+++ b/po/fr.po
@@ -141,6 +141,10 @@ msgid "$$ is not the pid. In fish, please use $fish_pid."
 msgstr "$$ n’est pas le PID. Dans fish, veuillez utiliser $fish_pid."
 
 #, c-format
+msgid "$%lc is not a valid variable in fish."
+msgstr "$%lc est un nom de variable invalide dans fish."
+
+#, c-format
 msgid "$%ls: originally inherited as |%ls|\n"
 msgstr ""
 
@@ -163,6 +167,10 @@ msgstr ""
 #, c-format
 msgid "%.*ls: invalid conversion specification"
 msgstr "%.*ls : spécification de conversion invalide"
+
+#, c-format
+msgid "%ls"
+msgstr ""
 
 #, c-format
 msgid "%ls %ls: Abbreviation %ls already exists, cannot rename %ls\n"
@@ -234,6 +242,10 @@ msgstr ""
 
 #, c-format
 msgid "%ls: %ls: contains a syntax error\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: %ls: expected %d arguments; got %d\n"
 msgstr ""
 
 #, c-format
@@ -765,6 +777,18 @@ msgid "%ls: exclusive flag string '%ls' is not valid\n"
 msgstr "%ls : le sémaphore texte exclusif '%ls' est invalide\n"
 
 #, c-format
+msgid "%ls: expected %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: expected <= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: expected >= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
 msgid "%ls: expected a numeric value"
 msgstr "%ls : valeur numérique attendue"
 
@@ -774,6 +798,10 @@ msgstr ""
 
 #, c-format
 msgid "%ls: given %d indexes but %d values\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: invalid option combination, %ls\n"
 msgstr ""
 
 #, c-format
@@ -790,6 +818,10 @@ msgstr "%ls : la tâche %d ('%ls') a été arrêtée et a reçu un signal pour 
 
 #, c-format
 msgid "%ls: line/column index starts at 1"
+msgstr ""
+
+#, c-format
+msgid "%ls: missing argument\n"
 msgstr ""
 
 #, c-format
@@ -924,18 +956,6 @@ msgid "--query and --names are mutually exclusive"
 msgstr ""
 
 msgid "--tokens options are mutually exclusive"
-msgstr ""
-
-msgid ".local/bin/"
-msgstr ""
-
-msgid ".local/share/"
-msgstr ""
-
-msgid ".local/share/doc/fish"
-msgstr ""
-
-msgid "/etc/"
 msgstr ""
 
 msgid "A second attempt to exit will terminate them.\n"
@@ -1599,6 +1619,14 @@ msgstr "Utilisez 'disown PID' pour retirer des tâches de la liste sans les abr�
 msgid "Variable: %ls"
 msgstr "Variable : %ls"
 
+#, c-format
+msgid "Variables cannot be bracketed. In fish, please use \"$%ls\"."
+msgstr "Les variables ne peuvent être placées entre crochets. Dans fish, veuillez utiliser \"$%ls\"."
+
+#, c-format
+msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
+msgstr "Les variables ne peuvent être placées entre crochets. Dans fish, veuillez utiliser {$%ls}."
+
 msgid "Wait for background processes completed"
 msgstr "Attendre la mort des processus en arrière-plan"
 
@@ -1672,9 +1700,6 @@ msgstr "exportée"
 
 msgid "file"
 msgstr "fichier"
-
-msgid "fish/install"
-msgstr ""
 
 #, c-format
 msgid ""
@@ -80651,18 +80676,6 @@ msgstr ""
 #, c-format
 #~ msgid "getcwd() failed with errno %d/%s"
 #~ msgstr "getcwd() a échoué avec l’erreur %d/%s"
-
-#, c-format
-#~ msgid "$%lc is not a valid variable in fish."
-#~ msgstr "$%lc est un nom de variable invalide dans fish."
-
-#, c-format
-#~ msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
-#~ msgstr "Les variables ne peuvent être placées entre crochets. Dans fish, veuillez utiliser {$%ls}."
-
-#, c-format
-#~ msgid "Variables cannot be bracketed. In fish, please use \"$%ls\"."
-#~ msgstr "Les variables ne peuvent être placées entre crochets. Dans fish, veuillez utiliser \"$%ls\"."
 
 #~ msgid "Print each token on a separate line"
 #~ msgstr "Afficher chaque lexème sur une ligne séparée"

--- a/po/pl.po
+++ b/po/pl.po
@@ -38,6 +38,10 @@ msgid "$$ is not the pid. In fish, please use $fish_pid."
 msgstr "$$ nie jest numerem identyfikacyjnym procesu. W fish używane jest $fish_pid."
 
 #, c-format
+msgid "$%lc is not a valid variable in fish."
+msgstr "$%lc nie jest prawidłową zmienną w fish."
+
+#, c-format
 msgid "$%ls: originally inherited as |%ls|\n"
 msgstr ""
 
@@ -59,6 +63,10 @@ msgstr ""
 
 #, c-format
 msgid "%.*ls: invalid conversion specification"
+msgstr ""
+
+#, c-format
+msgid "%ls"
 msgstr ""
 
 #, c-format
@@ -131,6 +139,10 @@ msgstr ""
 
 #, c-format
 msgid "%ls: %ls: contains a syntax error\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: %ls: expected %d arguments; got %d\n"
 msgstr ""
 
 #, c-format
@@ -662,6 +674,18 @@ msgid "%ls: exclusive flag string '%ls' is not valid\n"
 msgstr ""
 
 #, c-format
+msgid "%ls: expected %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: expected <= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: expected >= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
 msgid "%ls: expected a numeric value"
 msgstr "%ls: oczekiwano wartości liczbowej"
 
@@ -671,6 +695,10 @@ msgstr ""
 
 #, c-format
 msgid "%ls: given %d indexes but %d values\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: invalid option combination, %ls\n"
 msgstr ""
 
 #, c-format
@@ -687,6 +715,10 @@ msgstr ""
 
 #, c-format
 msgid "%ls: line/column index starts at 1"
+msgstr ""
+
+#, c-format
+msgid "%ls: missing argument\n"
 msgstr ""
 
 #, c-format
@@ -821,18 +853,6 @@ msgid "--query and --names are mutually exclusive"
 msgstr ""
 
 msgid "--tokens options are mutually exclusive"
-msgstr ""
-
-msgid ".local/bin/"
-msgstr ""
-
-msgid ".local/share/"
-msgstr ""
-
-msgid ".local/share/doc/fish"
-msgstr ""
-
-msgid "/etc/"
 msgstr ""
 
 msgid "A second attempt to exit will terminate them.\n"
@@ -1496,6 +1516,14 @@ msgstr ""
 msgid "Variable: %ls"
 msgstr "Zmienna: %ls"
 
+#, c-format
+msgid "Variables cannot be bracketed. In fish, please use \"$%ls\"."
+msgstr "Zmienne nie mogą znajdować się w nawiasach. W fish używane jest \"$%ls\"."
+
+#, c-format
+msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
+msgstr "Zmienne nie mogą znajdować się w nawiasach. W fish używane jest {$%ls}."
+
 msgid "Wait for background processes completed"
 msgstr ""
 
@@ -1566,9 +1594,6 @@ msgid "exported"
 msgstr ""
 
 msgid "file"
-msgstr ""
-
-msgid "fish/install"
 msgstr ""
 
 #, c-format
@@ -79019,18 +79044,6 @@ msgstr ""
 
 #~ msgid "Unused signal"
 #~ msgstr "Niewykorzystywany sygnał"
-
-#, c-format
-#~ msgid "$%lc is not a valid variable in fish."
-#~ msgstr "$%lc nie jest prawidłową zmienną w fish."
-
-#, c-format
-#~ msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
-#~ msgstr "Zmienne nie mogą znajdować się w nawiasach. W fish używane jest {$%ls}."
-
-#, c-format
-#~ msgid "Variables cannot be bracketed. In fish, please use \"$%ls\"."
-#~ msgstr "Zmienne nie mogą znajdować się w nawiasach. W fish używane jest \"$%ls\"."
 
 #, c-format
 #~ msgid "Send job %d '%ls' to background\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -43,6 +43,10 @@ msgid "$$ is not the pid. In fish, please use $fish_pid."
 msgstr ""
 
 #, c-format
+msgid "$%lc is not a valid variable in fish."
+msgstr ""
+
+#, c-format
 msgid "$%ls: originally inherited as |%ls|\n"
 msgstr ""
 
@@ -65,6 +69,10 @@ msgstr ""
 #, c-format
 msgid "%.*ls: invalid conversion specification"
 msgstr "%.*ls: especificação de conversão inválida"
+
+#, c-format
+msgid "%ls"
+msgstr ""
 
 #, c-format
 msgid "%ls %ls: Abbreviation %ls already exists, cannot rename %ls\n"
@@ -136,6 +144,10 @@ msgstr ""
 
 #, c-format
 msgid "%ls: %ls: contains a syntax error\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: %ls: expected %d arguments; got %d\n"
 msgstr ""
 
 #, c-format
@@ -667,6 +679,18 @@ msgid "%ls: exclusive flag string '%ls' is not valid\n"
 msgstr ""
 
 #, c-format
+msgid "%ls: expected %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: expected <= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: expected >= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
 msgid "%ls: expected a numeric value"
 msgstr "%ls: esperava valor numérico"
 
@@ -676,6 +700,10 @@ msgstr ""
 
 #, c-format
 msgid "%ls: given %d indexes but %d values\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: invalid option combination, %ls\n"
 msgstr ""
 
 #, c-format
@@ -692,6 +720,10 @@ msgstr ""
 
 #, c-format
 msgid "%ls: line/column index starts at 1"
+msgstr ""
+
+#, c-format
+msgid "%ls: missing argument\n"
 msgstr ""
 
 #, c-format
@@ -826,18 +858,6 @@ msgid "--query and --names are mutually exclusive"
 msgstr ""
 
 msgid "--tokens options are mutually exclusive"
-msgstr ""
-
-msgid ".local/bin/"
-msgstr ""
-
-msgid ".local/share/"
-msgstr ""
-
-msgid ".local/share/doc/fish"
-msgstr ""
-
-msgid "/etc/"
 msgstr ""
 
 msgid "A second attempt to exit will terminate them.\n"
@@ -1501,6 +1521,14 @@ msgstr ""
 msgid "Variable: %ls"
 msgstr "Variável: %ls"
 
+#, c-format
+msgid "Variables cannot be bracketed. In fish, please use \"$%ls\"."
+msgstr ""
+
+#, c-format
+msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
+msgstr ""
+
 msgid "Wait for background processes completed"
 msgstr "Espera até os processos no background completarem"
 
@@ -1572,9 +1600,6 @@ msgstr ""
 
 msgid "file"
 msgstr "arquivo"
-
-msgid "fish/install"
-msgstr ""
 
 #, c-format
 msgid ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -39,6 +39,10 @@ msgid "$$ is not the pid. In fish, please use $fish_pid."
 msgstr ""
 
 #, c-format
+msgid "$%lc is not a valid variable in fish."
+msgstr ""
+
+#, c-format
 msgid "$%ls: originally inherited as |%ls|\n"
 msgstr ""
 
@@ -60,6 +64,10 @@ msgstr ""
 
 #, c-format
 msgid "%.*ls: invalid conversion specification"
+msgstr ""
+
+#, c-format
+msgid "%ls"
 msgstr ""
 
 #, c-format
@@ -132,6 +140,10 @@ msgstr ""
 
 #, c-format
 msgid "%ls: %ls: contains a syntax error\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: %ls: expected %d arguments; got %d\n"
 msgstr ""
 
 #, c-format
@@ -663,6 +675,18 @@ msgid "%ls: exclusive flag string '%ls' is not valid\n"
 msgstr ""
 
 #, c-format
+msgid "%ls: expected %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: expected <= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: expected >= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
 msgid "%ls: expected a numeric value"
 msgstr ""
 
@@ -672,6 +696,10 @@ msgstr ""
 
 #, c-format
 msgid "%ls: given %d indexes but %d values\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: invalid option combination, %ls\n"
 msgstr ""
 
 #, c-format
@@ -688,6 +716,10 @@ msgstr ""
 
 #, c-format
 msgid "%ls: line/column index starts at 1"
+msgstr ""
+
+#, c-format
+msgid "%ls: missing argument\n"
 msgstr ""
 
 #, c-format
@@ -822,18 +854,6 @@ msgid "--query and --names are mutually exclusive"
 msgstr ""
 
 msgid "--tokens options are mutually exclusive"
-msgstr ""
-
-msgid ".local/bin/"
-msgstr ""
-
-msgid ".local/share/"
-msgstr ""
-
-msgid ".local/share/doc/fish"
-msgstr ""
-
-msgid "/etc/"
 msgstr ""
 
 msgid "A second attempt to exit will terminate them.\n"
@@ -1497,6 +1517,14 @@ msgstr ""
 msgid "Variable: %ls"
 msgstr "Variabel: %ls"
 
+#, c-format
+msgid "Variables cannot be bracketed. In fish, please use \"$%ls\"."
+msgstr ""
+
+#, c-format
+msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
+msgstr ""
+
 msgid "Wait for background processes completed"
 msgstr ""
 
@@ -1567,9 +1595,6 @@ msgid "exported"
 msgstr ""
 
 msgid "file"
-msgstr ""
-
-msgid "fish/install"
 msgstr ""
 
 #, c-format

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -34,6 +34,10 @@ msgid "$$ is not the pid. In fish, please use $fish_pid."
 msgstr "美元不是皮条客. 在fish中,请使用$fish_pid."
 
 #, c-format
+msgid "$%lc is not a valid variable in fish."
+msgstr ""
+
+#, c-format
 msgid "$%ls: originally inherited as |%ls|\n"
 msgstr "$%ls: 原为 |%ls| 继承 \n"
 
@@ -56,6 +60,10 @@ msgstr "$status 作为命令无效 . 见`help conditions`"
 #, c-format
 msgid "%.*ls: invalid conversion specification"
 msgstr "%.*ls: 无效的转换形式"
+
+#, c-format
+msgid "%ls"
+msgstr ""
 
 #, c-format
 msgid "%ls %ls: Abbreviation %ls already exists, cannot rename %ls\n"
@@ -128,6 +136,10 @@ msgstr "%ls: %ls: 无法将保留关键字作为函数名"
 #, c-format
 msgid "%ls: %ls: contains a syntax error\n"
 msgstr "%ls:%ls: 包含语法错误\n"
+
+#, c-format
+msgid "%ls: %ls: expected %d arguments; got %d\n"
+msgstr ""
 
 #, c-format
 msgid "%ls: %ls: invalid base value\n"
@@ -658,6 +670,18 @@ msgid "%ls: exclusive flag string '%ls' is not valid\n"
 msgstr "%ls: 排他性标志字符串 '%ls' 无效\n"
 
 #, c-format
+msgid "%ls: expected %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: expected <= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: expected >= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
 msgid "%ls: expected a numeric value"
 msgstr "%ls: 预期数字类型值"
 
@@ -668,6 +692,10 @@ msgstr "%ls: 函数名称是必须的"
 #, c-format
 msgid "%ls: given %d indexes but %d values\n"
 msgstr "%ls: 给定的 %d 索引但 %d 值\n"
+
+#, c-format
+msgid "%ls: invalid option combination, %ls\n"
+msgstr ""
 
 #, c-format
 msgid "%ls: invalid option combination\n"
@@ -683,6 +711,10 @@ msgstr "%ls: 任务 %d ('%ls') 已停止并指示要继续 .\n"
 
 #, c-format
 msgid "%ls: line/column index starts at 1"
+msgstr ""
+
+#, c-format
+msgid "%ls: missing argument\n"
 msgstr ""
 
 #, c-format
@@ -818,18 +850,6 @@ msgstr "--query和 --names 相互排斥"
 
 msgid "--tokens options are mutually exclusive"
 msgstr "--tokens 选项是相互排斥的"
-
-msgid ".local/bin/"
-msgstr ""
-
-msgid ".local/share/"
-msgstr ""
-
-msgid ".local/share/doc/fish"
-msgstr ""
-
-msgid "/etc/"
-msgstr ""
 
 msgid "A second attempt to exit will terminate them.\n"
 msgstr "第二次尝试退出将终止它们.\n"
@@ -1492,6 +1512,14 @@ msgstr "使用' 取消 PID ' 从列表中删除任务而不终止它们 .\n"
 msgid "Variable: %ls"
 msgstr "变量:%ls"
 
+#, c-format
+msgid "Variables cannot be bracketed. In fish, please use \"$%ls\"."
+msgstr ""
+
+#, c-format
+msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
+msgstr ""
+
 msgid "Wait for background processes completed"
 msgstr "等待背景进程完成"
 
@@ -1565,9 +1593,6 @@ msgstr "导出"
 
 msgid "file"
 msgstr "文件"
-
-msgid "fish/install"
-msgstr ""
 
 #, c-format
 msgid ""

--- a/printf/Cargo.toml
+++ b/printf/Cargo.toml
@@ -3,7 +3,7 @@ name = "fish-printf"
 edition.workspace = true
 rust-version.workspace = true
 version = "0.2.1"
-repository = "https://github.com/fish-shell/fish-shell"
+repository.workspace = true
 description = "printf implementation, based on musl"
 license = "MIT"
 

--- a/src/builtins/fg.rs
+++ b/src/builtins/fg.rs
@@ -97,10 +97,7 @@ pub fn fg(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Built
                     job_pos = Some(pos);
                     job = if !j.wants_job_control() {
                         streams.err.append(wgettext_fmt!(
-                            concat!(
-                                "%ls: Can't put job %d, '%ls' to foreground because ",
-                                "it is not under job control\n"
-                            ),
+                            "%ls: Can't put job %d, '%ls' to foreground because it is not under job control\n",
                             cmd,
                             raw_pid,
                             j.command()

--- a/src/builtins/read.rs
+++ b/src/builtins/read.rs
@@ -107,10 +107,7 @@ fn parse_cmd_opts(
             }
             'i' => {
                 streams.err.append(wgettext_fmt!(
-                    concat!(
-                        "%ls: usage of -i for --silent is deprecated. Please ",
-                        "use -s or --silent instead.\n"
-                    ),
+                    "%ls: usage of -i for --silent is deprecated. Please use -s or --silent instead.\n",
                     cmd
                 ));
                 return Err(STATUS_INVALID_ARGS);

--- a/src/builtins/shared.rs
+++ b/src/builtins/shared.rs
@@ -26,10 +26,8 @@ pub const DEFAULT_READ_PROMPT: &wstr =
 pub const BUILTIN_ERR_MISSING: &str = "%ls: %ls: option requires an argument\n";
 
 /// Error message on missing man page.
-pub const BUILTIN_ERR_MISSING_HELP: &str = concat!(
-    "fish: %ls: missing man page\nDocumentation may not be installed.\n`help %ls` will ",
-    "show an online version\n"
-);
+pub const BUILTIN_ERR_MISSING_HELP: &str =
+    "fish: %ls: missing man page\nDocumentation may not be installed.\n`help %ls` will show an online version\n";
 
 /// Error message on multiple scope levels for variables.
 pub const BUILTIN_ERR_GLOCAL: &str =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,5 +102,7 @@ pub mod wgetopt;
 pub mod widecharwidth;
 pub mod wildcard;
 
+pub extern crate fish_gettext_extraction;
+
 #[cfg(test)]
 mod tests;

--- a/src/parse_execution.rs
+++ b/src/parse_execution.rs
@@ -278,10 +278,7 @@ impl<'a> ExecutionContext<'a> {
                         ctx,
                         STATUS_NOT_EXECUTABLE,
                         &statement.command,
-                        concat!(
-                            "Unknown command. A component of '%ls' is not a ",
-                            "directory. Check your $PATH."
-                        ),
+                        "Unknown command. A component of '%ls' is not a directory. Check your $PATH.",
                         cmd
                     );
                 } else {

--- a/src/print_help.rs
+++ b/src/print_help.rs
@@ -1,6 +1,8 @@
 //! Helper for executables (not builtins) to print a help message
 //! Uses the fish in PATH, not necessarily the matching fish binary
 
+use crate::wgettext;
+
 use std::ffi::{OsStr, OsString};
 use std::process::Command;
 
@@ -16,9 +18,8 @@ pub fn print_help(command: &str) {
         .spawn()
         .and_then(|mut c| c.wait())
     {
-        // TODO: should be translated
-        Ok(status) if !status.success() => eprintf!("%s\n", HELP_ERR),
-        Err(e) => eprintf!("%s: %s\n", HELP_ERR, e),
+        Ok(status) if !status.success() => eprintf!("%s\n", wgettext!(HELP_ERR)),
+        Err(e) => eprintf!("%s: %s\n", wgettext!(HELP_ERR), e),
         _ => (),
     }
 }

--- a/src/wutil/gettext.rs
+++ b/src/wutil/gettext.rs
@@ -138,7 +138,9 @@ pub fn wgettext_str(s: &wstr) -> &'static wstr {
 #[macro_export]
 macro_rules! wgettext {
     ($string:expr) => {
-        $crate::wutil::gettext::wgettext_static_str(widestring::utf32str!($string))
+        $crate::wutil::gettext::wgettext_static_str(widestring::utf32str!(
+            fish_gettext_extraction::gettext_extract!($string)
+        ))
     };
 }
 pub use wgettext;


### PR DESCRIPTION
This is a replacement for the `cargo-expand`-based extraction.

When building with the `GETTEXT_EXTRACTION_DIR` environment variable set, the
`gettext_extract` proc macro will write the messages passed to the `wgettext!`
macro to a file in the directory specified by the variable.

The macro can handle string literals, which are written to the `literals` file
enclosed in double quotes and with a trailing newline.
Passing the name of string constants is also supported, but the proc macro is
unable to obtain the corresponding literal, so instead it writes the name of the
constant into the `consts` file. Actually extracting the string is then done in
`build_tools/fish_xgettext.fish`, which uses the identifiers from `consts` to
search the source files for the corresponding definitions.

Inspired by https://github.com/fish-shell/fish-shell/pull/11502#discussion_r2108889318.