### PR TITLE
fix(fmt): Resolve Rust 1.88 clippy warnings

### DIFF
--- a/printf/src/fmt_fp/mod.rs
+++ b/printf/src/fmt_fp/mod.rs
@@ -495,7 +495,7 @@ fn format_mantissa_e(
         let digit = if d < decimal.len_i32() { decimal[d] } else { 0 };
         let min_width = if d > 0 { DIGIT_WIDTH } else { 1 };
         buf.clear();
-        write!(buf, "{:0width$}", digit, width = min_width)?;
+        write!(buf, "{digit:0min_width$}")?;
         let mut s = buf.as_str();
         if d == 0 {
             // First digit. Emit it, and likely also a decimal point.

--- a/printf/src/printf_impl.rs
+++ b/printf/src/printf_impl.rs
@@ -464,7 +464,7 @@ pub fn sprintf_locale(
                 let uint = arg.as_uint()?;
                 if uint != 0 {
                     prefix = "0x";
-                    write!(buf, "{:x}", uint)?;
+                    write!(buf, "{uint:x}")?;
                 }
                 buf
             }
@@ -478,9 +478,9 @@ pub fn sprintf_locale(
                         prefix = if lower { "0x" } else { "0X" };
                     }
                     if lower {
-                        write!(buf, "{:x}", uint)?;
+                        write!(buf, "{uint:x}")?;
                     } else {
-                        write!(buf, "{:X}", uint)?;
+                        write!(buf, "{uint:X}")?;
                     }
                 }
                 buf
@@ -488,7 +488,7 @@ pub fn sprintf_locale(
             CS::o => {
                 let uint = arg.as_uint()?;
                 if uint != 0 {
-                    write!(buf, "{:o}", uint)?;
+                    write!(buf, "{uint:o}")?;
                 }
                 if flags.alt_form && desired_precision.unwrap_or(0) <= buf.len() + 1 {
                     desired_precision = Some(buf.len() + 1);
@@ -498,7 +498,7 @@ pub fn sprintf_locale(
             CS::u => {
                 let uint = arg.as_uint()?;
                 if uint != 0 {
-                    write!(buf, "{}", uint)?;
+                    write!(buf, "{uint}")?;
                 }
                 buf
             }


### PR DESCRIPTION
## Description

Update formatting macros to use the new inline variable syntax as recommended by Rust 1.88 clippy.