### PR TITLE
Add an example replicating bash behavior to `prompt_pwd` documentation

### DIFF
--- a/doc_src/cmds/prompt_pwd.rst
+++ b/doc_src/cmds/prompt_pwd.rst
@@ -55,3 +55,9 @@ Examples
 
     >_ prompt_pwd --full-length-dirs=2 --dir-length=1
     /t/b/s/with/mustard
+
+    >_ echo (prompt_pwd | string split /)[-1]
+    mustard
+
+    >_ echo (string join / (prompt_pwd | string split /)[-3..-1])
+    s/with/mustard


### PR DESCRIPTION
## Description

I work in deep directories sometimes, and find full paths to be too large, and do not find much value in shortened paths. I made this change locally and thought it would be useful to others. This setting mimics more closely bash behavior.

## TODOs:
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst