### PR TITLE
Additional cygwin support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,5 @@
 # normalize newlines
-* text=auto
-*.fish text
-*.bat eol=crlf
+* text=auto eol=lf
 
 # let git show off diff hunk headers, help git diff -L:
 # https://git-scm.com/docs/gitattributes

--- a/src/fd_monitor.rs
+++ b/src/fd_monitor.rs
@@ -389,7 +389,9 @@ impl BackgroundFdMonitor {
             drop(data);
             let ret =
                 fds.check_readable(timeout.map(Timeout::Duration).unwrap_or(Timeout::Forever));
-            if ret < 0 && !matches!(errno().0, libc::EINTR | libc::EBADF) {
+            // Cygwin reports ret < 0 && errno == 0 as success.
+            let err = errno().0;
+            if ret < 0 && !matches!(err, libc::EINTR | libc::EBADF) && !(cfg!(cygwin) && err == 0) {
                 // Surprising error
                 perror("select");
             }

--- a/src/path.rs
+++ b/src/path.rs
@@ -667,7 +667,7 @@ fn create_dir_all_with_mode<P: AsRef<std::path::Path>>(path: P, mode: u32) -> st
 /// Return whether the given path is on a remote filesystem.
 pub fn path_remoteness(path: &wstr) -> DirRemoteness {
     let narrow = wcs2zstring(path);
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", cygwin))]
     {
         let mut buf = MaybeUninit::uninit();
         if unsafe { libc::statfs(narrow.as_ptr(), buf.as_mut_ptr()) } < 0 {
@@ -701,7 +701,7 @@ pub fn path_remoteness(path: &wstr) -> DirRemoteness {
             }
         }
     }
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", cygwin)))]
     {
         fn remoteness_via_statfs<StatFS, Flags>(
             statfn: unsafe extern "C" fn(*const i8, *mut StatFS) -> libc::c_int,


### PR DESCRIPTION
See https://github.com/fish-shell/fish-shell/pull/11238#issuecomment-3113910238 first.

- [x] https://github.com/fish-shell/fish-shell/commit/6644cc9b0e29841e3d0a85fbc672a95c4a2fd000 introduced compatibility issues. This can be easily fixed by adding cygwin check. See changes for details.

- [x] `.gitattributes` uses `* text=auto` and `*.fish text`, breaking builds using `git clone` or `cargo install` on windows.

  > I'm using `cargo install` to make fish with embedded data.
  >
  > However, I'm not using `cargo install --git` because `*.fish` will end with CRLF in this case. The same goes for Git for Windows, regardless of `core.autocrlf=false`. Tarballs works well.

  https://git-scm.com/docs/gitattributes says that the default is eol=crlf on Windows. However it seems that git and cargo won't respect `core.autocrlf`.

  `*.fish eol=lf` works, but there is **`share/__fish_build_paths.fish.in`** which is configured with cmake. MSYS2 uses tarball so it will work as before, but for some people who use `git clone` and cmake to build fish, this might be a problem.

- [x] It's still possible that `select` returns -1 with errno 0, and perror says `select: No error`.

  ![](https://github.com/user-attachments/assets/44a80d29-82cf-494e-a3ef-0af20e73cc81)

  `strace` says `pselect: -1 = select(), errno 0` when running `strace fish -c 'status get-file config.fish'`.

- [ ] Should we add build instructions on cygwin/msys2 (experimental) to building section of README?

  `cargo install` only, should work after merging.

  ```bash
  rustup component add rust-src --toolchain nightly-x86_64-pc-windows-gnu
  cargo +nightly-x86_64-pc-windows-gnu install -Z build-std --target x86_64-pc-cygwin --git 
  https://github.com/fish-shell/fish-shell.git --bin fish
  ```
