### PR TITLE
Support incrementing/decrementing the number below the cursor

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -74635,6 +74635,9 @@ msgstr ""
 msgid "increase verbosity level by one"
 msgstr ""
 
+msgid "increment or decrement the number below the cursor"
+msgstr "Erhöhe oder verringere die Zahl unter dem Cursor"
+
 msgid "incremental mode"
 msgstr ""
 
@@ -79188,6 +79191,9 @@ msgstr ""
 
 msgid "~ expansion"
 msgstr ""
+
+#~ msgid "increment or decrement a number"
+#~ msgstr "Erhöhe oder verringere eine Zahl"
 
 #~ msgid "builtin\n"
 #~ msgstr "Eingebauter Befehl\n"

--- a/po/en.po
+++ b/po/en.po
@@ -74631,6 +74631,9 @@ msgstr ""
 msgid "increase verbosity level by one"
 msgstr ""
 
+msgid "increment or decrement the number below the cursor"
+msgstr ""
+
 msgid "incremental mode"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -74732,6 +74732,9 @@ msgstr ""
 msgid "increase verbosity level by one"
 msgstr "Incrémenter le niveau de verbosité"
 
+msgid "increment or decrement the number below the cursor"
+msgstr ""
+
 msgid "incremental mode"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -74627,6 +74627,9 @@ msgstr ""
 msgid "increase verbosity level by one"
 msgstr ""
 
+msgid "increment or decrement the number below the cursor"
+msgstr ""
+
 msgid "incremental mode"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -74654,6 +74654,9 @@ msgstr ""
 msgid "increase verbosity level by one"
 msgstr ""
 
+msgid "increment or decrement the number below the cursor"
+msgstr ""
+
 msgid "incremental mode"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -74630,6 +74630,9 @@ msgstr ""
 msgid "increase verbosity level by one"
 msgstr ""
 
+msgid "increment or decrement the number below the cursor"
+msgstr ""
+
 msgid "incremental mode"
 msgstr ""
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -74630,6 +74630,9 @@ msgstr "增加动词"
 msgid "increase verbosity level by one"
 msgstr "将动词水平增加一个"
 
+msgid "increment or decrement the number below the cursor"
+msgstr ""
+
 msgid "incremental mode"
 msgstr "递增模式"
 

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -1,3 +1,80 @@
+alias fish_vi_dec 'fish_vi_inc_dec dec'
+alias fish_vi_inc 'fish_vi_inc_dec inc'
+
+# TODO: Currently we do not support hexadecimal and octal values.
+function fish_vi_inc_dec --description 'increment or decrement the number below the cursor'
+  # The cursor is zero based, but all string functions assume 1 to be
+  # the lowest index. Adjust accordingly.
+  set --local cursor (math -- (commandline --cursor) + 1)
+  set --local line (commandline --current-buffer | string collect)
+
+  set --local candidate (string sub --start $cursor -- $line | string collect)
+  if set --local just_found (string match --regex '^-?[0-9]+' -- $candidate)
+    # Search from the current cursor position backwards for as long as we
+    # can identify a valid number.
+    set --function found $just_found
+    set --function found_at $cursor
+    set --local end (math -- $cursor + (string length -- $found) - 1)
+
+    set i (math -- $cursor - 1)
+    while [ $i -ge 1 ]
+      set candidate (string sub --start $i --end $end -- $line)
+      if set just_found (string match --regex '^-?[0-9]+$' -- $candidate)
+        set found $just_found
+        set found_at $i
+        # We found a candidate, but continue to make sure that we captured
+        # the complete number and not just part of it.
+      else
+        # We have already found a number earlier. Work with that.
+        break
+      end
+
+      set i (math -- $i - 1)
+    end
+  else
+    # We didn't find a match below the cursor. Mirror Vim behavior by
+    # checking ahead as well.
+    for i in (seq (math -- $cursor + 1) (math -- (string length -- $line) - 1))
+      set candidate (string sub --start $i -- $line | string collect)
+
+      if set just_found (string match --regex '^-?[0-9]+' -- $candidate)
+        set found $just_found
+        set found_at $i
+        break
+      end
+    end
+
+    if [ -z "$found" ]
+      return
+    end
+  end
+
+  if [ $argv = 'inc' ]
+    set number (math -- $found + 1)
+  else if [ $argv = 'dec' ]
+    set number (math -- $found - 1)
+  end
+
+  set --local number_abs (string trim --left --chars=- -- $number)
+  set --local signed $status
+  set --local found_abs (string trim --left --chars=- -- $found)
+  set number (string pad --char 0 --width (string length -- $found_abs) -- $number_abs)
+  if test $signed -eq 0
+    set number "-$number"
+  end
+
+  # `string sub` may bitch about `--end` being zero if `found_at` is 1.
+  # So ignore errors here...
+  set --local before (string sub --end (math -- $found_at - 1) -- $line 2> /dev/null | string collect)
+  set --local after (string sub --start (math -- $found_at + (string length -- $found)) -- $line | string collect)
+  commandline --replace -- "$before$number$after"
+  # Need to subtract two here because 1) cursor is zero based 2)
+  # `found_at` is the index of the first character of the match, but we
+  # want the one before that.
+  commandline --cursor -- (math -- $found_at + (string length -- $number) - 2)
+  commandline --function -- repaint
+end
+
 function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     if contains -- -h $argv
         or contains -- --help $argv
