### PR TITLE
Call `cursor_position()` lazily

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1553,7 +1553,7 @@ impl<'a> Reader<'a> {
         };
 
         let focused_on_pager = self.active_edit_line_tag() == EditableLineTag::SearchField;
-        let pager_search_field_position = focused_on_pager.then_some(self.pager.cursor_position());
+        let pager_search_field_position = focused_on_pager.then(|| self.pager.cursor_position());
         let last = &self.rendered_layout;
         check(self.force_exec_prompt_and_repaint, "forced")
             || check(self.command_line.text() != last.text, "text")
@@ -1603,8 +1603,7 @@ impl<'a> Reader<'a> {
         result.colors = self.command_line.colors().to_vec();
         assert!(result.text.len() == result.colors.len());
         result.position = self.command_line.position();
-        result.pager_search_field_position =
-            focused_on_pager.then_some(self.pager.cursor_position());
+        result.pager_search_field_position = focused_on_pager.then(|| self.pager.cursor_position());
         result.selection = self.selection;
         result.history_search_range = self.history_search.search_range_if_active();
         result.autosuggestion = self.autosuggestion.text.clone();


### PR DESCRIPTION
This function does not need to run when the pager is not focused. Calling it lazily eliminates the overhead of calling it when it is not needed. This code runs on each keypress when entering a command, so it makes sense to keep it as lean as possible. (At the very least it avoids spam when trying to debug/analyze gettext behavior.)