### PR TITLE
Update __fish_print_hostnames.fish

### DIFF
--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -76,6 +76,11 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
 
             set -l new_paths
             for path in $paths
+                # while ssh_config is using brackets to resolve env, they should be removed
+                # example
+                # in ssh_config: ${SOME_PATH}
+                # in fish:       $SOME_PATH
+                set path (string replace -r '\${([^}]+)}' '$1' $path)
                 set -l expanded_path
                 # Scope "relative" paths in accordance to ssh path resolution
                 if string match -qrv '^[~/]' $path


### PR DESCRIPTION
There was an issue in autocomplete of ssh. 

When you put in ~/.ssh/config line like this:

"Include ${HRL_SSH}/onprem_config"

and then trying to use fish complete for ssh, for example:

"ssh -J" and press key <b>Tab</b> it throughs an error that fish cannot understand ${HRL_SSH} with brackets.

## Description

Talk about your changes here.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
