### PR TITLE
Add colorful disassembler output completion for objdump

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -11172,6 +11172,9 @@ msgstr ""
 msgid "Control default input to the policy engine"
 msgstr "Standardeingabe zur Regelverwaltung leiten"
 
+msgid "Control disassembler syntax highlighting style"
+msgstr "Steuert den Stil der Syntaxhervorhebung im Disassembler"
+
 msgid "Control display of additional"
 msgstr ""
 

--- a/po/en.po
+++ b/po/en.po
@@ -11168,6 +11168,9 @@ msgstr ""
 msgid "Control default input to the policy engine"
 msgstr "Control default input to the policy engine"
 
+msgid "Control disassembler syntax highlighting style"
+msgstr ""
+
 msgid "Control display of additional"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -11269,6 +11269,9 @@ msgstr ""
 msgid "Control default input to the policy engine"
 msgstr "Choisir la version"
 
+msgid "Control disassembler syntax highlighting style"
+msgstr "Contrôle le style de surlignage syntaxique du désassembleur"
+
 msgid "Control display of additional"
 msgstr "Contrôler l’affichage des suppléments"
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -11164,6 +11164,9 @@ msgstr ""
 msgid "Control default input to the policy engine"
 msgstr ""
 
+msgid "Control disassembler syntax highlighting style"
+msgstr "Steruje stylem podświetlania składni w dezasemblerze"
+
 msgid "Control display of additional"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -11169,6 +11169,9 @@ msgstr ""
 msgid "Control default input to the policy engine"
 msgstr ""
 
+msgid "Control disassembler syntax highlighting style"
+msgstr ""
+
 msgid "Control display of additional"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -11167,6 +11167,9 @@ msgstr "Kontrollera skapandet av glesa filer"
 msgid "Control default input to the policy engine"
 msgstr "Kontrollera standardindata till policymotorn"
 
+msgid "Control disassembler syntax highlighting style"
+msgstr "Controla o estilo de realce de sintaxe do desassemblador"
+
 msgid "Control display of additional"
 msgstr ""
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -11167,6 +11167,9 @@ msgstr "控制稀有文件的创建"
 msgid "Control default input to the policy engine"
 msgstr "控制对策略引擎的默认输入"
 
+msgid "Control disassembler syntax highlighting style"
+msgstr "控制反汇编器的语法高亮样式"
+
 msgid "Control display of additional"
 msgstr "控制额外显示"
 

--- a/share/completions/objdump.fish
+++ b/share/completions/objdump.fish
@@ -24,6 +24,7 @@ complete -c objdump -l target -s b -d "Specify target object format" -x -a "elf6
 complete -c objdump -l architecture -s m -d "Specify target architecture" -x -a "i386 i386:x86-64 i386:x64-32 i8086 i386:intel i386:x86-64:intel i386:x64-32:intel i386:nacl i386:x86-64:nacl i386:x64-32:nacl iamcu iamcu:intel l1om l1om:intel k1om k1om:intel plugin"
 complete -c objdump -l section -s j -d "Only display information for given section" -x
 complete -c objdump -l disassembler-options -s M -d "Pass given options on to disassembler" -x
+complete -c objdump -l disassembler-color -d "Control the colored syntax highlighting output" -x -a "off terminal on extened"
 complete -c objdump -l endian -x -d "Set format endianness when disassembling" -a "big little"
 complete -c objdump -o EB -d "Assume big endian format when disassembling"
 complete -c objdump -o EL -d "Assume little endian format when disassembling"

--- a/share/completions/objdump.fish
+++ b/share/completions/objdump.fish
@@ -24,7 +24,7 @@ complete -c objdump -l target -s b -d "Specify target object format" -x -a "elf6
 complete -c objdump -l architecture -s m -d "Specify target architecture" -x -a "i386 i386:x86-64 i386:x64-32 i8086 i386:intel i386:x86-64:intel i386:x64-32:intel i386:nacl i386:x86-64:nacl i386:x64-32:nacl iamcu iamcu:intel l1om l1om:intel k1om k1om:intel plugin"
 complete -c objdump -l section -s j -d "Only display information for given section" -x
 complete -c objdump -l disassembler-options -s M -d "Pass given options on to disassembler" -x
-complete -c objdump -l disassembler-color -d "Control the colored syntax highlighting output" -x -a "off terminal on extened"
+complete -c objdump -l disassembler-color -d "Control disassembler syntax highlighting style" -x -a "off terminal on extended"
 complete -c objdump -l endian -x -d "Set format endianness when disassembling" -a "big little"
 complete -c objdump -o EB -d "Assume big endian format when disassembling"
 complete -c objdump -o EL -d "Assume little endian format when disassembling"


### PR DESCRIPTION
As described in objdump(1), --disassembler-color can be applied to enable or disable the use of syntax highlighting in disassembly output.

The options are:

--disassembler-color=off
--disassembler-color=terminal
--disassembler-color=on|color|colour
--disassembler-color=extended|extended-color|extended-colour