### PR TITLE
Remove manual contains

### DIFF
--- a/src/wchar_ext.rs
+++ b/src/wchar_ext.rs
@@ -272,7 +272,7 @@ pub trait WExt {
     }
 
     fn contains(&self, c: char) -> bool {
-        self.as_char_slice().iter().any(|&x| x == c)
+        self.as_char_slice().contains(&c)
     }
 
     /// Return whether we start with a given Prefix.


### PR DESCRIPTION
See https://rust-lang.github.io/rust-clippy/master/index.html#manual_contains.

The old code results in a clippy warning on Rust 1.87.