### PR TITLE
Do not `mmap` with len 0

### DIFF
--- a/src/history/file.rs
+++ b/src/history/file.rs
@@ -128,6 +128,12 @@ impl HistoryFileContents {
                 ))
             }
         };
+        if len == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "History file is empty. Cannot create memory mapping with length 0.",
+            ));
+        }
         let map_anon = |mut file: &File, len: usize| -> std::io::Result<MmapRegion> {
             let mut region = MmapRegion::map_anon(len)?;
             // If we mapped anonymous memory, we have to read from the file.


### PR DESCRIPTION
`mmap` should fail when the length argument is 0. Checking this in advance allows returning early, without performing unnecessary syscalls.

This also fixes an issue observed on FreeBSD 13.2 where `mmap` does not always fail when the length is 0, resulting in the `assert!(len > 0)` in `MmapRegion::new` failing.

Fixes https://github.com/fish-shell/fish-shell/issues/11595