### PR TITLE
Clear gettext cache on locale change

### DIFF
--- a/src/env_dispatch.rs
+++ b/src/env_dispatch.rs
@@ -613,6 +613,7 @@ fn init_locale(vars: &EnvStack) {
             unsafe {
                 _nl_msg_cat_cntr += 1;
             }
+            crate::wutil::gettext::wgettext_clear_cache();
         }
     }
 }


### PR DESCRIPTION
This prevents printing cached localizations which do not match the current locale.