### PR TITLE
Revert attempt to support elfpatching LOCALEDIR

### DIFF
--- a/src/env/config_paths.rs
+++ b/src/env/config_paths.rs
@@ -26,19 +26,13 @@ pub static CONFIG_PATHS: Lazy<ConfigPaths> = Lazy::new(|| {
         std::env::current_exe().unwrap_or(argv0)
     };
     let argv0 = argv0.canonicalize().unwrap_or(argv0);
-    determine_config_directory_paths(argv0)
-});
-
-fn determine_config_directory_paths(argv0: impl AsRef<Path>) -> ConfigPaths {
-    // PORTING: why is this not just an associated method on ConfigPaths?
-
     let mut paths = ConfigPaths::default();
     let mut done = false;
-    let exec_path = get_executable_path(argv0.as_ref());
+    let exec_path = get_executable_path(&argv0);
     if let Ok(exec_path) = exec_path.canonicalize() {
         FLOG!(
             config,
-            format!("exec_path: {:?}, argv[0]: {:?}", exec_path, argv0.as_ref())
+            format!("exec_path: {:?}, argv[0]: {:?}", exec_path, &argv0)
         );
         // TODO: we should determine program_name from argv0 somewhere in this file
 
@@ -155,7 +149,7 @@ fn determine_config_directory_paths(argv0: impl AsRef<Path>) -> ConfigPaths {
     );
 
     paths
-}
+});
 
 /// Get the absolute path to the fish executable itself
 pub fn get_executable_path(argv0: impl AsRef<Path>) -> PathBuf {

--- a/src/env/config_paths.rs
+++ b/src/env/config_paths.rs
@@ -13,6 +13,7 @@ const DOC_DIR: &str = env!("DOCDIR");
 const DATA_DIR: &str = env!("DATADIR");
 const DATA_DIR_SUBDIR: &str = env!("DATADIR_SUBDIR");
 const SYSCONF_DIR: &str = env!("SYSCONFDIR");
+const LOCALE_DIR: &str = env!("LOCALEDIR");
 const BIN_DIR: &str = env!("BINDIR");
 
 pub static CONFIG_PATHS: Lazy<ConfigPaths> = Lazy::new(|| {
@@ -114,6 +115,11 @@ pub static CONFIG_PATHS: Lazy<ConfigPaths> = Lazy::new(|| {
         } else {
             Some(PathBuf::from(BIN_DIR))
         };
+        let locale = if cfg!(feature = "embed-data") {
+            None
+        } else {
+            Some(PathBuf::from(LOCALE_DIR))
+        };
 
         FLOG!(config, "Using compiled in paths:");
         paths = ConfigPaths {
@@ -121,7 +127,7 @@ pub static CONFIG_PATHS: Lazy<ConfigPaths> = Lazy::new(|| {
             sysconf: PathBuf::from(SYSCONF_DIR).join("fish"),
             doc: DOC_DIR.into(),
             bin,
-            locale: data.map(|x| x.join("share")),
+            locale,
         }
     }
 

--- a/src/wutil/gettext.rs
+++ b/src/wutil/gettext.rs
@@ -52,9 +52,7 @@ fn wgettext_really_init() {
         return;
     };
     let package_name = CString::new(PACKAGE_NAME).unwrap();
-    // This contains `datadir`; which when replaced to make the binary relocatable,
-    // causes null bytes at the end of the string.
-    let localedir = CString::new(localepath.display().to_string()).unwrap();
+    let localedir = CString::new(localepath).unwrap();
     fish_bindtextdomain(&package_name, &localedir);
     fish_textdomain(&package_name);
 }


### PR DESCRIPTION
cc @hameerabbasi

Commit bf65b9e3a74 (Change `gettext` paths to be relocatable (#11195),
2025-03-30) is difficult to follow because it combines code movement with two
behavior changes.  The first behavior change was fixed up in the parent commit;
the second behavior change made us tolerate trailing NUL bytes in LOCALEDIR.
This was motivated because conda wants to use binary patching to change
the effective prefix at runtime, presumably so the user can move around the
"fish" binary arbitraily.

I don't understand why this is necessary.  Can't they use a symlink to
fish? Moving that should always work.  Alternatively, moving the entire
directory tree where fish is installed also works (see items 2/3 in the
parent commit).

I also don't understand how this patch can work given that it only applies
to LOCALEDIR. There are a few other paths such as share/ defined in
src/env/config_paths.rs.

Evidently it doesn't, see
https://matrix.to/#/!YLTeaulxSDauOOxBoR:matrix.org/$O68_ar8BsbXQ_Lq0TQbJQot75P5k27gkFMfi9R5nc94

Unless someone can help (at least by testing and reporting any problems),
remove this special treatment of LOCALEDIR, for consistency.

Alternatively, we could revert bf65b9e3a74 entirely (and redo the parts we
want to keep).
