### PR TITLE
More local checks

### DIFF
--- a/build_tools/check.sh
+++ b/build_tools/check.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -ex
+
+RUSTFLAGS='-D warnings'; export RUSTFLAGS
+RUSTDOCFLAGS='-D warnings'; export RUSTDOCFLAGS
+
+repo_root="$(dirname "$0")/.."
+build_dir="$repo_root/target/debug"
+
+PATH="$build_dir:$PATH" "$repo_root/build_tools/style.fish" --all --check
+
+cargo build --workspace --all-targets
+cargo clippy --workspace --all-targets
+cargo test --no-default-features --workspace --all-targets
+cargo test --doc --workspace
+cargo doc --workspace
+
+# TODO: parallelize
+"$repo_root/tests/test_driver.py" "$build_dir"

--- a/build_tools/diff_profiles.fish
+++ b/build_tools/diff_profiles.fish
@@ -5,7 +5,8 @@
 #
 # Usage: ./diff_profiles.fish profile1.log profile2.log > profile_diff.log
 
-if test (count $argv) -ne 2;
+if test (count $argv) -ne 2
+
     echo "Incorrect number of arguments."
     echo "Usage: "(status filename)" profile1.log profile2.log"
     exit 1

--- a/build_tools/update_translations.fish
+++ b/build_tools/update_translations.fish
@@ -44,7 +44,7 @@ function cleanup_exit
     exit $exit_status
 end
 
-argparse --exclusive 'no-mo,only-mo,dry-run' 'no-mo' 'only-mo' 'dry-run' -- $argv
+argparse --exclusive 'no-mo,only-mo,dry-run' no-mo only-mo dry-run -- $argv
 or exit $status
 
 # Make sure that the template file is not included in $po_files.

--- a/share/completions/patch.fish
+++ b/share/completions/patch.fish
@@ -3,7 +3,6 @@
 # TODO: POSIX patch
 #
 
-
 # No effect on POSIX systems that don't use O_BINARY/O_TEXT
 uname -s | string match -q CYGWIN\*
 and complete -c patch -l binary -d "Read & write data in binary mode"

--- a/share/completions/tofu.fish
+++ b/share/completions/tofu.fish
@@ -1,4 +1,3 @@
-
 # Returns 0 if the command has not had a subcommand yet
 # Does not currently account for -chdir
 function __fish_tofu_needs_command

--- a/share/functions/fish_config.fish
+++ b/share/functions/fish_config.fish
@@ -316,7 +316,7 @@ function fish_config --description "Launch fish's web based configuration"
                         if string match -qr '^tools/' -- $file
                             set content (status get-file $file)
                         else
-                            read -z content < $file
+                            read -z content <$file
                         end
 
                         printf %s\n $content | while read -lat toks

--- a/share/tools/web_config/webconfig.py
+++ b/share/tools/web_config/webconfig.py
@@ -244,7 +244,9 @@ def parse_color(color_str):
             underline = "single"
         elif comp.startswith("--underline="):
             underline = comp.stripprefix("--underline=")
-        elif comp.startswith("-u"): # Multiple short options like "-rucurly" are not yet supported.
+        elif comp.startswith(
+            "-u"
+        ):  # Multiple short options like "-rucurly" are not yet supported.
             underline = comp.stripprefix("-u")
         elif comp == "--italics" or comp == "-i":
             italics = True
@@ -253,7 +255,10 @@ def parse_color(color_str):
         elif comp == "--reverse" or comp == "-r":
             reverse = True
         else:
-            def parse_opt(current_best: str, i: int, long_opt: str, short_opt: str | None) -> str:
+
+            def parse_opt(
+                current_best: str, i: int, long_opt: str, short_opt: str | None
+            ) -> str:
                 if comp.startswith(long_opt):
                     c = comp[len(long_opt) :]
                     parsed_c = parse_one_color(c)
@@ -269,13 +274,18 @@ def parse_color(color_str):
                             c = comps[i + 1]
                             i += 1
                     else:
-                        c = comp[len(short_opt):]
+                        c = comp[len(short_opt) :]
                     parsed_c = parse_one_color(c)
                     if better_color(current_best, parsed_c) == parsed_c:
                         return True, c, i
                 return False, current_best, i
-            is_bg, background_color, i = parse_opt(background_color, i, "--background", "-b")
-            is_ul, underline_color, i = parse_opt(underline_color, i, "--underline-color", None)
+
+            is_bg, background_color, i = parse_opt(
+                background_color, i, "--background", "-b"
+            )
+            is_ul, underline_color, i = parse_opt(
+                underline_color, i, "--underline-color", None
+            )
             if not (is_bg or is_ul):
                 # Regular color
                 parsed_c = parse_one_color(comp)

--- a/src/widecharwidth/widechar_width.rs
+++ b/src/widecharwidth/widechar_width.rs
@@ -23,37 +23,31 @@ type R = (u32, u32);
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u8)]
 pub enum WcWidth {
-  /// The character is single-width
-  One,
-  /// The character is double-width
-  Two,
-  /// The character is not printable.
-  NonPrint,
-  /// The character is a zero-width combiner.
-  Combining,
-  /// The character is East-Asian ambiguous width.
-  Ambiguous,
-  /// The character is for private use.
-  PrivateUse,
-  /// The character is unassigned.
-  Unassigned,
-  /// Width is 1 in Unicode 8, 2 in Unicode 9+.
-  WidenedIn9,
-  /// The character is a noncharacter.
-  NonCharacter,
+    /// The character is single-width
+    One,
+    /// The character is double-width
+    Two,
+    /// The character is not printable.
+    NonPrint,
+    /// The character is a zero-width combiner.
+    Combining,
+    /// The character is East-Asian ambiguous width.
+    Ambiguous,
+    /// The character is for private use.
+    PrivateUse,
+    /// The character is unassigned.
+    Unassigned,
+    /// Width is 1 in Unicode 8, 2 in Unicode 9+.
+    WidenedIn9,
+    /// The character is a noncharacter.
+    NonCharacter,
 }
 
 /// Simple ASCII characters - used a lot, so we check them first.
