### PR TITLE
Build before running `style.fish`

### DIFF
--- a/build_tools/check.sh
+++ b/build_tools/check.sh
@@ -8,9 +8,8 @@ RUSTDOCFLAGS='-D warnings'; export RUSTDOCFLAGS
 repo_root="$(dirname "$0")/.."
 build_dir="$repo_root/target/debug"
 
-PATH="$build_dir:$PATH" "$repo_root/build_tools/style.fish" --all --check
-
 cargo build --workspace --all-targets
+PATH="$build_dir:$PATH" "$repo_root/build_tools/style.fish" --all --check
 cargo clippy --workspace --all-targets
 cargo test --no-default-features --workspace --all-targets
 cargo test --doc --workspace


### PR DESCRIPTION
This makes the latest versions of fish_indent (and fish) available to `style.fish`.

Inspired by https://github.com/fish-shell/fish-shell/pull/11550#discussion_r2133674329.