### PR TITLE
Check rustdocs in CI

### DIFF
--- a/.github/workflows/rust_checks.yml
+++ b/.github/workflows/rust_checks.yml
@@ -32,6 +32,19 @@ jobs:
       # into automatic CI failure day, so we don't do that.
       run: cargo clippy --workspace --all-targets
 
+  rustdoc:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@stable
+    - name: cargo doc
+      run: |
+        RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all
+    - name: cargo doctest
+      run: |
+        cargo test --doc --workspace --all
+
   # Disabling for now because it also checks "advisories",
   # making CI fail for reasons unrelated to the patch
   # cargo-deny:

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -1561,7 +1561,7 @@ static MIDNIGHT_COMMANDER_HACK: RelaxedAtomicBool = RelaxedAtomicBool::new(false
 
 /// Midnight Commander tries to extract the last line of the prompt, and does so in a way that is
 /// broken if you do '\r' after it like we normally do.
-/// See https://midnight-commander.org/ticket/4258.
+/// See <https://midnight-commander.org/ticket/4258>.
 pub fn screen_set_midnight_commander_hack() {
     MIDNIGHT_COMMANDER_HACK.store(true)
 }


### PR DESCRIPTION
Setting `RUSTDOCFLAGS='-D warnings'` is needed to fail on warnings. For `cargo test --doc` no equivalent option seems to exist. See https://github.com/rust-lang/cargo/issues/14802.