### PR TITLE
Fix missing bool to string cast causing errors

### DIFF
--- a/share/tools/web_config/webconfig.py
+++ b/share/tools/web_config/webconfig.py
@@ -315,7 +315,7 @@ def unparse_color(col):
     if col["bold"]:
         ret += " --bold"
     if col["underline"] is not None:
-        ret += " --underline=" + col["underline"]
+        ret += " --underline=" + str(col["underline"])
     if col["italics"]:
         ret += " --italics"
     if col["dim"]:


### PR DESCRIPTION
## Description

Currently, when trying to set a color, I encounter an error about not being able to concatenate `bool` with `str`.
This seems to be a simple missing `str()` cast, adding it makes everything work as expected.

Fixes issue N/A

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
