### PR TITLE
feat: add completions for cilium and hubble

### DIFF
--- a/share/completions/cilium.fish
+++ b/share/completions/cilium.fish
@@ -1,0 +1,1 @@
+cilium completion fish 2>/dev/null | source

--- a/share/completions/hubble.fish
+++ b/share/completions/hubble.fish
@@ -1,0 +1,1 @@
+hubble completion fish 2>/dev/null | source


### PR DESCRIPTION
## Description

Added completions for [Cilium and Hubble](https://docs.cilium.io/en/stable/overview/intro/) using the same method as [kubectl](https://github.com/fish-shell/fish-shell/blob/4e1b5e733f2d1aac5d82a15e28939b70e1b892a1/share/completions/kubectl.fish)

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
