### PR TITLE
Add run0 to alt-s commands

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -50,6 +50,7 @@ Interactive improvements
 - Left mouse click (as requested by `click_events <terminal-compatibility.html#click-events>`__) can now select pager items (:issue:`10932`).
 - Instead of flashing all the text to the left of the cursor, fish now flashes the matched token during history token search, the completed token during completion (:issue:`11050`), the autosuggestion when deleting it, and the full command line in all other cases.
 - Pasted commands are now stripped of any ``$`` prefix.
+- The :kbd:`alt-s` binding will now also use ``run0`` if available.
 
 New or improved bindings
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/share/functions/__fish_shared_key_bindings.fish
+++ b/share/functions/__fish_shared_key_bindings.fish
@@ -91,7 +91,7 @@ function __fish_shared_key_bindings -d "Bindings shared between emacs and vi mod
     bind --preset $argv alt-d 'if test "$(commandline; printf .)" = \n.; __fish_echo dirh; else; commandline -f kill-word; end'
     bind --preset $argv ctrl-d delete-or-exit
 
-    bind --preset $argv alt-s 'for cmd in sudo doas please; if command -q $cmd; fish_commandline_prepend $cmd; break; end; end'
+    bind --preset $argv alt-s 'for cmd in sudo doas please run0; if command -q $cmd; fish_commandline_prepend $cmd; break; end; end'
 
     # Allow reading manpages by pressing f1 (many GUI applications) or Alt+h (like in zsh).
     bind --preset $argv f1 __fish_man_page


### PR DESCRIPTION
https://www.freedesktop.org/software/systemd/man/devel/run0.html Since everyone using a systemd distro will have this, it's added at the end so that it's tried last

## Description

Talk about your changes here.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.: `doc_src/interactive.rst` only talks about sudo, not doas or please, so I didn't touch it
- [ ] Tests have been added for regressions fixed: NA
- [x] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
