### PR TITLE
funced: pretend copied functions are defined interactively

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,6 +51,7 @@ Interactive improvements
 - Instead of flashing all the text to the left of the cursor, fish now flashes the matched token during history token search, the completed token during completion (:issue:`11050`), the autosuggestion when deleting it, and the full command line in all other cases.
 - Pasted commands are now stripped of any ``$`` prefix.
 - The :kbd:`alt-s` binding will now also use ``run0`` if available.
+- ``funced`` will now edit copied functions directly, instead of the file where ``function --copy`` was invoked. (:issue:`11614`)
 
 New or improved bindings
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/share/functions/funced.fish
+++ b/share/functions/funced.fish
@@ -71,6 +71,11 @@ function funced --description 'Edit function definition'
 
     if not functions -q -- $funcname
         echo $init >$tmpname
+    else if not string match --quiet --regex '^(?:n/a|not-autoloaded|autoloaded)$' -- (functions --details --verbose -- $funcname)[2]
+        # Pretend this copied function does not have a definition file. Editing the file which
+        # originally defined it would not update this copy, and the file which copied it
+        # would not have a function body to edit. (issue #11614)
+        functions -- $funcname >$tmpname
     else if functions --details -- $funcname | string match --invert --quiet --regex '^(?:-|stdin|embedded:.*)$'
         set writepath (functions --details -- $funcname)
         # Use cat here rather than cp to avoid copying permissions

--- a/tests/checks/funced.fish
+++ b/tests/checks/funced.fish
@@ -1,0 +1,23 @@
+#RUN: %fish %s
+
+function my-src
+    echo hello
+end
+
+echo "functions --copy my-src my-dst" >my-copy-function.fish
+source my-copy-function.fish
+rm my-copy-function.fish # Cleanup
+
+functions --details --verbose my-dst
+# CHECK: my-copy-function.fish
+# CHECK: {{.*}}tests/checks/funced.fish
+# CHECK: 3
+# CHECK: scope-shadowing
+
+VISUAL=cat EDITOR=cat funced my-dst
+# CHECK: # Defined in {{.*}}/tests/checks/funced.fish @ line 3, copied in my-copy-function.fish @ line 1
+# CHECK: function my-dst
+# CHECK:     echo hello
+# CHECK: end
+# CHECK: Editor exited but the function was not modified
+# CHECK: If the editor is still running, check if it waits for completion, maybe a '--wait' option?


### PR DESCRIPTION
## Description

After #9542, the format for `functions -Dv` was changed for copied functions.

```diff
-stdin
-n/a
+[path to copy location]
+[path to original definition]
 [and a few more lines]
```

Some components were (and perhaps are) still expecting the old format, however. After a search, it looks like `funced` and `fish_config` are the only two functions using `functions -D` and `functions -Dv` in this repo (none are using `type -p`).

As noted in issue #11614, `funced` currently edits the file which copies the given copied function. Another option was to make `funced` edit the file which originally defined the function. Since the copied function would not have been updated either way, I modified `funced` so it would pretend that the copied function was defined interactively, like it was before.

(I did not find any preexisting test file for `funced`, so I did not write regressions test. Please tell me if I should.)

I did not modify `fish_config`, since it was only used for preset prompts in the web config, none of which used `functions --copy`. (Moreover, I believe it would have behaved correctly, since the preset would not have had to define the function, only copy it. (This grammar is making me dizzy.))

Fixes issue #11614

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
