### PR TITLE
Fix docker-based tests, drop their usage of CMake

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -26,7 +26,7 @@ linux_task:
         - lscpu || true
         - (cat /proc/meminfo | grep MemTotal) || true
         - mkdir build && cd build
-        - cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCTEST_PARALLEL_LEVEL=6 ..
+        - FISH_TEST_MAX_CONCURRENCY=6 cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug ..
         - ninja -j 6 fish
         - ninja fish_run_tests
     only_if: $CIRRUS_REPO_OWNER == 'fish-shell'
@@ -45,7 +45,7 @@ linux_arm_task:
         - lscpu || true
         - (cat /proc/meminfo | grep MemTotal) || true
         - mkdir build && cd build
-        - cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCTEST_PARALLEL_LEVEL=6 ..
+        - FISH_TEST_MAX_CONCURRENCY=6 cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug ..
         - ninja -j 6 fish
         - file ./fish
         - ninja fish_run_tests
@@ -54,17 +54,11 @@ linux_arm_task:
 
 freebsd_task:
     matrix:
-        # - name: FreeBSD 14
-        #   freebsd_instance:
-        #       image_family: freebsd-14-0-snap
-        - name: FreeBSD 13
+        - name: FreeBSD 14
           freebsd_instance:
-              image: freebsd-13-2-release-amd64
-        # - name: FreeBSD 12.3
-        #   freebsd_instance:
-        #       image: freebsd-12-3-release-amd64
+              image: freebsd-14-3-release-amd64-ufs
     tests_script:
-        - pkg install -y cmake-core devel/pcre2 devel/ninja misc/py-pexpect git-lite terminfo-db
+        - pkg install -y cmake-core devel/pcre2 devel/ninja lang/rust misc/py-pexpect git-lite
         # libclang.so is a required build dependency for rust-c++ ffi bridge
         - pkg install -y llvm
         # BSDs have the following behavior: root may open or access files even if
@@ -77,15 +71,7 @@ freebsd_task:
         - mkdir build && cd build
         - chown -R fish-user ..
         - sudo -u fish-user -s whoami
-        # FreeBSD's pkg currently has rust 1.66.0 while we need rust 1.70.0+. Use rustup to install
-        # the latest, but note that it only installs rust per-user.
-        - sudo -u fish-user -s fetch -qo - https://sh.rustup.rs > rustup.sh
-        - sudo -u fish-user -s sh ./rustup.sh -y --profile=minimal
-        # `sudo -s ...` does not invoke a login shell so we need a workaround to make sure the
-        # rustup environment is configured for subsequent `sudo -s ...` commands.
-        # For some reason, this doesn't do the job:
-        # - sudo -u fish-user sh -c 'echo source \$HOME/.cargo/env >> $HOME/.cshrc'
-        - sudo -u fish-user -s cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCTEST_PARALLEL_LEVEL=1 ..
-        - sudo -u fish-user sh -c '. $HOME/.cargo/env; ninja -j 6 fish'
-        - sudo -u fish-user sh -c '. $HOME/.cargo/env; ninja fish_run_tests'
+        - sudo -u fish-user -s FISH_TEST_MAX_CONCURRENCY=1 cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug ..
+        - sudo -u fish-user -s ninja -j 6 fish
+        - sudo -u fish-user -s ninja fish_run_tests
     only_if: $CIRRUS_REPO_OWNER == 'fish-shell'

--- a/.editorconfig
+++ b/.editorconfig
@@ -15,8 +15,8 @@ indent_style = tab
 [*.{md,rst}]
 trim_trailing_whitespace = false
 
-[*.{sh,ac}]
-indent_size = 2
+[*.sh]
+indent_size = 4
 
 [Dockerfile]
 indent_size = 2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: make fish_run_tests
 on: [push, pull_request]
 
 env:
-  CTEST_PARALLEL_LEVEL: "4"
+  FISH_TEST_MAX_CONCURRENCY: "4"
   CMAKE_BUILD_PARALLEL_LEVEL: "4"
 
 permissions:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 env:
   FISH_TEST_MAX_CONCURRENCY: "4"
   CMAKE_BUILD_PARALLEL_LEVEL: "4"
+  RUST_BACKTRACE: "1"
 
 permissions:
   contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,6 @@ Desktop.ini
 Thumbs.db
 ehthumbs.db
 
-po/template.po
 *.mo
 .directory
 .fuse_hidden*

