### PR TITLE
completions/adb: add listing device files for exec-out subcommand

### DIFF
--- a/share/completions/adb.fish
+++ b/share/completions/adb.fish
@@ -195,6 +195,7 @@ complete -n '__fish_seen_subcommand_from sideload' -c adb -k -xa '(__fish_comple
 complete -n '__fish_seen_subcommand_from reconnect' -c adb -x -a device -d 'Kick current connection from device side and make it reconnect.'
 
 # commands that accept listing device files
+complete -n '__fish_seen_subcommand_from exec-out' -c adb -f -a "(__fish_adb_list_files)" -d 'File on device'
 complete -n '__fish_seen_subcommand_from shell' -c adb -f -a "(__fish_adb_list_files)" -d 'File on device'
 complete -n '__fish_seen_subcommand_from pull' -c adb -F -a "(__fish_adb_list_files)" -d 'File on device'
 complete -n '__fish_seen_subcommand_from push' -c adb -ka "(__fish_adb_list_files)" -d 'File on device'


### PR DESCRIPTION
## Description
The usage of `adb exec-out` is basically the same as `adb shell`, but instead, it sends the output to stdout. 
So listing files for it is very useful and makes even more sense since you often need to cat a file into stdout with it.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
