### PR TITLE
add completion for `git rebase --keep-base`

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -31797,6 +31797,9 @@ msgstr ""
 msgid "Keep the backing chain relatively referenced"
 msgstr ""
 
+msgid "Keep the base commit as-is"
+msgstr ""
+
 msgid "Keep the commits that don't change anything"
 msgstr ""
 

--- a/po/en.po
+++ b/po/en.po
@@ -31793,6 +31793,9 @@ msgstr ""
 msgid "Keep the backing chain relatively referenced"
 msgstr ""
 
+msgid "Keep the base commit as-is"
+msgstr ""
+
 msgid "Keep the commits that don't change anything"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -31894,6 +31894,9 @@ msgstr ""
 msgid "Keep the backing chain relatively referenced"
 msgstr ""
 
+msgid "Keep the base commit as-is"
+msgstr ""
+
 msgid "Keep the commits that don't change anything"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -31789,6 +31789,9 @@ msgstr ""
 msgid "Keep the backing chain relatively referenced"
 msgstr ""
 
+msgid "Keep the base commit as-is"
+msgstr ""
+
 msgid "Keep the commits that don't change anything"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -31804,6 +31804,9 @@ msgstr ""
 msgid "Keep the backing chain relatively referenced"
 msgstr ""
 
+msgid "Keep the base commit as-is"
+msgstr ""
+
 msgid "Keep the commits that don't change anything"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -31792,6 +31792,9 @@ msgstr ""
 msgid "Keep the backing chain relatively referenced"
 msgstr ""
 
+msgid "Keep the base commit as-is"
+msgstr ""
+
 msgid "Keep the commits that don't change anything"
 msgstr ""
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -31792,6 +31792,9 @@ msgstr "关闭文件后继续激活应用程序"
 msgid "Keep the backing chain relatively referenced"
 msgstr "保持支持链相对引用"
 
+msgid "Keep the base commit as-is"
+msgstr ""
+
 msgid "Keep the commits that don't change anything"
 msgstr "保持承诺不会改变任何事情"
 

--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -2023,8 +2023,9 @@ __fish_git_add_revision_completion -n '__fish_git_using_command rebase'
 complete -f -c git -n '__fish_git_using_command rebase' -n __fish_git_is_rebasing -l continue -d 'Restart the rebasing process'
 complete -f -c git -n '__fish_git_using_command rebase' -n __fish_git_is_rebasing -l abort -d 'Abort the rebase operation'
 complete -f -c git -n '__fish_git_using_command rebase' -n __fish_git_is_rebasing -l edit-todo -d 'Edit the todo list'
-complete -f -c git -n '__fish_git_using_command rebase' -l keep-empty -d "Keep the commits that don't change anything"
 complete -f -c git -n '__fish_git_using_command rebase' -n __fish_git_is_rebasing -l skip -d 'Restart the rebasing process by skipping the current patch'
+complete -f -c git -n '__fish_git_using_command rebase' -l keep-empty -d "Keep the commits that don't change anything"
+complete -f -c git -n '__fish_git_using_command rebase' -l keep-base -d 'Keep the base commit as-is'
 complete -f -c git -n '__fish_git_using_command rebase' -s m -l merge -d 'Use merging strategies to rebase'
 complete -f -c git -n '__fish_git_using_command rebase' -s q -l quiet -d 'Be quiet'
 complete -f -c git -n '__fish_git_using_command rebase' -s v -l verbose -d 'Be verbose'


### PR DESCRIPTION
## Description

adds completions for the `--keep-base` option for `git rebase`

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
