### PR TITLE
Add info on formatting fish_git_prompt output

### DIFF
--- a/doc_src/cmds/fish_git_prompt.rst
+++ b/doc_src/cmds/fish_git_prompt.rst
@@ -8,7 +8,7 @@ Synopsis
 
 .. synopsis::
 
-    fish_git_prompt
+    fish_git_prompt [FORMAT]
 
 ::
 
@@ -23,6 +23,8 @@ Description
 The ``fish_git_prompt`` function displays information about the current git repository, if any.
 
 `Git <https://git-scm.com>`_ must be installed.
+
+It is possible to modify the output format by passing an argument. The default value is ``" (%s)"``.
 
 There are numerous customization options, which can be controlled with git options or fish variables. git options, where available, take precedence over the fish variable with the same function. git options can be set on a per-repository or global basis. git options can be set with the ``git config`` command, while fish variables can be set as usual with the :doc:`set <set>` command.
 


### PR DESCRIPTION
## Description

The possibility to modify the formatting of `fish_git_prompt` output is not mentioned in the docs. This information is quite helpful for constructing custom prompts.