### PR TITLE
`fish_indent -c/--check` completions

### DIFF
--- a/share/completions/fish_indent.fish
+++ b/share/completions/fish_indent.fish
@@ -1,5 +1,6 @@
 complete -c fish_indent -s h -l help -d 'Display help and exit'
 complete -c fish_indent -s v -l version -d 'Display version and exit'
+complete -c fish_indent -s c -l check -d 'Do not indent, only return 0 if the code is already indented as fish_indent would'
 complete -c fish_indent -s i -l no-indent -d 'Do not indent output, only reformat into one job per line'
 complete -c fish_indent -l only-indent -d 'Do not reformat, only indent lines'
 complete -c fish_indent -l only-unindent -d 'Do not reformat, only unindent lines'


### PR DESCRIPTION
Manpage `fish_indent(1)` documents the `-c/--check` option, which checks if a file is already indented as `fish_indent` would. This option is now included in the completions for `fish_indent`.

<img width="1452" height="780" alt="Screenshot from 2025-07-15 15-47-49" src="https://github.com/user-attachments/assets/941fe4e7-0dd9-4192-ad47-b16478a60fc1" />