### PR TITLE
Improve fish_git_prompt stashes detection.

### DIFF
--- a/share/functions/fish_git_prompt.fish
+++ b/share/functions/fish_git_prompt.fish
@@ -315,7 +315,7 @@ function fish_git_prompt --description "Prompt function for Git"
                 # *compute* the informative status, we might still count the stash.
                 if contains -- "$__fish_git_prompt_show_informative_status" yes true 1
                     set stashstate (count < $git_dir/logs/refs/stash)
-                else
+                else if test -s $git_dir/logs/refs/stash
                     set stashstate 1
                 end
             end


### PR DESCRIPTION
## Description

When the informative status is disabled, the stashstate variable was set to 1 if the $git_dir/logs/refs/stash file existed and was readable, even if the file itself was empty (i.e., no stashes). Now the stashstate variable is set only if the file is NOT empty.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