@@ -270,6 +347,12 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     # but this binding just move cursor backward, not delete the changes
     bind -s --preset -M replace backspace backward-char
     bind -s --preset -M replace shift-backspace backward-char
+
+    #
+    # Increment or decrement number below the cursor with ctrl+x ctrl+a
+    #
+    bind -s --preset -M default ctrl-a fish_vi_inc
+    bind -s --preset -M default ctrl-x fish_vi_dec
 
     #
     # visual mode

--- a/src/builtins/commandline.rs
+++ b/src/builtins/commandline.rs
@@ -636,19 +636,16 @@ pub fn commandline(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr])
         transient = parser.libdata().transient_commandline.clone().unwrap();
         current_buffer = &transient;
         current_cursor_pos = transient.len();
-    } else if rstate.initialized {
+    } else if is_interactive_session() {
         current_buffer = &rstate.text;
         current_cursor_pos = rstate.cursor_pos;
     } else {
-        // There is no command line, either because we are not interactive, or because we are
-        // interactive and are still reading init files (in which case we silently ignore this).
-        if !is_interactive_session() {
-            streams.err.append(cmd);
-            streams
-                .err
-                .append(L!(": Can not set commandline in non-interactive mode\n"));
-            builtin_print_error_trailer(parser, streams.err, cmd);
-        }
+        // There is no command line because we are not interactive.
+        streams.err.append(cmd);
+        streams
+            .err
+            .append(L!(": Can not set commandline in non-interactive mode\n"));
+        builtin_print_error_trailer(parser, streams.err, cmd);
         return Err(STATUS_CMD_ERROR);
     }
 

