### PR TITLE
fix(echo): handle overflow in octal/hex escape parsing

### DIFF
--- a/src/builtins/echo.rs
+++ b/src/builtins/echo.rs
@@ -110,7 +110,7 @@ where
         return None;
     }
 
-    let mut val = 0;
+    let mut val: u8 = 0;
     let mut consumed = start;
     for digit in chars
         .skip(start)
@@ -120,7 +120,7 @@ where
         // base is either 8 or 16, so digit can never be >255
         let digit = u8::try_from(digit).unwrap();
 
-        val = val * base + digit;
+        val = val.wrapping_mul(base).wrapping_add(digit);
 
         consumed += 1;
     }

--- a/tests/checks/basic.fish
+++ b/tests/checks/basic.fish
@@ -143,6 +143,11 @@ echo -e 'abc\121def'
 echo -e 'abc\1212def'
 #CHECK: abcQdef
 #CHECK: abcQ2def
+# Test octal overflow: \5555 = 555 octal = 365 decimal, wraps to 109 decimal (155 octal)
+# Followed by literal '5' character (065 octal)
+echo -ne '\5555' | display_bytes
+#CHECK: 0000000 155 065
+#CHECK: 0000002
 echo -e 'abc\cdef' # won't output a newline!
 #CHECK: abc
 echo ''


### PR DESCRIPTION
Use wrapping arithmetic when parsing octal and hex escapes in echo to prevent panics on overflow and ensure consistent behavior with other shells. This change allows echo to process escape sequences like \5555 without crashing, keeping the same behavior as 3.7.1.

```
$ ./fish --version
fish, version 3.7.1
$ ./fish -c 'echo -e "\5555"'
m5
```

Fixes #11624
