### PR TITLE
Test export shadowing and unshadowing, currently fails.  Issue #11637

### DIFF
--- a/tests/checks/env2.fish
+++ b/tests/checks/env2.fish
@@ -1,0 +1,14 @@
+# RUN: %fish -N %s
+
+set -f FISH_ENV_TEST_2 def
+set -gx FISH_ENV_TEST_2 abc
+env | string match FISH_ENV_TEST_\*
+# No output
+
+set -ef FISH_ENV_TEST_2
+env | string match FISH_ENV_TEST_\*
+# CHECK: FISH_ENV_TEST_2=abc
+
+set -e FISH_ENV_TEST_2
+env | string match FISH_ENV_TEST_\*
+# No output


### PR DESCRIPTION
Doesn't fail if added to the existing env.fish and seems like it can be affected by config files so hopefully being in a separate file run with fish -N this will reliably fail for everyone until fixed.  See discussion in Issue #11637 for more details.
