### PR TITLE
Parallelize test driver

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -219,12 +219,10 @@ Or you can run them on a fish, without involving cmake::
 
   cargo build
   cargo test # for the unit tests
-  tests/test_driver.py --cachedir=/tmp target/debug # for the script and interactive tests
+  tests/test_driver.py target/debug # for the script and interactive tests
 
 Here, the first argument to test_driver.py refers to a directory with ``fish``, ``fish_indent`` and ``fish_key_reader`` in it.
 In this example we're in the root of the git repo and have run ``cargo build`` without ``--release``, so it's a debug build.
-The ``--cachedir /tmp`` argument means it will keep the fish_test_helper binary in /tmp instead of recompiling it for every test.
-This saves some time, but isn't strictly necessary.
 
 Git hooks
 ---------

--- a/build_tools/check.sh
+++ b/build_tools/check.sh
@@ -15,5 +15,4 @@ cargo test --no-default-features --workspace --all-targets
 cargo test --doc --workspace
 cargo doc --workspace
 
-# TODO: parallelize
 "$repo_root/tests/test_driver.py" "$build_dir"

--- a/cmake/Tests.cmake
+++ b/cmake/Tests.cmake
@@ -63,7 +63,7 @@ foreach(CHECK ${FISH_CHECKS})
   get_filename_component(CHECK_NAME ${CHECK} NAME)
   get_filename_component(CHECK ${CHECK} NAME_WE)
   add_test(NAME ${CHECK_NAME}
-    COMMAND ${CMAKE_SOURCE_DIR}/tests/test_driver.py --cachedir=${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR}
+    COMMAND ${CMAKE_SOURCE_DIR}/tests/test_driver.py ${CMAKE_CURRENT_BINARY_DIR}
                 checks/${CHECK}.fish
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests
   )
