### PR TITLE
Figure out what to clean up on SIGTERM

### DIFF
--- a/src/input_common.rs
+++ b/src/input_common.rs
@@ -732,7 +732,7 @@ pub(crate) fn terminal_protocols_disable_ifn() {
             }
         })
     });
-    let mut out = Outputter::stdoutput().borrow_mut();
+    let mut out = Outputter::new_from_fd(libc::STDOUT_FILENO);
     if BRACKETED_PASTE.load(Ordering::Acquire) {
         out.write_command(DecrstBracketedPaste);
         if IS_TMUX.load() {

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -4,6 +4,7 @@ use std::num::NonZeroI32;
 use crate::common::exit_without_destructors;
 use crate::event::{enqueue_signal, is_signal_observed};
 use crate::nix::getpid;
+use crate::panic::AT_EXIT;
 use crate::reader::{reader_handle_sigint, reader_sighup, safe_restore_term_mode};
 use crate::termsize::TermsizeContainer;
 use crate::topic_monitor::{topic_monitor_principal, Generation, GenerationsList, Topic};
@@ -89,7 +90,9 @@ extern "C" fn fish_signal_handler(
         libc::SIGTERM => {
             // Handle sigterm. The only thing we do is restore the front process ID, then die.
             if !observed {
-                safe_restore_term_mode();
+                if let Some(at_exit) = AT_EXIT.get() {
+                    (at_exit)();
+                }
                 // Safety: signal() and raise() are async-signal-safe.
                 unsafe {
                     libc::signal(libc::SIGTERM, libc::SIG_DFL);

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -441,7 +441,7 @@ pub struct Outputter {
 impl Outputter {
     /// Construct an outputter which outputs to a given fd.
     /// If the fd is negative, the outputter will buffer its output.
-    const fn new_from_fd(fd: RawFd) -> Self {
+    pub const fn new_from_fd(fd: RawFd) -> Self {
         Self {
             contents: Vec::new(),
             buffer_count: 0,


### PR DESCRIPTION
Commit 941701da3d8 (Restore some async-signal discipline to SIGTERM,
2025-06-15) removed some SIGTERM cleanup.  If think the function to disable
terminal protocols (like the kitty keyboard protocol) is async-signal-safe
though I suppose there is an avoidable panic when `Outputter::stdoutput()`
is already borrowed. Fix that.

We should figure out what the SIGTERM handler should do, and if it's not needed
remove things like `FLOG_SAFE!(term_protocols, "Disabling extended keys");`.

Also maybe backport the fix from 941701da3d8.