-const ASCII_TABLE: &'static [R] = &[
-    (0x00020, 0x0007E)
-];
+const ASCII_TABLE: &'static [R] = &[(0x00020, 0x0007E)];
 
 /// Private usage range.
-const PRIVATE_TABLE: &'static [R] = &[
-    (0x0E000, 0x0F8FF),
-    (0xF0000, 0xFFFFD),
-    (0x100000, 0x10FFFD)
-];
+const PRIVATE_TABLE: &'static [R] = &[(0x0E000, 0x0F8FF), (0xF0000, 0xFFFFD), (0x100000, 0x10FFFD)];
 
 /// Nonprinting characters.
 const NONPRINT_TABLE: &'static [R] = &[
@@ -80,7 +74,7 @@ const NONPRINT_TABLE: &'static [R] = &[
     (0x1BCA0, 0x1BCA3),
     (0x1D173, 0x1D17A),
     (0xE0001, 0xE0001),
-    (0xE0020, 0xE007F)
+    (0xE0020, 0xE007F),
 ];
 
 /// Width 0 combining marks.
@@ -405,14 +399,11 @@ const COMBINING_TABLE: &'static [R] = &[
     (0x1E5EE, 0x1E5EF),
     (0x1E8D0, 0x1E8D6),
     (0x1E944, 0x1E94A),
-    (0xE0100, 0xE01EF)
+    (0xE0100, 0xE01EF),
 ];
 
 /// Width 0 combining letters.
-const COMBININGLETTERS_TABLE: &'static [R] = &[
-    (0x01160, 0x011FF),
-    (0x0D7B0, 0x0D7FF)
-];
+const COMBININGLETTERS_TABLE: &'static [R] = &[(0x01160, 0x011FF), (0x0D7B0, 0x0D7FF)];
 
 /// Width 2 characters.
 const DOUBLEWIDE_TABLE: &'static [R] = &[
@@ -488,7 +479,7 @@ const DOUBLEWIDE_TABLE: &'static [R] = &[
     (0x1FADF, 0x1FAE9),
     (0x1FAF0, 0x1FAF8),
     (0x20000, 0x2FFFD),
-    (0x30000, 0x3FFFD)
+    (0x30000, 0x3FFFD),
 ];
 
 /// Ambiguous-width characters.
@@ -671,7 +662,7 @@ const AMBIGUOUS_TABLE: &'static [R] = &[
     (0x1F19B, 0x1F1AC),
     (0xE0100, 0xE01EF),
     (0xF0000, 0xFFFFD),
-    (0x100000, 0x10FFFD)
+    (0x100000, 0x10FFFD),
 ];
 
 /// Unassigned characters.
@@ -1426,7 +1417,7 @@ const UNASSIGNED_TABLE: &'static [R] = &[
     (0xE0000, 0xE0000),
     (0xE0002, 0xE001F),
     (0xE0080, 0xE00FF),
-    (0xE01F0, 0xEFFFD)
+    (0xE01F0, 0xEFFFD),
 ];
 
 /// Non-characters.
@@ -1448,7 +1439,7 @@ const NONCHAR_TABLE: &'static [R] = &[
     (0xDFFFE, 0xDFFFF),
     (0xEFFFE, 0xEFFFF),
     (0xFFFFE, 0xFFFFF),
-    (0x10FFFE, 0x10FFFF)
+    (0x10FFFE, 0x10FFFF),
 ];
 
 /// Characters that were widened from width 1 to 2 in Unicode 9.
@@ -1518,7 +1509,7 @@ const WIDENED_TABLE: &'static [R] = &[
     (0x1F6EB, 0x1F6EC),
     (0x1F910, 0x1F918),
     (0x1F980, 0x1F984),
-    (0x1F9C0, 0x1F9C0)
+    (0x1F9C0, 0x1F9C0),
 ];
 
 fn in_table(arr: &[R], c: u32) -> bool {

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -73,7 +73,7 @@ def makeenv(script_path, home, test_helper_path):
         "LANGUAGE",
         "COLORTERM",
         "KONSOLE_VERSION",
-        "TERM", # Erase this since we still respect TERM=dumb etc.
+        "TERM",  # Erase this since we still respect TERM=dumb etc.
         "TERM_PROGRAM",
         "TERM_PROGRAM_VERSION",
         "VTE_VERSION",


### PR DESCRIPTION
## Description

This includes updates to the formatting script and a new script for running checks locally, motivated in part by https://github.com/fish-shell/fish-shell/pull/11545#discussion_r2121331880.


## TODOs:
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Are there additional checks we want to include?
- [ ] Improvements for `test_driver.py` checks: Should we use a cachedir? If so, at which path? Would it make sense to use ctest if it is available?
- [ ] Can we get rid of `cmake/Tests.cmake` and use this script (or parts of it) instead?