--- a/tests/checks/vi.fish
+++ b/tests/checks/vi.fish
@@ -1,0 +1,115 @@
+# RUN: %fish --interactive %s
+
+fish_vi_key_bindings
+
+commandline '1'; commandline --cursor 0; fish_vi_dec
+commandline --current-buffer
+# CHECK: 0
+
+commandline '0'; commandline --cursor 0; fish_vi_dec
+commandline --current-buffer
+# CHECK: -1
+
+commandline -- '-1'; commandline --cursor 0; fish_vi_dec
+commandline --current-buffer
+# CHECK: -2
+
+commandline -- '-1'; commandline --cursor 0; fish_vi_inc
+commandline --current-buffer
+# CHECK: 0
+
+commandline '0'; commandline --cursor 0; fish_vi_inc
+commandline --current-buffer
+# CHECK: 1
+
+commandline '123'; commandline --cursor 0; fish_vi_inc
+commandline --current-buffer
+# CHECK: 124
+
+commandline '123'; commandline --cursor 0; fish_vi_dec
+commandline --current-buffer
+# CHECK: 122
+
+commandline '123'; commandline --cursor 1; fish_vi_inc
+commandline --current-buffer
+# CHECK: 124
+
+commandline '123'; commandline --cursor 1; fish_vi_dec
+commandline --current-buffer
+# CHECK: 122
+
+commandline '123'; commandline --cursor 2; fish_vi_inc
+commandline --current-buffer
+# CHECK: 124
+
+commandline '123'; commandline --cursor 2; fish_vi_dec
+commandline --current-buffer
+# CHECK: 122
+
+commandline 'abc123'; commandline --cursor 1; fish_vi_inc
+commandline --current-buffer
+# CHECK: abc124
+
+commandline 'abc123'; commandline --cursor 1; fish_vi_dec
+commandline --current-buffer
+# CHECK: abc122
+
+commandline 'abc123def'; commandline --cursor 1; fish_vi_inc
+commandline --current-buffer
+# CHECK: abc124def
+
+commandline 'abc123def'; commandline --cursor 1; fish_vi_dec
+commandline --current-buffer
+# CHECK: abc122def
+
+commandline 'abc123def'; commandline --cursor 5; fish_vi_inc
+commandline --current-buffer
+# CHECK: abc124def
+
+commandline 'abc123def'; commandline --cursor 5; fish_vi_dec
+commandline --current-buffer
+# CHECK: abc122def
+
+commandline 'abc123def'; commandline --cursor 6; fish_vi_inc
+commandline --current-buffer
+# CHECK: abc123def
+
+commandline 'abc123def'; commandline --cursor 6; fish_vi_dec
+commandline --current-buffer
+# CHECK: abc123def
+
+commandline 'abc99def'; commandline --cursor 1; fish_vi_inc
+commandline --current-buffer
+# CHECK: abc100def
+
+commandline 'abc99def'; commandline --cursor 1; fish_vi_dec
+commandline --current-buffer
+# CHECK: abc98def
+
+commandline 'abc-99def'; commandline --cursor 1; fish_vi_inc
+commandline --current-buffer
+# CHECK: abc-98def
+
+commandline 'abc-99def'; commandline --cursor 1; fish_vi_dec
+commandline --current-buffer
+# CHECK: abc-100def
+
+commandline '2022-04-09'; commandline --cursor 7; fish_vi_inc
+commandline --current-buffer
+# CHECK: 2022-04-08
+
+commandline 'to 2022-04-09'; commandline --cursor 4; fish_vi_inc
+commandline --current-buffer
+# CHECK: to 2023-04-09
+
+commandline 'to 2022-04-09'; commandline --cursor 4; fish_vi_dec
+commandline --current-buffer
+# CHECK: to 2021-04-09
+
+commandline 'to 2022-04-09'; commandline --cursor 11; fish_vi_dec
+commandline --current-buffer
+# CHECK: to 2022-04-10
+
+commandline 'to 2022-04-09'; commandline --cursor 11; fish_vi_inc
+commandline --current-buffer
+# CHECK: to 2022-04-08


### PR DESCRIPTION
Vim supports incrementing & decrementing the number below the cursor (or after it) via Ctrl-a and Ctrl-x, respectively. Given fish's Vi mode support, it makes sense to provide similar functionality when working on the command line, to provide a more natural environment for Vim users. With this change we add the necessary functionality.

Closes: #8320 

I tested this via https://github.com/d-e-s-o/fish-shell/commit/23d42a9812eb341b83840a9b418b448c396bb7b1 (and had it running for years), but the unit tests seem to require `fish` modification to work.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
