### PR TITLE
Extract signal and debug option descriptions

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -297,12 +297,6 @@ Adding translations for a new language
 Creating new translations requires the Gettext tools.
 More specifically, you will need ``msguniq`` and ``msgmerge`` for creating translations for a new
 language.
-In addition, the ``cargo-expand`` tool is required.
-If you have ``cargo`` installed, run::
-
-  cargo install --locked --version 1.0.106 cargo-expand
-
-to install ``cargo-expand`` (Note that other versions might not work correctly with our scripts).
 To create a new translation, run::
 
     build_tools/update_translations.fish po/LANG.po

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,7 @@ dependencies = [
  "bitflags",
  "cc",
  "errno",
+ "fish-gettext-extraction",
  "fish-printf",
  "libc",
  "lru",
@@ -119,6 +120,13 @@ dependencies = [
  "terminfo",
  "unix_path",
  "widestring",
+]
+
+[[package]]
+name = "fish-gettext-extraction"
+version = "0.0.1"
+dependencies = [
+ "proc-macro2",
 ]
 
 [[package]]
@@ -348,18 +356,18 @@ checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ nix = { version = "0.30.1", default-features = false, features = [
 num-traits = "0.2.19"
 once_cell = "1.19.0"
 fish-printf = { path = "./printf", features = ["widestring"] }
+fish-gettext-extraction = { path = "./gettext_extraction" }
 
 # Don't use the "getrandom" feature as it requires "getentropy" which was not
 # available on macOS < 10.12. We can enable "getrandom" when we raise the

--- a/build.rs
+++ b/build.rs
@@ -63,6 +63,8 @@ fn main() {
     #[cfg(not(debug_assertions))]
     rsconf::rebuild_if_paths_changed(&["doc_src", "share"]);
 
+    rsconf::rebuild_if_env_changed("GETTEXT_EXTRACTION_DIR");
+
     cc::Build::new()
         .file("src/libc.c")
         .include(build_dir)

--- a/gettext_extraction/Cargo.toml
+++ b/gettext_extraction/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "fish-gettext-extraction"
+edition.workspace = true
+rust-version.workspace = true
+version = "0.0.1"
+repository = "https://github.com/fish-shell/fish-shell"
+description = "proc-macro for extracting strings for gettext translation"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.95"
+
+[lints]
+workspace = true

--- a/gettext_extraction/src/lib.rs
+++ b/gettext_extraction/src/lib.rs
@@ -1,0 +1,70 @@
+extern crate proc_macro;
+use proc_macro::TokenStream;
+use std::{fs::OpenOptions, io::Write};
+
+fn append_line_to_file(message: &TokenStream, file_name: &str) {
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(file_name)
+        .unwrap();
+    let mut message_string = message.to_string();
+    message_string.push('\n');
+    file.write_all(message_string.as_bytes()).unwrap();
+}
+
+/// The `message` is passed through unmodified.
+/// If `GETTEXT_EXTRACTION_DIR` is defined in the environment,
+/// this directory is used to write the message,
+/// so that it can then be used for generating gettext PO files.
+/// The `message` can be a string literal, in which case it is appended to the `literals` file
+/// in the directory. Literals are written enclosed in double quotes and with a trailing newline.
+/// Alternatively, the name of a constant can be passed as the `message`.
+/// In this case, the macro cannot obtain the corresponding string literal.
+/// (at least not without using unstable features/external commands)
+/// The names of such constants are written to the `consts` file.
+/// This file can then be used as a starting point for extracting the constant strings from the
+/// source files with external tooling.
+///
+/// # Panics
+///
+/// This macro panics if the `GETTEXT_EXTRACTION_DIR` variable is set and `message` has an
+/// unexpected format.
+/// Note that for example `concat!(...)` cannot be passed to this macro, because expansion works
+/// outside in, meaning this macro would still see the `concat!` macro invocation, instead of a
+/// string literal.
+#[proc_macro]
+pub fn gettext_extract(message: TokenStream) -> TokenStream {
+    if let Ok(dir) = std::env::var("GETTEXT_EXTRACTION_DIR") {
+        let pm2_message = proc_macro2::TokenStream::from(message.clone());
+        let token_trees = pm2_message.into_iter().collect::<Vec<_>>();
+        if token_trees.len() != 1 {
+            panic!("Invalid number of tokens passed to gettext_extract. Expected one token, got: {token_trees:?}")
+        }
+        match &token_trees[0] {
+            proc_macro2::TokenTree::Group(group) => {
+                let group_tokens = group.stream().into_iter().collect::<Vec<_>>();
+                if group_tokens.len() != 1 {
+                    panic!("Invalid number of tokens in group passed to gettext_extract. Expected one token, got: {group_tokens:?}")
+                }
+                match &group_tokens[0] {
+                    proc_macro2::TokenTree::Literal(_) => {
+                        append_line_to_file(&message, &format!("{dir}/literals"));
+                    }
+                    proc_macro2::TokenTree::Ident(_) => {
+                        append_line_to_file(&message, &format!("{dir}/consts"));
+                    }
+                    other => {
+                        panic!(
+                            "Expected literal or constant in gettext_extract, but got: {other:?}"
+                        );
+                    }
+                }
+            }
+            other => {
+                panic!("Expected group in gettext_extract, but got: {other:?}");
+            }
+        }
+    }
+    message
+}

--- a/po/de.po
+++ b/po/de.po
@@ -862,9 +862,21 @@ msgstr ""
 msgid "A second attempt to exit will terminate them.\n"
 msgstr "Ein zweites 'exit' wird sie beenden.\n"
 
+msgid "Abbreviation expansion"
+msgstr ""
+
 #, c-format
 msgid "Abbreviation: %ls"
 msgstr "Abkürzung: %ls"
+
+msgid "Abort"
+msgstr "Abbruch"
+
+msgid "Abort (Alias for SIGABRT)"
+msgstr ""
+
+msgid "Address boundary error"
+msgstr "Adressbereichsfehler"
 
 msgid "Always"
 msgstr "Immer"
@@ -876,14 +888,29 @@ msgstr "Fehler beim Einrichten der Pipe aufgetreten"
 msgid "Argument is not a number: '%ls'"
 msgstr "Argument ist keine Zahl: '%ls'"
 
+msgid "Background IO thread events"
+msgstr ""
+
 msgid "Backgrounded commands can not be used as conditionals"
 msgstr "Hintergrundbefehle können nicht als Bedingungen benutzt werden"
+
+msgid "Bad system call"
+msgstr "Fehlerhafter Systemaufruf"
 
 msgid "Block of code to run conditionally"
 msgstr "Einen Block Befehle zur bedingten Ausführung"
 
+msgid "Broken pipe"
+msgstr "zerstörte Pipe"
+
+msgid "CPU time limit exceeded"
+msgstr "CPU-Zeitbegrenzung überschritten"
+
 msgid "CPU\t"
 msgstr "CPU\t"
+
+msgid "Calls to fork()"
+msgstr ""
 
 msgid "Can not use the no-execute mode when running an interactive session"
 msgstr "Kann den no-execute Modus nicht in einer interaktiven Sitzung nutzen"
@@ -898,7 +925,22 @@ msgstr "Kann stdin (fd 0) nicht zur Ausgabe einer Pipe verwenden"
 msgid "Change working directory"
 msgstr "Arbeitsverzeichnis wechseln"
 
+msgid "Changes to exported variables"
+msgstr ""
+
+msgid "Changes to locale variables"
+msgstr ""
+
+msgid "Character encoding issues"
+msgstr ""
+
 msgid "Check if a thing is a thing"
+msgstr ""
+
+msgid "Child process status changed"
+msgstr "Kindprozessstatus geändert"
+
+msgid "Command history events"
 msgstr ""
 
 msgid "Command not executable"
@@ -912,6 +954,9 @@ msgstr "Befehlsname war ungültig"
 
 msgid "Conditionally run blocks of code"
 msgstr "Anweisungsblock bedingungsabhängig ausführen"
+
+msgid "Continue previously stopped process"
+msgstr "Vorher gestoppten Prozess fortsetzen"
 
 msgid "Could not determine current working directory. Is your locale set correctly?"
 msgstr "Das aktuelle Arbeitsverzeichnis konnte nicht bestimmt werden. Ist die locale korrekt eingestellt?"
@@ -931,6 +976,9 @@ msgstr "Die Anzahl Argumente zählen"
 
 msgid "Create a block of code"
 msgstr "Codeblock erstellen"
+
+msgid "Debugging aid (on by default)"
+msgstr ""
 
 msgid "Define a new function"
 msgstr "Neue Funktion definieren"
@@ -968,6 +1016,9 @@ msgstr "Fehler beim Umbenennen der Verlaufsdatei: %s"
 #, c-format
 msgid "Error while reading file %ls\n"
 msgstr "Fehler beim Lesen der Datei %ls\n"
+
+msgid "Errors reported by exec (on by default)"
+msgstr ""
 
 msgid "Evaluate a string as a statement"
 msgstr "Eine Zeichenfolge als Befehl ausführen"
@@ -1032,6 +1083,9 @@ msgstr ""
 msgid "Expression is bogus"
 msgstr "Ausdruck ist Unsinn"
 
+msgid "FD monitor events"
+msgstr ""
+
 msgid "Failed to assign shell to its own process group"
 msgstr "Konnte Shell nicht einer eigenen Prozessgruppe zuweisen"
 
@@ -1040,6 +1094,24 @@ msgstr "Konnte Terminalmodus nicht setzen"
 
 msgid "Failed to take control of the terminal"
 msgstr "Konnte Kontrolle über das Terminal nicht übernehmen"
+
+msgid "File size limit exceeded"
+msgstr "Dateigrößenbegrenzung überschritten"
+
+msgid "Finding and reading configuration"
+msgstr ""
+
+msgid "Firing events"
+msgstr ""
+
+msgid "Floating point exception"
+msgstr "Fließkomma-Ausnahmefehler"
+
+msgid "Forced quit"
+msgstr "Erzwungene Beendigung"
+
+msgid "Forced stop"
+msgstr "Erzwungener Stopp"
 
 msgid "Generate random number"
 msgstr "Zufallszahl generieren"
@@ -1068,6 +1140,9 @@ msgstr "Tipp: Eine führende '0' ohne 'x' gibt eine Oktalzahl an"
 msgid "History of commands executed by user"
 msgstr "Befehlsgeschichte"
 
+msgid "History performance measurements"
+msgstr ""
+
 #, c-format
 msgid "History session ID '%ls' is not a valid variable name. Falling back to `%ls`."
 msgstr "Verlaufs-ID '%ls' ist kein gültiger Variablenname. Nutze `%ls`."
@@ -1080,9 +1155,15 @@ msgstr "Heimordner für %ls"
 msgid "I appear to be an orphaned process, so I am quitting politely. My pid is %d."
 msgstr "Ich scheine ein verwaister Prozess zu sein, also beende ich mich höflich. Meine PID ist %d."
 
+msgid "I/O on asynchronous file descriptor is possible"
+msgstr "E/A auf asynchronem Dateideskriptor ist möglich"
+
 #, c-format
 msgid "Illegal file descriptor in redirection '%ls'"
 msgstr ""
+
+msgid "Illegal instruction"
+msgstr "Illegale Instruktion"
 
 #, c-format
 msgid "Incomplete escape sequence '%ls'"
@@ -1091,6 +1172,12 @@ msgstr "Unvollständige Escapesequenz '%ls'"
 #, c-format
 msgid "Integer %lld in '%ls' followed by non-digit"
 msgstr "Ganzzahl %lld in '%ls' gefolgt von nicht-Ziffer"
+
+msgid "Internal (non-forked) process events"
+msgstr ""
+
+msgid "Internal details of the topic monitor"
+msgstr ""
 
 msgid "Invalid arguments"
 msgstr "Ungültige Argumente"
@@ -1131,6 +1218,15 @@ msgstr "Jobsteuerung: %ls\n"
 msgid "Job\tGroup\t"
 msgstr "Job\tGruppe\t"
 
+msgid "Jobs being executed"
+msgstr ""
+
+msgid "Jobs changing status"
+msgstr ""
+
+msgid "Jobs getting started or continued"
+msgstr ""
+
 msgid "List or remove functions"
 msgstr "Funktionen auflisten oder entfernen"
 
@@ -1153,6 +1249,9 @@ msgstr "Strings manipulieren"
 
 msgid "Measure how long a command or block takes"
 msgstr "Dauer der Ausführung eines Befehls oder Blocks messen"
+
+msgid "Misaligned address error"
+msgstr "Fehler: nicht ausgerichtete Adresse"
 
 msgid "Mismatched braces"
 msgstr "Unpassende Klammern"
@@ -1196,6 +1295,9 @@ msgstr "Keine Funktion"
 msgid "Not a number"
 msgstr "Keine Zahl"
 
+msgid "Notifications about universal variable changes"
+msgstr ""
+
 msgid "Number is infinite"
 msgstr "Zahl ist unendlich"
 
@@ -1218,6 +1320,9 @@ msgstr ""
 msgid "Parse options in fish script"
 msgstr "Optionen in einem Fishskript parsen"
 
+msgid "Parsing fish AST"
+msgstr ""
+
 msgid "Perform a command multiple times"
 msgstr "Einen Befehl mehrmals ausführen"
 
@@ -1231,6 +1336,12 @@ msgstr "Bitte setzen sie $%ls auf ein Verzeichnis in das sie schreiben können."
 #, c-format
 msgid "Please set the %ls or HOME environment variable before starting fish."
 msgstr "Bitte setzen sie %ls oder die HOME Umgebungsvariable bevor sie fish starten."
+
+msgid "Polite quit request"
+msgstr "Höfliche Beendigungsanforderung"
+
+msgid "Power failure"
+msgstr "Stromausfall"
 
 #, c-format
 msgid "Press ctrl-%c again to exit\n"
@@ -1248,14 +1359,44 @@ msgstr "Das Arbeitsverzeichnis ausgeben"
 msgid "Prints formatted text"
 msgstr "Formatierten Text ausgeben"
 
+msgid "Process groups"
+msgstr ""
+
 msgid "Process\n"
 msgstr "Prozess\n"
+
+msgid "Profiling timer expired"
+msgstr "Profilierungszeitgeber abgelaufen"
+
+msgid "Quit request from job control (^C)"
+msgstr "Quit-Anforderung über Jobsteuerung (^C)"
+
+msgid "Quit request from job control with core dump (^\\)"
+msgstr "Quit-Anforderung über Jobsteuerung mit Speicherauszug (^\\)"
+
+msgid "Reacting to variables"
+msgstr ""
 
 msgid "Read a line of input into variables"
 msgstr "Eine Eingabezeile in Variablen einlesen"
 
+msgid "Reading/Writing the history file"
+msgstr ""
+
+msgid "Reaping external (forked) processes"
+msgstr ""
+
+msgid "Reaping internal (non-forked) processes"
+msgstr ""
+
+msgid "Refcell dynamic borrowing"
+msgstr ""
+
 msgid "Remove job from job list"
 msgstr "Job aus der Jobliste entfernen"
+
+msgid "Rendering the command line"
+msgstr ""
 
 #, c-format
 msgid "Requested redirection to '%ls', which is not a valid file descriptor"
@@ -1286,8 +1427,14 @@ msgstr "Führe Befehl aus wenn der Letzte gelang"
 msgid "Run command in current process"
 msgstr "Befehl im aktuellen Prozess ausführen"
 
+msgid "Screen repaints"
+msgstr ""
+
 msgid "Search for a specified string in a list"
 msgstr "Nach einem String in einer Liste suchen"
+
+msgid "Searching/using paths"
+msgstr ""
 
 #, c-format
 msgid "Send job %d (%ls) to foreground\n"
@@ -1303,6 +1450,9 @@ msgstr "Job in Hintergrund schicken"
 msgid "Send job to foreground"
 msgstr "Job in Vordergrund schicken"
 
+msgid "Serious unexpected errors (on by default)"
+msgstr ""
+
 msgid "Set or get the commandline"
 msgstr "Festlegen oder Abrufen der Befehlszeile"
 
@@ -1314,6 +1464,9 @@ msgstr "Absoluten Pfad ohne symbolische Verknüpfungen anzeigen"
 
 msgid "Skip over remaining innermost loop"
 msgstr "Über den Rest der innersten Schleife springen"
+
+msgid "Stack fault"
+msgstr ""
 
 msgid "Standard input"
 msgstr "Standardeingabe"
@@ -1332,6 +1485,15 @@ msgstr "Status\tBefehl\n"
 msgid "Stdin must be attached to a tty."
 msgstr ""
 
+msgid "Stop from terminal input"
+msgstr "Stopp durch Terminaleingabe"
+
+msgid "Stop from terminal output"
+msgstr "Stopp durch Terminalausgabe"
+
+msgid "Stop request from job control (^Z)"
+msgstr "Stoppanforderung über Jobsteuerung (^Z)"
+
 msgid "Stop the currently evaluated function"
 msgstr "Derzeit ausgewertete Funktion stoppen"
 
@@ -1340,6 +1502,18 @@ msgstr "Innerste Schleife beenden"
 
 msgid "Temporarily block delivery of events"
 msgstr "Ereignisweitergabe vorübergehend blockieren"
+
+msgid "Terminal feature detection"
+msgstr ""
+
+msgid "Terminal hung up"
+msgstr "Terminal getrennt"
+
+msgid "Terminal ownership events"
+msgstr ""
+
+msgid "Terminal protocol negotiation"
+msgstr ""
 
 msgid "Test a condition"
 msgstr "Teste eine Bedingung"
@@ -1358,6 +1532,9 @@ msgstr "Der 'time' Befehl darf nur am Anfang einer Pipeline stehen"
 msgid "The call stack limit has been exceeded. Do you have an accidental infinite loop?"
 msgstr ""
 
+msgid "The completion system"
+msgstr ""
+
 #, c-format
 msgid "The error was '%s'."
 msgstr "Der Fehler war '%s'."
@@ -1372,6 +1549,9 @@ msgstr ""
 msgid "The function '%ls' calls itself immediately, which would result in an infinite loop."
 msgstr "Die Funktion '%ls' ruft sich sofort selbst auf. Dies wäre eine Endlosschleife."
 
+msgid "The interactive reader/input system"
+msgstr ""
+
 msgid "There are still jobs active:\n"
 msgstr ""
 
@@ -1380,6 +1560,9 @@ msgstr ""
 
 msgid "This is not a login shell\n"
 msgstr ""
+
+msgid "Timer expired"
+msgstr "Zeitgeber abgelaufen"
 
 msgid "Too few arguments"
 msgstr ""
@@ -1393,8 +1576,14 @@ msgstr "Zu viele Argumente"
 msgid "Too much data emitted by command substitution so it was discarded"
 msgstr ""
 
+msgid "Trace or breakpoint trap"
+msgstr "Verfolgungs- oder Haltepunkt erreicht"
+
 msgid "Translate a string"
 msgstr "Übersetze eine Zeichenkette"
+
+msgid "Trying to print invalid output"
+msgstr ""
 
 #, c-format
 msgid "Unable to create temporary file '%ls': %s"
@@ -1510,8 +1699,17 @@ msgstr "Nicht passender Platzhalter"
 msgid "Unsupported use of '='. In fish, please use 'set %ls %ls'."
 msgstr ""
 
+msgid "Urgent socket condition"
+msgstr "Vorrangige Socket-Bedingung"
+
 msgid "Use 'disown PID' to remove jobs from the list without terminating them.\n"
 msgstr ""
+
+msgid "User defined signal 1"
+msgstr "Benutzerdefiniertes Signal 1"
+
+msgid "User defined signal 2"
+msgstr "Benutzerdefiniertes Signal 2"
 
 #, c-format
 msgid "Variable: %ls"
@@ -1525,8 +1723,26 @@ msgstr ""
 msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
 msgstr ""
 
+msgid "Virtual timefr expired"
+msgstr ""
+
 msgid "Wait for background processes completed"
 msgstr "Auf den Abschluss von Hintergrundprozessen warten"
+
+msgid "Warning about using test's zero- or one-argument modes (`test -d $foo`), which will be changed in future."
+msgstr ""
+
+msgid "Warnings (on by default)"
+msgstr ""
+
+msgid "Warnings about unusable paths for config/history (on by default)"
+msgstr ""
+
+msgid "Window size change"
+msgstr "Änderung der Fenstergröße"
+
+msgid "Writing/reading the universal variable store"
+msgstr ""
 
 msgid "[: the last argument must be ']'"
 msgstr ""
@@ -1540,6 +1756,9 @@ msgstr ""
 
 msgid "array indices start at 1, not 0."
 msgstr "Array Indexe beginnen mit 1, nicht 0"
+
+msgid "autoloading"
+msgstr ""
 
 #, c-format
 msgid "builtin %ls: %ls: %s\n"
@@ -79147,95 +79366,8 @@ msgstr ""
 #~ msgid "Could not return shell to foreground"
 #~ msgstr "Konnte Shell nicht wieder in Vordergrund zurückholen"
 
-#~ msgid "Terminal hung up"
-#~ msgstr "Terminal getrennt"
-
-#~ msgid "Quit request from job control (^C)"
-#~ msgstr "Quit-Anforderung über Jobsteuerung (^C)"
-
-#~ msgid "Quit request from job control with core dump (^\\)"
-#~ msgstr "Quit-Anforderung über Jobsteuerung mit Speicherauszug (^\\)"
-
-#~ msgid "Illegal instruction"
-#~ msgstr "Illegale Instruktion"
-
-#~ msgid "Trace or breakpoint trap"
-#~ msgstr "Verfolgungs- oder Haltepunkt erreicht"
-
-#~ msgid "Abort"
-#~ msgstr "Abbruch"
-
-#~ msgid "Misaligned address error"
-#~ msgstr "Fehler: nicht ausgerichtete Adresse"
-
-#~ msgid "Floating point exception"
-#~ msgstr "Fließkomma-Ausnahmefehler"
-
-#~ msgid "Forced quit"
-#~ msgstr "Erzwungene Beendigung"
-
-#~ msgid "User defined signal 1"
-#~ msgstr "Benutzerdefiniertes Signal 1"
-
-#~ msgid "User defined signal 2"
-#~ msgstr "Benutzerdefiniertes Signal 2"
-
-#~ msgid "Address boundary error"
-#~ msgstr "Adressbereichsfehler"
-
-#~ msgid "Broken pipe"
-#~ msgstr "zerstörte Pipe"
-
-#~ msgid "Timer expired"
-#~ msgstr "Zeitgeber abgelaufen"
-
-#~ msgid "Polite quit request"
-#~ msgstr "Höfliche Beendigungsanforderung"
-
-#~ msgid "Child process status changed"
-#~ msgstr "Kindprozessstatus geändert"
-
-#~ msgid "Continue previously stopped process"
-#~ msgstr "Vorher gestoppten Prozess fortsetzen"
-
-#~ msgid "Forced stop"
-#~ msgstr "Erzwungener Stopp"
-
-#~ msgid "Stop request from job control (^Z)"
-#~ msgstr "Stoppanforderung über Jobsteuerung (^Z)"
-
-#~ msgid "Stop from terminal input"
-#~ msgstr "Stopp durch Terminaleingabe"
-
-#~ msgid "Stop from terminal output"
-#~ msgstr "Stopp durch Terminalausgabe"
-
-#~ msgid "Urgent socket condition"
-#~ msgstr "Vorrangige Socket-Bedingung"
-
-#~ msgid "CPU time limit exceeded"
-#~ msgstr "CPU-Zeitbegrenzung überschritten"
-
-#~ msgid "File size limit exceeded"
-#~ msgstr "Dateigrößenbegrenzung überschritten"
-
 #~ msgid "Virtual timer expired"
 #~ msgstr "Virtueller Zeitgeber abgelaufen"
-
-#~ msgid "Profiling timer expired"
-#~ msgstr "Profilierungszeitgeber abgelaufen"
-
-#~ msgid "Window size change"
-#~ msgstr "Änderung der Fenstergröße"
-
-#~ msgid "I/O on asynchronous file descriptor is possible"
-#~ msgstr "E/A auf asynchronem Dateideskriptor ist möglich"
-
-#~ msgid "Power failure"
-#~ msgstr "Stromausfall"
-
-#~ msgid "Bad system call"
-#~ msgstr "Fehlerhafter Systemaufruf"
 
 #, c-format
 #~ msgid "getcwd() failed with errno %d/%s"

--- a/po/de.po
+++ b/po/de.po
@@ -42,6 +42,10 @@ msgid "$$ is not the pid. In fish, please use $fish_pid."
 msgstr ""
 
 #, c-format
+msgid "$%lc is not a valid variable in fish."
+msgstr ""
+
+#, c-format
 msgid "$%ls: originally inherited as |%ls|\n"
 msgstr "$%ls: Ursprünglich geerbt als |%ls|\n"
 
@@ -64,6 +68,10 @@ msgstr "$status ist kein gültiger Befehl. Siehe `help conditions`"
 #, c-format
 msgid "%.*ls: invalid conversion specification"
 msgstr "%.*ls: Ungültige Umwandlungsspezifikation"
+
+#, c-format
+msgid "%ls"
+msgstr ""
 
 #, c-format
 msgid "%ls %ls: Abbreviation %ls already exists, cannot rename %ls\n"
@@ -136,6 +144,10 @@ msgstr ""
 #, c-format
 msgid "%ls: %ls: contains a syntax error\n"
 msgstr "%ls: %ls: enthält einen Syntaxfehler\n"
+
+#, c-format
+msgid "%ls: %ls: expected %d arguments; got %d\n"
+msgstr ""
 
 #, c-format
 msgid "%ls: %ls: invalid base value\n"
@@ -666,6 +678,18 @@ msgid "%ls: exclusive flag string '%ls' is not valid\n"
 msgstr "%ls: Exklusive option '%ls' ist ungültig\n"
 
 #, c-format
+msgid "%ls: expected %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: expected <= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: expected >= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
 msgid "%ls: expected a numeric value"
 msgstr "%ls: Erwartete numerischen Wert"
 
@@ -675,6 +699,10 @@ msgstr "%ls: Brauche Funktionsnamen"
 
 #, c-format
 msgid "%ls: given %d indexes but %d values\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: invalid option combination, %ls\n"
 msgstr ""
 
 #, c-format
@@ -691,6 +719,10 @@ msgstr ""
 
 #, c-format
 msgid "%ls: line/column index starts at 1"
+msgstr ""
+
+#, c-format
+msgid "%ls: missing argument\n"
 msgstr ""
 
 #, c-format
@@ -827,18 +859,6 @@ msgstr ""
 msgid "--tokens options are mutually exclusive"
 msgstr ""
 
-msgid ".local/bin/"
-msgstr ""
-
-msgid ".local/share/"
-msgstr ""
-
-msgid ".local/share/doc/fish"
-msgstr ""
-
-msgid "/etc/"
-msgstr ""
-
 msgid "A second attempt to exit will terminate them.\n"
 msgstr "Ein zweites 'exit' wird sie beenden.\n"
 
@@ -901,9 +921,6 @@ msgstr "Konnte Terminalmodus für neuen Job nicht festlegen"
 
 msgid "Could not set terminal mode for shell"
 msgstr "Konnte Terminalmodus für neue Shell nicht festlegen"
-
-msgid "Could not show help message"
-msgstr "Hilfemeldung konnte nicht angezeigt werden"
 
 #, c-format
 msgid "Could not write profiling information to file '%s': %s"
@@ -1500,6 +1517,14 @@ msgstr ""
 msgid "Variable: %ls"
 msgstr "Variable: %ls"
 
+#, c-format
+msgid "Variables cannot be bracketed. In fish, please use \"$%ls\"."
+msgstr ""
+
+#, c-format
+msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
+msgstr ""
+
 msgid "Wait for background processes completed"
 msgstr "Auf den Abschluss von Hintergrundprozessen warten"
 
@@ -1573,9 +1598,6 @@ msgstr "exportiert"
 
 msgid "file"
 msgstr "Datei"
-
-msgid "fish/install"
-msgstr ""
 
 #, c-format
 msgid ""
@@ -78937,6 +78959,9 @@ msgstr ""
 
 msgid "~ expansion"
 msgstr ""
+
+#~ msgid "Could not show help message"
+#~ msgstr "Hilfemeldung konnte nicht angezeigt werden"
 
 #~ msgid "builtin\n"
 #~ msgstr "Eingebauter Befehl\n"

--- a/po/en.po
+++ b/po/en.po
@@ -42,6 +42,10 @@ msgid "$$ is not the pid. In fish, please use $fish_pid."
 msgstr ""
 
 #, c-format
+msgid "$%lc is not a valid variable in fish."
+msgstr "$%lc is not a valid variable in fish."
+
+#, c-format
 msgid "$%ls: originally inherited as |%ls|\n"
 msgstr ""
 
@@ -64,6 +68,10 @@ msgstr ""
 #, c-format
 msgid "%.*ls: invalid conversion specification"
 msgstr "%.*ls: invalid conversion specification"
+
+#, c-format
+msgid "%ls"
+msgstr ""
 
 #, c-format
 msgid "%ls %ls: Abbreviation %ls already exists, cannot rename %ls\n"
@@ -135,6 +143,10 @@ msgstr ""
 
 #, c-format
 msgid "%ls: %ls: contains a syntax error\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: %ls: expected %d arguments; got %d\n"
 msgstr ""
 
 #, c-format
@@ -666,6 +678,18 @@ msgid "%ls: exclusive flag string '%ls' is not valid\n"
 msgstr ""
 
 #, c-format
+msgid "%ls: expected %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: expected <= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: expected >= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
 msgid "%ls: expected a numeric value"
 msgstr "%ls: expected a numeric value"
 
@@ -675,6 +699,10 @@ msgstr ""
 
 #, c-format
 msgid "%ls: given %d indexes but %d values\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: invalid option combination, %ls\n"
 msgstr ""
 
 #, c-format
@@ -691,6 +719,10 @@ msgstr ""
 
 #, c-format
 msgid "%ls: line/column index starts at 1"
+msgstr ""
+
+#, c-format
+msgid "%ls: missing argument\n"
 msgstr ""
 
 #, c-format
@@ -827,18 +859,6 @@ msgstr ""
 msgid "--tokens options are mutually exclusive"
 msgstr ""
 
-msgid ".local/bin/"
-msgstr ""
-
-msgid ".local/share/"
-msgstr ""
-
-msgid ".local/share/doc/fish"
-msgstr ""
-
-msgid "/etc/"
-msgstr ""
-
 msgid "A second attempt to exit will terminate them.\n"
 msgstr ""
 
@@ -901,9 +921,6 @@ msgstr "Could not set terminal mode for new job"
 
 msgid "Could not set terminal mode for shell"
 msgstr "Could not set terminal mode for shell"
-
-msgid "Could not show help message"
-msgstr ""
 
 #, c-format
 msgid "Could not write profiling information to file '%s': %s"
@@ -1500,6 +1517,14 @@ msgstr ""
 msgid "Variable: %ls"
 msgstr "Variable: %ls"
 
+#, c-format
+msgid "Variables cannot be bracketed. In fish, please use \"$%ls\"."
+msgstr ""
+
+#, c-format
+msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
+msgstr ""
+
 msgid "Wait for background processes completed"
 msgstr ""
 
@@ -1571,9 +1596,6 @@ msgstr ""
 
 msgid "file"
 msgstr "file"
-
-msgid "fish/install"
-msgstr ""
 
 #, c-format
 msgid ""
@@ -79261,10 +79283,6 @@ msgstr ""
 
 #~ msgid "Unused signal"
 #~ msgstr "Unused signal"
-
-#, c-format
-#~ msgid "$%lc is not a valid variable in fish."
-#~ msgstr "$%lc is not a valid variable in fish."
 
 #~ msgid "Process file after the compiler reads in the standard specs file, in order to override the defaults that the gcc driver program uses when determining what switches to pass to cc1, cc1plus, as, ld, etc"
 #~ msgstr "Process file after the compiler reads in the standard specs file, in order to override the defaults that the gcc driver program uses when determining what switches to pass to cc1, cc1plus, as, ld, etc"

--- a/po/en.po
+++ b/po/en.po
@@ -862,9 +862,21 @@ msgstr ""
 msgid "A second attempt to exit will terminate them.\n"
 msgstr ""
 
+msgid "Abbreviation expansion"
+msgstr ""
+
 #, c-format
 msgid "Abbreviation: %ls"
 msgstr ""
+
+msgid "Abort"
+msgstr "Abort"
+
+msgid "Abort (Alias for SIGABRT)"
+msgstr "Abort (Alias for SIGABRT)"
+
+msgid "Address boundary error"
+msgstr "Address boundary error"
 
 msgid "Always"
 msgstr "Always"
@@ -876,14 +888,29 @@ msgstr "An error occurred while setting up pipe"
 msgid "Argument is not a number: '%ls'"
 msgstr ""
 
+msgid "Background IO thread events"
+msgstr ""
+
 msgid "Backgrounded commands can not be used as conditionals"
 msgstr "Backgrounded commands can not be used as conditionals"
+
+msgid "Bad system call"
+msgstr "Bad system call"
 
 msgid "Block of code to run conditionally"
 msgstr ""
 
+msgid "Broken pipe"
+msgstr "Broken pipe"
+
+msgid "CPU time limit exceeded"
+msgstr "CPU time limit exceeded"
+
 msgid "CPU\t"
 msgstr "CPU\t"
+
+msgid "Calls to fork()"
+msgstr ""
 
 msgid "Can not use the no-execute mode when running an interactive session"
 msgstr "Can not use the no-execute mode when running an interactive session"
@@ -898,7 +925,22 @@ msgstr "Cannot use stdin (fd 0) as pipe output"
 msgid "Change working directory"
 msgstr "Change working directory"
 
+msgid "Changes to exported variables"
+msgstr ""
+
+msgid "Changes to locale variables"
+msgstr ""
+
+msgid "Character encoding issues"
+msgstr ""
+
 msgid "Check if a thing is a thing"
+msgstr ""
+
+msgid "Child process status changed"
+msgstr "Child process status changed"
+
+msgid "Command history events"
 msgstr ""
 
 msgid "Command not executable"
@@ -912,6 +954,9 @@ msgstr ""
 
 msgid "Conditionally run blocks of code"
 msgstr ""
+
+msgid "Continue previously stopped process"
+msgstr "Continue previously stopped process"
 
 msgid "Could not determine current working directory. Is your locale set correctly?"
 msgstr ""
@@ -931,6 +976,9 @@ msgstr "Count the number of arguments"
 
 msgid "Create a block of code"
 msgstr "Create a block of code"
+
+msgid "Debugging aid (on by default)"
+msgstr ""
 
 msgid "Define a new function"
 msgstr "Define a new function"
@@ -968,6 +1016,9 @@ msgstr ""
 #, c-format
 msgid "Error while reading file %ls\n"
 msgstr "Error while reading file %ls\n"
+
+msgid "Errors reported by exec (on by default)"
+msgstr ""
 
 msgid "Evaluate a string as a statement"
 msgstr ""
@@ -1032,6 +1083,9 @@ msgstr ""
 msgid "Expression is bogus"
 msgstr ""
 
+msgid "FD monitor events"
+msgstr ""
+
 msgid "Failed to assign shell to its own process group"
 msgstr ""
 
@@ -1040,6 +1094,24 @@ msgstr ""
 
 msgid "Failed to take control of the terminal"
 msgstr ""
+
+msgid "File size limit exceeded"
+msgstr "File size limit exceeded"
+
+msgid "Finding and reading configuration"
+msgstr ""
+
+msgid "Firing events"
+msgstr ""
+
+msgid "Floating point exception"
+msgstr "Floating point exception"
+
+msgid "Forced quit"
+msgstr "Forced quit"
+
+msgid "Forced stop"
+msgstr "Forced stop"
 
 msgid "Generate random number"
 msgstr "Generate random number"
@@ -1068,6 +1140,9 @@ msgstr ""
 msgid "History of commands executed by user"
 msgstr "History of commands executed by user"
 
+msgid "History performance measurements"
+msgstr ""
+
 #, c-format
 msgid "History session ID '%ls' is not a valid variable name. Falling back to `%ls`."
 msgstr ""
@@ -1080,9 +1155,15 @@ msgstr "Home for %ls"
 msgid "I appear to be an orphaned process, so I am quitting politely. My pid is %d."
 msgstr "I appear to be an orphaned process, so I am quitting politely. My pid is %d."
 
+msgid "I/O on asynchronous file descriptor is possible"
+msgstr "I/O on asynchronous file descriptor is possible"
+
 #, c-format
 msgid "Illegal file descriptor in redirection '%ls'"
 msgstr "Illegal file descriptor in redirection “%ls”"
+
+msgid "Illegal instruction"
+msgstr "Illegal instruction"
 
 #, c-format
 msgid "Incomplete escape sequence '%ls'"
@@ -1090,6 +1171,12 @@ msgstr ""
 
 #, c-format
 msgid "Integer %lld in '%ls' followed by non-digit"
+msgstr ""
+
+msgid "Internal (non-forked) process events"
+msgstr ""
+
+msgid "Internal details of the topic monitor"
 msgstr ""
 
 msgid "Invalid arguments"
@@ -1131,6 +1218,15 @@ msgstr "Job control: %ls\n"
 msgid "Job\tGroup\t"
 msgstr "Job\tGroup\t"
 
+msgid "Jobs being executed"
+msgstr ""
+
+msgid "Jobs changing status"
+msgstr ""
+
+msgid "Jobs getting started or continued"
+msgstr ""
+
 msgid "List or remove functions"
 msgstr "List or remove functions"
 
@@ -1153,6 +1249,9 @@ msgstr ""
 
 msgid "Measure how long a command or block takes"
 msgstr ""
+
+msgid "Misaligned address error"
+msgstr "Misaligned address error"
 
 msgid "Mismatched braces"
 msgstr ""
@@ -1196,6 +1295,9 @@ msgstr ""
 msgid "Not a number"
 msgstr ""
 
+msgid "Notifications about universal variable changes"
+msgstr ""
+
 msgid "Number is infinite"
 msgstr ""
 
@@ -1218,6 +1320,9 @@ msgstr ""
 msgid "Parse options in fish script"
 msgstr ""
 
+msgid "Parsing fish AST"
+msgstr ""
+
 msgid "Perform a command multiple times"
 msgstr "Perform a command multiple times"
 
@@ -1231,6 +1336,12 @@ msgstr ""
 #, c-format
 msgid "Please set the %ls or HOME environment variable before starting fish."
 msgstr ""
+
+msgid "Polite quit request"
+msgstr "Polite quit request"
+
+msgid "Power failure"
+msgstr "Power failure"
 
 #, c-format
 msgid "Press ctrl-%c again to exit\n"
@@ -1248,13 +1359,43 @@ msgstr "Print the working directory"
 msgid "Prints formatted text"
 msgstr "Prints formatted text"
 
+msgid "Process groups"
+msgstr ""
+
 msgid "Process\n"
 msgstr "Process\n"
+
+msgid "Profiling timer expired"
+msgstr "Profiling timer expired"
+
+msgid "Quit request from job control (^C)"
+msgstr "Quit request from job control (^C)"
+
+msgid "Quit request from job control with core dump (^\\)"
+msgstr "Quit request from job control with core dump (^\\)"
+
+msgid "Reacting to variables"
+msgstr ""
 
 msgid "Read a line of input into variables"
 msgstr "Read a line of input into variables"
 
+msgid "Reading/Writing the history file"
+msgstr ""
+
+msgid "Reaping external (forked) processes"
+msgstr ""
+
+msgid "Reaping internal (non-forked) processes"
+msgstr ""
+
+msgid "Refcell dynamic borrowing"
+msgstr ""
+
 msgid "Remove job from job list"
+msgstr ""
+
+msgid "Rendering the command line"
 msgstr ""
 
 #, c-format
@@ -1286,8 +1427,14 @@ msgstr ""
 msgid "Run command in current process"
 msgstr "Run command in current process"
 
+msgid "Screen repaints"
+msgstr ""
+
 msgid "Search for a specified string in a list"
 msgstr "Search for a specified string in a list"
+
+msgid "Searching/using paths"
+msgstr ""
 
 #, c-format
 msgid "Send job %d (%ls) to foreground\n"
@@ -1303,6 +1450,9 @@ msgstr "Send job to background"
 msgid "Send job to foreground"
 msgstr "Send job to foreground"
 
+msgid "Serious unexpected errors (on by default)"
+msgstr ""
+
 msgid "Set or get the commandline"
 msgstr "Set or get the commandline"
 
@@ -1314,6 +1464,9 @@ msgstr ""
 
 msgid "Skip over remaining innermost loop"
 msgstr ""
+
+msgid "Stack fault"
+msgstr "Stack fault"
 
 msgid "Standard input"
 msgstr "Standard input"
@@ -1332,6 +1485,15 @@ msgstr "State\tCommand\n"
 msgid "Stdin must be attached to a tty."
 msgstr ""
 
+msgid "Stop from terminal input"
+msgstr "Stop from terminal input"
+
+msgid "Stop from terminal output"
+msgstr "Stop from terminal output"
+
+msgid "Stop request from job control (^Z)"
+msgstr "Stop request from job control (^Z)"
+
 msgid "Stop the currently evaluated function"
 msgstr "Stop the currently evaluated function"
 
@@ -1340,6 +1502,18 @@ msgstr "Stop the innermost loop"
 
 msgid "Temporarily block delivery of events"
 msgstr "Temporarily block delivery of events"
+
+msgid "Terminal feature detection"
+msgstr ""
+
+msgid "Terminal hung up"
+msgstr "Terminal hung up"
+
+msgid "Terminal ownership events"
+msgstr ""
+
+msgid "Terminal protocol negotiation"
+msgstr ""
 
 msgid "Test a condition"
 msgstr "Test a condition"
@@ -1358,6 +1532,9 @@ msgstr ""
 msgid "The call stack limit has been exceeded. Do you have an accidental infinite loop?"
 msgstr ""
 
+msgid "The completion system"
+msgstr ""
+
 #, c-format
 msgid "The error was '%s'."
 msgstr "The error was '%s'."
@@ -1372,6 +1549,9 @@ msgstr ""
 msgid "The function '%ls' calls itself immediately, which would result in an infinite loop."
 msgstr "The function “%ls” calls itself immediately, which would result in an infinite loop."
 
+msgid "The interactive reader/input system"
+msgstr ""
+
 msgid "There are still jobs active:\n"
 msgstr ""
 
@@ -1380,6 +1560,9 @@ msgstr "This is a login shell\n"
 
 msgid "This is not a login shell\n"
 msgstr "This is not a login shell\n"
+
+msgid "Timer expired"
+msgstr "Timer expired"
 
 msgid "Too few arguments"
 msgstr ""
@@ -1393,7 +1576,13 @@ msgstr ""
 msgid "Too much data emitted by command substitution so it was discarded"
 msgstr ""
 
+msgid "Trace or breakpoint trap"
+msgstr "Trace or breakpoint trap"
+
 msgid "Translate a string"
+msgstr ""
+
+msgid "Trying to print invalid output"
 msgstr ""
 
 #, c-format
@@ -1510,8 +1699,17 @@ msgstr ""
 msgid "Unsupported use of '='. In fish, please use 'set %ls %ls'."
 msgstr ""
 
+msgid "Urgent socket condition"
+msgstr "Urgent socket condition"
+
 msgid "Use 'disown PID' to remove jobs from the list without terminating them.\n"
 msgstr ""
+
+msgid "User defined signal 1"
+msgstr "User defined signal 1"
+
+msgid "User defined signal 2"
+msgstr "User defined signal 2"
 
 #, c-format
 msgid "Variable: %ls"
@@ -1525,7 +1723,25 @@ msgstr ""
 msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
 msgstr ""
 
+msgid "Virtual timefr expired"
+msgstr ""
+
 msgid "Wait for background processes completed"
+msgstr ""
+
+msgid "Warning about using test's zero- or one-argument modes (`test -d $foo`), which will be changed in future."
+msgstr ""
+
+msgid "Warnings (on by default)"
+msgstr ""
+
+msgid "Warnings about unusable paths for config/history (on by default)"
+msgstr ""
+
+msgid "Window size change"
+msgstr "Window size change"
+
+msgid "Writing/reading the universal variable store"
 msgstr ""
 
 msgid "[: the last argument must be ']'"
@@ -1537,6 +1753,9 @@ msgid ""
 msgstr ""
 
 msgid "array indices start at 1, not 0."
+msgstr ""
+
+msgid "autoloading"
 msgstr ""
 
 #, c-format
@@ -79179,107 +79398,14 @@ msgstr ""
 #~ msgid "Could not return shell to foreground"
 #~ msgstr "Could not return shell to foreground"
 
-#~ msgid "Terminal hung up"
-#~ msgstr "Terminal hung up"
-
-#~ msgid "Quit request from job control (^C)"
-#~ msgstr "Quit request from job control (^C)"
-
-#~ msgid "Quit request from job control with core dump (^\\)"
-#~ msgstr "Quit request from job control with core dump (^\\)"
-
-#~ msgid "Illegal instruction"
-#~ msgstr "Illegal instruction"
-
-#~ msgid "Trace or breakpoint trap"
-#~ msgstr "Trace or breakpoint trap"
-
-#~ msgid "Abort"
-#~ msgstr "Abort"
-
-#~ msgid "Misaligned address error"
-#~ msgstr "Misaligned address error"
-
-#~ msgid "Floating point exception"
-#~ msgstr "Floating point exception"
-
-#~ msgid "Forced quit"
-#~ msgstr "Forced quit"
-
-#~ msgid "User defined signal 1"
-#~ msgstr "User defined signal 1"
-
-#~ msgid "User defined signal 2"
-#~ msgstr "User defined signal 2"
-
-#~ msgid "Address boundary error"
-#~ msgstr "Address boundary error"
-
-#~ msgid "Broken pipe"
-#~ msgstr "Broken pipe"
-
-#~ msgid "Timer expired"
-#~ msgstr "Timer expired"
-
-#~ msgid "Polite quit request"
-#~ msgstr "Polite quit request"
-
-#~ msgid "Child process status changed"
-#~ msgstr "Child process status changed"
-
-#~ msgid "Continue previously stopped process"
-#~ msgstr "Continue previously stopped process"
-
-#~ msgid "Forced stop"
-#~ msgstr "Forced stop"
-
-#~ msgid "Stop request from job control (^Z)"
-#~ msgstr "Stop request from job control (^Z)"
-
-#~ msgid "Stop from terminal input"
-#~ msgstr "Stop from terminal input"
-
-#~ msgid "Stop from terminal output"
-#~ msgstr "Stop from terminal output"
-
-#~ msgid "Urgent socket condition"
-#~ msgstr "Urgent socket condition"
-
-#~ msgid "CPU time limit exceeded"
-#~ msgstr "CPU time limit exceeded"
-
-#~ msgid "File size limit exceeded"
-#~ msgstr "File size limit exceeded"
-
 #~ msgid "Virtual timer expired"
 #~ msgstr "Virtual timer expired"
-
-#~ msgid "Profiling timer expired"
-#~ msgstr "Profiling timer expired"
-
-#~ msgid "Window size change"
-#~ msgstr "Window size change"
-
-#~ msgid "I/O on asynchronous file descriptor is possible"
-#~ msgstr "I/O on asynchronous file descriptor is possible"
-
-#~ msgid "Power failure"
-#~ msgstr "Power failure"
-
-#~ msgid "Bad system call"
-#~ msgstr "Bad system call"
 
 #~ msgid "Information request"
 #~ msgstr "Information request"
 
-#~ msgid "Stack fault"
-#~ msgstr "Stack fault"
-
 #~ msgid "Emulator trap"
 #~ msgstr "Emulator trap"
-
-#~ msgid "Abort (Alias for SIGABRT)"
-#~ msgstr "Abort (Alias for SIGABRT)"
 
 #~ msgid "Unused signal"
 #~ msgstr "Unused signal"

--- a/po/fr.po
+++ b/po/fr.po
@@ -141,6 +141,10 @@ msgid "$$ is not the pid. In fish, please use $fish_pid."
 msgstr "$$ n’est pas le PID. Dans fish, veuillez utiliser $fish_pid."
 
 #, c-format
+msgid "$%lc is not a valid variable in fish."
+msgstr "$%lc est un nom de variable invalide dans fish."
+
+#, c-format
 msgid "$%ls: originally inherited as |%ls|\n"
 msgstr ""
 
@@ -163,6 +167,10 @@ msgstr ""
 #, c-format
 msgid "%.*ls: invalid conversion specification"
 msgstr "%.*ls : spécification de conversion invalide"
+
+#, c-format
+msgid "%ls"
+msgstr ""
 
 #, c-format
 msgid "%ls %ls: Abbreviation %ls already exists, cannot rename %ls\n"
@@ -234,6 +242,10 @@ msgstr ""
 
 #, c-format
 msgid "%ls: %ls: contains a syntax error\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: %ls: expected %d arguments; got %d\n"
 msgstr ""
 
 #, c-format
@@ -765,6 +777,18 @@ msgid "%ls: exclusive flag string '%ls' is not valid\n"
 msgstr "%ls : le sémaphore texte exclusif '%ls' est invalide\n"
 
 #, c-format
+msgid "%ls: expected %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: expected <= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: expected >= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
 msgid "%ls: expected a numeric value"
 msgstr "%ls : valeur numérique attendue"
 
@@ -774,6 +798,10 @@ msgstr ""
 
 #, c-format
 msgid "%ls: given %d indexes but %d values\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: invalid option combination, %ls\n"
 msgstr ""
 
 #, c-format
@@ -790,6 +818,10 @@ msgstr "%ls : la tâche %d ('%ls') a été arrêtée et a reçu un signal pour 
 
 #, c-format
 msgid "%ls: line/column index starts at 1"
+msgstr ""
+
+#, c-format
+msgid "%ls: missing argument\n"
 msgstr ""
 
 #, c-format
@@ -926,18 +958,6 @@ msgstr ""
 msgid "--tokens options are mutually exclusive"
 msgstr ""
 
-msgid ".local/bin/"
-msgstr ""
-
-msgid ".local/share/"
-msgstr ""
-
-msgid ".local/share/doc/fish"
-msgstr ""
-
-msgid "/etc/"
-msgstr ""
-
 msgid "A second attempt to exit will terminate them.\n"
 msgstr "Une seconde tentative d’arrêt les terminera.\n"
 
@@ -1000,9 +1020,6 @@ msgstr "Impossible de paramétrer le mode du terminal pour la nouvelle tâche"
 
 msgid "Could not set terminal mode for shell"
 msgstr "Impossible de paramétrer le mode du terminal pour le shell"
-
-msgid "Could not show help message"
-msgstr ""
 
 #, c-format
 msgid "Could not write profiling information to file '%s': %s"
@@ -1599,6 +1616,14 @@ msgstr "Utilisez 'disown PID' pour retirer des tâches de la liste sans les abr�
 msgid "Variable: %ls"
 msgstr "Variable : %ls"
 
+#, c-format
+msgid "Variables cannot be bracketed. In fish, please use \"$%ls\"."
+msgstr "Les variables ne peuvent être placées entre crochets. Dans fish, veuillez utiliser \"$%ls\"."
+
+#, c-format
+msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
+msgstr "Les variables ne peuvent être placées entre crochets. Dans fish, veuillez utiliser {$%ls}."
+
 msgid "Wait for background processes completed"
 msgstr "Attendre la mort des processus en arrière-plan"
 
@@ -1672,9 +1697,6 @@ msgstr "exportée"
 
 msgid "file"
 msgstr "fichier"
-
-msgid "fish/install"
-msgstr ""
 
 #, c-format
 msgid ""
@@ -80651,18 +80673,6 @@ msgstr ""
 #, c-format
 #~ msgid "getcwd() failed with errno %d/%s"
 #~ msgstr "getcwd() a échoué avec l’erreur %d/%s"
-
-#, c-format
-#~ msgid "$%lc is not a valid variable in fish."
-#~ msgstr "$%lc est un nom de variable invalide dans fish."
-
-#, c-format
-#~ msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
-#~ msgstr "Les variables ne peuvent être placées entre crochets. Dans fish, veuillez utiliser {$%ls}."
-
-#, c-format
-#~ msgid "Variables cannot be bracketed. In fish, please use \"$%ls\"."
-#~ msgstr "Les variables ne peuvent être placées entre crochets. Dans fish, veuillez utiliser \"$%ls\"."
 
 #~ msgid "Print each token on a separate line"
 #~ msgstr "Afficher chaque lexème sur une ligne séparée"

--- a/po/fr.po
+++ b/po/fr.po
@@ -961,9 +961,21 @@ msgstr ""
 msgid "A second attempt to exit will terminate them.\n"
 msgstr "Une seconde tentative d’arrêt les terminera.\n"
 
+msgid "Abbreviation expansion"
+msgstr ""
+
 #, c-format
 msgid "Abbreviation: %ls"
 msgstr ""
+
+msgid "Abort"
+msgstr "Abandon"
+
+msgid "Abort (Alias for SIGABRT)"
+msgstr "Abandon (Alias pour SIGABRT)"
+
+msgid "Address boundary error"
+msgstr "Erreur de frontière d'adresse"
 
 msgid "Always"
 msgstr "Toujours"
@@ -975,14 +987,29 @@ msgstr "Une erreur est survenue lors du paramétrage du tube"
 msgid "Argument is not a number: '%ls'"
 msgstr ""
 
+msgid "Background IO thread events"
+msgstr ""
+
 msgid "Backgrounded commands can not be used as conditionals"
 msgstr "Les commandes en arrière-plan ne peuvent être utilisées comme des conditionnelles"
+
+msgid "Bad system call"
+msgstr "Mauvais appel système"
 
 msgid "Block of code to run conditionally"
 msgstr ""
 
+msgid "Broken pipe"
+msgstr "Tube interrompu"
+
+msgid "CPU time limit exceeded"
+msgstr "Limite de temps CPU dépassée"
+
 msgid "CPU\t"
 msgstr "CPU\t"
+
+msgid "Calls to fork()"
+msgstr ""
 
 msgid "Can not use the no-execute mode when running an interactive session"
 msgstr "Le mode no-execute ne peut pas être utilisé dans une session interactive"
@@ -997,7 +1024,22 @@ msgstr "Impossible d’utiliser l’entrée standard (fd 0) comme sortie de tube
 msgid "Change working directory"
 msgstr "Modifier le dossier de travail"
 
+msgid "Changes to exported variables"
+msgstr ""
+
+msgid "Changes to locale variables"
+msgstr ""
+
+msgid "Character encoding issues"
+msgstr ""
+
 msgid "Check if a thing is a thing"
+msgstr ""
+
+msgid "Child process status changed"
+msgstr "L’état du processus fils a été modifié"
+
+msgid "Command history events"
 msgstr ""
 
 msgid "Command not executable"
@@ -1011,6 +1053,9 @@ msgstr ""
 
 msgid "Conditionally run blocks of code"
 msgstr ""
+
+msgid "Continue previously stopped process"
+msgstr "Continuer le processus précédemment arrêté"
 
 msgid "Could not determine current working directory. Is your locale set correctly?"
 msgstr "Impossible de déterminer le dossier de travail. Vos paramètres régionaux sont-ils corrects ?"
@@ -1030,6 +1075,9 @@ msgstr "Compter le nombre d’arguments"
 
 msgid "Create a block of code"
 msgstr "Créer un bloc de code"
+
+msgid "Debugging aid (on by default)"
+msgstr ""
 
 msgid "Define a new function"
 msgstr "Définir une nouvelle fonction"
@@ -1067,6 +1115,9 @@ msgstr ""
 #, c-format
 msgid "Error while reading file %ls\n"
 msgstr "Erreur lors de la lecture du fichier %ls\n"
+
+msgid "Errors reported by exec (on by default)"
+msgstr ""
 
 msgid "Evaluate a string as a statement"
 msgstr ""
@@ -1131,6 +1182,9 @@ msgstr ""
 msgid "Expression is bogus"
 msgstr ""
 
+msgid "FD monitor events"
+msgstr ""
+
 msgid "Failed to assign shell to its own process group"
 msgstr ""
 
@@ -1139,6 +1193,24 @@ msgstr ""
 
 msgid "Failed to take control of the terminal"
 msgstr ""
+
+msgid "File size limit exceeded"
+msgstr "Limite de taille de fichier dépassée"
+
+msgid "Finding and reading configuration"
+msgstr ""
+
+msgid "Firing events"
+msgstr ""
+
+msgid "Floating point exception"
+msgstr "Exception de virgule flottante"
+
+msgid "Forced quit"
+msgstr "Forcé à quitter"
+
+msgid "Forced stop"
+msgstr "Arrêt forcé"
 
 msgid "Generate random number"
 msgstr "Génère un nombre aléatoire"
@@ -1167,6 +1239,9 @@ msgstr ""
 msgid "History of commands executed by user"
 msgstr "Historique des commandes exécutées par l'utilisateur"
 
+msgid "History performance measurements"
+msgstr ""
+
 #, c-format
 msgid "History session ID '%ls' is not a valid variable name. Falling back to `%ls`."
 msgstr "L’ID de session d’historique '%ls' n’est pas un nom de variable valide ; retour à la valeur par défaut `%ls`."
@@ -1179,9 +1254,15 @@ msgstr ""
 msgid "I appear to be an orphaned process, so I am quitting politely. My pid is %d."
 msgstr "Il semblerait que je sois un processus orphelin, je m'arrête donc. Mon pid est %d."
 
+msgid "I/O on asynchronous file descriptor is possible"
+msgstr "E/S sur un descripteur de fichier asynchrone possible"
+
 #, c-format
 msgid "Illegal file descriptor in redirection '%ls'"
 msgstr "Descripteur de fichier erroné dans la redirection '%ls'"
+
+msgid "Illegal instruction"
+msgstr "Instruction illégale"
 
 #, c-format
 msgid "Incomplete escape sequence '%ls'"
@@ -1189,6 +1270,12 @@ msgstr ""
 
 #, c-format
 msgid "Integer %lld in '%ls' followed by non-digit"
+msgstr ""
+
+msgid "Internal (non-forked) process events"
+msgstr ""
+
+msgid "Internal details of the topic monitor"
 msgstr ""
 
 msgid "Invalid arguments"
@@ -1230,6 +1317,15 @@ msgstr "Contrôle des tâches : %ls\n"
 msgid "Job\tGroup\t"
 msgstr "Tâche\tGroupe\t"
 
+msgid "Jobs being executed"
+msgstr ""
+
+msgid "Jobs changing status"
+msgstr ""
+
+msgid "Jobs getting started or continued"
+msgstr ""
+
 msgid "List or remove functions"
 msgstr "Lister ou supprimer des fonctions"
 
@@ -1252,6 +1348,9 @@ msgstr "Manipuler les chaînes"
 
 msgid "Measure how long a command or block takes"
 msgstr ""
+
+msgid "Misaligned address error"
+msgstr "Erreur de mauvaise adresse"
 
 msgid "Mismatched braces"
 msgstr ""
@@ -1295,6 +1394,9 @@ msgstr "Pas une fonction"
 msgid "Not a number"
 msgstr ""
 
+msgid "Notifications about universal variable changes"
+msgstr ""
+
 msgid "Number is infinite"
 msgstr ""
 
@@ -1317,6 +1419,9 @@ msgstr ""
 msgid "Parse options in fish script"
 msgstr "Analyser les options du script fish"
 
+msgid "Parsing fish AST"
+msgstr ""
+
 msgid "Perform a command multiple times"
 msgstr "Exécuter une commande plusieurs fois"
 
@@ -1330,6 +1435,12 @@ msgstr "Veuillez paramétrer $%ls à un dossier dans lequel vous avez un accès 
 #, c-format
 msgid "Please set the %ls or HOME environment variable before starting fish."
 msgstr "Veuillez paramétrer la variable d’environnement %ls ou HOME avant de lancer fish."
+
+msgid "Polite quit request"
+msgstr "Demande polie de quitter"
+
+msgid "Power failure"
+msgstr "Panne de courant"
 
 #, c-format
 msgid "Press ctrl-%c again to exit\n"
@@ -1347,14 +1458,44 @@ msgstr "Afficher le dossier de travail"
 msgid "Prints formatted text"
 msgstr "Affiche le texte formaté"
 
+msgid "Process groups"
+msgstr ""
+
 msgid "Process\n"
 msgstr "Processus\n"
+
+msgid "Profiling timer expired"
+msgstr "Délai de profilage expiré"
+
+msgid "Quit request from job control (^C)"
+msgstr "Requête de sortie du contrôle des tâches (^C)"
+
+msgid "Quit request from job control with core dump (^\\)"
+msgstr "Requête de sortie du contrôle des tâches avec core dump (^\\)"
+
+msgid "Reacting to variables"
+msgstr ""
 
 msgid "Read a line of input into variables"
 msgstr "Lire une ligne d'entrée dans des variables"
 
+msgid "Reading/Writing the history file"
+msgstr ""
+
+msgid "Reaping external (forked) processes"
+msgstr ""
+
+msgid "Reaping internal (non-forked) processes"
+msgstr ""
+
+msgid "Refcell dynamic borrowing"
+msgstr ""
+
 msgid "Remove job from job list"
 msgstr "Supprimer la tâche de la liste des tâches"
+
+msgid "Rendering the command line"
+msgstr ""
 
 #, c-format
 msgid "Requested redirection to '%ls', which is not a valid file descriptor"
@@ -1385,8 +1526,14 @@ msgstr ""
 msgid "Run command in current process"
 msgstr "Exécuter la commande dans le processus actuel"
 
+msgid "Screen repaints"
+msgstr ""
+
 msgid "Search for a specified string in a list"
 msgstr "Rechercher une chaîne de caractères donnée dans une liste"
+
+msgid "Searching/using paths"
+msgstr ""
 
 #, c-format
 msgid "Send job %d (%ls) to foreground\n"
@@ -1402,6 +1549,9 @@ msgstr "Mettre la tâche en arrière-plan"
 msgid "Send job to foreground"
 msgstr "Mettre la tâche en premier plan"
 
+msgid "Serious unexpected errors (on by default)"
+msgstr ""
+
 msgid "Set or get the commandline"
 msgstr "Paramétrer ou obtenir la ligne de commande"
 
@@ -1413,6 +1563,9 @@ msgstr ""
 
 msgid "Skip over remaining innermost loop"
 msgstr ""
+
+msgid "Stack fault"
+msgstr "Faute de pile"
 
 msgid "Standard input"
 msgstr "Entrée standard"
@@ -1431,6 +1584,15 @@ msgstr "État\tCommande\n"
 msgid "Stdin must be attached to a tty."
 msgstr ""
 
+msgid "Stop from terminal input"
+msgstr "Arrêt de l'entrée du terminal"
+
+msgid "Stop from terminal output"
+msgstr "Arrêt de la sortie du terminal"
+
+msgid "Stop request from job control (^Z)"
+msgstr "Demande d'arrêt du contrôle des tâches (^Z)"
+
 msgid "Stop the currently evaluated function"
 msgstr "Arrêter la fonction actuellement en évaluation"
 
@@ -1439,6 +1601,18 @@ msgstr "Arrêter la boucle interne"
 
 msgid "Temporarily block delivery of events"
 msgstr "Bloquer temporairement la distribution des événements"
+
+msgid "Terminal feature detection"
+msgstr ""
+
+msgid "Terminal hung up"
+msgstr "Le terminal a raccroché"
+
+msgid "Terminal ownership events"
+msgstr ""
+
+msgid "Terminal protocol negotiation"
+msgstr ""
 
 msgid "Test a condition"
 msgstr "Vérifier une condition"
@@ -1457,6 +1631,9 @@ msgstr ""
 msgid "The call stack limit has been exceeded. Do you have an accidental infinite loop?"
 msgstr ""
 
+msgid "The completion system"
+msgstr ""
+
 #, c-format
 msgid "The error was '%s'."
 msgstr "L’erreur était '%s'"
@@ -1471,6 +1648,9 @@ msgstr ""
 msgid "The function '%ls' calls itself immediately, which would result in an infinite loop."
 msgstr "La fonction '%ls' s’appelle immédiatement, ce qui provoquerait une boucle infinie."
 
+msgid "The interactive reader/input system"
+msgstr ""
+
 msgid "There are still jobs active:\n"
 msgstr "Des tâches sont toujours actives :\n"
 
@@ -1479,6 +1659,9 @@ msgstr "Ceci est un shell de connexion\n"
 
 msgid "This is not a login shell\n"
 msgstr "Ceci n’est pas un shell de connexion\n"
+
+msgid "Timer expired"
+msgstr "Expiration du délai"
 
 msgid "Too few arguments"
 msgstr ""
@@ -1492,7 +1675,13 @@ msgstr ""
 msgid "Too much data emitted by command substitution so it was discarded"
 msgstr ""
 
+msgid "Trace or breakpoint trap"
+msgstr "Déroutement de suivi/point d'arrêt"
+
 msgid "Translate a string"
+msgstr ""
+
+msgid "Trying to print invalid output"
 msgstr ""
 
 #, c-format
@@ -1609,8 +1798,17 @@ msgstr ""
 msgid "Unsupported use of '='. In fish, please use 'set %ls %ls'."
 msgstr "Usage de '=' non supporté. Dans fish, veuillez utiliser 'set %ls %ls'."
 
+msgid "Urgent socket condition"
+msgstr "Condition urgente de socket"
+
 msgid "Use 'disown PID' to remove jobs from the list without terminating them.\n"
 msgstr "Utilisez 'disown PID' pour retirer des tâches de la liste sans les abréger\n"
+
+msgid "User defined signal 1"
+msgstr "Signal défini par l'utilisateur 1"
+
+msgid "User defined signal 2"
+msgstr "Signal défini par l'utilisateur 2"
 
 #, c-format
 msgid "Variable: %ls"
@@ -1624,8 +1822,26 @@ msgstr "Les variables ne peuvent être placées entre crochets. Dans fish, veuil
 msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
 msgstr "Les variables ne peuvent être placées entre crochets. Dans fish, veuillez utiliser {$%ls}."
 
+msgid "Virtual timefr expired"
+msgstr ""
+
 msgid "Wait for background processes completed"
 msgstr "Attendre la mort des processus en arrière-plan"
+
+msgid "Warning about using test's zero- or one-argument modes (`test -d $foo`), which will be changed in future."
+msgstr ""
+
+msgid "Warnings (on by default)"
+msgstr ""
+
+msgid "Warnings about unusable paths for config/history (on by default)"
+msgstr ""
+
+msgid "Window size change"
+msgstr "Modification de dimension de fenêtre"
+
+msgid "Writing/reading the universal variable store"
+msgstr ""
 
 msgid "[: the last argument must be ']'"
 msgstr ""
@@ -1638,6 +1854,9 @@ msgstr ""
 "   PID Commande\n"
 
 msgid "array indices start at 1, not 0."
+msgstr ""
+
+msgid "autoloading"
 msgstr ""
 
 #, c-format
@@ -80565,107 +80784,14 @@ msgstr ""
 #~ msgid "Could not return shell to foreground"
 #~ msgstr "Impossible de remettre le shell en premier plan"
 
-#~ msgid "Terminal hung up"
-#~ msgstr "Le terminal a raccroché"
-
-#~ msgid "Quit request from job control (^C)"
-#~ msgstr "Requête de sortie du contrôle des tâches (^C)"
-
-#~ msgid "Quit request from job control with core dump (^\\)"
-#~ msgstr "Requête de sortie du contrôle des tâches avec core dump (^\\)"
-
-#~ msgid "Illegal instruction"
-#~ msgstr "Instruction illégale"
-
-#~ msgid "Trace or breakpoint trap"
-#~ msgstr "Déroutement de suivi/point d'arrêt"
-
-#~ msgid "Abort"
-#~ msgstr "Abandon"
-
-#~ msgid "Misaligned address error"
-#~ msgstr "Erreur de mauvaise adresse"
-
-#~ msgid "Floating point exception"
-#~ msgstr "Exception de virgule flottante"
-
-#~ msgid "Forced quit"
-#~ msgstr "Forcé à quitter"
-
-#~ msgid "User defined signal 1"
-#~ msgstr "Signal défini par l'utilisateur 1"
-
-#~ msgid "User defined signal 2"
-#~ msgstr "Signal défini par l'utilisateur 2"
-
-#~ msgid "Address boundary error"
-#~ msgstr "Erreur de frontière d'adresse"
-
-#~ msgid "Broken pipe"
-#~ msgstr "Tube interrompu"
-
-#~ msgid "Timer expired"
-#~ msgstr "Expiration du délai"
-
-#~ msgid "Polite quit request"
-#~ msgstr "Demande polie de quitter"
-
-#~ msgid "Child process status changed"
-#~ msgstr "L’état du processus fils a été modifié"
-
-#~ msgid "Continue previously stopped process"
-#~ msgstr "Continuer le processus précédemment arrêté"
-
-#~ msgid "Forced stop"
-#~ msgstr "Arrêt forcé"
-
-#~ msgid "Stop request from job control (^Z)"
-#~ msgstr "Demande d'arrêt du contrôle des tâches (^Z)"
-
-#~ msgid "Stop from terminal input"
-#~ msgstr "Arrêt de l'entrée du terminal"
-
-#~ msgid "Stop from terminal output"
-#~ msgstr "Arrêt de la sortie du terminal"
-
-#~ msgid "Urgent socket condition"
-#~ msgstr "Condition urgente de socket"
-
-#~ msgid "CPU time limit exceeded"
-#~ msgstr "Limite de temps CPU dépassée"
-
-#~ msgid "File size limit exceeded"
-#~ msgstr "Limite de taille de fichier dépassée"
-
 #~ msgid "Virtual timer expired"
 #~ msgstr "Délai virtuel expiré"
-
-#~ msgid "Profiling timer expired"
-#~ msgstr "Délai de profilage expiré"
-
-#~ msgid "Window size change"
-#~ msgstr "Modification de dimension de fenêtre"
-
-#~ msgid "I/O on asynchronous file descriptor is possible"
-#~ msgstr "E/S sur un descripteur de fichier asynchrone possible"
-
-#~ msgid "Power failure"
-#~ msgstr "Panne de courant"
-
-#~ msgid "Bad system call"
-#~ msgstr "Mauvais appel système"
 
 #~ msgid "Information request"
 #~ msgstr "Demande d'information"
 
-#~ msgid "Stack fault"
-#~ msgstr "Faute de pile"
-
 #~ msgid "Emulator trap"
 #~ msgstr "Déroutement d'émulation"
-
-#~ msgid "Abort (Alias for SIGABRT)"
-#~ msgstr "Abandon (Alias pour SIGABRT)"
 
 #~ msgid "Unused signal"
 #~ msgstr "Signal inutilisé"

--- a/po/pl.po
+++ b/po/pl.po
@@ -38,6 +38,10 @@ msgid "$$ is not the pid. In fish, please use $fish_pid."
 msgstr "$$ nie jest numerem identyfikacyjnym procesu. W fish używane jest $fish_pid."
 
 #, c-format
+msgid "$%lc is not a valid variable in fish."
+msgstr "$%lc nie jest prawidłową zmienną w fish."
+
+#, c-format
 msgid "$%ls: originally inherited as |%ls|\n"
 msgstr ""
 
@@ -59,6 +63,10 @@ msgstr ""
 
 #, c-format
 msgid "%.*ls: invalid conversion specification"
+msgstr ""
+
+#, c-format
+msgid "%ls"
 msgstr ""
 
 #, c-format
@@ -131,6 +139,10 @@ msgstr ""
 
 #, c-format
 msgid "%ls: %ls: contains a syntax error\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: %ls: expected %d arguments; got %d\n"
 msgstr ""
 
 #, c-format
@@ -662,6 +674,18 @@ msgid "%ls: exclusive flag string '%ls' is not valid\n"
 msgstr ""
 
 #, c-format
+msgid "%ls: expected %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: expected <= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: expected >= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
 msgid "%ls: expected a numeric value"
 msgstr "%ls: oczekiwano wartości liczbowej"
 
@@ -671,6 +695,10 @@ msgstr ""
 
 #, c-format
 msgid "%ls: given %d indexes but %d values\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: invalid option combination, %ls\n"
 msgstr ""
 
 #, c-format
@@ -687,6 +715,10 @@ msgstr ""
 
 #, c-format
 msgid "%ls: line/column index starts at 1"
+msgstr ""
+
+#, c-format
+msgid "%ls: missing argument\n"
 msgstr ""
 
 #, c-format
@@ -823,18 +855,6 @@ msgstr ""
 msgid "--tokens options are mutually exclusive"
 msgstr ""
 
-msgid ".local/bin/"
-msgstr ""
-
-msgid ".local/share/"
-msgstr ""
-
-msgid ".local/share/doc/fish"
-msgstr ""
-
-msgid "/etc/"
-msgstr ""
-
 msgid "A second attempt to exit will terminate them.\n"
 msgstr ""
 
@@ -896,9 +916,6 @@ msgid "Could not set terminal mode for new job"
 msgstr "Nie można ustawić trybu terminala dla nowego zadania"
 
 msgid "Could not set terminal mode for shell"
-msgstr ""
-
-msgid "Could not show help message"
 msgstr ""
 
 #, c-format
@@ -1496,6 +1513,14 @@ msgstr ""
 msgid "Variable: %ls"
 msgstr "Zmienna: %ls"
 
+#, c-format
+msgid "Variables cannot be bracketed. In fish, please use \"$%ls\"."
+msgstr "Zmienne nie mogą znajdować się w nawiasach. W fish używane jest \"$%ls\"."
+
+#, c-format
+msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
+msgstr "Zmienne nie mogą znajdować się w nawiasach. W fish używane jest {$%ls}."
+
 msgid "Wait for background processes completed"
 msgstr ""
 
@@ -1566,9 +1591,6 @@ msgid "exported"
 msgstr ""
 
 msgid "file"
-msgstr ""
-
-msgid "fish/install"
 msgstr ""
 
 #, c-format
@@ -79019,18 +79041,6 @@ msgstr ""
 
 #~ msgid "Unused signal"
 #~ msgstr "Niewykorzystywany sygnał"
-
-#, c-format
-#~ msgid "$%lc is not a valid variable in fish."
-#~ msgstr "$%lc nie jest prawidłową zmienną w fish."
-
-#, c-format
-#~ msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
-#~ msgstr "Zmienne nie mogą znajdować się w nawiasach. W fish używane jest {$%ls}."
-
-#, c-format
-#~ msgid "Variables cannot be bracketed. In fish, please use \"$%ls\"."
-#~ msgstr "Zmienne nie mogą znajdować się w nawiasach. W fish używane jest \"$%ls\"."
 
 #, c-format
 #~ msgid "Send job %d '%ls' to background\n"

--- a/po/pl.po
+++ b/po/pl.po
@@ -858,8 +858,20 @@ msgstr ""
 msgid "A second attempt to exit will terminate them.\n"
 msgstr ""
 
+msgid "Abbreviation expansion"
+msgstr ""
+
 #, c-format
 msgid "Abbreviation: %ls"
+msgstr ""
+
+msgid "Abort"
+msgstr "Przerwij"
+
+msgid "Abort (Alias for SIGABRT)"
+msgstr ""
+
+msgid "Address boundary error"
 msgstr ""
 
 msgid "Always"
@@ -872,14 +884,29 @@ msgstr ""
 msgid "Argument is not a number: '%ls'"
 msgstr ""
 
+msgid "Background IO thread events"
+msgstr ""
+
 msgid "Backgrounded commands can not be used as conditionals"
+msgstr ""
+
+msgid "Bad system call"
 msgstr ""
 
 msgid "Block of code to run conditionally"
 msgstr ""
 
+msgid "Broken pipe"
+msgstr ""
+
+msgid "CPU time limit exceeded"
+msgstr ""
+
 msgid "CPU\t"
 msgstr "CPU\t"
+
+msgid "Calls to fork()"
+msgstr ""
 
 msgid "Can not use the no-execute mode when running an interactive session"
 msgstr "Nie możesz użyć trybu niewykonywalnego kiedy uruchomiona jest sesja interaktywna"
@@ -894,7 +921,22 @@ msgstr ""
 msgid "Change working directory"
 msgstr "Zmień katalog roboczy"
 
+msgid "Changes to exported variables"
+msgstr ""
+
+msgid "Changes to locale variables"
+msgstr ""
+
+msgid "Character encoding issues"
+msgstr ""
+
 msgid "Check if a thing is a thing"
+msgstr ""
+
+msgid "Child process status changed"
+msgstr "Zmieniono status procesu potomnego"
+
+msgid "Command history events"
 msgstr ""
 
 msgid "Command not executable"
@@ -908,6 +950,9 @@ msgstr ""
 
 msgid "Conditionally run blocks of code"
 msgstr ""
+
+msgid "Continue previously stopped process"
+msgstr "Kontynuuj wcześniej zatrzymany proces"
 
 msgid "Could not determine current working directory. Is your locale set correctly?"
 msgstr ""
@@ -927,6 +972,9 @@ msgstr "Wylicz liczbę argumentów"
 
 msgid "Create a block of code"
 msgstr "Stwórz blok kodu"
+
+msgid "Debugging aid (on by default)"
+msgstr ""
 
 msgid "Define a new function"
 msgstr "Zdefiniuj nową funkcję"
@@ -964,6 +1012,9 @@ msgstr ""
 #, c-format
 msgid "Error while reading file %ls\n"
 msgstr "Wystąpił błąd podczas odczytywania pliku %ls\n"
+
+msgid "Errors reported by exec (on by default)"
+msgstr ""
 
 msgid "Evaluate a string as a statement"
 msgstr ""
@@ -1028,6 +1079,9 @@ msgstr ""
 msgid "Expression is bogus"
 msgstr ""
 
+msgid "FD monitor events"
+msgstr ""
+
 msgid "Failed to assign shell to its own process group"
 msgstr ""
 
@@ -1036,6 +1090,24 @@ msgstr ""
 
 msgid "Failed to take control of the terminal"
 msgstr ""
+
+msgid "File size limit exceeded"
+msgstr "Przekroczony limit rozmiaru pliku"
+
+msgid "Finding and reading configuration"
+msgstr ""
+
+msgid "Firing events"
+msgstr ""
+
+msgid "Floating point exception"
+msgstr ""
+
+msgid "Forced quit"
+msgstr "Przymusowe wyjście"
+
+msgid "Forced stop"
+msgstr "Wymuszono zatrzymanie"
 
 msgid "Generate random number"
 msgstr "Zwróć losową liczbę"
@@ -1064,6 +1136,9 @@ msgstr ""
 msgid "History of commands executed by user"
 msgstr "Historia komend wykonanych przez użytkownika"
 
+msgid "History performance measurements"
+msgstr ""
+
 #, c-format
 msgid "History session ID '%ls' is not a valid variable name. Falling back to `%ls`."
 msgstr ""
@@ -1076,9 +1151,15 @@ msgstr "Katalog domowy dla %ls"
 msgid "I appear to be an orphaned process, so I am quitting politely. My pid is %d."
 msgstr ""
 
+msgid "I/O on asynchronous file descriptor is possible"
+msgstr ""
+
 #, c-format
 msgid "Illegal file descriptor in redirection '%ls'"
 msgstr ""
+
+msgid "Illegal instruction"
+msgstr "Niedozwolona instrukcja"
 
 #, c-format
 msgid "Incomplete escape sequence '%ls'"
@@ -1086,6 +1167,12 @@ msgstr ""
 
 #, c-format
 msgid "Integer %lld in '%ls' followed by non-digit"
+msgstr ""
+
+msgid "Internal (non-forked) process events"
+msgstr ""
+
+msgid "Internal details of the topic monitor"
 msgstr ""
 
 msgid "Invalid arguments"
@@ -1127,6 +1214,15 @@ msgstr "Kontrola zadania: %ls\n"
 msgid "Job\tGroup\t"
 msgstr "Zadanie\tGrupa\t"
 
+msgid "Jobs being executed"
+msgstr ""
+
+msgid "Jobs changing status"
+msgstr ""
+
+msgid "Jobs getting started or continued"
+msgstr ""
+
 msgid "List or remove functions"
 msgstr "Wypisz lub usuń funkcje"
 
@@ -1148,6 +1244,9 @@ msgid "Manipulate strings"
 msgstr "Zmień wartości ciągów znaków"
 
 msgid "Measure how long a command or block takes"
+msgstr ""
+
+msgid "Misaligned address error"
 msgstr ""
 
 msgid "Mismatched braces"
@@ -1192,6 +1291,9 @@ msgstr ""
 msgid "Not a number"
 msgstr ""
 
+msgid "Notifications about universal variable changes"
+msgstr ""
+
 msgid "Number is infinite"
 msgstr ""
 
@@ -1214,6 +1316,9 @@ msgstr ""
 msgid "Parse options in fish script"
 msgstr ""
 
+msgid "Parsing fish AST"
+msgstr ""
+
 msgid "Perform a command multiple times"
 msgstr "Wykonaj komendę wielokrotnie"
 
@@ -1226,6 +1331,12 @@ msgstr ""
 
 #, c-format
 msgid "Please set the %ls or HOME environment variable before starting fish."
+msgstr ""
+
+msgid "Polite quit request"
+msgstr ""
+
+msgid "Power failure"
 msgstr ""
 
 #, c-format
@@ -1244,13 +1355,43 @@ msgstr "Zwróć katalog roboczy"
 msgid "Prints formatted text"
 msgstr "Zwraca sformatowany tekst"
 
+msgid "Process groups"
+msgstr ""
+
 msgid "Process\n"
 msgstr "Proces\n"
+
+msgid "Profiling timer expired"
+msgstr ""
+
+msgid "Quit request from job control (^C)"
+msgstr ""
+
+msgid "Quit request from job control with core dump (^\\)"
+msgstr ""
+
+msgid "Reacting to variables"
+msgstr ""
 
 msgid "Read a line of input into variables"
 msgstr ""
 
+msgid "Reading/Writing the history file"
+msgstr ""
+
+msgid "Reaping external (forked) processes"
+msgstr ""
+
+msgid "Reaping internal (non-forked) processes"
+msgstr ""
+
+msgid "Refcell dynamic borrowing"
+msgstr ""
+
 msgid "Remove job from job list"
+msgstr ""
+
+msgid "Rendering the command line"
 msgstr ""
 
 #, c-format
@@ -1282,8 +1423,14 @@ msgstr ""
 msgid "Run command in current process"
 msgstr "Uruchom komendę w obecnym procesie"
 
+msgid "Screen repaints"
+msgstr ""
+
 msgid "Search for a specified string in a list"
 msgstr "Szukaj określonego ciągu znaków w liście"
+
+msgid "Searching/using paths"
+msgstr ""
 
 #, c-format
 msgid "Send job %d (%ls) to foreground\n"
@@ -1299,6 +1446,9 @@ msgstr "Przenieś zadanie w tło"
 msgid "Send job to foreground"
 msgstr ""
 
+msgid "Serious unexpected errors (on by default)"
+msgstr ""
+
 msgid "Set or get the commandline"
 msgstr ""
 
@@ -1309,6 +1459,9 @@ msgid "Show absolute path sans symlinks"
 msgstr ""
 
 msgid "Skip over remaining innermost loop"
+msgstr ""
+
+msgid "Stack fault"
 msgstr ""
 
 msgid "Standard input"
@@ -1328,6 +1481,15 @@ msgstr "Stan\tKomenda\n"
 msgid "Stdin must be attached to a tty."
 msgstr ""
 
+msgid "Stop from terminal input"
+msgstr ""
+
+msgid "Stop from terminal output"
+msgstr ""
+
+msgid "Stop request from job control (^Z)"
+msgstr ""
+
 msgid "Stop the currently evaluated function"
 msgstr "Zatrzymaj obecnie używaną funkcję"
 
@@ -1335,6 +1497,18 @@ msgid "Stop the innermost loop"
 msgstr ""
 
 msgid "Temporarily block delivery of events"
+msgstr ""
+
+msgid "Terminal feature detection"
+msgstr ""
+
+msgid "Terminal hung up"
+msgstr "Terminal zawieszony"
+
+msgid "Terminal ownership events"
+msgstr ""
+
+msgid "Terminal protocol negotiation"
 msgstr ""
 
 msgid "Test a condition"
@@ -1354,6 +1528,9 @@ msgstr ""
 msgid "The call stack limit has been exceeded. Do you have an accidental infinite loop?"
 msgstr ""
 
+msgid "The completion system"
+msgstr ""
+
 #, c-format
 msgid "The error was '%s'."
 msgstr ""
@@ -1368,6 +1545,9 @@ msgstr ""
 msgid "The function '%ls' calls itself immediately, which would result in an infinite loop."
 msgstr "Funkcja '%ls' wywołuje natychmiastowo siebie. Może to skutkować nieskończoną pętlą."
 
+msgid "The interactive reader/input system"
+msgstr ""
+
 msgid "There are still jobs active:\n"
 msgstr ""
 
@@ -1376,6 +1556,9 @@ msgstr "To jest powłoka logowania\n"
 
 msgid "This is not a login shell\n"
 msgstr "To nie jest powłoka logowania\n"
+
+msgid "Timer expired"
+msgstr ""
 
 msgid "Too few arguments"
 msgstr ""
@@ -1389,7 +1572,13 @@ msgstr ""
 msgid "Too much data emitted by command substitution so it was discarded"
 msgstr ""
 
+msgid "Trace or breakpoint trap"
+msgstr ""
+
 msgid "Translate a string"
+msgstr ""
+
+msgid "Trying to print invalid output"
 msgstr ""
 
 #, c-format
@@ -1506,8 +1695,17 @@ msgstr ""
 msgid "Unsupported use of '='. In fish, please use 'set %ls %ls'."
 msgstr "Nieobsługiwane użycie '='. W fish używane jest 'set %ls %ls'."
 
+msgid "Urgent socket condition"
+msgstr ""
+
 msgid "Use 'disown PID' to remove jobs from the list without terminating them.\n"
 msgstr ""
+
+msgid "User defined signal 1"
+msgstr "Sygnał zdefiniowany przez użytkownika 1"
+
+msgid "User defined signal 2"
+msgstr "Sygnał zdefiniowany przez użytkownika 2"
 
 #, c-format
 msgid "Variable: %ls"
@@ -1521,7 +1719,25 @@ msgstr "Zmienne nie mogą znajdować się w nawiasach. W fish używane jest \"$%
 msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
 msgstr "Zmienne nie mogą znajdować się w nawiasach. W fish używane jest {$%ls}."
 
+msgid "Virtual timefr expired"
+msgstr ""
+
 msgid "Wait for background processes completed"
+msgstr ""
+
+msgid "Warning about using test's zero- or one-argument modes (`test -d $foo`), which will be changed in future."
+msgstr ""
+
+msgid "Warnings (on by default)"
+msgstr ""
+
+msgid "Warnings about unusable paths for config/history (on by default)"
+msgstr ""
+
+msgid "Window size change"
+msgstr "Zmiana rozmiaru okna"
+
+msgid "Writing/reading the universal variable store"
 msgstr ""
 
 msgid "[: the last argument must be ']'"
@@ -1533,6 +1749,9 @@ msgid ""
 msgstr ""
 
 msgid "array indices start at 1, not 0."
+msgstr ""
+
+msgid "autoloading"
 msgstr ""
 
 #, c-format
@@ -79002,39 +79221,6 @@ msgstr ""
 
 #~ msgid "Could not return shell to foreground"
 #~ msgstr "Nie można przywrócić powłoki na pierwszy plan"
-
-#~ msgid "Terminal hung up"
-#~ msgstr "Terminal zawieszony"
-
-#~ msgid "Illegal instruction"
-#~ msgstr "Niedozwolona instrukcja"
-
-#~ msgid "Abort"
-#~ msgstr "Przerwij"
-
-#~ msgid "Forced quit"
-#~ msgstr "Przymusowe wyjście"
-
-#~ msgid "User defined signal 1"
-#~ msgstr "Sygnał zdefiniowany przez użytkownika 1"
-
-#~ msgid "User defined signal 2"
-#~ msgstr "Sygnał zdefiniowany przez użytkownika 2"
-
-#~ msgid "Child process status changed"
-#~ msgstr "Zmieniono status procesu potomnego"
-
-#~ msgid "Continue previously stopped process"
-#~ msgstr "Kontynuuj wcześniej zatrzymany proces"
-
-#~ msgid "Forced stop"
-#~ msgstr "Wymuszono zatrzymanie"
-
-#~ msgid "File size limit exceeded"
-#~ msgstr "Przekroczony limit rozmiaru pliku"
-
-#~ msgid "Window size change"
-#~ msgstr "Zmiana rozmiaru okna"
 
 #~ msgid "Information request"
 #~ msgstr "Żądanie informacji"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -863,9 +863,21 @@ msgstr ""
 msgid "A second attempt to exit will terminate them.\n"
 msgstr ""
 
+msgid "Abbreviation expansion"
+msgstr ""
+
 #, c-format
 msgid "Abbreviation: %ls"
 msgstr ""
+
+msgid "Abort"
+msgstr "Abortado"
+
+msgid "Abort (Alias for SIGABRT)"
+msgstr "Abortado (Outro nome para SIGABRT)"
+
+msgid "Address boundary error"
+msgstr "Erro de fronteira de endereço (Falha de segmentação)"
 
 msgid "Always"
 msgstr "Sempre"
@@ -877,14 +889,29 @@ msgstr "Ocorreu um erro ao preparar pipe"
 msgid "Argument is not a number: '%ls'"
 msgstr ""
 
+msgid "Background IO thread events"
+msgstr ""
+
 msgid "Backgrounded commands can not be used as conditionals"
 msgstr ""
+
+msgid "Bad system call"
+msgstr "Chamada de sistema ruim"
 
 msgid "Block of code to run conditionally"
 msgstr ""
 
+msgid "Broken pipe"
+msgstr "Pipe sem saída"
+
+msgid "CPU time limit exceeded"
+msgstr "Limite de tempo da CPU excedido"
+
 msgid "CPU\t"
 msgstr "CPU\t"
+
+msgid "Calls to fork()"
+msgstr ""
 
 msgid "Can not use the no-execute mode when running an interactive session"
 msgstr "Não pode usar o modo não-executar durante uma sessão interativa"
@@ -899,8 +926,23 @@ msgstr "Não pode usar entrada padrão (fd 0) como saída de pipe"
 msgid "Change working directory"
 msgstr "Muda diretório de trabalho"
 
+msgid "Changes to exported variables"
+msgstr ""
+
+msgid "Changes to locale variables"
+msgstr ""
+
+msgid "Character encoding issues"
+msgstr ""
+
 msgid "Check if a thing is a thing"
 msgstr "Verifica se uma coisa é uma coisa"
+
+msgid "Child process status changed"
+msgstr "Mudança de estado de processo filho"
+
+msgid "Command history events"
+msgstr ""
 
 msgid "Command not executable"
 msgstr ""
@@ -913,6 +955,9 @@ msgstr ""
 
 msgid "Conditionally run blocks of code"
 msgstr ""
+
+msgid "Continue previously stopped process"
+msgstr "Continuar processo previamente parado"
 
 msgid "Could not determine current working directory. Is your locale set correctly?"
 msgstr ""
@@ -932,6 +977,9 @@ msgstr "Conta o número de argumentos"
 
 msgid "Create a block of code"
 msgstr "Cria um bloco de código"
+
+msgid "Debugging aid (on by default)"
+msgstr ""
 
 msgid "Define a new function"
 msgstr "Define uma nova função"
@@ -969,6 +1017,9 @@ msgstr ""
 #, c-format
 msgid "Error while reading file %ls\n"
 msgstr "Erro ao ler arquivo %ls\n"
+
+msgid "Errors reported by exec (on by default)"
+msgstr ""
 
 msgid "Evaluate a string as a statement"
 msgstr "Avaliar a string como um comando"
@@ -1033,6 +1084,9 @@ msgstr ""
 msgid "Expression is bogus"
 msgstr ""
 
+msgid "FD monitor events"
+msgstr ""
+
 msgid "Failed to assign shell to its own process group"
 msgstr ""
 
@@ -1041,6 +1095,24 @@ msgstr ""
 
 msgid "Failed to take control of the terminal"
 msgstr ""
+
+msgid "File size limit exceeded"
+msgstr "Limite de tamanho de arquivo excedido"
+
+msgid "Finding and reading configuration"
+msgstr ""
+
+msgid "Firing events"
+msgstr ""
+
+msgid "Floating point exception"
+msgstr "Exceção de ponto flutuante"
+
+msgid "Forced quit"
+msgstr "Saída forçada"
+
+msgid "Forced stop"
+msgstr "Parada forçada"
 
 msgid "Generate random number"
 msgstr "Gera um número aleatório"
@@ -1069,6 +1141,9 @@ msgstr ""
 msgid "History of commands executed by user"
 msgstr "Histórico de funções executadas pelo usuário"
 
+msgid "History performance measurements"
+msgstr ""
+
 #, c-format
 msgid "History session ID '%ls' is not a valid variable name. Falling back to `%ls`."
 msgstr ""
@@ -1081,9 +1156,15 @@ msgstr "Diretório de usuário para %ls"
 msgid "I appear to be an orphaned process, so I am quitting politely. My pid is %d."
 msgstr "Pareço um processo órfão, então estou saindo educadamente. Meu pid é %d."
 
+msgid "I/O on asynchronous file descriptor is possible"
+msgstr "E/S em descritor de arquivo assíncrono possível"
+
 #, c-format
 msgid "Illegal file descriptor in redirection '%ls'"
 msgstr "Descritor de arquivo ilegal na redireção “%ls”"
+
+msgid "Illegal instruction"
+msgstr "Instrução ilegal"
 
 #, c-format
 msgid "Incomplete escape sequence '%ls'"
@@ -1091,6 +1172,12 @@ msgstr ""
 
 #, c-format
 msgid "Integer %lld in '%ls' followed by non-digit"
+msgstr ""
+
+msgid "Internal (non-forked) process events"
+msgstr ""
+
+msgid "Internal details of the topic monitor"
 msgstr ""
 
 msgid "Invalid arguments"
@@ -1132,6 +1219,15 @@ msgstr "Controle de tarefa: %ls\n"
 msgid "Job\tGroup\t"
 msgstr "Tarefa\tGrupo\t"
 
+msgid "Jobs being executed"
+msgstr ""
+
+msgid "Jobs changing status"
+msgstr ""
+
+msgid "Jobs getting started or continued"
+msgstr ""
+
 msgid "List or remove functions"
 msgstr "Lista ou remove funções"
 
@@ -1154,6 +1250,9 @@ msgstr "Manipula strings"
 
 msgid "Measure how long a command or block takes"
 msgstr "Mede quanto tempo demora um comando ou bloco"
+
+msgid "Misaligned address error"
+msgstr "Erro de endereço de barramento"
 
 msgid "Mismatched braces"
 msgstr ""
@@ -1197,6 +1296,9 @@ msgstr ""
 msgid "Not a number"
 msgstr ""
 
+msgid "Notifications about universal variable changes"
+msgstr ""
+
 msgid "Number is infinite"
 msgstr ""
 
@@ -1219,6 +1321,9 @@ msgstr ""
 msgid "Parse options in fish script"
 msgstr "Parsear opções em um script fish"
 
+msgid "Parsing fish AST"
+msgstr ""
+
 msgid "Perform a command multiple times"
 msgstr "Executa um comando várias vezes"
 
@@ -1232,6 +1337,12 @@ msgstr ""
 #, c-format
 msgid "Please set the %ls or HOME environment variable before starting fish."
 msgstr ""
+
+msgid "Polite quit request"
+msgstr "Requisição educada de término"
+
+msgid "Power failure"
+msgstr "Falha de energia"
 
 #, c-format
 msgid "Press ctrl-%c again to exit\n"
@@ -1249,14 +1360,44 @@ msgstr "Imprime o diretório de trabalho"
 msgid "Prints formatted text"
 msgstr "Imprime texto formatado"
 
+msgid "Process groups"
+msgstr ""
+
 msgid "Process\n"
 msgstr "Processo\n"
+
+msgid "Profiling timer expired"
+msgstr "Temporizador de análise expirado"
+
+msgid "Quit request from job control (^C)"
+msgstr "Interrupção de teclado (^C)"
+
+msgid "Quit request from job control with core dump (^\\)"
+msgstr "Interrupção com imagem do núcleo gravada (^\\)"
+
+msgid "Reacting to variables"
+msgstr ""
 
 msgid "Read a line of input into variables"
 msgstr "Lê uma linha de entrada e a coloca em variáveis"
 
+msgid "Reading/Writing the history file"
+msgstr ""
+
+msgid "Reaping external (forked) processes"
+msgstr ""
+
+msgid "Reaping internal (non-forked) processes"
+msgstr ""
+
+msgid "Refcell dynamic borrowing"
+msgstr ""
+
 msgid "Remove job from job list"
 msgstr "Remove a tarefa da lista de tarefas"
+
+msgid "Rendering the command line"
+msgstr ""
 
 #, c-format
 msgid "Requested redirection to '%ls', which is not a valid file descriptor"
@@ -1287,8 +1428,14 @@ msgstr ""
 msgid "Run command in current process"
 msgstr "Executa um comando como o processo atual"
 
+msgid "Screen repaints"
+msgstr ""
+
 msgid "Search for a specified string in a list"
 msgstr "Procura uma string especificada em uma lista"
+
+msgid "Searching/using paths"
+msgstr ""
 
 #, c-format
 msgid "Send job %d (%ls) to foreground\n"
@@ -1304,6 +1451,9 @@ msgstr "Envia tarefa para segundo plano"
 msgid "Send job to foreground"
 msgstr "Envia tarefa para primeiro plano"
 
+msgid "Serious unexpected errors (on by default)"
+msgstr ""
+
 msgid "Set or get the commandline"
 msgstr "Obtém ou altera o buffer da linha de comando"
 
@@ -1315,6 +1465,9 @@ msgstr ""
 
 msgid "Skip over remaining innermost loop"
 msgstr ""
+
+msgid "Stack fault"
+msgstr "Falha de pilha"
 
 msgid "Standard input"
 msgstr "Entrada padrão"
@@ -1333,6 +1486,15 @@ msgstr "Estado\tComando\n"
 msgid "Stdin must be attached to a tty."
 msgstr ""
 
+msgid "Stop from terminal input"
+msgstr "Parada para entrada de terminal"
+
+msgid "Stop from terminal output"
+msgstr "Parada para saída de terminal"
+
+msgid "Stop request from job control (^Z)"
+msgstr "Parada requisitada por teclado (^Z)"
+
 msgid "Stop the currently evaluated function"
 msgstr "Pára a função em execução"
 
@@ -1341,6 +1503,18 @@ msgstr "Pára o laço mais interno"
 
 msgid "Temporarily block delivery of events"
 msgstr "Bloqueia temporariamente a entrega de eventos"
+
+msgid "Terminal feature detection"
+msgstr ""
+
+msgid "Terminal hung up"
+msgstr "Término de comunicação com terminal"
+
+msgid "Terminal ownership events"
+msgstr ""
+
+msgid "Terminal protocol negotiation"
+msgstr ""
 
 msgid "Test a condition"
 msgstr "Testa uma condição"
@@ -1359,6 +1533,9 @@ msgstr ""
 msgid "The call stack limit has been exceeded. Do you have an accidental infinite loop?"
 msgstr ""
 
+msgid "The completion system"
+msgstr ""
+
 #, c-format
 msgid "The error was '%s'."
 msgstr ""
@@ -1373,6 +1550,9 @@ msgstr "O comand expandido estava vazio."
 msgid "The function '%ls' calls itself immediately, which would result in an infinite loop."
 msgstr "A função “%ls” se chama imediatamente, o que causaria um loop infinito."
 
+msgid "The interactive reader/input system"
+msgstr ""
+
 msgid "There are still jobs active:\n"
 msgstr ""
 
@@ -1381,6 +1561,9 @@ msgstr "Este é um shell de login\n"
 
 msgid "This is not a login shell\n"
 msgstr "Este não é um shell de login\n"
+
+msgid "Timer expired"
+msgstr "Temporizador expirado"
 
 msgid "Too few arguments"
 msgstr ""
@@ -1394,8 +1577,14 @@ msgstr ""
 msgid "Too much data emitted by command substitution so it was discarded"
 msgstr ""
 
+msgid "Trace or breakpoint trap"
+msgstr "Atingiu ponto de parada"
+
 msgid "Translate a string"
 msgstr "Traduz uma string"
+
+msgid "Trying to print invalid output"
+msgstr ""
 
 #, c-format
 msgid "Unable to create temporary file '%ls': %s"
@@ -1511,8 +1700,17 @@ msgstr ""
 msgid "Unsupported use of '='. In fish, please use 'set %ls %ls'."
 msgstr ""
 
+msgid "Urgent socket condition"
+msgstr "Condição urgente de socket"
+
 msgid "Use 'disown PID' to remove jobs from the list without terminating them.\n"
 msgstr ""
+
+msgid "User defined signal 1"
+msgstr "Sinal definido pelo usuário 1"
+
+msgid "User defined signal 2"
+msgstr "Sinal definido pelo usuário 2"
 
 #, c-format
 msgid "Variable: %ls"
@@ -1526,8 +1724,26 @@ msgstr ""
 msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
 msgstr ""
 
+msgid "Virtual timefr expired"
+msgstr ""
+
 msgid "Wait for background processes completed"
 msgstr "Espera até os processos no background completarem"
+
+msgid "Warning about using test's zero- or one-argument modes (`test -d $foo`), which will be changed in future."
+msgstr ""
+
+msgid "Warnings (on by default)"
+msgstr ""
+
+msgid "Warnings about unusable paths for config/history (on by default)"
+msgstr ""
+
+msgid "Window size change"
+msgstr "Mudança de tamanho de janela"
+
+msgid "Writing/reading the universal variable store"
+msgstr ""
 
 msgid "[: the last argument must be ']'"
 msgstr ""
@@ -1538,6 +1754,9 @@ msgid ""
 msgstr ""
 
 msgid "array indices start at 1, not 0."
+msgstr ""
+
+msgid "autoloading"
 msgstr ""
 
 #, c-format
@@ -79056,107 +79275,14 @@ msgstr ""
 #~ msgid "Could not return shell to foreground"
 #~ msgstr "Não foi possível retornar shell ao primeiro plano"
 
-#~ msgid "Terminal hung up"
-#~ msgstr "Término de comunicação com terminal"
-
-#~ msgid "Quit request from job control (^C)"
-#~ msgstr "Interrupção de teclado (^C)"
-
-#~ msgid "Quit request from job control with core dump (^\\)"
-#~ msgstr "Interrupção com imagem do núcleo gravada (^\\)"
-
-#~ msgid "Illegal instruction"
-#~ msgstr "Instrução ilegal"
-
-#~ msgid "Trace or breakpoint trap"
-#~ msgstr "Atingiu ponto de parada"
-
-#~ msgid "Abort"
-#~ msgstr "Abortado"
-
-#~ msgid "Misaligned address error"
-#~ msgstr "Erro de endereço de barramento"
-
-#~ msgid "Floating point exception"
-#~ msgstr "Exceção de ponto flutuante"
-
-#~ msgid "Forced quit"
-#~ msgstr "Saída forçada"
-
-#~ msgid "User defined signal 1"
-#~ msgstr "Sinal definido pelo usuário 1"
-
-#~ msgid "User defined signal 2"
-#~ msgstr "Sinal definido pelo usuário 2"
-
-#~ msgid "Address boundary error"
-#~ msgstr "Erro de fronteira de endereço (Falha de segmentação)"
-
-#~ msgid "Broken pipe"
-#~ msgstr "Pipe sem saída"
-
-#~ msgid "Timer expired"
-#~ msgstr "Temporizador expirado"
-
-#~ msgid "Polite quit request"
-#~ msgstr "Requisição educada de término"
-
-#~ msgid "Child process status changed"
-#~ msgstr "Mudança de estado de processo filho"
-
-#~ msgid "Continue previously stopped process"
-#~ msgstr "Continuar processo previamente parado"
-
-#~ msgid "Forced stop"
-#~ msgstr "Parada forçada"
-
-#~ msgid "Stop request from job control (^Z)"
-#~ msgstr "Parada requisitada por teclado (^Z)"
-
-#~ msgid "Stop from terminal input"
-#~ msgstr "Parada para entrada de terminal"
-
-#~ msgid "Stop from terminal output"
-#~ msgstr "Parada para saída de terminal"
-
-#~ msgid "Urgent socket condition"
-#~ msgstr "Condição urgente de socket"
-
-#~ msgid "CPU time limit exceeded"
-#~ msgstr "Limite de tempo da CPU excedido"
-
-#~ msgid "File size limit exceeded"
-#~ msgstr "Limite de tamanho de arquivo excedido"
-
 #~ msgid "Virtual timer expired"
 #~ msgstr "Temporizador virtual expirado"
-
-#~ msgid "Profiling timer expired"
-#~ msgstr "Temporizador de análise expirado"
-
-#~ msgid "Window size change"
-#~ msgstr "Mudança de tamanho de janela"
-
-#~ msgid "I/O on asynchronous file descriptor is possible"
-#~ msgstr "E/S em descritor de arquivo assíncrono possível"
-
-#~ msgid "Power failure"
-#~ msgstr "Falha de energia"
-
-#~ msgid "Bad system call"
-#~ msgstr "Chamada de sistema ruim"
 
 #~ msgid "Information request"
 #~ msgstr "Requisição de informação"
 
-#~ msgid "Stack fault"
-#~ msgstr "Falha de pilha"
-
 #~ msgid "Emulator trap"
 #~ msgstr "Armadilha de emulador"
-
-#~ msgid "Abort (Alias for SIGABRT)"
-#~ msgstr "Abortado (Outro nome para SIGABRT)"
 
 #~ msgid "Unused signal"
 #~ msgstr "Sinal não utilizado"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -43,6 +43,10 @@ msgid "$$ is not the pid. In fish, please use $fish_pid."
 msgstr ""
 
 #, c-format
+msgid "$%lc is not a valid variable in fish."
+msgstr ""
+
+#, c-format
 msgid "$%ls: originally inherited as |%ls|\n"
 msgstr ""
 
@@ -65,6 +69,10 @@ msgstr ""
 #, c-format
 msgid "%.*ls: invalid conversion specification"
 msgstr "%.*ls: especificação de conversão inválida"
+
+#, c-format
+msgid "%ls"
+msgstr ""
 
 #, c-format
 msgid "%ls %ls: Abbreviation %ls already exists, cannot rename %ls\n"
@@ -136,6 +144,10 @@ msgstr ""
 
 #, c-format
 msgid "%ls: %ls: contains a syntax error\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: %ls: expected %d arguments; got %d\n"
 msgstr ""
 
 #, c-format
@@ -667,6 +679,18 @@ msgid "%ls: exclusive flag string '%ls' is not valid\n"
 msgstr ""
 
 #, c-format
+msgid "%ls: expected %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: expected <= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: expected >= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
 msgid "%ls: expected a numeric value"
 msgstr "%ls: esperava valor numérico"
 
@@ -676,6 +700,10 @@ msgstr ""
 
 #, c-format
 msgid "%ls: given %d indexes but %d values\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: invalid option combination, %ls\n"
 msgstr ""
 
 #, c-format
@@ -692,6 +720,10 @@ msgstr ""
 
 #, c-format
 msgid "%ls: line/column index starts at 1"
+msgstr ""
+
+#, c-format
+msgid "%ls: missing argument\n"
 msgstr ""
 
 #, c-format
@@ -828,18 +860,6 @@ msgstr ""
 msgid "--tokens options are mutually exclusive"
 msgstr ""
 
-msgid ".local/bin/"
-msgstr ""
-
-msgid ".local/share/"
-msgstr ""
-
-msgid ".local/share/doc/fish"
-msgstr ""
-
-msgid "/etc/"
-msgstr ""
-
 msgid "A second attempt to exit will terminate them.\n"
 msgstr ""
 
@@ -902,9 +922,6 @@ msgstr "Não foi possível definir modo do terminal para a nova tarefa"
 
 msgid "Could not set terminal mode for shell"
 msgstr "Não foi possível preparar modo do terminal para shell"
-
-msgid "Could not show help message"
-msgstr ""
 
 #, c-format
 msgid "Could not write profiling information to file '%s': %s"
@@ -1501,6 +1518,14 @@ msgstr ""
 msgid "Variable: %ls"
 msgstr "Variável: %ls"
 
+#, c-format
+msgid "Variables cannot be bracketed. In fish, please use \"$%ls\"."
+msgstr ""
+
+#, c-format
+msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
+msgstr ""
+
 msgid "Wait for background processes completed"
 msgstr "Espera até os processos no background completarem"
 
@@ -1572,9 +1597,6 @@ msgstr ""
 
 msgid "file"
 msgstr "arquivo"
-
-msgid "fish/install"
-msgstr ""
 
 #, c-format
 msgid ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -39,6 +39,10 @@ msgid "$$ is not the pid. In fish, please use $fish_pid."
 msgstr ""
 
 #, c-format
+msgid "$%lc is not a valid variable in fish."
+msgstr ""
+
+#, c-format
 msgid "$%ls: originally inherited as |%ls|\n"
 msgstr ""
 
@@ -60,6 +64,10 @@ msgstr ""
 
 #, c-format
 msgid "%.*ls: invalid conversion specification"
+msgstr ""
+
+#, c-format
+msgid "%ls"
 msgstr ""
 
 #, c-format
@@ -132,6 +140,10 @@ msgstr ""
 
 #, c-format
 msgid "%ls: %ls: contains a syntax error\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: %ls: expected %d arguments; got %d\n"
 msgstr ""
 
 #, c-format
@@ -663,6 +675,18 @@ msgid "%ls: exclusive flag string '%ls' is not valid\n"
 msgstr ""
 
 #, c-format
+msgid "%ls: expected %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: expected <= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: expected >= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
 msgid "%ls: expected a numeric value"
 msgstr ""
 
@@ -672,6 +696,10 @@ msgstr ""
 
 #, c-format
 msgid "%ls: given %d indexes but %d values\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: invalid option combination, %ls\n"
 msgstr ""
 
 #, c-format
@@ -688,6 +716,10 @@ msgstr ""
 
 #, c-format
 msgid "%ls: line/column index starts at 1"
+msgstr ""
+
+#, c-format
+msgid "%ls: missing argument\n"
 msgstr ""
 
 #, c-format
@@ -824,18 +856,6 @@ msgstr ""
 msgid "--tokens options are mutually exclusive"
 msgstr ""
 
-msgid ".local/bin/"
-msgstr ""
-
-msgid ".local/share/"
-msgstr ""
-
-msgid ".local/share/doc/fish"
-msgstr ""
-
-msgid "/etc/"
-msgstr ""
-
 msgid "A second attempt to exit will terminate them.\n"
 msgstr ""
 
@@ -898,9 +918,6 @@ msgstr "Kunde inte återställa terminalen för nytt jobb"
 
 msgid "Could not set terminal mode for shell"
 msgstr "Kunde inte återställa terminalen till skalet"
-
-msgid "Could not show help message"
-msgstr ""
 
 #, c-format
 msgid "Could not write profiling information to file '%s': %s"
@@ -1497,6 +1514,14 @@ msgstr ""
 msgid "Variable: %ls"
 msgstr "Variabel: %ls"
 
+#, c-format
+msgid "Variables cannot be bracketed. In fish, please use \"$%ls\"."
+msgstr ""
+
+#, c-format
+msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
+msgstr ""
+
 msgid "Wait for background processes completed"
 msgstr ""
 
@@ -1567,9 +1592,6 @@ msgid "exported"
 msgstr ""
 
 msgid "file"
-msgstr ""
-
-msgid "fish/install"
 msgstr ""
 
 #, c-format

--- a/po/sv.po
+++ b/po/sv.po
@@ -859,9 +859,21 @@ msgstr ""
 msgid "A second attempt to exit will terminate them.\n"
 msgstr ""
 
+msgid "Abbreviation expansion"
+msgstr ""
+
 #, c-format
 msgid "Abbreviation: %ls"
 msgstr ""
+
+msgid "Abort"
+msgstr "Avbrott"
+
+msgid "Abort (Alias for SIGABRT)"
+msgstr "Avbrott (Alias för SIGABRT)"
+
+msgid "Address boundary error"
+msgstr "Minnesadress korsar segmentgräns"
 
 msgid "Always"
 msgstr "Alltid"
@@ -873,14 +885,29 @@ msgstr "Ett fel inträffade under skapandet av ett rör"
 msgid "Argument is not a number: '%ls'"
 msgstr ""
 
+msgid "Background IO thread events"
+msgstr ""
+
 msgid "Backgrounded commands can not be used as conditionals"
 msgstr ""
+
+msgid "Bad system call"
+msgstr "Felaktigt systemanrop"
 
 msgid "Block of code to run conditionally"
 msgstr ""
 
+msgid "Broken pipe"
+msgstr "Avbrutet rör"
+
+msgid "CPU time limit exceeded"
+msgstr "Slut på processortid"
+
 msgid "CPU\t"
 msgstr "CPU\t"
+
+msgid "Calls to fork()"
+msgstr ""
 
 msgid "Can not use the no-execute mode when running an interactive session"
 msgstr "no-execute läget kan inte användas i en interaktiv session"
@@ -895,7 +922,22 @@ msgstr ""
 msgid "Change working directory"
 msgstr "Ändra arbetskatalog"
 
+msgid "Changes to exported variables"
+msgstr ""
+
+msgid "Changes to locale variables"
+msgstr ""
+
+msgid "Character encoding issues"
+msgstr ""
+
 msgid "Check if a thing is a thing"
+msgstr ""
+
+msgid "Child process status changed"
+msgstr "Barnprocess fick ändrad status"
+
+msgid "Command history events"
 msgstr ""
 
 msgid "Command not executable"
@@ -909,6 +951,9 @@ msgstr ""
 
 msgid "Conditionally run blocks of code"
 msgstr ""
+
+msgid "Continue previously stopped process"
+msgstr "Fortsätt tidigare stannad process"
 
 msgid "Could not determine current working directory. Is your locale set correctly?"
 msgstr ""
@@ -928,6 +973,9 @@ msgstr "Räkna antalet argument"
 
 msgid "Create a block of code"
 msgstr "Skapa ett kodblock"
+
+msgid "Debugging aid (on by default)"
+msgstr ""
 
 msgid "Define a new function"
 msgstr "Definera en ny funktion"
@@ -965,6 +1013,9 @@ msgstr ""
 #, c-format
 msgid "Error while reading file %ls\n"
 msgstr "Ett fel uppstod medan filen '%ls' lästes\n"
+
+msgid "Errors reported by exec (on by default)"
+msgstr ""
 
 msgid "Evaluate a string as a statement"
 msgstr ""
@@ -1029,6 +1080,9 @@ msgstr ""
 msgid "Expression is bogus"
 msgstr ""
 
+msgid "FD monitor events"
+msgstr ""
+
 msgid "Failed to assign shell to its own process group"
 msgstr ""
 
@@ -1037,6 +1091,24 @@ msgstr ""
 
 msgid "Failed to take control of the terminal"
 msgstr ""
+
+msgid "File size limit exceeded"
+msgstr "Maximal filstorlek överskriden"
+
+msgid "Finding and reading configuration"
+msgstr ""
+
+msgid "Firing events"
+msgstr ""
+
+msgid "Floating point exception"
+msgstr "Flyttalsundantag"
+
+msgid "Forced quit"
+msgstr "Tvingad avslutning"
+
+msgid "Forced stop"
+msgstr "Tvingad att stoppa"
 
 msgid "Generate random number"
 msgstr "Generera ett slumptal"
@@ -1065,6 +1137,9 @@ msgstr ""
 msgid "History of commands executed by user"
 msgstr "Historik över användarens körda kommandon"
 
+msgid "History performance measurements"
+msgstr ""
+
 #, c-format
 msgid "History session ID '%ls' is not a valid variable name. Falling back to `%ls`."
 msgstr ""
@@ -1077,9 +1152,15 @@ msgstr ""
 msgid "I appear to be an orphaned process, so I am quitting politely. My pid is %d."
 msgstr ""
 
+msgid "I/O on asynchronous file descriptor is possible"
+msgstr "Läsning/skrivning på asynkron filidentifierare möjligt"
+
 #, c-format
 msgid "Illegal file descriptor in redirection '%ls'"
 msgstr ""
+
+msgid "Illegal instruction"
+msgstr "Ogiltig instruktion"
 
 #, c-format
 msgid "Incomplete escape sequence '%ls'"
@@ -1087,6 +1168,12 @@ msgstr ""
 
 #, c-format
 msgid "Integer %lld in '%ls' followed by non-digit"
+msgstr ""
+
+msgid "Internal (non-forked) process events"
+msgstr ""
+
+msgid "Internal details of the topic monitor"
 msgstr ""
 
 msgid "Invalid arguments"
@@ -1128,6 +1215,15 @@ msgstr "Jobkontroll: %ls\n"
 msgid "Job\tGroup\t"
 msgstr "Jobb\tGrupp\t"
 
+msgid "Jobs being executed"
+msgstr ""
+
+msgid "Jobs changing status"
+msgstr ""
+
+msgid "Jobs getting started or continued"
+msgstr ""
+
 msgid "List or remove functions"
 msgstr "Visa eller ta bort funktioner"
 
@@ -1150,6 +1246,9 @@ msgstr ""
 
 msgid "Measure how long a command or block takes"
 msgstr ""
+
+msgid "Misaligned address error"
+msgstr "Bussfel (Ogiltigt justerad minnesadress)"
 
 msgid "Mismatched braces"
 msgstr ""
@@ -1193,6 +1292,9 @@ msgstr ""
 msgid "Not a number"
 msgstr ""
 
+msgid "Notifications about universal variable changes"
+msgstr ""
+
 msgid "Number is infinite"
 msgstr ""
 
@@ -1215,6 +1317,9 @@ msgstr ""
 msgid "Parse options in fish script"
 msgstr ""
 
+msgid "Parsing fish AST"
+msgstr ""
+
 msgid "Perform a command multiple times"
 msgstr "Kör ett kommando upprepade gånger"
 
@@ -1228,6 +1333,12 @@ msgstr ""
 #, c-format
 msgid "Please set the %ls or HOME environment variable before starting fish."
 msgstr ""
+
+msgid "Polite quit request"
+msgstr "Artig avslutning"
+
+msgid "Power failure"
+msgstr "Strömavbrott"
 
 #, c-format
 msgid "Press ctrl-%c again to exit\n"
@@ -1245,13 +1356,43 @@ msgstr ""
 msgid "Prints formatted text"
 msgstr ""
 
+msgid "Process groups"
+msgstr ""
+
 msgid "Process\n"
+msgstr ""
+
+msgid "Profiling timer expired"
+msgstr "Profileringstimer utlöst"
+
+msgid "Quit request from job control (^C)"
+msgstr "Avslutning via jobbkontroll (^C)"
+
+msgid "Quit request from job control with core dump (^\\)"
+msgstr "Avslutning via jobbkontroll med minnesdump (^\\)"
+
+msgid "Reacting to variables"
 msgstr ""
 
 msgid "Read a line of input into variables"
 msgstr "Läs in en rad till variabler"
 
+msgid "Reading/Writing the history file"
+msgstr ""
+
+msgid "Reaping external (forked) processes"
+msgstr ""
+
+msgid "Reaping internal (non-forked) processes"
+msgstr ""
+
+msgid "Refcell dynamic borrowing"
+msgstr ""
+
 msgid "Remove job from job list"
+msgstr ""
+
+msgid "Rendering the command line"
 msgstr ""
 
 #, c-format
@@ -1283,8 +1424,14 @@ msgstr ""
 msgid "Run command in current process"
 msgstr "Kör ett kommando i den nuvarande processen"
 
+msgid "Screen repaints"
+msgstr ""
+
 msgid "Search for a specified string in a list"
 msgstr "Sök efter en angiven sträng i en lista"
+
+msgid "Searching/using paths"
+msgstr ""
 
 #, c-format
 msgid "Send job %d (%ls) to foreground\n"
@@ -1300,6 +1447,9 @@ msgstr "Skicka jobb till bakgrunden"
 msgid "Send job to foreground"
 msgstr "Skick jobb till förgrunden"
 
+msgid "Serious unexpected errors (on by default)"
+msgstr ""
+
 msgid "Set or get the commandline"
 msgstr "Ändra eller visa kommandoraden"
 
@@ -1311,6 +1461,9 @@ msgstr ""
 
 msgid "Skip over remaining innermost loop"
 msgstr ""
+
+msgid "Stack fault"
+msgstr "Stackfel"
 
 msgid "Standard input"
 msgstr "Standard in"
@@ -1329,6 +1482,15 @@ msgstr "Status\tKommando\n"
 msgid "Stdin must be attached to a tty."
 msgstr ""
 
+msgid "Stop from terminal input"
+msgstr "Stoppad från terminalläsning"
+
+msgid "Stop from terminal output"
+msgstr "Stoppad från terminalskrivning"
+
+msgid "Stop request from job control (^Z)"
+msgstr "Stoppad genom jobbkontroll (^Z)"
+
 msgid "Stop the currently evaluated function"
 msgstr "Avbryt den nuvarande funktionen"
 
@@ -1337,6 +1499,18 @@ msgstr "Avbryt den innersta loopen"
 
 msgid "Temporarily block delivery of events"
 msgstr "Blockera tillfälligt leverans av händelser"
+
+msgid "Terminal feature detection"
+msgstr ""
+
+msgid "Terminal hung up"
+msgstr "Terminalen bröt uppkopplingen"
+
+msgid "Terminal ownership events"
+msgstr ""
+
+msgid "Terminal protocol negotiation"
+msgstr ""
 
 msgid "Test a condition"
 msgstr ""
@@ -1355,6 +1529,9 @@ msgstr ""
 msgid "The call stack limit has been exceeded. Do you have an accidental infinite loop?"
 msgstr ""
 
+msgid "The completion system"
+msgstr ""
+
 #, c-format
 msgid "The error was '%s'."
 msgstr ""
@@ -1369,6 +1546,9 @@ msgstr ""
 msgid "The function '%ls' calls itself immediately, which would result in an infinite loop."
 msgstr ""
 
+msgid "The interactive reader/input system"
+msgstr ""
+
 msgid "There are still jobs active:\n"
 msgstr ""
 
@@ -1377,6 +1557,9 @@ msgstr "Detta är ett login-skal\n"
 
 msgid "This is not a login shell\n"
 msgstr "Detta är inte ett login-skal\n"
+
+msgid "Timer expired"
+msgstr "Timer utlöstes"
 
 msgid "Too few arguments"
 msgstr ""
@@ -1390,7 +1573,13 @@ msgstr ""
 msgid "Too much data emitted by command substitution so it was discarded"
 msgstr ""
 
+msgid "Trace or breakpoint trap"
+msgstr "Spårnings eller brytpunktsfälla utlöstes"
+
 msgid "Translate a string"
+msgstr ""
+
+msgid "Trying to print invalid output"
 msgstr ""
 
 #, c-format
@@ -1507,8 +1696,17 @@ msgstr ""
 msgid "Unsupported use of '='. In fish, please use 'set %ls %ls'."
 msgstr ""
 
+msgid "Urgent socket condition"
+msgstr "Viktig socket-situation"
+
 msgid "Use 'disown PID' to remove jobs from the list without terminating them.\n"
 msgstr ""
+
+msgid "User defined signal 1"
+msgstr "Användardefinerad signal 1"
+
+msgid "User defined signal 2"
+msgstr "Användardefinerad signal 2"
 
 #, c-format
 msgid "Variable: %ls"
@@ -1522,7 +1720,25 @@ msgstr ""
 msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
 msgstr ""
 
+msgid "Virtual timefr expired"
+msgstr ""
+
 msgid "Wait for background processes completed"
+msgstr ""
+
+msgid "Warning about using test's zero- or one-argument modes (`test -d $foo`), which will be changed in future."
+msgstr ""
+
+msgid "Warnings (on by default)"
+msgstr ""
+
+msgid "Warnings about unusable paths for config/history (on by default)"
+msgstr ""
+
+msgid "Window size change"
+msgstr "Terminalfönstret ändrade storlek"
+
+msgid "Writing/reading the universal variable store"
 msgstr ""
 
 msgid "[: the last argument must be ']'"
@@ -1534,6 +1750,9 @@ msgid ""
 msgstr ""
 
 msgid "array indices start at 1, not 0."
+msgstr ""
+
+msgid "autoloading"
 msgstr ""
 
 #, c-format
@@ -79047,107 +79266,14 @@ msgstr ""
 #~ msgid "Could not return shell to foreground"
 #~ msgstr "Kunde inte återställa skalet till förgrunden"
 
-#~ msgid "Terminal hung up"
-#~ msgstr "Terminalen bröt uppkopplingen"
-
-#~ msgid "Quit request from job control (^C)"
-#~ msgstr "Avslutning via jobbkontroll (^C)"
-
-#~ msgid "Quit request from job control with core dump (^\\)"
-#~ msgstr "Avslutning via jobbkontroll med minnesdump (^\\)"
-
-#~ msgid "Illegal instruction"
-#~ msgstr "Ogiltig instruktion"
-
-#~ msgid "Trace or breakpoint trap"
-#~ msgstr "Spårnings eller brytpunktsfälla utlöstes"
-
-#~ msgid "Abort"
-#~ msgstr "Avbrott"
-
-#~ msgid "Misaligned address error"
-#~ msgstr "Bussfel (Ogiltigt justerad minnesadress)"
-
-#~ msgid "Floating point exception"
-#~ msgstr "Flyttalsundantag"
-
-#~ msgid "Forced quit"
-#~ msgstr "Tvingad avslutning"
-
-#~ msgid "User defined signal 1"
-#~ msgstr "Användardefinerad signal 1"
-
-#~ msgid "User defined signal 2"
-#~ msgstr "Användardefinerad signal 2"
-
-#~ msgid "Address boundary error"
-#~ msgstr "Minnesadress korsar segmentgräns"
-
-#~ msgid "Broken pipe"
-#~ msgstr "Avbrutet rör"
-
-#~ msgid "Timer expired"
-#~ msgstr "Timer utlöstes"
-
-#~ msgid "Polite quit request"
-#~ msgstr "Artig avslutning"
-
-#~ msgid "Child process status changed"
-#~ msgstr "Barnprocess fick ändrad status"
-
-#~ msgid "Continue previously stopped process"
-#~ msgstr "Fortsätt tidigare stannad process"
-
-#~ msgid "Forced stop"
-#~ msgstr "Tvingad att stoppa"
-
-#~ msgid "Stop request from job control (^Z)"
-#~ msgstr "Stoppad genom jobbkontroll (^Z)"
-
-#~ msgid "Stop from terminal input"
-#~ msgstr "Stoppad från terminalläsning"
-
-#~ msgid "Stop from terminal output"
-#~ msgstr "Stoppad från terminalskrivning"
-
-#~ msgid "Urgent socket condition"
-#~ msgstr "Viktig socket-situation"
-
-#~ msgid "CPU time limit exceeded"
-#~ msgstr "Slut på processortid"
-
-#~ msgid "File size limit exceeded"
-#~ msgstr "Maximal filstorlek överskriden"
-
 #~ msgid "Virtual timer expired"
 #~ msgstr "Virtuell timer utlöst"
-
-#~ msgid "Profiling timer expired"
-#~ msgstr "Profileringstimer utlöst"
-
-#~ msgid "Window size change"
-#~ msgstr "Terminalfönstret ändrade storlek"
-
-#~ msgid "I/O on asynchronous file descriptor is possible"
-#~ msgstr "Läsning/skrivning på asynkron filidentifierare möjligt"
-
-#~ msgid "Power failure"
-#~ msgstr "Strömavbrott"
-
-#~ msgid "Bad system call"
-#~ msgstr "Felaktigt systemanrop"
 
 #~ msgid "Information request"
 #~ msgstr "Informationsbegäran"
 
-#~ msgid "Stack fault"
-#~ msgstr "Stackfel"
-
 #~ msgid "Emulator trap"
 #~ msgstr "Emulatorfälla"
-
-#~ msgid "Abort (Alias for SIGABRT)"
-#~ msgstr "Avbrott (Alias för SIGABRT)"
 
 #~ msgid "Unused signal"
 #~ msgstr "Oanvänd signal"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -854,9 +854,21 @@ msgstr "--tokens 选项是相互排斥的"
 msgid "A second attempt to exit will terminate them.\n"
 msgstr "第二次尝试退出将终止它们.\n"
 
+msgid "Abbreviation expansion"
+msgstr ""
+
 #, c-format
 msgid "Abbreviation: %ls"
 msgstr "缩写:%ls"
+
+msgid "Abort"
+msgstr ""
+
+msgid "Abort (Alias for SIGABRT)"
+msgstr ""
+
+msgid "Address boundary error"
+msgstr ""
 
 msgid "Always"
 msgstr "总是"
@@ -868,14 +880,29 @@ msgstr "设置管道时出错"
 msgid "Argument is not a number: '%ls'"
 msgstr "参数不是数字:  '%ls'"
 
+msgid "Background IO thread events"
+msgstr ""
+
 msgid "Backgrounded commands can not be used as conditionals"
 msgstr "后台命令不能用作条件"
+
+msgid "Bad system call"
+msgstr ""
 
 msgid "Block of code to run conditionally"
 msgstr "有条件运行的代码块"
 
+msgid "Broken pipe"
+msgstr ""
+
+msgid "CPU time limit exceeded"
+msgstr ""
+
 msgid "CPU\t"
 msgstr "CPU\t"
+
+msgid "Calls to fork()"
+msgstr ""
 
 msgid "Can not use the no-execute mode when running an interactive session"
 msgstr "运行交互式会话时不能使用 no-execute模式"
@@ -890,8 +917,23 @@ msgstr "无法使用 stdin (fd 0) 作为管道输出"
 msgid "Change working directory"
 msgstr "改变工作目录"
 
+msgid "Changes to exported variables"
+msgstr ""
+
+msgid "Changes to locale variables"
+msgstr ""
+
+msgid "Character encoding issues"
+msgstr ""
+
 msgid "Check if a thing is a thing"
 msgstr "检查某事是否是其自身"
+
+msgid "Child process status changed"
+msgstr ""
+
+msgid "Command history events"
+msgstr ""
 
 msgid "Command not executable"
 msgstr "命令不是可执行的"
@@ -904,6 +946,9 @@ msgstr "命令名称无效"
 
 msgid "Conditionally run blocks of code"
 msgstr "有条件运行代码块"
+
+msgid "Continue previously stopped process"
+msgstr ""
 
 msgid "Could not determine current working directory. Is your locale set correctly?"
 msgstr "无法确定当前工作目录 . 你的本地设置正确吗?"
@@ -923,6 +968,9 @@ msgstr "计算参数个数"
 
 msgid "Create a block of code"
 msgstr "创建代码区块"
+
+msgid "Debugging aid (on by default)"
+msgstr ""
 
 msgid "Define a new function"
 msgstr "定义一个新函数"
@@ -960,6 +1008,9 @@ msgstr "重命名历史文件时出错:%s"
 #, c-format
 msgid "Error while reading file %ls\n"
 msgstr "读取文件 %ls 时出错\n"
+
+msgid "Errors reported by exec (on by default)"
+msgstr ""
 
 msgid "Evaluate a string as a statement"
 msgstr "将此字符串视为一条程序语句进行执行"
@@ -1024,6 +1075,9 @@ msgstr ""
 msgid "Expression is bogus"
 msgstr "表达式存在问题"
 
+msgid "FD monitor events"
+msgstr ""
+
 msgid "Failed to assign shell to its own process group"
 msgstr "无法将shell分配到它自己的进程组"
 
@@ -1032,6 +1086,24 @@ msgstr "设置启动终端模式失败 !"
 
 msgid "Failed to take control of the terminal"
 msgstr "控制终端失败"
+
+msgid "File size limit exceeded"
+msgstr ""
+
+msgid "Finding and reading configuration"
+msgstr ""
+
+msgid "Firing events"
+msgstr ""
+
+msgid "Floating point exception"
+msgstr ""
+
+msgid "Forced quit"
+msgstr ""
+
+msgid "Forced stop"
+msgstr ""
 
 msgid "Generate random number"
 msgstr "生成随机数"
@@ -1060,6 +1132,9 @@ msgstr "提示: 起始'0'没有跟'x' 表示八进制数字"
 msgid "History of commands executed by user"
 msgstr "用户执行的历史命令"
 
+msgid "History performance measurements"
+msgstr ""
+
 #, c-format
 msgid "History session ID '%ls' is not a valid variable name. Falling back to `%ls`."
 msgstr "历史会话 ID '%ls' 不是有效的可变名称 . 切换回`%ls`."
@@ -1072,9 +1147,15 @@ msgstr "%ls 的 Home"
 msgid "I appear to be an orphaned process, so I am quitting politely. My pid is %d."
 msgstr "检测到自身为孤立进程，优雅退出。进程 pid 为 %d."
 
+msgid "I/O on asynchronous file descriptor is possible"
+msgstr ""
+
 #, c-format
 msgid "Illegal file descriptor in redirection '%ls'"
 msgstr "重定向 '%ls' 中的非法文件描述符  '"
+
+msgid "Illegal instruction"
+msgstr ""
 
 #, c-format
 msgid "Incomplete escape sequence '%ls'"
@@ -1083,6 +1164,12 @@ msgstr "不完整的转义序列 '%ls'"
 #, c-format
 msgid "Integer %lld in '%ls' followed by non-digit"
 msgstr "整数 %lld 在 '%ls' 中,后面跟随着非数字"
+
+msgid "Internal (non-forked) process events"
+msgstr ""
+
+msgid "Internal details of the topic monitor"
+msgstr ""
 
 msgid "Invalid arguments"
 msgstr "无效的参数"
@@ -1123,6 +1210,15 @@ msgstr "任务控制:%ls\n"
 msgid "Job\tGroup\t"
 msgstr "任务\t组\t"
 
+msgid "Jobs being executed"
+msgstr ""
+
+msgid "Jobs changing status"
+msgstr ""
+
+msgid "Jobs getting started or continued"
+msgstr ""
+
 msgid "List or remove functions"
 msgstr "列出或移除函数"
 
@@ -1145,6 +1241,9 @@ msgstr "操纵字符串"
 
 msgid "Measure how long a command or block takes"
 msgstr "测量命令或块需要多长时间"
+
+msgid "Misaligned address error"
+msgstr ""
 
 msgid "Mismatched braces"
 msgstr "牙套不匹配"
@@ -1188,6 +1287,9 @@ msgstr "不是一个函数"
 msgid "Not a number"
 msgstr "没有号码"
 
+msgid "Notifications about universal variable changes"
+msgstr ""
+
 msgid "Number is infinite"
 msgstr "数字是无限的"
 
@@ -1210,6 +1312,9 @@ msgstr ""
 msgid "Parse options in fish script"
 msgstr "分析fish文脚本中的选项"
 
+msgid "Parsing fish AST"
+msgstr ""
+
 msgid "Perform a command multiple times"
 msgstr "多次执行一条命令"
 
@@ -1223,6 +1328,12 @@ msgstr "请将 $ls 设置为您有写入权限的目录 ."
 #, c-format
 msgid "Please set the %ls or HOME environment variable before starting fish."
 msgstr "请在开始钓fish前设置 %ls 或 home 环境变量 ."
+
+msgid "Polite quit request"
+msgstr ""
+
+msgid "Power failure"
+msgstr ""
 
 #, c-format
 msgid "Press ctrl-%c again to exit\n"
@@ -1240,14 +1351,44 @@ msgstr "打印工作目录"
 msgid "Prints formatted text"
 msgstr "打印格式化文本"
 
+msgid "Process groups"
+msgstr ""
+
 msgid "Process\n"
 msgstr "进程\n"
+
+msgid "Profiling timer expired"
+msgstr ""
+
+msgid "Quit request from job control (^C)"
+msgstr ""
+
+msgid "Quit request from job control with core dump (^\\)"
+msgstr ""
+
+msgid "Reacting to variables"
+msgstr ""
 
 msgid "Read a line of input into variables"
 msgstr "将输入的一行读入到变量中"
 
+msgid "Reading/Writing the history file"
+msgstr ""
+
+msgid "Reaping external (forked) processes"
+msgstr ""
+
+msgid "Reaping internal (non-forked) processes"
+msgstr ""
+
+msgid "Refcell dynamic borrowing"
+msgstr ""
+
 msgid "Remove job from job list"
 msgstr "从工作列表中删除任务"
+
+msgid "Rendering the command line"
+msgstr ""
 
 #, c-format
 msgid "Requested redirection to '%ls', which is not a valid file descriptor"
@@ -1278,8 +1419,14 @@ msgstr "如果上次命令成功运行命令"
 msgid "Run command in current process"
 msgstr "在当前进程下执行命令"
 
+msgid "Screen repaints"
+msgstr ""
+
 msgid "Search for a specified string in a list"
 msgstr "在指定列表中搜索一个特定的字符串"
+
+msgid "Searching/using paths"
+msgstr ""
 
 #, c-format
 msgid "Send job %d (%ls) to foreground\n"
@@ -1295,6 +1442,9 @@ msgstr "将任务置于后台"
 msgid "Send job to foreground"
 msgstr "将任务带回到前台"
 
+msgid "Serious unexpected errors (on by default)"
+msgstr ""
+
 msgid "Set or get the commandline"
 msgstr "设置或取得命令行"
 
@@ -1306,6 +1456,9 @@ msgstr "显示绝对路径 sans 符号链接"
 
 msgid "Skip over remaining innermost loop"
 msgstr "跳过剩下的最内环"
+
+msgid "Stack fault"
+msgstr ""
 
 msgid "Standard input"
 msgstr "标准输入"
@@ -1324,6 +1477,15 @@ msgstr "状态\t命令\n"
 msgid "Stdin must be attached to a tty."
 msgstr ""
 
+msgid "Stop from terminal input"
+msgstr ""
+
+msgid "Stop from terminal output"
+msgstr ""
+
+msgid "Stop request from job control (^Z)"
+msgstr ""
+
 msgid "Stop the currently evaluated function"
 msgstr "停止当前求值的函数"
 
@@ -1332,6 +1494,18 @@ msgstr "停止最内层的循环"
 
 msgid "Temporarily block delivery of events"
 msgstr "Temporarily block delivery of events"
+
+msgid "Terminal feature detection"
+msgstr ""
+
+msgid "Terminal hung up"
+msgstr ""
+
+msgid "Terminal ownership events"
+msgstr ""
+
+msgid "Terminal protocol negotiation"
+msgstr ""
 
 msgid "Test a condition"
 msgstr "测试一个条件"
@@ -1350,6 +1524,9 @@ msgstr "'time'命令可能只在管道开始的时候"
 msgid "The call stack limit has been exceeded. Do you have an accidental infinite loop?"
 msgstr "呼叫堆栈限制已经超过 . 你有一个意外的无限循环?"
 
+msgid "The completion system"
+msgstr ""
+
 #, c-format
 msgid "The error was '%s'."
 msgstr "错误为 '%s' ."
@@ -1364,6 +1541,9 @@ msgstr "扩展的命令为空 ."
 msgid "The function '%ls' calls itself immediately, which would result in an infinite loop."
 msgstr "函数 '%ls' 立即调用它, 会导致无限循环 ."
 
+msgid "The interactive reader/input system"
+msgstr ""
+
 msgid "There are still jobs active:\n"
 msgstr "仍然有活动的工作: \n"
 
@@ -1372,6 +1552,9 @@ msgstr "这是登录shell\n"
 
 msgid "This is not a login shell\n"
 msgstr "这不是登录shell\n"
+
+msgid "Timer expired"
+msgstr ""
 
 msgid "Too few arguments"
 msgstr "参数太少"
@@ -1385,8 +1568,14 @@ msgstr "太多参数"
 msgid "Too much data emitted by command substitution so it was discarded"
 msgstr "命令替换释放的数据过多, 因此被丢弃"
 
+msgid "Trace or breakpoint trap"
+msgstr ""
+
 msgid "Translate a string"
 msgstr "翻译字符串"
+
+msgid "Trying to print invalid output"
+msgstr ""
 
 #, c-format
 msgid "Unable to create temporary file '%ls': %s"
@@ -1502,8 +1691,17 @@ msgstr "未匹配的通配符"
 msgid "Unsupported use of '='. In fish, please use 'set %ls %ls'."
 msgstr "不支持使用'='. 在fish类中,请使用'set %ls %ls'."
 
+msgid "Urgent socket condition"
+msgstr ""
+
 msgid "Use 'disown PID' to remove jobs from the list without terminating them.\n"
 msgstr "使用' 取消 PID ' 从列表中删除任务而不终止它们 .\n"
+
+msgid "User defined signal 1"
+msgstr ""
+
+msgid "User defined signal 2"
+msgstr ""
 
 #, c-format
 msgid "Variable: %ls"
@@ -1517,8 +1715,26 @@ msgstr ""
 msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
 msgstr ""
 
+msgid "Virtual timefr expired"
+msgstr ""
+
 msgid "Wait for background processes completed"
 msgstr "等待背景进程完成"
+
+msgid "Warning about using test's zero- or one-argument modes (`test -d $foo`), which will be changed in future."
+msgstr ""
+
+msgid "Warnings (on by default)"
+msgstr ""
+
+msgid "Warnings about unusable paths for config/history (on by default)"
+msgstr ""
+
+msgid "Window size change"
+msgstr ""
+
+msgid "Writing/reading the universal variable store"
+msgstr ""
 
 msgid "[: the last argument must be ']'"
 msgstr "[:最后的论点必须是  '"
@@ -1532,6 +1748,9 @@ msgstr ""
 
 msgid "array indices start at 1, not 0."
 msgstr "数组指数起始时间为 1,而不是 0."
+
+msgid "autoloading"
+msgstr ""
 
 #, c-format
 msgid "builtin %ls: %ls: %s\n"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -34,6 +34,10 @@ msgid "$$ is not the pid. In fish, please use $fish_pid."
 msgstr "美元不是皮条客. 在fish中,请使用$fish_pid."
 
 #, c-format
+msgid "$%lc is not a valid variable in fish."
+msgstr ""
+
+#, c-format
 msgid "$%ls: originally inherited as |%ls|\n"
 msgstr "$%ls: 原为 |%ls| 继承 \n"
 
@@ -56,6 +60,10 @@ msgstr "$status 作为命令无效 . 见`help conditions`"
 #, c-format
 msgid "%.*ls: invalid conversion specification"
 msgstr "%.*ls: 无效的转换形式"
+
+#, c-format
+msgid "%ls"
+msgstr ""
 
 #, c-format
 msgid "%ls %ls: Abbreviation %ls already exists, cannot rename %ls\n"
@@ -128,6 +136,10 @@ msgstr "%ls: %ls: 无法将保留关键字作为函数名"
 #, c-format
 msgid "%ls: %ls: contains a syntax error\n"
 msgstr "%ls:%ls: 包含语法错误\n"
+
+#, c-format
+msgid "%ls: %ls: expected %d arguments; got %d\n"
+msgstr ""
 
 #, c-format
 msgid "%ls: %ls: invalid base value\n"
@@ -658,6 +670,18 @@ msgid "%ls: exclusive flag string '%ls' is not valid\n"
 msgstr "%ls: 排他性标志字符串 '%ls' 无效\n"
 
 #, c-format
+msgid "%ls: expected %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: expected <= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%ls: expected >= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
 msgid "%ls: expected a numeric value"
 msgstr "%ls: 预期数字类型值"
 
@@ -668,6 +692,10 @@ msgstr "%ls: 函数名称是必须的"
 #, c-format
 msgid "%ls: given %d indexes but %d values\n"
 msgstr "%ls: 给定的 %d 索引但 %d 值\n"
+
+#, c-format
+msgid "%ls: invalid option combination, %ls\n"
+msgstr ""
 
 #, c-format
 msgid "%ls: invalid option combination\n"
@@ -683,6 +711,10 @@ msgstr "%ls: 任务 %d ('%ls') 已停止并指示要继续 .\n"
 
 #, c-format
 msgid "%ls: line/column index starts at 1"
+msgstr ""
+
+#, c-format
+msgid "%ls: missing argument\n"
 msgstr ""
 
 #, c-format
@@ -819,18 +851,6 @@ msgstr "--query和 --names 相互排斥"
 msgid "--tokens options are mutually exclusive"
 msgstr "--tokens 选项是相互排斥的"
 
-msgid ".local/bin/"
-msgstr ""
-
-msgid ".local/share/"
-msgstr ""
-
-msgid ".local/share/doc/fish"
-msgstr ""
-
-msgid "/etc/"
-msgstr ""
-
 msgid "A second attempt to exit will terminate them.\n"
 msgstr "第二次尝试退出将终止它们.\n"
 
@@ -893,9 +913,6 @@ msgstr "无法为新任务设置终端模式"
 
 msgid "Could not set terminal mode for shell"
 msgstr "无法为 shell 设置终端模式"
-
-msgid "Could not show help message"
-msgstr "无法显示帮助消息"
 
 #, c-format
 msgid "Could not write profiling information to file '%s': %s"
@@ -1492,6 +1509,14 @@ msgstr "使用' 取消 PID ' 从列表中删除任务而不终止它们 .\n"
 msgid "Variable: %ls"
 msgstr "变量:%ls"
 
+#, c-format
+msgid "Variables cannot be bracketed. In fish, please use \"$%ls\"."
+msgstr ""
+
+#, c-format
+msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
+msgstr ""
+
 msgid "Wait for background processes completed"
 msgstr "等待背景进程完成"
 
@@ -1565,9 +1590,6 @@ msgstr "导出"
 
 msgid "file"
 msgstr "文件"
-
-msgid "fish/install"
-msgstr ""
 
 #, c-format
 msgid ""
@@ -78932,6 +78954,9 @@ msgstr "缩放"
 
 msgid "~ expansion"
 msgstr "~ 扩大"
+
+#~ msgid "Could not show help message"
+#~ msgstr "无法显示帮助消息"
 
 #~ msgid "builtin\n"
 #~ msgstr "内建\n"

--- a/src/bin/fish.rs
+++ b/src/bin/fish.rs
@@ -319,6 +319,7 @@ fn fish_parse_opt(args: &mut [WString], opts: &mut FishCmdOpts) -> ControlFlow<i
                 // A little extra space.
                 name_width += 2;
                 for cat in cats.iter() {
+                    // Extraction happens in the `src/flog.rs:declare_category!` macro.
                     let desc = wgettext_str(cat.description);
                     // this is left-justified
                     printf!("%-*ls %ls\n", name_width, cat.name, desc);

--- a/src/builtins/fg.rs
+++ b/src/builtins/fg.rs
@@ -97,10 +97,7 @@ pub fn fg(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Built
                     job_pos = Some(pos);
                     job = if !j.wants_job_control() {
                         streams.err.append(wgettext_fmt!(
-                            concat!(
-                                "%ls: Can't put job %d, '%ls' to foreground because ",
-                                "it is not under job control\n"
-                            ),
+                            "%ls: Can't put job %d, '%ls' to foreground because it is not under job control\n",
                             cmd,
                             raw_pid,
                             j.command()

--- a/src/builtins/read.rs
+++ b/src/builtins/read.rs
@@ -107,10 +107,7 @@ fn parse_cmd_opts(
             }
             'i' => {
                 streams.err.append(wgettext_fmt!(
-                    concat!(
-                        "%ls: usage of -i for --silent is deprecated. Please ",
-                        "use -s or --silent instead.\n"
-                    ),
+                    "%ls: usage of -i for --silent is deprecated. Please use -s or --silent instead.\n",
                     cmd
                 ));
                 return Err(STATUS_INVALID_ARGS);

--- a/src/builtins/shared.rs
+++ b/src/builtins/shared.rs
@@ -26,10 +26,8 @@ pub const DEFAULT_READ_PROMPT: &wstr =
 pub const BUILTIN_ERR_MISSING: &str = "%ls: %ls: option requires an argument\n";
 
 /// Error message on missing man page.
-pub const BUILTIN_ERR_MISSING_HELP: &str = concat!(
-    "fish: %ls: missing man page\nDocumentation may not be installed.\n`help %ls` will ",
-    "show an online version\n"
-);
+pub const BUILTIN_ERR_MISSING_HELP: &str =
+    "fish: %ls: missing man page\nDocumentation may not be installed.\n`help %ls` will show an online version\n";
 
 /// Error message on multiple scope levels for variables.
 pub const BUILTIN_ERR_GLOCAL: &str =

--- a/src/builtins/shared.rs
+++ b/src/builtins/shared.rs
@@ -1005,6 +1005,10 @@ fn builtin_false(_parser: &Parser, _streams: &mut IoStreams, _argv: &mut [&wstr]
     Err(STATUS_CMD_ERROR)
 }
 
+/// Used for the fish `_` builtin for requesting translations.
+/// For scripts in `share/`, the corresponding strings are extracted from the scripts using
+/// `build_tools/fish_xgettext.fish`.
+/// Strings not present in our repo would require a custom MO file for translation to be possible.
 fn builtin_gettext(_parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> BuiltinResult {
     for arg in &argv[1..] {
         streams.out.append(wgettext_str(arg));

--- a/src/complete.rs
+++ b/src/complete.rs
@@ -70,19 +70,6 @@ static COMPLETE_VAR_DESC_VAL: Lazy<&wstr> = Lazy::new(|| wgettext!("Variable: %l
 /// Description for abbreviations.
 static ABBR_DESC: Lazy<&wstr> = Lazy::new(|| wgettext!("Abbreviation: %ls"));
 
-/// The special cased translation macro for completions. The empty string needs to be special cased,
-/// since it can occur, and should not be translated. (Gettext returns the version information as
-/// the response).
-#[inline(always)]
-#[allow(non_snake_case)]
-fn C_(s: &wstr) -> &'static wstr {
-    if s.is_empty() {
-        L!("")
-    } else {
-        wgettext_str(s)
-    }
-}
-
 #[derive(Clone, Copy, Default, PartialEq, Eq, Debug)]
 pub struct CompletionMode {
     /// If set, skip file completions.
@@ -399,7 +386,16 @@ struct CompleteEntryOpt {
 
 impl CompleteEntryOpt {
     pub fn localized_desc(&self) -> &'static wstr {
-        C_(&self.desc)
+        if self.desc.is_empty() {
+            // The empty string needs to be special cased,
+            // since it can occur, and should not be translated.
+            // (Gettext returns the version information as the response.)
+            L!("")
+        } else {
+            // The descriptions are extracted from the completion scripts.
+            // No extraction is required (or possible) from fish's code.
+            wgettext_str(&self.desc)
+        }
     }
 
     pub fn expected_dash_count(&self) -> usize {

--- a/src/flog.rs
+++ b/src/flog.rs
@@ -25,7 +25,7 @@ pub mod categories {
         ) => {
             pub static $var: category_t = category_t {
                 name: L!($name),
-                description: L!($description),
+                description: L!(fish_gettext_extraction::gettext_extract!($description)),
                 enabled: AtomicBool::new($enabled),
             };
         };

--- a/src/function.rs
+++ b/src/function.rs
@@ -369,6 +369,8 @@ impl FunctionProperties {
         if self.description.is_empty() {
             L!("")
         } else {
+            // The descriptions are extracted from the completion scripts.
+            // No extraction is required (or possible) from fish's code.
             wgettext_str(&self.description)
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,5 +102,7 @@ pub mod wgetopt;
 pub mod widecharwidth;
 pub mod wildcard;
 
+pub extern crate fish_gettext_extraction;
+
 #[cfg(test)]
 mod tests;

--- a/src/parse_execution.rs
+++ b/src/parse_execution.rs
@@ -278,10 +278,7 @@ impl<'a> ExecutionContext<'a> {
                         ctx,
                         STATUS_NOT_EXECUTABLE,
                         &statement.command,
-                        concat!(
-                            "Unknown command. A component of '%ls' is not a ",
-                            "directory. Check your $PATH."
-                        ),
+                        "Unknown command. A component of '%ls' is not a directory. Check your $PATH.",
                         cmd
                     );
                 } else {

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -366,7 +366,11 @@ impl LookupEntry {
 
 macro_rules! signal_entry {
     ($name:ident, $desc:expr) => {
-        LookupEntry::new(libc::$name, L!(stringify!($name)), L!($desc))
+        LookupEntry::new(
+            libc::$name,
+            L!(stringify!($name)),
+            L!(fish_gettext_extraction::gettext_extract!($desc)),
+        )
     };
 }
 
@@ -479,7 +483,10 @@ impl Signal {
     /// Previously signal_get_desc().
     pub fn desc(&self) -> &'static wstr {
         match self.get_lookup_entry() {
-            Some(entry) => wgettext_str(entry.desc),
+            Some(entry) => {
+                // Extraction happens in the `signal_entry!` macro.
+                wgettext_str(entry.desc)
+            }
             None => wgettext!("Unknown"),
         }
     }

--- a/src/wutil/gettext.rs
+++ b/src/wutil/gettext.rs
@@ -138,7 +138,9 @@ pub fn wgettext_str(s: &wstr) -> &'static wstr {
 #[macro_export]
 macro_rules! wgettext {
     ($string:expr) => {
-        $crate::wutil::gettext::wgettext_static_str(widestring::utf32str!($string))
+        $crate::wutil::gettext::wgettext_static_str(widestring::utf32str!(
+            fish_gettext_extraction::gettext_extract!($string)
+        ))
     };
 }
 pub use wgettext;


### PR DESCRIPTION
Document call sites of `wgettext_str` to indicate where xgettext extraction
happens.

Update the po files. Signal descriptions already had translations in some
languages, which are restored.

This is on top of #11536, to address the issue described in https://github.com/fish-shell/fish-shell/pull/11536#issuecomment-2920588250.