@@ -76,7 +76,7 @@ FILE(GLOB PEXPECTS CONFIGURE_DEPENDS ${CMAKE_SOURCE_DIR}/tests/pexpects/*.py)
 foreach(PEXPECT ${PEXPECTS})
   get_filename_component(PEXPECT ${PEXPECT} NAME)
   add_test(NAME ${PEXPECT}
-    COMMAND ${CMAKE_SOURCE_DIR}/tests/test_driver.py --cachedir=${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR}
+    COMMAND ${CMAKE_SOURCE_DIR}/tests/test_driver.py ${CMAKE_CURRENT_BINARY_DIR}
                 pexpects/${PEXPECT}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests
   )

--- a/tests/littlecheck.py
+++ b/tests/littlecheck.py
@@ -4,20 +4,21 @@
 
 from __future__ import unicode_literals
 from __future__ import print_function
-
 import argparse
 import datetime
+from difflib import SequenceMatcher
 import io
 import re
 import shlex
 import subprocess
 import sys
+import unicodedata
 
 try:
     from itertools import zip_longest
 except ImportError:
     from itertools import izip_longest as zip_longest
-from difflib import SequenceMatcher
+
 
 # Directives can occur at the beginning of a line, or anywhere in a line that does not start with #.
 COMMENT_RE = r"^(?:[^#].*)?#\s*"
@@ -91,9 +92,6 @@ class Config(object):
 
 def output(*args):
     print("".join(args) + "\n")
-
-
-import unicodedata
 
 
 def esc(m):
@@ -382,7 +380,7 @@ def perform_substitution(input_str, subs):
     return re.sub(r"%(%|[a-zA-Z0-9_-]+)", subber, input_str)
 
 
-def runproc(cmd):
+def runproc(cmd, env=None):
     """Wrapper around subprocess.Popen to save typing"""
     PIPE = subprocess.PIPE
     proc = subprocess.Popen(
@@ -392,18 +390,20 @@ def runproc(cmd):
         stderr=PIPE,
         shell=True,
         close_fds=True,  # For Python 2.6 as shipped on RHEL 6
+        env=env,
     )
     return proc
 
 
 class TestRun(object):
-    def __init__(self, name, runcmd, checker, subs, config):
+    def __init__(self, name, runcmd, checker, subs, config, env=None):
         self.name = name
         self.runcmd = runcmd
         self.subbed_command = perform_substitution(runcmd.args, subs)
         self.checker = checker
         self.subs = subs
         self.config = config
+        self.env = env
 
     def check(self, lines, checks):
         # Reverse our lines and checks so we can pop off the end.
@@ -489,7 +489,7 @@ class TestRun(object):
 
         if self.config.verbose:
             print(self.subbed_command)
-        proc = runproc(self.subbed_command)
+        proc = runproc(self.subbed_command, env=self.env)
         stdout, stderr = proc.communicate()
         # HACK: This is quite cheesy: POSIX specifies that sh should return 127 for a missing command.
         # It's also possible that it'll be returned in other situations,
@@ -668,7 +668,7 @@ class Checker(object):
         ]
 
 
-def check_file(input_file, name, subs, config, failure_handler):
+def check_file(input_file, name, subs, config, failure_handler, env=None):
     """Check a single file. Return a True on success, False on error."""
     success = True
     lines = Line.readfile(input_file, name)
@@ -677,7 +677,7 @@ def check_file(input_file, name, subs, config, failure_handler):
     # Run all the REQUIRES lines first,
     # if any of them fail it's a SKIP
     for reqcmd in checker.requirecmds:
-        proc = runproc(perform_substitution(reqcmd.args, subs))
+        proc = runproc(perform_substitution(reqcmd.args, subs), env=env)
         proc.communicate()
         if proc.returncode > 0:
             return SKIP
@@ -687,16 +687,16 @@ def check_file(input_file, name, subs, config, failure_handler):
 
     # Only then run the RUN lines.
     for runcmd in checker.runcmds:
-        failure = TestRun(name, runcmd, checker, subs, config).run()
+        failure = TestRun(name, runcmd, checker, subs, config, env=env).run()
         if failure:
             failure_handler(failure)
             success = False
     return success
 
 
-def check_path(path, subs, config, failure_handler):
+def check_path(path, subs, config, failure_handler, env=None):
     with io.open(path, encoding="utf-8") as fd:
-        return check_file(fd, path, subs, config, failure_handler)
+        return check_file(fd, path, subs, config, failure_handler, env=env)
 
 
 def parse_subs(subs):

--- a/tests/littlecheck.py
+++ b/tests/littlecheck.py
@@ -5,12 +5,12 @@
 from __future__ import unicode_literals
 from __future__ import print_function
 import argparse
+import asyncio
 import datetime
 from difflib import SequenceMatcher
 import io
 import re
 import shlex
-import subprocess
 import sys
 import unicodedata
 
@@ -382,17 +382,15 @@ def perform_substitution(input_str, subs):
 
 def runproc(cmd, env=None):
     """Wrapper around subprocess.Popen to save typing"""
-    PIPE = subprocess.PIPE
-    proc = subprocess.Popen(
-        cmd,
-        stdin=PIPE,
-        stdout=PIPE,
-        stderr=PIPE,
-        shell=True,
-        close_fds=True,  # For Python 2.6 as shipped on RHEL 6
-        env=env,
+    return asyncio.run(runproc_async(cmd, env=env))
+
+
+async def runproc_async(cmd, env=None):
+    """Wrapper around subprocess.Popen to save typing"""
+    PIPE = asyncio.subprocess.PIPE
+    return await asyncio.create_subprocess_shell(
+        cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, env=env
     )
-    return proc
 
 
 class TestRun(object):
@@ -477,6 +475,10 @@ class TestRun(object):
 
     def run(self):
         """Run the command. Return a TestFailure, or None."""
+        return asyncio.run(self.run_async())
+
+    async def run_async(self):
+        """Run the command. Return a TestFailure, or None."""
 
         def split_by_newlines(s):
             """Decode a string and split it by newlines only,
@@ -489,8 +491,8 @@ class TestRun(object):
 
         if self.config.verbose:
             print(self.subbed_command)
-        proc = runproc(self.subbed_command, env=self.env)
-        stdout, stderr = proc.communicate()
+        proc = await runproc_async(self.subbed_command, env=self.env)
+        stdout, stderr = await proc.communicate()
         # HACK: This is quite cheesy: POSIX specifies that sh should return 127 for a missing command.
         # It's also possible that it'll be returned in other situations,
         # most likely when the last command in a shell script doesn't exist.
@@ -670,6 +672,13 @@ class Checker(object):
 
 def check_file(input_file, name, subs, config, failure_handler, env=None):
     """Check a single file. Return a True on success, False on error."""
+    return asyncio.run(
+        check_file_async(input_file, name, subs, config, failure_handler, env=env)
+    )
+
+
+async def check_file_async(input_file, name, subs, config, failure_handler, env=None):
+    """Check a single file. Return a True on success, False on error."""
     success = True
     lines = Line.readfile(input_file, name)
     checker = Checker(name, lines)
@@ -677,8 +686,8 @@ def check_file(input_file, name, subs, config, failure_handler, env=None):
     # Run all the REQUIRES lines first,
     # if any of them fail it's a SKIP
     for reqcmd in checker.requirecmds:
-        proc = runproc(perform_substitution(reqcmd.args, subs), env=env)
-        proc.communicate()
+        proc = await runproc_async(perform_substitution(reqcmd.args, subs), env=env)
+        await proc.communicate()
         if proc.returncode > 0:
             return SKIP
 
@@ -687,7 +696,9 @@ def check_file(input_file, name, subs, config, failure_handler, env=None):
 
     # Only then run the RUN lines.
     for runcmd in checker.runcmds:
-        failure = TestRun(name, runcmd, checker, subs, config, env=env).run()
+        failure = await TestRun(
+            name, runcmd, checker, subs, config, env=env
+        ).run_async()
         if failure:
             failure_handler(failure)
             success = False
@@ -695,8 +706,12 @@ def check_file(input_file, name, subs, config, failure_handler, env=None):
 
 
 def check_path(path, subs, config, failure_handler, env=None):
+    return asyncio.run(check_path_async(path, subs, config, failure_handler, env=env))
+
+
+async def check_path_async(path, subs, config, failure_handler, env=None):
     with io.open(path, encoding="utf-8") as fd:
-        return check_file(fd, path, subs, config, failure_handler, env=env)
+        return await check_file_async(fd, path, subs, config, failure_handler, env=env)
 
 
 def parse_subs(subs):

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -87,7 +87,8 @@ def compile_test_helper(source_path: Path, binary_path: Path) -> None:
             source_path,
             "-o",
             binary_path,
-        ]
+        ],
+        check=True,
     )
 
 

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -196,7 +196,7 @@ def main():
         print(f"{passcount} / {passcount + failcount} passed ({skipcount} skipped)")
     if failcount:
         failstr = "\n    ".join(failed)
-        print(f"{RED}Failed tests{RESET}: \n    {failstr}")
+        print(f"{RED}Failed tests{RESET}:\n    {failstr}")
     if passcount == 0 and failcount == 0 and skipcount:
         return 125
     return 1 if failcount else 0

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -80,25 +80,15 @@ def makeenv(script_path: Path, home: Path):
     )
 
 
-def compile_test_helper(
-    cachedir: Optional[str], source_path: Path, binary_path: Path
-) -> None:
-    # Compile fish_test_helper if necessary.
-    # If we're run multiple times, allow keeping this around to save time.
-    if cachedir:
-        thp = Path(cachedir) / "fish_test_helper"
-        if not os.path.exists(thp):
-            subprocess.run(["cc", source_path, "-o", thp])
-        shutil.copy(thp, binary_path)
-    else:
-        subprocess.run(
-            [
-                "cc",
-                source_path,
-                "-o",
-                binary_path,
-            ]
-        )
+def compile_test_helper(source_path: Path, binary_path: Path) -> None:
+    subprocess.run(
+        [
+            "cc",
+            source_path,
+            "-o",
+            binary_path,
+        ]
+    )
 
 
 def main():
@@ -110,14 +100,6 @@ def main():
 
     argparser = argparse.ArgumentParser(
         description="test_driver: Run fish's test suite"
-    )
-    argparser.add_argument(
-        "-f",
-        "--cachedir",
-        type=str,
-        help="Path to keep outputs to speed up the next run",
-        action="store",
-        default=None,
     )
     argparser.add_argument("fish", nargs=1, help="Fish to test")
     argparser.add_argument("file", nargs="*", help="Tests to run")
@@ -176,7 +158,6 @@ def main():
         tmp_root = Path(tmp_root)
 
         compile_test_helper(
-            args.cachedir,
             script_path / "fish_test_helper.c",
             tmp_root / "fish_test_helper",
         )

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -174,22 +174,21 @@ def main():
             f"{arg.ljust(longest_test_name_length)}  {color}{result}{RESET}  {duration_str}{suffix_str}"
         )
 
-    tmp_root = tempfile.mkdtemp(prefix="fishtest-root-")
-
-    for f, arg in files:
-        match run_test(tmp_root, f, arg, script_path, args, def_subs, lconfig, fishdir):
-            case TestSkip(arg):
-                skipcount += 1
-                print_result(arg, "SKIPPED", BLUE)
-            case TestFail(arg, duration_ms, error_message):
-                failcount += 1
-                failed += [arg]
-                print_result(arg, "FAILED", RED, duration_ms, error_message)
-            case TestPass(arg, duration_ms):
-                passcount += 1
-                print_result(arg, "PASSED", GREEN, duration_ms)
-
-    shutil.rmtree(tmp_root)
+    with tempfile.TemporaryDirectory(prefix="fishtest-root-") as tmp_root:
+        for f, arg in files:
+            match run_test(
+                tmp_root, f, arg, script_path, args, def_subs, lconfig, fishdir
+            ):
+                case TestSkip(arg):
+                    skipcount += 1
+                    print_result(arg, "SKIPPED", BLUE)
+                case TestFail(arg, duration_ms, error_message):
+                    failcount += 1
+                    failed += [arg]
+                    print_result(arg, "FAILED", RED, duration_ms, error_message)
+                case TestPass(arg, duration_ms):
+                    passcount += 1
+                    print_result(arg, "PASSED", GREEN, duration_ms)
 
     if passcount + failcount + skipcount > 1:
         print(f"{passcount} / {passcount + failcount} passed ({skipcount} skipped)")


### PR DESCRIPTION
This uses Python's `asyncio` to run tests in parallel, which speeds up test
execution significantly.

The timeout is removed. It would be possible to add a timeout to
`asyncio.as_completed()` if we want that.

On top of #11560.