### PR TITLE
Fix `funced` to not expand or execute function name when editing interactively (`-i`)

### DIFF
--- a/share/functions/funced.fish
+++ b/share/functions/funced.fish
@@ -47,7 +47,7 @@ function funced --description 'Edit function definition'
             functions --no-details -- $funcname | __fish_indent --only-unindent | __fish_indent --no-indent | read -z init
         end
 
-        set -l prompt 'printf "%s%s%s> " (set_color green) '$funcname' (set_color normal)'
+        set -l prompt 'printf "%s%s%s> " (set_color green) $funcname (set_color normal)'
         if read -p $prompt -c "$init" --shell cmd
             echo -n $cmd | __fish_indent --only-unindent | read -lz cmd
             eval "$cmd"


### PR DESCRIPTION
## Description

Due to unnecessary quotes in the prompt command given to `read` by `funced` when editing a function interactively (using `-i`), the name of the function to edit would be evaluated, expanded and even executed (when using command substitution for example), which is at least annoying when using unusual but valid and allowed function names like `*` or `head (cat)`.

Example:

```fish
$ function '(echo 3)'
  end
$ funced -i '(echo 3)'
3> function '(echo 3)'

   end
```

Instead of the `3> ` prompt it should be `(echo 3)> ` which should be fixed by this PR.