--- a/build.rs
+++ b/build.rs
@@ -46,7 +46,7 @@ fn main() {
 
     std::env::set_var("FISH_BUILD_VERSION", version);
 
-    let targetman = cargo_target_dir.join("man");
+    let targetman = cargo_target_dir.join("fish-man");
 
     #[cfg(feature = "embed-data")]
     #[cfg(not(clippy))]

--- a/build.rs
+++ b/build.rs
@@ -25,14 +25,8 @@ fn main() {
         .unwrap_or(canonicalize(MANIFEST_DIR).join("target"));
 
     // FISH_BUILD_DIR is set by CMake, if we are using it.
-    // OUT_DIR is set by Cargo when the build script is running (not compiling)
-    let default_build_dir = env::var("OUT_DIR").unwrap();
-    let build_dir = option_env!("FISH_BUILD_DIR").unwrap_or(&default_build_dir);
-    let build_dir = canonicalize_str(build_dir);
-    rsconf::set_env_value("FISH_BUILD_DIR", &build_dir);
-
     rsconf::set_env_value(
-        "FISH_BUILD_OUTPUT_DIR",
+        "FISH_BUILD_DIR",
         option_env!("FISH_BUILD_DIR").unwrap_or(cargo_target_dir.to_str().unwrap()),
     );
 

--- a/build.rs
+++ b/build.rs
@@ -20,6 +20,10 @@ fn main() {
     // Add our default to enable tools that don't go through CMake, like "cargo test" and the
     // language server.
 
+    let cargo_target_dir: PathBuf = option_env!("CARGO_TARGET_DIR")
+        .map(canonicalize)
+        .unwrap_or(canonicalize(MANIFEST_DIR).join("target"));
+
     // FISH_BUILD_DIR is set by CMake, if we are using it.
     // OUT_DIR is set by Cargo when the build script is running (not compiling)
     let default_build_dir = env::var("OUT_DIR").unwrap();
@@ -42,8 +46,7 @@ fn main() {
 
     std::env::set_var("FISH_BUILD_VERSION", version);
 
-    let cman = canonicalize(MANIFEST_DIR);
-    let targetman = cman.as_path().join("target").join("man");
+    let targetman = cargo_target_dir.join("man");
 
     #[cfg(feature = "embed-data")]
     #[cfg(not(clippy))]

--- a/build.rs
+++ b/build.rs
@@ -12,6 +12,8 @@ fn canonicalize_str(path: &str) -> String {
     canonicalize(path).to_str().unwrap().to_owned()
 }
 
+const MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
+
 fn main() {
     setup_paths();
 
@@ -26,10 +28,7 @@ fn main() {
     rsconf::set_env_value("FISH_BUILD_DIR", &build_dir);
     // We need to canonicalize (i.e. realpath) the manifest dir because we want to be able to
     // compare it directly as a string at runtime.
-    rsconf::set_env_value(
-        "CARGO_MANIFEST_DIR",
-        &canonicalize_str(env!("CARGO_MANIFEST_DIR")),
-    );
+    rsconf::set_env_value("CARGO_MANIFEST_DIR", &canonicalize_str(MANIFEST_DIR));
 
     // Some build info
     rsconf::set_env_value("BUILD_TARGET_TRIPLE", &env::var("TARGET").unwrap());
@@ -43,7 +42,7 @@ fn main() {
 
     std::env::set_var("FISH_BUILD_VERSION", version);
 
-    let cman = canonicalize(env!("CARGO_MANIFEST_DIR"));
+    let cman = canonicalize(MANIFEST_DIR);
     let targetman = cman.as_path().join("target").join("man");
 
     #[cfg(feature = "embed-data")]
@@ -350,8 +349,8 @@ fn get_version(src_dir: &Path) -> String {
     // or because it refused (safe.directory applies to `git describe`!)
     // So we read the SHA ourselves.
     fn get_git_hash() -> Result<String, Box<dyn std::error::Error>> {
-        let gitdir = Path::new(env!("CARGO_MANIFEST_DIR")).join(".git");
-        let jjdir = Path::new(env!("CARGO_MANIFEST_DIR")).join(".jj");
+        let gitdir = Path::new(MANIFEST_DIR).join(".git");
+        let jjdir = Path::new(MANIFEST_DIR).join(".jj");
         let commit_id = if gitdir.exists() {
             // .git/HEAD contains ref: refs/heads/branch
             let headpath = gitdir.join("HEAD");
@@ -396,7 +395,7 @@ fn build_man(build_dir: &Path) {
     use std::process::Command;
     let mandir = build_dir;
     let sec1dir = mandir.join("man1");
-    let docsrc_path = canonicalize(env!("CARGO_MANIFEST_DIR")).join("doc_src");
+    let docsrc_path = canonicalize(MANIFEST_DIR).join("doc_src");
     let docsrc = docsrc_path.to_str().unwrap();
     let args = &[
         "-j",

--- a/build.rs
+++ b/build.rs
@@ -65,10 +65,7 @@ fn main() {
 
     rsconf::rebuild_if_env_changed("FISH_GETTEXT_EXTRACTION_FILE");
 
-    cc::Build::new()
-        .file("src/libc.c")
-        .include(build_dir)
-        .compile("flibc.a");
+    cc::Build::new().file("src/libc.c").compile("flibc.a");
 
     let mut build = cc::Build::new();
     // Add to the default library search path

--- a/build.rs
+++ b/build.rs
@@ -5,10 +5,10 @@ use std::env;
 use std::error::Error;
 use std::path::{Path, PathBuf};
 
-fn canonicalize(path: &str) -> PathBuf {
+fn canonicalize<P: AsRef<Path>>(path: P) -> PathBuf {
     std::fs::canonicalize(path).unwrap()
 }
-fn canonicalize_str(path: &str) -> String {
+fn canonicalize_str<P: AsRef<Path>>(path: P) -> String {
     canonicalize(path).to_str().unwrap().to_owned()
 }
 
@@ -30,6 +30,12 @@ fn main() {
     let build_dir = option_env!("FISH_BUILD_DIR").unwrap_or(&default_build_dir);
     let build_dir = canonicalize_str(build_dir);
     rsconf::set_env_value("FISH_BUILD_DIR", &build_dir);
+
+    rsconf::set_env_value(
+        "FISH_BUILD_OUTPUT_DIR",
+        option_env!("FISH_BUILD_DIR").unwrap_or(cargo_target_dir.to_str().unwrap()),
+    );
+
     // We need to canonicalize (i.e. realpath) the manifest dir because we want to be able to
     // compare it directly as a string at runtime.
     rsconf::set_env_value("CARGO_MANIFEST_DIR", &canonicalize_str(MANIFEST_DIR));

--- a/build_tools/check.sh
+++ b/build_tools/check.sh
@@ -2,6 +2,24 @@
 
 set -ex
 
+lint=true
+if [ "$FISH_CHECK_LINT" = false ]; then
+    lint=false
+fi
+
+cargo_args=$FISH_CHECK_CARGO_ARGS
+target_triple=$FISH_CHECK_TARGET_TRIPLE
+if [ -n "$target_triple" ]; then
+    cargo_args="$cargo_args --target=$FISH_CHECK_TARGET_TRIPLE"
+fi
+
+cargo() {
+    subcmd=$1
+    shift
+    # shellcheck disable=2086
+    command cargo "$subcmd" $cargo_args "$@"
+}
+
 cleanup () {
     if [ -n "$template_file" ] && [ -e "$template_file" ]; then
         rm "$template_file"
@@ -10,17 +28,23 @@ cleanup () {
 
 trap cleanup EXIT INT TERM HUP
 
-RUSTFLAGS='-D warnings'; export RUSTFLAGS
-RUSTDOCFLAGS='-D warnings'; export RUSTDOCFLAGS
+if $lint; then
+    export RUSTFLAGS='-D warnings'
+    export RUSTDOCFLAGS='-D warnings'
+fi
 
 repo_root="$(dirname "$0")/.."
-build_dir="$repo_root/target/debug"
+build_dir="${CARGO_TARGET_DIR:-$repo_root/target}/${target_triple}/debug"
 
 template_file=$(mktemp)
 FISH_GETTEXT_EXTRACTION_FILE=$template_file cargo build --workspace --all-targets
-PATH="$build_dir:$PATH" "$repo_root/build_tools/style.fish" --all --check
-cargo clippy --workspace --all-targets
+if $lint; then
+    PATH="$build_dir:$PATH" "$repo_root/build_tools/style.fish" --all --check
+    cargo clippy --workspace --all-targets
+fi
 cargo test --no-default-features --workspace --all-targets
 cargo test --doc --workspace
-cargo doc --workspace
+if $lint; then
+    cargo doc --workspace
+fi
 FISH_GETTEXT_EXTRACTION_FILE=$template_file "$repo_root/tests/test_driver.py" "$build_dir"

--- a/build_tools/check.sh
+++ b/build_tools/check.sh
@@ -29,8 +29,8 @@ cleanup () {
 trap cleanup EXIT INT TERM HUP
 
 if $lint; then
-    export RUSTFLAGS='-D warnings'
-    export RUSTDOCFLAGS='-D warnings'
+    export RUSTFLAGS="${RUSTFLAGS} --deny=warnings"
+    export RUSTDOCFLAGS="${RUSTDOCFLAGS} --deny=warnings"
 fi
 
 repo_root="$(dirname "$0")/.."

--- a/build_tools/check.sh
+++ b/build_tools/check.sh
@@ -3,9 +3,9 @@
 set -ex
 
 cleanup () {
-  if [ -n "$template_file" ] && [ -e "$template_file" ]; then
-    rm "$template_file"
-  fi
+    if [ -n "$template_file" ] && [ -e "$template_file" ]; then
+        rm "$template_file"
+    fi
 }
 
 trap cleanup EXIT INT TERM HUP

--- a/build_tools/check.sh
+++ b/build_tools/check.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+{
 set -ex
 
 lint=true
@@ -48,3 +49,6 @@ if $lint; then
     cargo doc --workspace
 fi
 FISH_GETTEXT_EXTRACTION_FILE=$template_file "$repo_root/tests/test_driver.py" "$build_dir"
+
+exit
+}

--- a/build_tools/make_pkg.sh
+++ b/build_tools/make_pkg.sh
@@ -3,18 +3,18 @@
 # Script to produce an OS X installer .pkg and .app(.zip)
 
 usage() {
-  echo "Build macOS packages, optionally signing and notarizing them."
-  echo "Usage: $0 options"
-  echo "Options:"
-  echo "  -s                            Enables code signing"
-  echo "  -f <APP_KEY.p12>              Path to .p12 file for application signing"
-  echo "  -i <INSTALLER_KEY.p12>        Path to .p12 file for installer signing"
-  echo "  -p <PASSWORD>                 Password for the .p12 files (necessary to access the certificates)"
-  echo "  -e <entitlements file>        (Optional) Path to an entitlements XML file"
-  echo "  -n                            Enables notarization. This will fail if code signing is not also enabled."
-  echo "  -j <API_KEY.JSON>             Path to JSON file generated with \`rcodesign encode-app-store-connect-api-key\` (required for notarization)"
-  echo
-  exit 1
+    echo "Build macOS packages, optionally signing and notarizing them."
+    echo "Usage: $0 options"
+    echo "Options:"
+    echo "  -s                            Enables code signing"
+    echo "  -f <APP_KEY.p12>              Path to .p12 file for application signing"
+    echo "  -i <INSTALLER_KEY.p12>        Path to .p12 file for installer signing"
+    echo "  -p <PASSWORD>                 Password for the .p12 files (necessary to access the certificates)"
+    echo "  -e <entitlements file>        (Optional) Path to an entitlements XML file"
+    echo "  -n                            Enables notarization. This will fail if code signing is not also enabled."
+    echo "  -j <API_KEY.JSON>             Path to JSON file generated with \`rcodesign encode-app-store-connect-api-key\` (required for notarization)"
+    echo
+    exit 1
 }
 
 set -x
@@ -33,32 +33,32 @@ X86_64_DEPLOY_TARGET='MACOSX_DEPLOYMENT_TARGET=10.9'
 RUST_VERSION_X86_64=1.73.0
 
 while getopts "sf:i:p:e:nj:" opt; do
-  case $opt in
-    s) SIGN=1;;
-    f) P12_APP_FILE=$(realpath "$OPTARG");;
-    i) P12_INSTALL_FILE=$(realpath "$OPTARG");;
-    p) P12_PASSWORD="$OPTARG";;
-    e) ENTITLEMENTS_FILE=$(realpath "$OPTARG");;
-    n) NOTARIZE=1;;
-    j) API_KEY_FILE=$(realpath "$OPTARG");;
-    \?) usage;;
-  esac
+    case $opt in
+        s) SIGN=1;;
+        f) P12_APP_FILE=$(realpath "$OPTARG");;
+        i) P12_INSTALL_FILE=$(realpath "$OPTARG");;
+        p) P12_PASSWORD="$OPTARG";;
+        e) ENTITLEMENTS_FILE=$(realpath "$OPTARG");;
+        n) NOTARIZE=1;;
+        j) API_KEY_FILE=$(realpath "$OPTARG");;
+        \?) usage;;
+    esac
 done
 
 if [ -n "$SIGN" ] && { [ -z "$P12_APP_FILE" ] || [ -z "$P12_INSTALL_FILE" ] || [ -z "$P12_PASSWORD" ]; }; then
-  usage
+    usage
 fi
 
 if [ -n "$NOTARIZE" ] && [ -z "$API_KEY_FILE" ]; then
-  usage
+    usage
 fi
 
 VERSION=$(git describe --always --dirty 2>/dev/null)
 if test -z "$VERSION" ; then
-  echo "Could not get version from git"
-  if test -f version; then
-    VERSION=$(cat version)
-  fi
+    echo "Could not get version from git"
+    if test -f version; then
+        VERSION=$(cat version)
+    fi
 fi
 
 echo "Version is $VERSION"
@@ -76,7 +76,7 @@ mkdir -p "$PKGDIR/build_x86_64" "$PKGDIR/build_arm64" "$PKGDIR/root" "$PKGDIR/in
 # and will probably not be built universal, so the package will fail to validate/run on other systems.
 # Note CMAKE_OSX_ARCHITECTURES is still relevant for the Mac app.
 { cd "$PKGDIR/build_arm64" \
-  && cmake \
+    && cmake \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_EXE_LINKER_FLAGS="-Wl,-ld_classic" \
         -DWITH_GETTEXT=OFF \
@@ -91,7 +91,7 @@ mkdir -p "$PKGDIR/build_x86_64" "$PKGDIR/build_arm64" "$PKGDIR/root" "$PKGDIR/in
 # Build for x86-64 but do not install; instead we will make some fat binaries inside the root.
 # Set RUST_VERSION_X86_64 to the last version of Rust that supports macOS 10.9.
 { cd "$PKGDIR/build_x86_64" \
-  && cmake \
+    && cmake \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_EXE_LINKER_FLAGS="-Wl,-ld_classic" \
         -DWITH_GETTEXT=OFF \
@@ -99,7 +99,7 @@ mkdir -p "$PKGDIR/build_x86_64" "$PKGDIR/build_arm64" "$PKGDIR/root" "$PKGDIR/in
         -DRust_CARGO_TARGET=x86_64-apple-darwin \
         -DCMAKE_OSX_ARCHITECTURES='arm64;x86_64' \
         -DFISH_USE_SYSTEM_PCRE2=OFF "$SRC_DIR" \
-  && env $X86_64_DEPLOY_TARGET make VERBOSE=1 -j 12; }
+    && env $X86_64_DEPLOY_TARGET make VERBOSE=1 -j 12; }
 
 # Fatten them up.
 for FILE in "$PKGDIR"/root/usr/local/bin/*; do

--- a/build_tools/make_tarball.sh
+++ b/build_tools/make_tarball.sh
@@ -18,22 +18,22 @@ set -e
 BUILD_TOOL="make"
 BUILD_GENERATOR="Unix Makefiles"
 if command -v ninja >/dev/null; then
-  BUILD_TOOL="ninja"
-  BUILD_GENERATOR="Ninja"
+    BUILD_TOOL="ninja"
+    BUILD_GENERATOR="Ninja"
 fi
 
 # We need GNU tar as that supports the --mtime and --transform options
 TAR=notfound
 for try in tar gtar gnutar; do
-  if $try -Pcf /dev/null --mtime now /dev/null >/dev/null 2>&1; then
-    TAR=$try
-    break
-  fi
+    if $try -Pcf /dev/null --mtime now /dev/null >/dev/null 2>&1; then
+        TAR=$try
+        break
+    fi
 done
 
 if [ "$TAR" = "notfound" ]; then
-  echo 'No suitable tar (supporting --mtime) found as tar/gtar/gnutar in PATH'
-  exit 1
+    echo 'No suitable tar (supporting --mtime) found as tar/gtar/gnutar in PATH'
+    exit 1
 fi
 
 # Get the current directory, which we'll use for symlinks
@@ -63,7 +63,7 @@ cmake -G "$BUILD_GENERATOR" -DCMAKE_BUILD_TYPE=Debug "$wd"
 $BUILD_TOOL doc
 
 TAR_APPEND="$TAR --append --file=$path --mtime=now --owner=0 --group=0 \
-  --mode=g+w,a+rX --transform s/^/$prefix\//"
+    --mode=g+w,a+rX --transform s/^/$prefix\//"
 $TAR_APPEND --no-recursion user_doc
 $TAR_APPEND user_doc/html user_doc/man
 $TAR_APPEND version

--- a/build_tools/make_vendor_tarball.sh
+++ b/build_tools/make_vendor_tarball.sh
@@ -11,15 +11,15 @@ set -e
 # We need GNU tar as that supports the --mtime and --transform options
 TAR=notfound
 for try in tar gtar gnutar; do
-  if $try -Pcf /dev/null --mtime now /dev/null >/dev/null 2>&1; then
-    TAR=$try
-    break
-  fi
+    if $try -Pcf /dev/null --mtime now /dev/null >/dev/null 2>&1; then
+        TAR=$try
+        break
+    fi
 done
 
 if [ "$TAR" = "notfound" ]; then
-  echo 'No suitable tar (supporting --mtime) found as tar/gtar/gnutar in PATH'
-  exit 1
+    echo 'No suitable tar (supporting --mtime) found as tar/gtar/gnutar in PATH'
+    exit 1
 fi
 
 # Get the current directory, which we'll use for telling Cargo where to find the sources

--- a/build_tools/update_translations.fish
+++ b/build_tools/update_translations.fish
@@ -36,7 +36,7 @@
 set -gx LC_ALL C.UTF-8
 
 set -l build_tools (status dirname)
-set -l template_file $build_tools/../po/template.po
+set -g tmpdir
 set -l po_dir $build_tools/../po
 
 set -l extract
@@ -45,9 +45,6 @@ set -l mo
 
 argparse --exclusive 'no-mo,only-mo,dry-run' no-mo only-mo dry-run use-existing-template= -- $argv
 or exit $status
-
-# Make sure that the template file is not included in $po_files.
-rm $template_file 2>/dev/null
 
 if test -z $argv[1]
     # Update everything if not specified otherwise.
@@ -82,11 +79,14 @@ if set -l --query _flag_only_mo
     set -l --erase po
 end
 
+set -g template_file (mktemp)
 # Protect from externally set $tmpdir leaking into this script.
 set -g --erase tmpdir
 
 function cleanup_exit
     set -l exit_status $status
+
+    rm $template_file
 
     if set -g --query tmpdir[1]
         rm -r $tmpdir
@@ -101,7 +101,7 @@ if set -l --query extract
         set xgettext_args --use-existing-template=$_flag_use_existing_template
     end
     $build_tools/fish_xgettext.fish $xgettext_args >$template_file
-    or exit 1
+    or cleanup_exit
 end
 
 if set -l --query _flag_dry_run
@@ -136,10 +136,7 @@ for po_file in $po_files
     end
 end
 
-rm $template_file
-
 if set -g --query tmpdir
-    rm $tmpdir/template.po
     diff -ur $po_dir $tmpdir
     or cleanup_exit
 end

--- a/build_tools/update_translations.fish
+++ b/build_tools/update_translations.fish
@@ -43,16 +43,6 @@ set -l extract
 set -l po
 set -l mo
 
-function cleanup_exit
-    set -l exit_status $status
-
-    if set -g --query tmpdir
-        rm -r $tmpdir
-    end
-
-    exit $exit_status
-end
-
 argparse --exclusive 'no-mo,only-mo,dry-run' no-mo only-mo dry-run use-existing-template= -- $argv
 or exit $status
 
@@ -92,6 +82,19 @@ if set -l --query _flag_only_mo
     set -l --erase po
 end
 
+# Protect from externally set $tmpdir leaking into this script.
+set -g --erase tmpdir
+
+function cleanup_exit
+    set -l exit_status $status
+
+    if set -g --query tmpdir[1]
+        rm -r $tmpdir
+    end
+
+    exit $exit_status
+end
+
 if set -l --query extract
     set -l xgettext_args
     if set -l --query _flag_use_existing_template
@@ -101,8 +104,6 @@ if set -l --query extract
     or exit 1
 end
 
-# Protect from externally set $tmpdir leaking into this script.
-set -g --erase tmpdir
 if set -l --query _flag_dry_run
     # On a dry run, we do not modify po/ but write to a temporary directory instead and check if
     # there is a difference between po/ and the tmpdir after re-generating the PO files.

--- a/cmake/Tests.cmake
+++ b/cmake/Tests.cmake
@@ -1,92 +1,33 @@
-# This adds ctest support to the project
-enable_testing()
-
-# By default, ctest runs tests serially
-# Support CTEST_PARALLEL_LEVEL as an environment variable in addition to a CMake variable
-if(NOT CTEST_PARALLEL_LEVEL)
-  set(CTEST_PARALLEL_LEVEL $ENV{CTEST_PARALLEL_LEVEL})
-  if(NOT CTEST_PARALLEL_LEVEL)
-    include(ProcessorCount)
-    ProcessorCount(CORES)
-    math(EXPR halfcores "${CORES} / 2")
-    set(CTEST_PARALLEL_LEVEL ${halfcores})
-  endif()
-endif()
-
-
-# Put in a tests folder to reduce the top level targets in IDEs.
-set(CMAKE_FOLDER tests)
-
-# We will use 125 as a reserved exit code to indicate that a test has been skipped, i.e. it did not
-# pass but it should not be considered a failed test run, either.
-set(SKIP_RETURN_CODE 125)
-
-# Even though we are using CMake's ctest for testing, we still define our own `make fish_run_tests` target
-# rather than use its default for many reasons:
-#  * CMake doesn't run tests in-proc or even add each tests as an individual node in the ninja
-#    dependency tree, instead it just bundles all tests into a target called `test` that always just
-#    shells out to `ctest`, so there are no build-related benefits to not doing that ourselves.
-#  * CMake devs insist that it is appropriate for `make fish_run_tests` to never depend on `make all`, i.e.
-#    running `make fish_run_tests` does not require any of the binaries to be built before testing.
-#  * It is not possible to set top-level CTest options/settings such as CTEST_PARALLEL_LEVEL from
-#    within the CMake configuration file.
-#  * The only way to have a test depend on a binary is to add a fake test with a name like
-#    "build_fish" that executes CMake recursively to build the `fish` target.
-#  * Circling back to the point about individual tests not being actual Makefile targets, CMake does
-#    not offer any way to execute a named test via the `make`/`ninja`/whatever interface; the only
-#    way to manually invoke test `foo` is to to manually run `ctest` and specify a regex matching
-#    `foo` as an argument, e.g. `ctest -R ^foo$`... which is really crazy.
-
-# The top-level test target is "fish_run_tests".
-add_custom_target(fish_run_tests
-  COMMAND env CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL} FISH_FORCE_COLOR=1
-          ${CMAKE_CTEST_COMMAND} --force-new-ctest-process # --verbose
-          --output-on-failure --progress
-  DEPENDS fish fish_indent fish_key_reader fish_test_helper
-  USES_TERMINAL
-)
-
-# CMake being CMake, you can't just add a DEPENDS argument to add_test to make it depend on any of
-# your binaries actually being built before `make fish_run_tests` is executed (requiring `make all` first),
-# and the only dependency a test can have is on another test. So we make building fish
-# prerequisites to our entire top-level `test` target.
-function(add_test_target NAME)
-  string(REPLACE "/" "-" NAME ${NAME})
-  add_custom_target("test_${NAME}" COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -R "^${NAME}$$"
-    DEPENDS fish fish_indent fish_key_reader fish_test_helper USES_TERMINAL)
-endfunction()
-
 add_executable(fish_test_helper tests/fish_test_helper.c)
 
 FILE(GLOB FISH_CHECKS CONFIGURE_DEPENDS ${CMAKE_SOURCE_DIR}/tests/checks/*.fish)
 foreach(CHECK ${FISH_CHECKS})
   get_filename_component(CHECK_NAME ${CHECK} NAME)
-  get_filename_component(CHECK ${CHECK} NAME_WE)
-  add_test(NAME ${CHECK_NAME}
+  add_custom_target(
+    test_${CHECK_NAME}
     COMMAND ${CMAKE_SOURCE_DIR}/tests/test_driver.py ${CMAKE_CURRENT_BINARY_DIR}
-                checks/${CHECK}.fish
+                checks/${CHECK_NAME}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests
+    DEPENDS fish fish_indent fish_key_reader fish_test_helper
+    USES_TERMINAL
   )
-  set_tests_properties(${CHECK_NAME} PROPERTIES SKIP_RETURN_CODE ${SKIP_RETURN_CODE})
-  set_tests_properties(${CHECK_NAME} PROPERTIES ENVIRONMENT FISH_FORCE_COLOR=1)
-  add_test_target("${CHECK_NAME}")
 endforeach(CHECK)
 
 FILE(GLOB PEXPECTS CONFIGURE_DEPENDS ${CMAKE_SOURCE_DIR}/tests/pexpects/*.py)
 foreach(PEXPECT ${PEXPECTS})
   get_filename_component(PEXPECT ${PEXPECT} NAME)
-  add_test(NAME ${PEXPECT}
+  add_custom_target(
+    test_${PEXPECT}
     COMMAND ${CMAKE_SOURCE_DIR}/tests/test_driver.py ${CMAKE_CURRENT_BINARY_DIR}
                 pexpects/${PEXPECT}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests
+    DEPENDS fish fish_indent fish_key_reader fish_test_helper
+    USES_TERMINAL
   )
-  set_tests_properties(${PEXPECT} PROPERTIES SKIP_RETURN_CODE ${SKIP_RETURN_CODE})
-  set_tests_properties(${PEXPECT} PROPERTIES ENVIRONMENT FISH_FORCE_COLOR=1)
-  add_test_target("${PEXPECT}")
 endforeach(PEXPECT)
 
-set(cargo_test_flags)
 # Rust stuff.
+set(cargo_test_flags)
 if(DEFINED ASAN)
     # Rust w/ -Zsanitizer=address requires explicitly specifying the --target triple or else linker
     # errors pertaining to asan symbols will ensue.
@@ -107,10 +48,17 @@ if(DEFINED Rust_CARGO_TARGET)
     list(APPEND cargo_test_flags "--lib")
 endif()
 
-add_test(
-    NAME "cargo-test"
-    COMMAND env ${VARS_FOR_CARGO} cargo test --no-default-features ${CARGO_FLAGS} --workspace --target-dir ${rust_target_dir} ${cargo_test_flags}
-    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+set(max_concurrency_flag)
+if(DEFINED ENV{FISH_TEST_MAX_CONCURRENCY})
+    list(APPEND max_concurrency_flag "--max-concurrency" $ENV{FISH_TEST_MAX_CONCURRENCY})
+endif()
+
+# The top-level test target is "fish_run_tests".
+add_custom_target(fish_run_tests
+  # TODO: This should be replaced with a unified solution, possibly build_tools/check.sh.
+  COMMAND ${CMAKE_SOURCE_DIR}/tests/test_driver.py ${max_concurrency_flag} ${CMAKE_CURRENT_BINARY_DIR}
+  COMMAND env ${VARS_FOR_CARGO} cargo test --no-default-features ${CARGO_FLAGS} --workspace --target-dir ${rust_target_dir} ${cargo_test_flags}
+  WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+  DEPENDS fish fish_indent fish_key_reader fish_test_helper
+  USES_TERMINAL
 )
-set_tests_properties("cargo-test" PROPERTIES SKIP_RETURN_CODE ${SKIP_RETURN_CODE})
-add_test_target("cargo-test")

--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -1,8 +1,8 @@
 FROM alpine:3.19
 LABEL org.opencontainers.image.source=https://github.com/fish-shell/fish-shell
 
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
 
 RUN apk add --no-cache \
     bash \

--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -7,13 +7,11 @@ ENV LC_ALL=C.UTF-8
 RUN apk add --no-cache \
     bash \
     cargo \
-    cmake \
     g++ \
     gettext-dev \
     git \
     libintl \
     musl-dev \
-    ninja \
     pcre2-dev \
     py3-pexpect \
     python3 \
@@ -39,5 +37,7 @@ USER fishuser
 WORKDIR /home/fishuser
 
 COPY fish_run_tests.sh /
+
+ENV FISH_CHECK_LINT=false
 
 CMD /fish_run_tests.sh

--- a/docker/centos9.Dockerfile
+++ b/docker/centos9.Dockerfile
@@ -8,17 +8,13 @@ RUN cd /etc/yum.repos.d/ && \
   sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 
 
-# install powertools to get ninja-build
 RUN dnf -y install dnf-plugins-core \
-  && dnf config-manager --set-enabled powertools \
   && yum install --assumeyes epel-release \
   && yum install --assumeyes \
     cargo \
-    cmake \
     diffutils \
     gcc-c++ \
     git \
-    ninja-build \
     python3 \
     python3-pexpect \
     openssl \
@@ -38,5 +34,7 @@ USER fishuser
 WORKDIR /home/fishuser
 
 COPY fish_run_tests.sh /
+
+ENV FISH_CHECK_LINT=false
 
 CMD /fish_run_tests.sh

--- a/docker/context/fish_run_tests.sh
+++ b/docker/context/fish_run_tests.sh
@@ -5,6 +5,8 @@ set -e
 # This script is copied into the root directory of our Docker tests.
 # It is the entry point for running Docker-based tests.
 
+echo build_tools/check.sh >>~/.bash_history
+
 cd /fish-source
 git config --global --add safe.directory /fish-source
 

--- a/docker/context/fish_run_tests.sh
+++ b/docker/context/fish_run_tests.sh
@@ -5,24 +5,32 @@ set -e
 # This script is copied into the root directory of our Docker tests.
 # It is the entry point for running Docker-based tests.
 
-cd ~/fish-build
+cd /fish-source
 git config --global --add safe.directory /fish-source
-cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug /fish-source "$@"
+
+export CARGO_TARGET_DIR="$HOME"/fish-build
+
+interactive_shell() {
+    echo
+    echo "+ export=CARGO_TARGET_DIR=$CARGO_TARGET_DIR"
+    echo
+    bash -i
+}
 
 # Spawn a shell if FISH_RUN_SHELL_BEFORE_TESTS is set.
 if test -n "$FISH_RUN_SHELL_BEFORE_TESTS"
 then
-    bash -i
+    interactive_shell
 fi
 
 set +e
-ninja && ninja fish_run_tests
+build_tools/check.sh
 RES=$?
 set -e
 
 # Drop the user into a shell if FISH_RUN_SHELL_AFTER_TESTS is set.
 if test -n "$FISH_RUN_SHELL_AFTER_TESTS"; then
-    bash -i
+    interactive_shell
 fi
 
 exit $RES

--- a/docker/context/fish_run_tests.sh
+++ b/docker/context/fish_run_tests.sh
@@ -15,8 +15,10 @@ then
     bash -i
 fi
 
-(set +e; ninja && ninja fish_run_tests)
+set +e
+ninja && ninja fish_run_tests
 RES=$?
+set -e
 
 # Drop the user into a shell if FISH_RUN_SHELL_AFTER_TESTS is set.
 if test -n "$FISH_RUN_SHELL_AFTER_TESTS"; then

--- a/docker/docker_run_tests.sh
+++ b/docker/docker_run_tests.sh
@@ -29,6 +29,12 @@ while [ $# -gt 1 ]; do
         --shell-after)
             DOCKER_EXTRA_ARGS="$DOCKER_EXTRA_ARGS --env FISH_RUN_SHELL_AFTER_TESTS=1"
             ;;
+        --lint)
+            DOCKER_EXTRA_ARGS="$DOCKER_EXTRA_ARGS --env FISH_CHECK_LINT=true"
+            ;;
+        --no-lint)
+            DOCKER_EXTRA_ARGS="$DOCKER_EXTRA_ARGS --env FISH_CHECK_LINT=false"
+            ;;
         *)
             usage
             ;;

--- a/docker/fedora.Dockerfile
+++ b/docker/fedora.Dockerfile
@@ -2,11 +2,9 @@ FROM fedora:latest
 LABEL org.opencontainers.image.source=https://github.com/fish-shell/fish-shell
 
 RUN dnf install --assumeyes \
-      cmake \
       diffutils \
       gcc-c++ \
       git-core \
-      ninja-build \
       pcre2-devel \
       python3 \
       python3-pip \
@@ -27,5 +25,7 @@ USER fishuser
 WORKDIR /home/fishuser
 
 COPY fish_run_tests.sh /
+
+ENV FISH_CHECK_LINT=false
 
 CMD /fish_run_tests.sh

--- a/docker/focal-32bit.Dockerfile
+++ b/docker/focal-32bit.Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:20.04
 LABEL org.opencontainers.image.source=https://github.com/fish-shell/fish-shell
 
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
 ENV CFLAGS="-m32"
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/docker/focal-32bit.Dockerfile
+++ b/docker/focal-32bit.Dockerfile
@@ -3,18 +3,15 @@ LABEL org.opencontainers.image.source=https://github.com/fish-shell/fish-shell
 
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
-ENV CFLAGS="-m32"
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
   && apt-get -y install \
     build-essential \
-    cmake \
     g++-multilib \
     gettext \
     git \
     locales \
-    ninja-build \
     pkg-config \
     python3 \
     python3-pexpect \
@@ -38,6 +35,13 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /tmp/rustup.sh \
 
 COPY fish_run_tests.sh /
 
+ENV \
+    CFLAGS=-m32 \
+    PCRE2_SYS_STATIC=1 \
+    FISH_CHECK_TARGET_TRIPLE=i686-unknown-linux-gnu
+
+ENV FISH_CHECK_LINT=false
+
 CMD . ~/.cargo/env \
-    && rustup target add i686-unknown-linux-gnu \
-    && /fish_run_tests.sh -DFISH_USE_SYSTEM_PCRE2=OFF -DRust_CARGO_TARGET=i686-unknown-linux-gnu
+    && rustup target add ${FISH_CHECK_TARGET_TRIPLE} \
+    && /fish_run_tests.sh

--- a/docker/focal-arm64.Dockerfile
+++ b/docker/focal-arm64.Dockerfile
@@ -9,13 +9,11 @@ RUN apt-get update \
   && apt-get -y install \
     build-essential \
     cargo \
-    cmake \
     clang \
     gettext \
     git \
     libpcre2-dev \
     locales \
-    ninja-build \
     python3 \
     python3-pexpect \
     rustc \
@@ -35,5 +33,7 @@ USER fishuser
 WORKDIR /home/fishuser
 
 COPY fish_run_tests.sh /
+
+ENV FISH_CHECK_LINT=false
 
 CMD /fish_run_tests.sh

--- a/docker/focal-arm64.Dockerfile
+++ b/docker/focal-arm64.Dockerfile
@@ -1,8 +1,8 @@
 FROM arm64v8/ubuntu:focal
 LABEL org.opencontainers.image.source=https://github.com/fish-shell/fish-shell
 
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \

--- a/docker/focal.Dockerfile
+++ b/docker/focal.Dockerfile
@@ -9,11 +9,9 @@ RUN apt-get update \
   && apt-get -y install \
     build-essential \
     cargo \
-    cmake \
     gettext \
     git \
     locales \
-    ninja-build \
     pkg-config \
     python3 \
     python3-pexpect \
@@ -34,5 +32,7 @@ USER fishuser
 WORKDIR /home/fishuser
 
 COPY fish_run_tests.sh /
+
+ENV FISH_CHECK_LINT=false
 
 CMD /fish_run_tests.sh

--- a/docker/focal.Dockerfile
+++ b/docker/focal.Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:20.04
 LABEL org.opencontainers.image.source=https://github.com/fish-shell/fish-shell
 
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \

--- a/docker/jammy-armv7-32bit.Dockerfile
+++ b/docker/jammy-armv7-32bit.Dockerfile
@@ -9,14 +9,12 @@ RUN apt-get update \
   && apt-get -y install \
     build-essential \
     cargo \
-    cmake \
     file \
     g++ \
     gettext \
     git \
     libpcre2-dev \
     locales \
-    ninja-build \
     pkg-config \
     python3 \
     python3-pexpect \
@@ -37,5 +35,7 @@ USER fishuser
 WORKDIR /home/fishuser
 
 COPY fish_run_tests.sh /
+
+ENV FISH_CHECK_LINT=false
 
 CMD /fish_run_tests.sh

--- a/docker/jammy-armv7-32bit.Dockerfile
+++ b/docker/jammy-armv7-32bit.Dockerfile
@@ -1,8 +1,8 @@
 FROM arm32v7/ubuntu:jammy
 LABEL org.opencontainers.image.source=https://github.com/fish-shell/fish-shell
 
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \

--- a/docker/jammy-asan.Dockerfile
+++ b/docker/jammy-asan.Dockerfile
@@ -7,13 +7,11 @@ ENV LC_ALL=C.UTF-8
 RUN apt-get update \
   && apt-get -y install \
     build-essential \
-    cmake \
     clang \
     gettext \
     git \
     libpcre2-dev \
     locales \
-    ninja-build \
     python3 \
     python3-pexpect \
     sudo \
@@ -42,12 +40,17 @@ COPY fish_run_tests.sh /
 ENV \
     RUSTFLAGS=-Zsanitizer=address \
     RUSTDOCFLAGS=-Zsanitizer=address \
+    FISH_CHECK_CARGO_ARGS='-Zbuild-std --features=tsan' \
+    FISH_CHECK_TARGET_TRIPLE=x86_64-unknown-linux-gnu \
+    FISH_CI_SAN=1 \
+    FISH_TEST_MAX_CONCURRENCY=4 \
     CC=clang \
     CXX=clang++ \
     ASAN_OPTIONS=check_initialization_order=1:detect_stack_use_after_return=1:detect_leaks=1 \
-    LSAN_OPTIONS=verbosity=0:log_threads=0:use_tls=1:print_suppressions=0:suppressions=/fish-source/build_tools/lsan_suppressions.txt \
-    FISH_CI_SAN=1
+    LSAN_OPTIONS=verbosity=0:log_threads=0:use_tls=1:print_suppressions=0:suppressions=/fish-source/build_tools/lsan_suppressions.txt
+
+ENV FISH_CHECK_LINT=false
 
 CMD . ~/.cargo/env \
-  && ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer-$(cat /.llvm-version) \
-       /fish_run_tests.sh -DASAN=1 -DRust_CARGO_TARGET=x86_64-unknown-linux-gnu
+    && ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer-$(cat /.llvm-version) \
+    && /fish_run_tests.sh

--- a/docker/jammy-asan.Dockerfile
+++ b/docker/jammy-asan.Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:jammy
 LABEL org.opencontainers.image.source=https://github.com/fish-shell/fish-shell
 
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
 
 RUN apt-get update \
   && apt-get -y install \

--- a/docker/jammy-tsan.Dockerfile
+++ b/docker/jammy-tsan.Dockerfile
@@ -7,13 +7,11 @@ ENV LC_ALL=C.UTF-8
 RUN apt-get update \
   && apt-get -y install \
     build-essential \
-    cmake \
     clang \
     gettext \
     git \
     libpcre2-dev \
     locales \
-    ninja-build \
     python3 \
     python3-pexpect \
     sudo \
@@ -37,9 +35,13 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /tmp/rustup.sh \
 COPY fish_run_tests.sh /
 
 ENV \
-    RUSTFLAGS=-Zsanitizer=thread \
+    RUSTFLAGS='-Zsanitizer=thread ' \
     RUSTDOCFLAGS=-Zsanitizer=thread \
-    FISH_CI_SAN=1
+    FISH_CHECK_CARGO_ARGS='-Zbuild-std --features=tsan' \
+    FISH_CHECK_TARGET_TRIPLE=x86_64-unknown-linux-gnu \
+    FISH_CI_SAN=1 \
+    FISH_TEST_MAX_CONCURRENCY=4
 
-CMD . ~/.cargo/env \
-  && /fish_run_tests.sh -DTSAN=1 -DRust_CARGO_TARGET=x86_64-unknown-linux-gnu
+ENV FISH_CHECK_LINT=false
+
+CMD . ~/.cargo/env && /fish_run_tests.sh

--- a/docker/jammy-tsan.Dockerfile
+++ b/docker/jammy-tsan.Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:jammy
 LABEL org.opencontainers.image.source=https://github.com/fish-shell/fish-shell
 
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
 
 RUN apt-get update \
   && apt-get -y install \

--- a/docker/jammy.Dockerfile
+++ b/docker/jammy.Dockerfile
@@ -8,13 +8,11 @@ RUN apt-get update \
   && apt-get -y install \
     build-essential \
     cargo \
-    cmake \
     clang \
     gettext \
     git \
     libpcre2-dev \
     locales \
-    ninja-build \
     python3 \
     python3-pexpect \
     rustc \
@@ -34,5 +32,7 @@ USER fishuser
 WORKDIR /home/fishuser
 
 COPY fish_run_tests.sh /
+
+ENV FISH_CHECK_LINT=false
 
 CMD /fish_run_tests.sh

--- a/docker/jammy.Dockerfile
+++ b/docker/jammy.Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:jammy
 LABEL org.opencontainers.image.source=https://github.com/fish-shell/fish-shell
 
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
 
 RUN apt-get update \
   && apt-get -y install \

--- a/docker/noble.Dockerfile
+++ b/docker/noble.Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:noble
 LABEL org.opencontainers.image.source=https://github.com/fish-shell/fish-shell
 
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
 
 RUN apt-get update \
   && apt-get -y install \

--- a/docker/noble.Dockerfile
+++ b/docker/noble.Dockerfile
@@ -7,12 +7,10 @@ ENV LC_ALL=C.UTF-8
 RUN apt-get update \
   && apt-get -y install \
     build-essential \
-    cmake \
     gettext \
     git \
     libpcre2-dev \
     locales \
-    ninja-build \
     python3 \
     python3-pexpect \
     tmux \
@@ -35,6 +33,8 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > /tmp/rustup.sh \
   && sh /tmp/rustup.sh -y --default-toolchain 1.75
 
 COPY fish_run_tests.sh /
+
+ENV FISH_CHECK_LINT=false
 
 CMD . ~/.cargo/env \
   && /fish_run_tests.sh

--- a/docker/opensuse-tumbleweed.docker
+++ b/docker/opensuse-tumbleweed.docker
@@ -1,8 +1,8 @@
 FROM opensuse/tumbleweed:latest
 LABEL org.opencontainers.image.source=https://github.com/fish-shell/fish-shell
 
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
 
 RUN zypper --non-interactive install \
   bash \

--- a/src/builtins/status.rs
+++ b/src/builtins/status.rs
@@ -322,7 +322,7 @@ use rust_embed::RustEmbed;
 
 #[cfg(feature = "embed-data")]
 #[derive(RustEmbed)]
-#[folder = "target/man/man1"]
+#[folder = "target/fish-man/man1"]
 #[prefix = "man/man1/"]
 struct Docs;
 

--- a/src/env/config_paths.rs
+++ b/src/env/config_paths.rs
@@ -32,7 +32,7 @@ pub static CONFIG_PATHS: Lazy<ConfigPaths> = Lazy::new(|| {
         // TODO: we should determine program_name from argv0 somewhere in this file
 
         // Detect if we're running right out of the CMAKE build directory
-        if exec_path.starts_with(env!("FISH_BUILD_OUTPUT_DIR")) {
+        if exec_path.starts_with(env!("FISH_BUILD_DIR")) {
             let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
             FLOG!(
                 config,

--- a/src/env/config_paths.rs
+++ b/src/env/config_paths.rs
@@ -32,7 +32,7 @@ pub static CONFIG_PATHS: Lazy<ConfigPaths> = Lazy::new(|| {
         // TODO: we should determine program_name from argv0 somewhere in this file
 
         // Detect if we're running right out of the CMAKE build directory
-        if exec_path.starts_with(env!("CARGO_MANIFEST_DIR")) {
+        if exec_path.starts_with(env!("FISH_BUILD_OUTPUT_DIR")) {
             let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
             FLOG!(
                 config,

--- a/src/path.rs
+++ b/src/path.rs
@@ -600,7 +600,7 @@ fn make_base_directory(xdg_var: &wstr, non_xdg_homepath: &wstr) -> BaseDirectory
         use std::path::PathBuf;
 
         let mut build_dir = PathBuf::from(env!("FISH_BUILD_DIR"));
-        build_dir.push("fish_root");
+        build_dir.push("fish-test-home");
 
         let err = match std::fs::create_dir_all(&build_dir) {
             Ok(_) => 0,

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -42,6 +42,7 @@ pub mod prelude {
     use std::cell::RefCell;
     use std::env::set_current_dir;
     use std::ffi::CString;
+    use std::path::PathBuf;
 
     /// A wrapper around a Parser with some test helpers.
     pub struct TestParser {
@@ -89,8 +90,10 @@ pub mod prelude {
         DONE.get_or_init(|| {
             // If we are building with `cargo build` and have build w/ `cmake`, FISH_BUILD_DIR might
             // not yet exist.
-            std::fs::create_dir_all(env!("FISH_BUILD_DIR")).unwrap();
-            set_current_dir(env!("FISH_BUILD_DIR")).unwrap();
+            let mut test_dir = PathBuf::from(env!("FISH_BUILD_DIR"));
+            test_dir.push("fish-test");
+            std::fs::create_dir_all(&test_dir).unwrap();
+            set_current_dir(&test_dir).unwrap();
             {
                 let s = CString::new("").unwrap();
                 unsafe {

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -121,7 +121,11 @@ async def main():
         type=int,
         help="Maximum number of tests to run concurrently. The default is to run all tests concurrently.",
     )
-    argparser.add_argument("fish", nargs=1, help="Fish to test")
+    argparser.add_argument(
+        "fish",
+        nargs=1,
+        help="Directory containing fish binaries to test (typically 'target/debug')",
+    )
     argparser.add_argument("file", nargs="*", help="Tests to run")
     args = argparser.parse_args()
 

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -119,6 +119,7 @@ async def main():
         "--max-concurrency",
         type=int,
         help="Maximum number of tests to run concurrently. The default is to run all tests concurrently.",
+        default=os.environ.get("FISH_TEST_MAX_CONCURRENCY"),
     )
     argparser.add_argument(
         "fish",

--- a/tests/test_functions/sphinx-shared.sh
+++ b/tests/test_functions/sphinx-shared.sh
@@ -3,9 +3,9 @@
 set -e
 
 cleanup () {
-  if [ -n "$tmp_dir" ] && [ -e "$tmp_dir" ]; then
-    rm -r "$tmp_dir"
-  fi
+    if [ -n "$tmp_dir" ] && [ -e "$tmp_dir" ]; then
+        rm -r "$tmp_dir"
+    fi
 }
 
 trap cleanup EXIT INT TERM HUP
@@ -17,12 +17,12 @@ tmp_dir=$(mktemp -d)
 doctree=$tmp_dir/doctree
 output_dir=$tmp_dir/$builder
 sphinx-build \
-  -j auto \
-  -q \
-  -W \
-  -E \
-  -b "$builder" \
-  -c "$docsrc" \
-  -d "$doctree" \
-  "$docsrc" \
-  "$output_dir"
+    -j auto \
+    -q \
+    -W \
+    -E \
+    -b "$builder" \
+    -c "$docsrc" \
+    -d "$doctree" \
+    "$docsrc" \
+    "$output_dir"


### PR DESCRIPTION
Make commands like

	sudo docker/docker_run_tests.sh --shell-after docker/focal.Dockerfile

work again, plus tangential changes

@danielrainer you might wanna check
- 482e6869 (docker_run_tests.sh: stop using cmake)
  (I just realized this breaks `docker/jammy-asan.Dockerfile`; we can probably add this
  back by passing the right options to check.sh?)
- e0babd76 (build_tools/update_translations.fish: remove forward reference)
- 6dda18c3 (build_tools/update_translations.fish: move po/template.po to /tmp) 
