### PR TITLE
Various additions to `argparse` and `fish_opt`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,6 +43,7 @@ Scripting improvements
 ----------------------
 - The ``psub`` command now allows combining ``--suffix`` with ``--fifo`` (:issue:`11729`).
 - ``argparse`` now saves recognised options and values in ``$argv_opts``, allowing them to be forwarded to other commands (:issue:`6466`).
+- ``argparse`` options can now be marked to be deleted from ``$argv_opts`` (by adding a ``&`` at the end of the option spec, before a ``!`` if present). There is now also a corresponding ``-d`` / ``--delete`` option to ``fish_opt``.
 
 Interactive improvements
 ------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,6 +51,7 @@ Scripting improvements
 - ``argparse`` now allows specifying options that take multiple optional values by using ``=*`` in the option spec, the parsing of the option is the same as ones with optional values (i.e. ``=?``), but each successive use accumulates more values (or an empty string if no value), instead of replacing the previous value (i.e. it behaves similarly to ``=+``) (:issue:`8432`). In addition, ``fish_opt`` has been modified to support such options by using the ``--multiple-vals`` together with ``-o`` / ``--optional-val``; ``-m`` is also now acceptable as an abbreviation for ``--multiple-vals``.
 - ``fish_opt`` no longer requires you give a short flag name when defining options, provided you give it a long flag name with more than one character.
 - ``argparse`` option specifiers for long only options can now start with ``/``, allowing the definition of long options with a single letter (withouht the ``/``, an option with a single letter is always interpreted as a short flag). Due to this change, the ``--long-only`` option to ``fish_opt`` is now no longer necessary and is deprecated.
+- ``fish_opt`` now has a ``-v`` / ``--validate`` option you can use to give a fish script to validate values of the option.
 
 Interactive improvements
 ------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,6 +44,7 @@ Scripting improvements
 - The ``psub`` command now allows combining ``--suffix`` with ``--fifo`` (:issue:`11729`).
 - ``argparse`` now saves recognised options and values in ``$argv_opts``, allowing them to be forwarded to other commands (:issue:`6466`).
 - ``argparse`` options can now be marked to be deleted from ``$argv_opts`` (by adding a ``&`` at the end of the option spec, before a ``!`` if present). There is now also a corresponding ``-d`` / ``--delete`` option to ``fish_opt``.
+- ``argparse --ignore-unknown`` now removes preceding known short options from groups containing unknown options (e.g. when parsing ``-abc``, if ``a`` is known but ``b`` is not, then ``$argv`` will contain ``-bc``).
 
 Interactive improvements
 ------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -48,6 +48,7 @@ Scripting improvements
 - ``argparse`` now has an ``-u`` / ``--move-unknown`` option that works like ``--ignore-unknown``, but unknown options (and their arguments) are moved from ``$argv`` to ``$argv_opts``. whereas ``--ignore-unknown`` keeps them in ``$argv``.
 - ``argparse`` now has an ``-S`` / ``--strict-longopts`` option that forbids abbreviating long options or passing them with a single dash (e.g. if there is a long option called ``foo``, ``--fo`` and ``--foo`` won't match it).
 - ``argparse`` now has a ``-U`` / ``--unknown-arguments`` *KIND* option, where *KIND* is either ``optional``, ``required``, or ``none``, indicating whether unknown options are parsed as taking optional, required, or no arguments. This implies ``--move-unknown``.
+- ``argparse`` now allows specifying options that take multiple optional values by using ``=*`` in the option spec, the parsing of the option is the same as ones with optional values (i.e. ``=?``), but each successive use accumulates more values (or an empty string if no value), instead of replacing the previous value (i.e. it behaves similarly to ``=+``) (:issue:`8432`). In addition, ``fish_opt`` has been modified to support such options by using the ``--multiple-vals`` together with ``-o`` / ``--optional-val``; ``-m`` is also now acceptable as an abbreviation for ``--multiple-vals``.
 
 Interactive improvements
 ------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -50,6 +50,7 @@ Scripting improvements
 - ``argparse`` now has a ``-U`` / ``--unknown-arguments`` *KIND* option, where *KIND* is either ``optional``, ``required``, or ``none``, indicating whether unknown options are parsed as taking optional, required, or no arguments. This implies ``--move-unknown``.
 - ``argparse`` now allows specifying options that take multiple optional values by using ``=*`` in the option spec, the parsing of the option is the same as ones with optional values (i.e. ``=?``), but each successive use accumulates more values (or an empty string if no value), instead of replacing the previous value (i.e. it behaves similarly to ``=+``) (:issue:`8432`). In addition, ``fish_opt`` has been modified to support such options by using the ``--multiple-vals`` together with ``-o`` / ``--optional-val``; ``-m`` is also now acceptable as an abbreviation for ``--multiple-vals``.
 - ``fish_opt`` no longer requires you give a short flag name when defining options, provided you give it a long flag name with more than one character.
+- ``argparse`` option specifiers for long only options can now start with ``/``, allowing the definition of long options with a single letter (withouht the ``/``, an option with a single letter is always interpreted as a short flag). Due to this change, the ``--long-only`` option to ``fish_opt`` is now no longer necessary and is deprecated.
 
 Interactive improvements
 ------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -49,6 +49,7 @@ Scripting improvements
 - ``argparse`` now has an ``-S`` / ``--strict-longopts`` option that forbids abbreviating long options or passing them with a single dash (e.g. if there is a long option called ``foo``, ``--fo`` and ``--foo`` won't match it).
 - ``argparse`` now has a ``-U`` / ``--unknown-arguments`` *KIND* option, where *KIND* is either ``optional``, ``required``, or ``none``, indicating whether unknown options are parsed as taking optional, required, or no arguments. This implies ``--move-unknown``.
 - ``argparse`` now allows specifying options that take multiple optional values by using ``=*`` in the option spec, the parsing of the option is the same as ones with optional values (i.e. ``=?``), but each successive use accumulates more values (or an empty string if no value), instead of replacing the previous value (i.e. it behaves similarly to ``=+``) (:issue:`8432`). In addition, ``fish_opt`` has been modified to support such options by using the ``--multiple-vals`` together with ``-o`` / ``--optional-val``; ``-m`` is also now acceptable as an abbreviation for ``--multiple-vals``.
+- ``fish_opt`` no longer requires you give a short flag name when defining options, provided you give it a long flag name with more than one character.
 
 Interactive improvements
 ------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,6 +45,7 @@ Scripting improvements
 - ``argparse`` now saves recognised options and values in ``$argv_opts``, allowing them to be forwarded to other commands (:issue:`6466`).
 - ``argparse`` options can now be marked to be deleted from ``$argv_opts`` (by adding a ``&`` at the end of the option spec, before a ``!`` if present). There is now also a corresponding ``-d`` / ``--delete`` option to ``fish_opt``.
 - ``argparse --ignore-unknown`` now removes preceding known short options from groups containing unknown options (e.g. when parsing ``-abc``, if ``a`` is known but ``b`` is not, then ``$argv`` will contain ``-bc``).
+- ``argparse`` now has an ``-u`` / ``--move-unknown`` option that works like ``--ignore-unknown``, but unknown options (and their arguments) are moved from ``$argv`` to ``$argv_opts``. whereas ``--ignore-unknown`` keeps them in ``$argv``.
 
 Interactive improvements
 ------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -47,6 +47,7 @@ Scripting improvements
 - ``argparse --ignore-unknown`` now removes preceding known short options from groups containing unknown options (e.g. when parsing ``-abc``, if ``a`` is known but ``b`` is not, then ``$argv`` will contain ``-bc``).
 - ``argparse`` now has an ``-u`` / ``--move-unknown`` option that works like ``--ignore-unknown``, but unknown options (and their arguments) are moved from ``$argv`` to ``$argv_opts``. whereas ``--ignore-unknown`` keeps them in ``$argv``.
 - ``argparse`` now has an ``-S`` / ``--strict-longopts`` option that forbids abbreviating long options or passing them with a single dash (e.g. if there is a long option called ``foo``, ``--fo`` and ``--foo`` won't match it).
+- ``argparse`` now has a ``-U`` / ``--unknown-arguments`` *KIND* option, where *KIND* is either ``optional``, ``required``, or ``none``, indicating whether unknown options are parsed as taking optional, required, or no arguments. This implies ``--move-unknown``.
 
 Interactive improvements
 ------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,6 +46,7 @@ Scripting improvements
 - ``argparse`` options can now be marked to be deleted from ``$argv_opts`` (by adding a ``&`` at the end of the option spec, before a ``!`` if present). There is now also a corresponding ``-d`` / ``--delete`` option to ``fish_opt``.
 - ``argparse --ignore-unknown`` now removes preceding known short options from groups containing unknown options (e.g. when parsing ``-abc``, if ``a`` is known but ``b`` is not, then ``$argv`` will contain ``-bc``).
 - ``argparse`` now has an ``-u`` / ``--move-unknown`` option that works like ``--ignore-unknown``, but unknown options (and their arguments) are moved from ``$argv`` to ``$argv_opts``. whereas ``--ignore-unknown`` keeps them in ``$argv``.
+- ``argparse`` now has an ``-S`` / ``--strict-longopts`` option that forbids abbreviating long options or passing them with a single dash (e.g. if there is a long option called ``foo``, ``--fo`` and ``--foo`` won't match it).
 
 Interactive improvements
 ------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,7 @@ Deprecations and removed features
 Scripting improvements
 ----------------------
 - The ``psub`` command now allows combining ``--suffix`` with ``--fifo`` (:issue:`11729`).
+- ``argparse`` now saves recognised options and values in ``$argv_opts``, allowing them to be forwarded to other commands (:issue:`6466`).
 
 Interactive improvements
 ------------------------

--- a/doc_src/cmds/argparse.rst
+++ b/doc_src/cmds/argparse.rst
@@ -69,7 +69,7 @@ The following ``argparse`` options are available. They must appear before all *O
     This option implies **--move-unknown**, unless **--ignore-unknown** is also given.
     This will modify the parsing behaviour of unknown options depending on the value of *KIND*:
 
-        - **optional** (the default), allows each unknown option to take an optional argument (i.e. as if it had ``=?`` in its option specification). For example, ``argparse --ignore-unknown --unknown-arguments=optional ab -- -u -a -ub`` will set ``_flag_a`` but *not* ``_flag_b``, as the ``b`` is treated as an argument to the second use of ``-u``.
+        - **optional** (the default), allows each unknown option to take an optional argument (i.e. as if it had ``=?`` or ``=*`` in its option specification). For example, ``argparse --ignore-unknown --unknown-arguments=optional ab -- -u -a -ub`` will set ``_flag_a`` but *not* ``_flag_b``, as the ``b`` is treated as an argument to the second use of ``-u``.
 
         - **required** requires each unknown option to take an argument (i.e. as if it had ``=`` or ``=+`` in its option specification). If the above example was changed to use ``--unknown-arguments=required``, *neither* ``_flag_a`` nor ``_flag_b`` would be set: the ``-a`` will be treated as an argument to the first use of ``-u``, and the ``b`` as an argument to the second.
 
@@ -146,7 +146,9 @@ Each option specification consists of:
 
     - **=?** if it takes an optional value and only the last instance of the flag is saved, or
 
-    - **=+** if it requires a value and each instance of the flag is saved.
+    - **=+** if it requires a value and each instance of the flag is saved, or
+
+    - **=\*** if it takes an optional value *and* each instance of the flag is saved, storing the empty string when the flag was not given a value.
 
 - Optionally a ``&``, indicating that the option and any attached values are not to be saved in ``$argv`` or ``$argv_opts``. This does not affect the the ``_flag_`` variables.
 
@@ -170,7 +172,7 @@ This does not read numbers given as ``+NNN``, only those that look like flags - 
 Note: Optional arguments
 ------------------------
 
-An option defined with ``=?`` can take optional arguments. Optional arguments have to be *directly attached* to the option they belong to.
+An option defined with ``=?`` or ``=*`` can take optional arguments. Optional arguments have to be *directly attached* to the option they belong to.
 
 That means the argument will only be used for the option if you use it like::
 
@@ -244,6 +246,8 @@ Some *OPTION_SPEC* examples:
 - ``n/name=`` means that both ``-n`` and ``--name`` are valid. It requires a value and can be used at most once. If the flag is seen then ``_flag_n`` and ``_flag_name`` will be set with the single mandatory value associated with the flag.
 
 - ``n/name=?`` means that both ``-n`` and ``--name`` are valid. It accepts an optional value and can be used at most once. If the flag is seen then ``_flag_n`` and ``_flag_name`` will be set with the value associated with the flag if one was provided else it will be set with no values.
+
+- ``n/name=*`` is similar, but the flag can be used more than once. If the flag is seen then ``_flag_n`` and ``_flag_name`` will be set with the values associated with each occurence. Each value will be the value given to the option, or the empty string if no value was given.
 
 - ``name=+`` means that only ``--name`` is valid. It requires a value and can be used more than once. If the flag is seen then ``_flag_name`` will be set with the values associated with each occurrence.
 

--- a/doc_src/cmds/argparse.rst
+++ b/doc_src/cmds/argparse.rst
@@ -41,7 +41,11 @@ The following ``argparse`` options are available. They must appear before all *O
     The maximum number of acceptable non-option arguments. The default is infinity.
 
 **-i** or **--ignore-unknown**
-    Ignores unknown options, keeping them and their arguments in $argv instead.
+    Ignore unknown options, keeping them and their arguments in ``$argv`` instead and not moving them to ``$argv_opts``. Unknown options are treated as if they take optional arguments (i.e. have option spec ``=?``).
+
+    The above means that if a group of short options contains an unknown short option *followed* by a known short option, the known short option is
+    treated as an argument to the unknown one (e.g. ``--ignore-unknown h -- -oh`` will treat ``h`` as the argument to ``-o``, and so ``_flag_h`` will *not* be set).
+    In contrast, if the known option comes first (and does not take any arguments), the known option will be recognised and moved from ``$argv`` to ``$argv_opts`` (e.g. ``argparse --ignore-unknown h -- -ho`` will set ``$argv`` to ``-o`` and ``$argv_opts`` to ``-h``)
 
 **-s** or **--stop-nonopt**
     Causes scanning the arguments to stop as soon as the first non-option argument is seen. Among other things, this is useful to implement subcommands that have their own options.
@@ -299,18 +303,3 @@ An example of using ``$argv_opts`` to forward known options to another command, 
 The argparse call above saves all the options we do *not* want to process in ``$argv_opts``. (The ``--qwords`` and ``--bytes`` options are *not* saved there as their option spec's end in a ``~``). The code then processes the ``--qwords`` and ``--bytess`` options using the the ``$_flag_OPTION`` variables, and puts the transformed options in ``$argv_opts`` (which already contains all the original options, *other* than ``--qwords`` and ``--bytes``).
 
 Note that the ``argparse`` call does need to know all the options to the original ``head`` so that we can accurately work out the *non*-option arguments (i.e. ``$argv``, the filenames that ``head`` is to operate on). We'd similarly need to tell ``argparse`` the options if we wanted to modify the given filenames.
-
-Limitations
------------
-
-One limitation with **--ignore-unknown** is that, if an unknown option is given in a group with known options, the entire group will be kept in $argv. ``argparse`` will not do any permutations here.
-
-For instance::
-
-  argparse --ignore-unknown h -- -ho
-  echo $_flag_h # is -h, because -h was given
-  echo $argv # is still -ho
-
-This limitation may be lifted in future.
-
-Additionally, it can only parse known options up to the first unknown option in the group - the unknown option could take options, so it isn't clear what any character after an unknown option means.

--- a/doc_src/cmds/argparse.rst
+++ b/doc_src/cmds/argparse.rst
@@ -156,7 +156,9 @@ Each option specification consists of:
 
 - Optionally a ``&``, indicating that the option and any attached values are not to be saved in ``$argv`` or ``$argv_opts``. This does not affect the the ``_flag_`` variables.
 
-- Optionally a ``!`` followed by fish script to validate the value. Typically this will be a function to run. If the exit status is zero the value for the flag is valid. If non-zero the value is invalid. Any error messages should be written to stdout (not stderr). See the section on :ref:`Flag Value Validation <flag-value-validation>` for more information.
+- Nothing if the flag is a boolean that takes no argument, or
+
+    - ``!`` followed by fish script to validate the value. Typically this will be a function to run. If the exit status is zero the value for the flag is valid. If non-zero the value is invalid. Any error messages should be written to stdout (not stderr). See the section on :ref:`Flag Value Validation <flag-value-validation>` for more information.
 
 See the :doc:`fish_opt <fish_opt>` command for a friendlier but more verbose way to create option specifications.
 

--- a/doc_src/cmds/argparse.rst
+++ b/doc_src/cmds/argparse.rst
@@ -40,12 +40,15 @@ The following ``argparse`` options are available. They must appear before all *O
 **-X** or **--max-args** *NUMBER*
     The maximum number of acceptable non-option arguments. The default is infinity.
 
-**-i** or **--ignore-unknown**
-    Ignore unknown options, keeping them and their arguments in ``$argv`` instead and not moving them to ``$argv_opts``. Unknown options are treated as if they take optional arguments (i.e. have option spec ``=?``).
+**-u** or **--move-unknown**
+    Allow unknown options, and move them from ``$argv`` to ``$argv_opts``. Unknown options are treated as if they take optional arguments (i.e. have option spec ``=?``).
 
     The above means that if a group of short options contains an unknown short option *followed* by a known short option, the known short option is
-    treated as an argument to the unknown one (e.g. ``--ignore-unknown h -- -oh`` will treat ``h`` as the argument to ``-o``, and so ``_flag_h`` will *not* be set).
-    In contrast, if the known option comes first (and does not take any arguments), the known option will be recognised and moved from ``$argv`` to ``$argv_opts`` (e.g. ``argparse --ignore-unknown h -- -ho`` will set ``$argv`` to ``-o`` and ``$argv_opts`` to ``-h``)
+    treated as an argument to the unknown one (e.g. ``--move-unknown h -- -oh`` will treat ``h`` as the argument to ``-o``, and so ``_flag_h`` will *not* be set).
+    In contrast, if the known option comes first (and does not take any arguments), the known option will be recognised (e.g. ``argparse --move-unknown h -- -ho`` *will* set ``$_flag_h`` to ``-h``)
+
+**-i** or **--ignore-unknown**
+    Deprecated. This is like **--move-unknown**, except that unknown options and their arguments are kept in ``$argv`` and not moved to ``$argv_opts``. Unlike **--move-unknown**, this option makes it impossible to distinguish between an unknown option and non-option argument that starts with a ``-`` (since any ``--`` seperator in ``$argv`` will be removed).
 
 **-s** or **--stop-nonopt**
     Causes scanning the arguments to stop as soon as the first non-option argument is seen. Among other things, this is useful to implement subcommands that have their own options.
@@ -95,7 +98,7 @@ But this is not::
     set -l argv
     argparse 'h/help' 'n/name' $argv
 
-The first ``--`` seen is what allows the ``argparse`` command to reliably separate the option specifications and options to ``argparse`` itself (like ``--ignore-unknown``) from the command arguments, so it is required.
+The first ``--`` seen is what allows the ``argparse`` command to reliably separate the option specifications and options to ``argparse`` itself (like ``--move-unknown``) from the command arguments, so it is required.
 
 .. _cmd-argparse-option-specification:
 
@@ -274,8 +277,7 @@ An example of using ``$argv_opts`` to forward known options to another command, 
         set -l opt_spec n/lines= q/quiet silent v/verbose z/zero-terminated help version
         # --qwords is a new option, but --bytes is an existing one which we will modify below
         set -a opt_spec "qwords=&" "c/bytes=&"
-        argparse $opt_spec -- $argv || return
-
+        argparse --move-unknown $opt_spec -- $argv || return
         if set -q _flag_qwords
             # --qwords allows specifying the size in multiples of 8 bytes
             set -a argv_opts --bytes=(math -- $_flag_qwords \* 8 || return)
@@ -302,4 +304,4 @@ An example of using ``$argv_opts`` to forward known options to another command, 
 
 The argparse call above saves all the options we do *not* want to process in ``$argv_opts``. (The ``--qwords`` and ``--bytes`` options are *not* saved there as their option spec's end in a ``~``). The code then processes the ``--qwords`` and ``--bytess`` options using the the ``$_flag_OPTION`` variables, and puts the transformed options in ``$argv_opts`` (which already contains all the original options, *other* than ``--qwords`` and ``--bytes``).
 
-Note that the ``argparse`` call does need to know all the options to the original ``head`` so that we can accurately work out the *non*-option arguments (i.e. ``$argv``, the filenames that ``head`` is to operate on). We'd similarly need to tell ``argparse`` the options if we wanted to modify the given filenames.
+Note that because the ``argparse`` call above uses ``--move-unknown``, if the original ``head`` adds any new options, the wrapper script can still be used; however, such new options must have their arguments given in "stuck" form (e.g. ``-o<arg>`` or ``--opt=<arg>``). This is needed for the wrapper script to work out the *non*-option arguments (i.e. ``$argv``, the filenames that ``head`` is to operate on).

--- a/doc_src/cmds/argparse.rst
+++ b/doc_src/cmds/argparse.rst
@@ -50,6 +50,21 @@ The following ``argparse`` options are available. They must appear before all *O
 **-i** or **--ignore-unknown**
     Deprecated. This is like **--move-unknown**, except that unknown options and their arguments are kept in ``$argv`` and not moved to ``$argv_opts``. Unlike **--move-unknown**, this option makes it impossible to distinguish between an unknown option and non-option argument that starts with a ``-`` (since any ``--`` seperator in ``$argv`` will be removed).
 
+**-S** or **--strict-longopts**
+    This makes the parsing of long options more strict. In particular, *without* this flag, if ``long`` is a known long option flag, ``--long`` and ``--long=<value>`` can be abbreviated as:
+
+    - ``-long`` and ``-long=<value>``, but *only* if there is no short flag ``l``.
+
+    - ``--lo`` and ``--lo=<value>``, but *only* if there is no other long flag that starts with ``lo``. Similarly with any other non-empty prefix of ``long``.
+
+    - ``-lo`` and ``-lo=<value>`` (i.e. combining the above two).
+
+    With the ``--strict-longopts`` flag, the above three are parse errors: one must use the syntax ``--long`` or ``--long=<value>`` to use a long option called ``long``.
+
+    This flag has no effect on the parsing of unknown options (which are parsed as if this flag is on).
+
+    This option may be on all the time in the future, so do not rely on the behaviour without it.
+
 **-s** or **--stop-nonopt**
     Causes scanning the arguments to stop as soon as the first non-option argument is seen. Among other things, this is useful to implement subcommands that have their own options.
 

--- a/doc_src/cmds/argparse.rst
+++ b/doc_src/cmds/argparse.rst
@@ -138,7 +138,9 @@ Each option specification consists of:
 
 - An optional alphanumeric short flag character.
 
-- An optional long flag name, seperated from the short flag (if present) by a ``/``. If neither a short flag nor long flag are present, an error is reported.
+- An optional long flag name preceded by a ``/``. If neither a short flag nor long flag are present, an error is reported.
+
+    - If there is no short flag, and the long flag name is more than one character, the ``/`` can be omitted.
 
     - For backwards compatibility, if there is a short and a long flag, a ``-`` can be used in place of the ``/``, if the short flag is not to be usable by users (in which case it will also not be exposed as a flag variable).
 
@@ -254,6 +256,8 @@ Some *OPTION_SPEC* examples:
 - ``name=+`` means that only ``--name`` is valid. It requires a value and can be used more than once. If the flag is seen then ``_flag_name`` will be set with the values associated with each occurrence.
 
 - ``x`` means that only ``-x`` is valid. It is a boolean that can be used more than once. If it is seen then ``_flag_x`` will be set as above.
+
+- ``/x`` is similar, but only ``--x`` is valid (instead of ``-x``).
 
 - ``x=``, ``x=?``, and ``x=+`` are similar to the n/name examples above but there is no long flag alternative to the short flag ``-x``.
 

--- a/doc_src/cmds/argparse.rst
+++ b/doc_src/cmds/argparse.rst
@@ -27,8 +27,8 @@ Options
 
 The following ``argparse`` options are available. They must appear before all *OPTION_SPEC*\ s:
 
-**-n** or **--name**
-    The command name for use in error messages. By default the current function name will be used, or ``argparse`` if run outside of a function.
+**-n** or **--name** *NAME*
+    Use *NAME* in error messages. By default the current function name will be used, or ``argparse`` if run outside of a function.
 
 **-x** or **--exclusive** *OPTIONS*
     A comma separated list of options that are mutually exclusive. You can use this more than once to define multiple sets of mutually exclusive options.

--- a/doc_src/cmds/argparse.rst
+++ b/doc_src/cmds/argparse.rst
@@ -136,9 +136,11 @@ Option Specifications
 
 Each option specification consists of:
 
-- An optional alphanumeric short flag character, followed by a ``/`` if the short flag can be used by someone invoking your command or, for backwards compatibility, a ``-`` if it should not be exposed as a valid short flag (in which case it will also not be exposed as a flag variable).
+- An optional alphanumeric short flag character.
 
-- An optional long flag name, which if not present the short flag can be used, and if that is also not present, an error is reported
+- An optional long flag name, seperated from the short flag (if present) by a ``/``. If neither a short flag nor long flag are present, an error is reported.
+
+    - For backwards compatibility, if there is a short and a long flag, a ``-`` can be used in place of the ``/``, if the short flag is not to be usable by users (in which case it will also not be exposed as a flag variable).
 
 - Nothing if the flag is a boolean that takes no argument or is an integer flag, or
 

--- a/doc_src/cmds/fish_opt.rst
+++ b/doc_src/cmds/fish_opt.rst
@@ -8,7 +8,7 @@ Synopsis
 
 .. synopsis::
 
-    fish_opt -s ALPHANUM [-l LONG-NAME] [-or] [--multiple-vals] [--long-only]
+    fish_opt -s ALPHANUM [-l LONG-NAME] [-ord] [--multiple-vals] [--long-only]
     fish_opt --help
 
 Description
@@ -35,6 +35,10 @@ The following ``argparse`` options are available:
 
 **--multiple-vals**
     The option being defined requires a value each time it is seen. Each instance is stored. This means the resulting flag variable created by ``argparse`` will have one element for each instance of this option in the arguments.
+
+**-d** or **--delete**
+    The option and any values will be deleted from the ``$argv_opts`` variables set by ``argparse``
+    (as with other options, it will also be deleted from ``$argv``).
 
 **-h** or **--help**
     Displays help about using this command.

--- a/doc_src/cmds/fish_opt.rst
+++ b/doc_src/cmds/fish_opt.rst
@@ -8,7 +8,7 @@ Synopsis
 
 .. synopsis::
 
-    fish_opt -s ALPHANUM [-l LONG-NAME] [-ormd] [--long-only]
+    fish_opt [-s ALPHANUM] [-l LONG-NAME] [-ormd] [--long-only]
     fish_opt --help
 
 Description
@@ -19,13 +19,13 @@ This command provides a way to produce option specifications suitable for use wi
 The following ``argparse`` options are available:
 
 **-s** or **--short** *ALPHANUM*
-    Takes a single letter that is used as the short flag in the option being defined. This option is mandatory.
+    Takes a single letter or number that is used as the short flag in the option being defined. Either this option or the **--long** option must be provided.
 
 **-l** or **--long** *LONG-NAME*
-    Takes a string that is used as the long flag in the option being defined. This option is optional and has no default. If no long flag is defined then only the short flag will be allowed when parsing arguments using the option specification.
+    Takes a string that is used as the long flag in the option being defined. This option is optional and has no default. If no long flag is defined then only the short flag will be allowed when parsing arguments using the option specification.  If there is no **--short** flag, the long flag name must be more than one character (use **--short** together with **--long-only** to bypass this restriction).
 
 **--long-only**
-    The option being defined will only allow the long flag name to be used. The short flag name must still be defined (i.e., **--short** must be specified) but it cannot be used when parsing arguments using this option specification.
+    The option being defined will only allow the long flag name to be used, even if the short flag is defined (i.e., **--short** is specified).
 
 **-o** or **--optional-val**
     The option being defined can take a value, but it is optional rather than required. If the option is seen more than once when parsing arguments, only the last value seen is saved. This means the resulting flag variable created by ``argparse`` will zero elements if no value was given with the option else it will have exactly one element.
@@ -67,7 +67,7 @@ Same as above but with a second flag that requires a value:
     argparse $options -- $argv
 
 
-Same as above but with a third flag that can be given multiple times saving the value of each instance seen and only the long flag name (``--token``) can be used:
+Same as above but with a third flag that can be given multiple times saving the value of each instance seen and only a long flag name (``--token``) is defined:
 
 
 
@@ -75,6 +75,6 @@ Same as above but with a third flag that can be given multiple times saving the 
 
     set -l options (fish_opt --short=h --long=help)
     set options $options (fish_opt --short=m --long=max --required-val)
-    set options $options (fish_opt --short=t --long=token --multiple-vals --long-only)
+    set options $options (fish_opt --long=token --multiple-vals)
     argparse $options -- $argv
 

--- a/doc_src/cmds/fish_opt.rst
+++ b/doc_src/cmds/fish_opt.rst
@@ -8,7 +8,7 @@ Synopsis
 
 .. synopsis::
 
-    fish_opt -s ALPHANUM [-l LONG-NAME] [-ord] [--multiple-vals] [--long-only]
+    fish_opt -s ALPHANUM [-l LONG-NAME] [-ormd] [--long-only]
     fish_opt --help
 
 Description
@@ -33,8 +33,8 @@ The following ``argparse`` options are available:
 **-r** or **--required-val**
     The option being defined requires a value. If the option is seen more than once when parsing arguments, only the last value seen is saved. This means the resulting flag variable created by ``argparse`` will have exactly one element.
 
-**--multiple-vals**
-    The option being defined requires a value each time it is seen. Each instance is stored. This means the resulting flag variable created by ``argparse`` will have one element for each instance of this option in the arguments.
+**-m** or **--multiple-vals**
+    The value of each instance of the option is accumulated. If **--optional-val** is provided, the value is optional, and an empty string is stored if no value is provided. Otherwise, the **--requiured-val** option is implied and each instance of the option requires a value. This means the resulting flag variable created by ``argparse`` will have one element for each instance of this option in the arguments, even for instances that did not provide a value.
 
 **-d** or **--delete**
     The option and any values will be deleted from the ``$argv_opts`` variables set by ``argparse``

--- a/doc_src/cmds/fish_opt.rst
+++ b/doc_src/cmds/fish_opt.rst
@@ -8,7 +8,7 @@ Synopsis
 
 .. synopsis::
 
-    fish_opt [-s ALPHANUM] [-l LONG-NAME] [-ormd] [--long-only]
+    fish_opt [-s ALPHANUM] [-l LONG-NAME] [-ormd] [--long-only] [-v COMMAND OPTIONS ... ]
     fish_opt --help
 
 Description
@@ -40,6 +40,9 @@ The following ``argparse`` options are available:
     The option and any values will be deleted from the ``$argv_opts`` variables set by ``argparse``
     (as with other options, it will also be deleted from ``$argv``).
 
+**-v** or **--validate** *COMMAND* *OPTION...*
+    This option must be the last one, and requires one of ``-o``, ``-r``, or ``-m``. All the remaining arguments are interpreted a fish script to run to validate the value of the argument, see ``argparse`` documentation for more details. Note that the interpretation of *COMMAND* *OPTION...* is similar to ``eval``, so you may need to quote or escape special characters *twice* if you want them to be interpreted literally when the validate script is run.
+
 **-h** or **--help**
     Displays help about using this command.
 
@@ -63,9 +66,16 @@ Same as above but with a second flag that requires a value:
 ::
 
     set -l options (fish_opt -s h -l help)
-    set options $options (fish_opt -s m -l max --required-val)
+    set options $options (fish_opt -s m -l max -r)
     argparse $options -- $argv
 
+Same as above but the value of the second flag cannot be the empty string:
+
+::
+
+    set -l options (fish_opt -s h -l help)
+    set options $options (fish_opt -s m -l max -rv test \$_flag_valu != "''")
+    argparse $options -- $argv
 
 Same as above but with a third flag that can be given multiple times saving the value of each instance seen and only a long flag name (``--token``) is defined:
 
@@ -74,7 +84,7 @@ Same as above but with a third flag that can be given multiple times saving the 
 ::
 
     set -l options (fish_opt --short=h --long=help)
-    set options $options (fish_opt --short=m --long=max --required-val)
+    set options $options (fish_opt --short=m --long=max --required-val --validate test \$_flag_valu != "''")
     set options $options (fish_opt --long=token --multiple-vals)
     argparse $options -- $argv
 

--- a/doc_src/cmds/fish_opt.rst
+++ b/doc_src/cmds/fish_opt.rst
@@ -8,7 +8,7 @@ Synopsis
 
 .. synopsis::
 
-    fish_opt [(-slor | --multiple-vals=) OPTNAME]
+    fish_opt -s ALPHANUM [-l LONG-NAME] [-or] [--multiple-vals] [--long-only]
     fish_opt --help
 
 Description
@@ -18,10 +18,10 @@ This command provides a way to produce option specifications suitable for use wi
 
 The following ``argparse`` options are available:
 
-**-s** or **--short**
+**-s** or **--short** *ALPHANUM*
     Takes a single letter that is used as the short flag in the option being defined. This option is mandatory.
 
-**-l** or **--long**
+**-l** or **--long** *LONG-NAME*
     Takes a string that is used as the long flag in the option being defined. This option is optional and has no default. If no long flag is defined then only the short flag will be allowed when parsing arguments using the option specification.
 
 **--long-only**

--- a/doc_src/cmds/fish_opt.rst
+++ b/doc_src/cmds/fish_opt.rst
@@ -22,10 +22,10 @@ The following ``argparse`` options are available:
     Takes a single letter or number that is used as the short flag in the option being defined. Either this option or the **--long** option must be provided.
 
 **-l** or **--long** *LONG-NAME*
-    Takes a string that is used as the long flag in the option being defined. This option is optional and has no default. If no long flag is defined then only the short flag will be allowed when parsing arguments using the option specification.  If there is no **--short** flag, the long flag name must be more than one character (use **--short** together with **--long-only** to bypass this restriction).
+    Takes a string that is used as the long flag in the option being defined. This option is optional and has no default. If no long flag is defined then only the short flag will be allowed when parsing arguments using the option specification.
 
 **--long-only**
-    The option being defined will only allow the long flag name to be used, even if the short flag is defined (i.e., **--short** is specified).
+    Deprecated. The option being defined will only allow the long flag name to be used, even if the short flag is defined (i.e., **--short** is specified).
 
 **-o** or **--optional-val**
     The option being defined can take a value, but it is optional rather than required. If the option is seen more than once when parsing arguments, only the last value seen is saved. This means the resulting flag variable created by ``argparse`` will zero elements if no value was given with the option else it will have exactly one element.

--- a/po/de.po
+++ b/po/de.po
@@ -1945,9 +1945,6 @@ msgstr "%s: Ungültige Maske '%s'\\n"
 msgid "%s: Not inside of command substitution"
 msgstr ""
 
-msgid "%s: The --long flag must be more than one character when no --short flag is provided\\n"
-msgstr ""
-
 msgid "%s: The --long-only flag requires the --long flag\\n"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -1939,6 +1939,9 @@ msgstr ""
 msgid "%s: Expected exactly one argument, got %s.\\n\\nSynopsis:\\n\\t%svared%s VARIABLE\\n"
 msgstr ""
 
+msgid "%s: Extra non-option arguments were provided\\n"
+msgstr ""
+
 msgid "%s: Invalid mask '%s'\\n"
 msgstr "%s: Ungültige Maske '%s'\\n"
 
@@ -1949,6 +1952,12 @@ msgid "%s: The --long-only flag requires the --long flag\\n"
 msgstr ""
 
 msgid "%s: The --short flag must be a single character\\n"
+msgstr ""
+
+msgid "%s: The --validate flag requires subsequent arguments\\n"
+msgstr ""
+
+msgid "%s: The --validate flag requires the --required-val, --optional-value, or --multiple-vals flag\\n"
 msgstr ""
 
 msgid "%s: The number of positions to skip must be a non-negative integer\\n"
@@ -25442,6 +25451,9 @@ msgid "First page to convert"
 msgstr ""
 
 msgid "First remove existing destination files"
+msgstr ""
+
+msgid "Fish script to validate option values"
 msgstr ""
 
 msgid "Fish's release notes"

--- a/po/de.po
+++ b/po/de.po
@@ -413,6 +413,11 @@ msgstr ""
 msgid "%ls: Invalid --min-args value '%ls'\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: Invalid --unknown-arguments value '%ls'\n"
+msgstr ""
+
 #, c-format
 msgid "%ls: Invalid count value '%ls'\n"
 msgstr "%ls: Ungültiger 'count'-Wert '%ls'\n"

--- a/po/de.po
+++ b/po/de.po
@@ -196,6 +196,11 @@ msgstr "%ls: %ls: ungültiger Unterbefehl\n"
 msgid "%ls: %ls: invalid variable name. See `help identifiers`\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: %ls: option does not take an argument\n"
+msgstr ""
+
 #, c-format
 msgid "%ls: %ls: option requires an argument\n"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -1930,6 +1930,9 @@ msgstr ""
 msgid "%s: Directory stack is empty…\\n"
 msgstr ""
 
+msgid "%s: Either the --short or --long flag must be provided\\n"
+msgstr ""
+
 msgid "%s: Expected 1, 2 or 3 arguments, got %d\\n"
 msgstr ""
 
@@ -1942,7 +1945,13 @@ msgstr "%s: Ungültige Maske '%s'\\n"
 msgid "%s: Not inside of command substitution"
 msgstr ""
 
-msgid "%s: The --short flag is required and must be a single character\\n"
+msgid "%s: The --long flag must be more than one character when no --short flag is provided\\n"
+msgstr ""
+
+msgid "%s: The --long-only flag requires the --long flag\\n"
+msgstr ""
+
+msgid "%s: The --short flag must be a single character\\n"
 msgstr ""
 
 msgid "%s: The number of positions to skip must be a non-negative integer\\n"

--- a/po/de.po
+++ b/po/de.po
@@ -13617,6 +13617,9 @@ msgstr ""
 msgid "Delete only those tarballs which aren't present in a snapshot"
 msgstr ""
 
+msgid "Delete option from argv_opts"
+msgstr ""
+
 msgid "Delete previous settime entry"
 msgstr ""
 

--- a/po/en.po
+++ b/po/en.po
@@ -1941,9 +1941,6 @@ msgstr "%s: Invalid mask “%s”\\n"
 msgid "%s: Not inside of command substitution"
 msgstr "%s: Not inside of command substitution"
 
-msgid "%s: The --long flag must be more than one character when no --short flag is provided\\n"
-msgstr ""
-
 msgid "%s: The --long-only flag requires the --long flag\\n"
 msgstr ""
 

--- a/po/en.po
+++ b/po/en.po
@@ -194,6 +194,11 @@ msgstr ""
 msgid "%ls: %ls: invalid variable name. See `help identifiers`\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: %ls: option does not take an argument\n"
+msgstr ""
+
 #, c-format
 msgid "%ls: %ls: option requires an argument\n"
 msgstr ""

--- a/po/en.po
+++ b/po/en.po
@@ -13613,6 +13613,9 @@ msgstr ""
 msgid "Delete only those tarballs which aren't present in a snapshot"
 msgstr ""
 
+msgid "Delete option from argv_opts"
+msgstr ""
+
 msgid "Delete previous settime entry"
 msgstr ""
 

--- a/po/en.po
+++ b/po/en.po
@@ -1935,6 +1935,9 @@ msgstr "%s: Expected 1, 2 or 3 arguments, got %d\\n"
 msgid "%s: Expected exactly one argument, got %s.\\n\\nSynopsis:\\n\\t%svared%s VARIABLE\\n"
 msgstr "%s: Expected exactly one argument, got %s.\\n\\nSynopsis:\\n\\t%svared%s VARIABLE\\n"
 
+msgid "%s: Extra non-option arguments were provided\\n"
+msgstr ""
+
 msgid "%s: Invalid mask '%s'\\n"
 msgstr "%s: Invalid mask “%s”\\n"
 
@@ -1945,6 +1948,12 @@ msgid "%s: The --long-only flag requires the --long flag\\n"
 msgstr ""
 
 msgid "%s: The --short flag must be a single character\\n"
+msgstr ""
+
+msgid "%s: The --validate flag requires subsequent arguments\\n"
+msgstr ""
+
+msgid "%s: The --validate flag requires the --required-val, --optional-value, or --multiple-vals flag\\n"
 msgstr ""
 
 msgid "%s: The number of positions to skip must be a non-negative integer\\n"
@@ -25438,6 +25447,9 @@ msgid "First page to convert"
 msgstr ""
 
 msgid "First remove existing destination files"
+msgstr ""
+
+msgid "Fish script to validate option values"
 msgstr ""
 
 msgid "Fish's release notes"

--- a/po/en.po
+++ b/po/en.po
@@ -411,6 +411,11 @@ msgstr ""
 msgid "%ls: Invalid --min-args value '%ls'\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: Invalid --unknown-arguments value '%ls'\n"
+msgstr ""
+
 #, c-format
 msgid "%ls: Invalid count value '%ls'\n"
 msgstr ""

--- a/po/en.po
+++ b/po/en.po
@@ -1926,6 +1926,9 @@ msgstr "%s: Could not find a web browser.\\n"
 msgid "%s: Directory stack is empty…\\n"
 msgstr ""
 
+msgid "%s: Either the --short or --long flag must be provided\\n"
+msgstr ""
+
 msgid "%s: Expected 1, 2 or 3 arguments, got %d\\n"
 msgstr "%s: Expected 1, 2 or 3 arguments, got %d\\n"
 
@@ -1938,7 +1941,13 @@ msgstr "%s: Invalid mask “%s”\\n"
 msgid "%s: Not inside of command substitution"
 msgstr "%s: Not inside of command substitution"
 
-msgid "%s: The --short flag is required and must be a single character\\n"
+msgid "%s: The --long flag must be more than one character when no --short flag is provided\\n"
+msgstr ""
+
+msgid "%s: The --long-only flag requires the --long flag\\n"
+msgstr ""
+
+msgid "%s: The --short flag must be a single character\\n"
 msgstr ""
 
 msgid "%s: The number of positions to skip must be a non-negative integer\\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -295,6 +295,11 @@ msgstr ""
 msgid "%ls: %ls: invalid variable name. See `help identifiers`\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: %ls: option does not take an argument\n"
+msgstr ""
+
 #, c-format
 msgid "%ls: %ls: option requires an argument\n"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -2027,6 +2027,9 @@ msgstr "%s : Impossible de trouver un navigateur Web.\\n"
 msgid "%s: Directory stack is empty…\\n"
 msgstr "%s : Pile de dossiers vide…\\n"
 
+msgid "%s: Either the --short or --long flag must be provided\\n"
+msgstr ""
+
 msgid "%s: Expected 1, 2 or 3 arguments, got %d\\n"
 msgstr "%s : 1, 2 ou 3 arguments attendus, %d reçu(s)\\n"
 
@@ -2039,8 +2042,14 @@ msgstr "%s : Masque '%s' invalide\\n"
 msgid "%s: Not inside of command substitution"
 msgstr "%s : hors de la substitution de commande"
 
-msgid "%s: The --short flag is required and must be a single character\\n"
-msgstr "%s : L’option --short est requise et doit être un caractère unique\\n"
+msgid "%s: The --long flag must be more than one character when no --short flag is provided\\n"
+msgstr ""
+
+msgid "%s: The --long-only flag requires the --long flag\\n"
+msgstr ""
+
+msgid "%s: The --short flag must be a single character\\n"
+msgstr ""
 
 msgid "%s: The number of positions to skip must be a non-negative integer\\n"
 msgstr "%s : Le nombre de positions à passer doit être un entier naturel\\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -512,6 +512,11 @@ msgstr "%ls : Valeur --max-args '%ls' invalide\n"
 msgid "%ls: Invalid --min-args value '%ls'\n"
 msgstr "%ls : Valeur --min-args '%ls' invalide\n"
 
+#
+#, c-format
+msgid "%ls: Invalid --unknown-arguments value '%ls'\n"
+msgstr ""
+
 #, c-format
 msgid "%ls: Invalid count value '%ls'\n"
 msgstr "%ls : compte '%ls' invalide\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -13714,6 +13714,9 @@ msgstr ""
 msgid "Delete only those tarballs which aren't present in a snapshot"
 msgstr ""
 
+msgid "Delete option from argv_opts"
+msgstr ""
+
 msgid "Delete previous settime entry"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -2036,6 +2036,9 @@ msgstr "%s : 1, 2 ou 3 arguments attendus, %d reçu(s)\\n"
 msgid "%s: Expected exactly one argument, got %s.\\n\\nSynopsis:\\n\\t%svared%s VARIABLE\\n"
 msgstr "%s : Un argument attendu, %s reçu(s).\\n\\nRésumé :\\n\\t%svared%s VARIABLE\\n"
 
+msgid "%s: Extra non-option arguments were provided\\n"
+msgstr ""
+
 msgid "%s: Invalid mask '%s'\\n"
 msgstr "%s : Masque '%s' invalide\\n"
 
@@ -2046,6 +2049,12 @@ msgid "%s: The --long-only flag requires the --long flag\\n"
 msgstr ""
 
 msgid "%s: The --short flag must be a single character\\n"
+msgstr ""
+
+msgid "%s: The --validate flag requires subsequent arguments\\n"
+msgstr ""
+
+msgid "%s: The --validate flag requires the --required-val, --optional-value, or --multiple-vals flag\\n"
 msgstr ""
 
 msgid "%s: The number of positions to skip must be a non-negative integer\\n"
@@ -25539,6 +25548,9 @@ msgid "First page to convert"
 msgstr ""
 
 msgid "First remove existing destination files"
+msgstr ""
+
+msgid "Fish script to validate option values"
 msgstr ""
 
 msgid "Fish's release notes"

--- a/po/fr.po
+++ b/po/fr.po
@@ -2042,9 +2042,6 @@ msgstr "%s : Masque '%s' invalide\\n"
 msgid "%s: Not inside of command substitution"
 msgstr "%s : hors de la substitution de commande"
 
-msgid "%s: The --long flag must be more than one character when no --short flag is provided\\n"
-msgstr ""
-
 msgid "%s: The --long-only flag requires the --long flag\\n"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -13609,6 +13609,9 @@ msgstr ""
 msgid "Delete only those tarballs which aren't present in a snapshot"
 msgstr ""
 
+msgid "Delete option from argv_opts"
+msgstr ""
+
 msgid "Delete previous settime entry"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -1931,6 +1931,9 @@ msgstr ""
 msgid "%s: Expected exactly one argument, got %s.\\n\\nSynopsis:\\n\\t%svared%s VARIABLE\\n"
 msgstr ""
 
+msgid "%s: Extra non-option arguments were provided\\n"
+msgstr ""
+
 msgid "%s: Invalid mask '%s'\\n"
 msgstr ""
 
@@ -1941,6 +1944,12 @@ msgid "%s: The --long-only flag requires the --long flag\\n"
 msgstr ""
 
 msgid "%s: The --short flag must be a single character\\n"
+msgstr ""
+
+msgid "%s: The --validate flag requires subsequent arguments\\n"
+msgstr ""
+
+msgid "%s: The --validate flag requires the --required-val, --optional-value, or --multiple-vals flag\\n"
 msgstr ""
 
 msgid "%s: The number of positions to skip must be a non-negative integer\\n"
@@ -25434,6 +25443,9 @@ msgid "First page to convert"
 msgstr ""
 
 msgid "First remove existing destination files"
+msgstr ""
+
+msgid "Fish script to validate option values"
 msgstr ""
 
 msgid "Fish's release notes"

--- a/po/pl.po
+++ b/po/pl.po
@@ -1937,9 +1937,6 @@ msgstr ""
 msgid "%s: Not inside of command substitution"
 msgstr ""
 
-msgid "%s: The --long flag must be more than one character when no --short flag is provided\\n"
-msgstr ""
-
 msgid "%s: The --long-only flag requires the --long flag\\n"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -1922,6 +1922,9 @@ msgstr ""
 msgid "%s: Directory stack is empty…\\n"
 msgstr ""
 
+msgid "%s: Either the --short or --long flag must be provided\\n"
+msgstr ""
+
 msgid "%s: Expected 1, 2 or 3 arguments, got %d\\n"
 msgstr ""
 
@@ -1934,7 +1937,13 @@ msgstr ""
 msgid "%s: Not inside of command substitution"
 msgstr ""
 
-msgid "%s: The --short flag is required and must be a single character\\n"
+msgid "%s: The --long flag must be more than one character when no --short flag is provided\\n"
+msgstr ""
+
+msgid "%s: The --long-only flag requires the --long flag\\n"
+msgstr ""
+
+msgid "%s: The --short flag must be a single character\\n"
 msgstr ""
 
 msgid "%s: The number of positions to skip must be a non-negative integer\\n"

--- a/po/pl.po
+++ b/po/pl.po
@@ -190,6 +190,11 @@ msgstr ""
 msgid "%ls: %ls: invalid variable name. See `help identifiers`\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: %ls: option does not take an argument\n"
+msgstr ""
+
 #, c-format
 msgid "%ls: %ls: option requires an argument\n"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -407,6 +407,11 @@ msgstr ""
 msgid "%ls: Invalid --min-args value '%ls'\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: Invalid --unknown-arguments value '%ls'\n"
+msgstr ""
+
 #, c-format
 msgid "%ls: Invalid count value '%ls'\n"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1936,6 +1936,9 @@ msgstr ""
 msgid "%s: Expected exactly one argument, got %s.\\n\\nSynopsis:\\n\\t%svared%s VARIABLE\\n"
 msgstr ""
 
+msgid "%s: Extra non-option arguments were provided\\n"
+msgstr ""
+
 msgid "%s: Invalid mask '%s'\\n"
 msgstr ""
 
@@ -1946,6 +1949,12 @@ msgid "%s: The --long-only flag requires the --long flag\\n"
 msgstr ""
 
 msgid "%s: The --short flag must be a single character\\n"
+msgstr ""
+
+msgid "%s: The --validate flag requires subsequent arguments\\n"
+msgstr ""
+
+msgid "%s: The --validate flag requires the --required-val, --optional-value, or --multiple-vals flag\\n"
 msgstr ""
 
 msgid "%s: The number of positions to skip must be a non-negative integer\\n"
@@ -25449,6 +25458,9 @@ msgid "First page to convert"
 msgstr ""
 
 msgid "First remove existing destination files"
+msgstr ""
+
+msgid "Fish script to validate option values"
 msgstr ""
 
 msgid "Fish's release notes"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1927,6 +1927,9 @@ msgstr ""
 msgid "%s: Directory stack is empty…\\n"
 msgstr ""
 
+msgid "%s: Either the --short or --long flag must be provided\\n"
+msgstr ""
+
 msgid "%s: Expected 1, 2 or 3 arguments, got %d\\n"
 msgstr ""
 
@@ -1939,7 +1942,13 @@ msgstr ""
 msgid "%s: Not inside of command substitution"
 msgstr ""
 
-msgid "%s: The --short flag is required and must be a single character\\n"
+msgid "%s: The --long flag must be more than one character when no --short flag is provided\\n"
+msgstr ""
+
+msgid "%s: The --long-only flag requires the --long flag\\n"
+msgstr ""
+
+msgid "%s: The --short flag must be a single character\\n"
 msgstr ""
 
 msgid "%s: The number of positions to skip must be a non-negative integer\\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -13614,6 +13614,9 @@ msgstr ""
 msgid "Delete only those tarballs which aren't present in a snapshot"
 msgstr ""
 
+msgid "Delete option from argv_opts"
+msgstr ""
+
 msgid "Delete previous settime entry"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -195,6 +195,11 @@ msgstr ""
 msgid "%ls: %ls: invalid variable name. See `help identifiers`\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: %ls: option does not take an argument\n"
+msgstr ""
+
 #, c-format
 msgid "%ls: %ls: option requires an argument\n"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1942,9 +1942,6 @@ msgstr ""
 msgid "%s: Not inside of command substitution"
 msgstr ""
 
-msgid "%s: The --long flag must be more than one character when no --short flag is provided\\n"
-msgstr ""
-
 msgid "%s: The --long-only flag requires the --long flag\\n"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -412,6 +412,11 @@ msgstr ""
 msgid "%ls: Invalid --min-args value '%ls'\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: Invalid --unknown-arguments value '%ls'\n"
+msgstr ""
+
 #, c-format
 msgid "%ls: Invalid count value '%ls'\n"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -408,6 +408,11 @@ msgstr ""
 msgid "%ls: Invalid --min-args value '%ls'\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: Invalid --unknown-arguments value '%ls'\n"
+msgstr ""
+
 #, c-format
 msgid "%ls: Invalid count value '%ls'\n"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -191,6 +191,11 @@ msgstr ""
 msgid "%ls: %ls: invalid variable name. See `help identifiers`\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: %ls: option does not take an argument\n"
+msgstr ""
+
 #, c-format
 msgid "%ls: %ls: option requires an argument\n"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -1932,6 +1932,9 @@ msgstr "%s: Förväntade 1, 2 eller 3 argument, fick %d\\n"
 msgid "%s: Expected exactly one argument, got %s.\\n\\nSynopsis:\\n\\t%svared%s VARIABLE\\n"
 msgstr "%s: Förväntade exakt ett argument, fick %s\\n\\nSynopsis:\\n\\t%svared%s VARIABEL\\n"
 
+msgid "%s: Extra non-option arguments were provided\\n"
+msgstr ""
+
 msgid "%s: Invalid mask '%s'\\n"
 msgstr "%s: Ogiltigt mask '%s'\\n"
 
@@ -1942,6 +1945,12 @@ msgid "%s: The --long-only flag requires the --long flag\\n"
 msgstr ""
 
 msgid "%s: The --short flag must be a single character\\n"
+msgstr ""
+
+msgid "%s: The --validate flag requires subsequent arguments\\n"
+msgstr ""
+
+msgid "%s: The --validate flag requires the --required-val, --optional-value, or --multiple-vals flag\\n"
 msgstr ""
 
 msgid "%s: The number of positions to skip must be a non-negative integer\\n"
@@ -25437,6 +25446,9 @@ msgid "First page to convert"
 msgstr ""
 
 msgid "First remove existing destination files"
+msgstr ""
+
+msgid "Fish script to validate option values"
 msgstr ""
 
 msgid "Fish's release notes"

--- a/po/sv.po
+++ b/po/sv.po
@@ -1938,9 +1938,6 @@ msgstr "%s: Ogiltigt mask '%s'\\n"
 msgid "%s: Not inside of command substitution"
 msgstr ""
 
-msgid "%s: The --long flag must be more than one character when no --short flag is provided\\n"
-msgstr ""
-
 msgid "%s: The --long-only flag requires the --long flag\\n"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -13612,6 +13612,9 @@ msgstr ""
 msgid "Delete only those tarballs which aren't present in a snapshot"
 msgstr ""
 
+msgid "Delete option from argv_opts"
+msgstr ""
+
 msgid "Delete previous settime entry"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -1923,6 +1923,9 @@ msgstr "%s: Kunde inte hitta en webbrowser\\n"
 msgid "%s: Directory stack is empty…\\n"
 msgstr ""
 
+msgid "%s: Either the --short or --long flag must be provided\\n"
+msgstr ""
+
 msgid "%s: Expected 1, 2 or 3 arguments, got %d\\n"
 msgstr "%s: Förväntade 1, 2 eller 3 argument, fick %d\\n"
 
@@ -1935,7 +1938,13 @@ msgstr "%s: Ogiltigt mask '%s'\\n"
 msgid "%s: Not inside of command substitution"
 msgstr ""
 
-msgid "%s: The --short flag is required and must be a single character\\n"
+msgid "%s: The --long flag must be more than one character when no --short flag is provided\\n"
+msgstr ""
+
+msgid "%s: The --long-only flag requires the --long flag\\n"
+msgstr ""
+
+msgid "%s: The --short flag must be a single character\\n"
 msgstr ""
 
 msgid "%s: The number of positions to skip must be a non-negative integer\\n"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -405,6 +405,11 @@ msgstr "%ls: 无效的 --max-args 值 '%ls'\n"
 msgid "%ls: Invalid --min-args value '%ls'\n"
 msgstr "%ls: 无效的 --min-args 值 '%ls'\n"
 
+#
+#, c-format
+msgid "%ls: Invalid --unknown-arguments value '%ls'\n"
+msgstr ""
+
 #, fuzzy, c-format
 msgid "%ls: Invalid count value '%ls'\n"
 msgstr "%s: 无效的计数值 '%s'\n"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1934,6 +1934,9 @@ msgstr "%s: 预期参数 1, 2 或 3, 获得 %d\\n"
 msgid "%s: Expected exactly one argument, got %s.\\n\\nSynopsis:\\n\\t%svared%s VARIABLE\\n"
 msgstr "%s: 需要精确的一条参数, 获得 %s.\\n\\nSynopsis:\\n\\t%svared%s VARIABLE\\n"
 
+msgid "%s: Extra non-option arguments were provided\\n"
+msgstr ""
+
 msgid "%s: Invalid mask '%s'\\n"
 msgstr "%s:无效的掩码'%s'\\n"
 
@@ -1944,6 +1947,12 @@ msgid "%s: The --long-only flag requires the --long flag\\n"
 msgstr ""
 
 msgid "%s: The --short flag must be a single character\\n"
+msgstr ""
+
+msgid "%s: The --validate flag requires subsequent arguments\\n"
+msgstr ""
+
+msgid "%s: The --validate flag requires the --required-val, --optional-value, or --multiple-vals flag\\n"
 msgstr ""
 
 msgid "%s: The number of positions to skip must be a non-negative integer\\n"
@@ -25438,6 +25447,9 @@ msgstr "要转换的第一个页面"
 
 msgid "First remove existing destination files"
 msgstr "首先删除已有目的文件"
+
+msgid "Fish script to validate option values"
+msgstr ""
 
 msgid "Fish's release notes"
 msgstr "fish的放行记录"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1925,6 +1925,9 @@ msgstr "%s: 找不到网页浏览器.\\n"
 msgid "%s: Directory stack is empty…\\n"
 msgstr "%s: 目录堆栈为空...\\n"
 
+msgid "%s: Either the --short or --long flag must be provided\\n"
+msgstr ""
+
 msgid "%s: Expected 1, 2 or 3 arguments, got %d\\n"
 msgstr "%s: 预期参数 1, 2 或 3, 获得 %d\\n"
 
@@ -1937,8 +1940,14 @@ msgstr "%s:无效的掩码'%s'\\n"
 msgid "%s: Not inside of command substitution"
 msgstr "%s: 命令替换不在内"
 
-msgid "%s: The --short flag is required and must be a single character\\n"
-msgstr "%s:需要 --short旗并必须是单一字符\\n"
+msgid "%s: The --long flag must be more than one character when no --short flag is provided\\n"
+msgstr ""
+
+msgid "%s: The --long-only flag requires the --long flag\\n"
+msgstr ""
+
+msgid "%s: The --short flag must be a single character\\n"
+msgstr ""
 
 msgid "%s: The number of positions to skip must be a non-negative integer\\n"
 msgstr "%s:要跳过的位置数必须是非负整数\\n"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1940,9 +1940,6 @@ msgstr "%s:无效的掩码'%s'\\n"
 msgid "%s: Not inside of command substitution"
 msgstr "%s: 命令替换不在内"
 
-msgid "%s: The --long flag must be more than one character when no --short flag is provided\\n"
-msgstr ""
-
 msgid "%s: The --long-only flag requires the --long flag\\n"
 msgstr ""
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -188,6 +188,11 @@ msgstr "%ls: %ls:无效的子命令\n"
 msgid "%ls: %ls: invalid variable name. See `help identifiers`\n"
 msgstr "%ls: %ls:无效的可变名称. 参见`help identifiers`\n"
 
+#
+#, c-format
+msgid "%ls: %ls: option does not take an argument\n"
+msgstr ""
+
 #, c-format
 msgid "%ls: %ls: option requires an argument\n"
 msgstr "%ls:%ls: 选项需要参数\n"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -13612,6 +13612,9 @@ msgstr "只删除 libvirt 元数据, 留下快照内容"
 msgid "Delete only those tarballs which aren't present in a snapshot"
 msgstr ""
 
+msgid "Delete option from argv_opts"
+msgstr ""
+
 msgid "Delete previous settime entry"
 msgstr "删除上一个设定时间项"
 

--- a/share/completions/argparse.fish
+++ b/share/completions/argparse.fish
@@ -72,5 +72,7 @@ complete --command argparse --short-option i --long-option ignore-unknown \
 complete --command argparse --short-option u --long-option move-unknown \
     -n '! __fish_seen_argument --short i --long ignore-unknown' \
     --description 'Move unknown options into \$argv_opts'
+complete --command argparse --short-option S --long-option strict-longopts \
+    --description 'Pass long options strictly'
 complete --command argparse --short-option s --long-option stop-nonopt \
     --description 'Exit on subcommand'

--- a/share/completions/argparse.fish
+++ b/share/completions/argparse.fish
@@ -74,5 +74,8 @@ complete --command argparse --short-option u --long-option move-unknown \
     --description 'Move unknown options into \$argv_opts'
 complete --command argparse --short-option S --long-option strict-longopts \
     --description 'Pass long options strictly'
+complete --command argparse --short-option U --long-option unknown-arguments --no-files --require-parameter \
+    --arguments "optional required none" \
+    --description 'Whether unknown options can have arguments'
 complete --command argparse --short-option s --long-option stop-nonopt \
     --description 'Exit on subcommand'

--- a/share/completions/argparse.fish
+++ b/share/completions/argparse.fish
@@ -67,6 +67,10 @@ complete --command argparse --short-option N --long-option min-args --no-files -
 complete --command argparse --short-option X --long-option max-args --no-files --require-parameter \
     --description 'Specify maximum non-option argument count'
 complete --command argparse --short-option i --long-option ignore-unknown \
+    -n '! __fish_seen_argument --short u --long move-unknown' \
     --description 'Ignore unknown options'
+complete --command argparse --short-option u --long-option move-unknown \
+    -n '! __fish_seen_argument --short i --long ignore-unknown' \
+    --description 'Move unknown options into \$argv_opts'
 complete --command argparse --short-option s --long-option stop-nonopt \
     --description 'Exit on subcommand'

--- a/share/completions/conda.fish
+++ b/share/completions/conda.fish
@@ -29,9 +29,9 @@ function __fish_conda_subcommand
     # get the commandline args without the "conda"
     set -l toks (commandline -xpc)[2..-1]
 
-    # Remove any important options - if we had options with arguments,
+    # if we had options with arguments,
     # they'd need to be listed here to be removed.
-    argparse -i h/help v/version -- $toks 2>/dev/null
+    argparse -u -- $toks 2>/dev/null
     # Return false if it fails - this shouldn't really happen,
     # so all bets are off
     or return 2
@@ -44,19 +44,12 @@ function __fish_conda_subcommand
         if test "$subcmds[1]" = "$argv[1]"
             set -e argv[1]
             set -e subcmds[1]
-        else if string match -q -- '-*' $argv[1]
-            set -e argv[1]
         else
             return 1
         end
     end
 
-    # Skip any remaining options.
-    while string match -q -- '-*' $argv[1]
-        set -e argv[1]
-    end
-
-    # If we have no subcommand left,
+    # If we have no subcommand
     # we either matched all given subcommands or we need one.
     if not set -q argv[1]
         return $have_sub

--- a/share/completions/fish_opt.fish
+++ b/share/completions/fish_opt.fish
@@ -10,3 +10,4 @@ complete --command fish_opt --long-option longonly --description 'Use only long 
 complete --command fish_opt --short-option o --long-option optional-val -n $CONDITION --description 'Don\'t require value'
 complete --command fish_opt --short-option r --long-option required-val -n $CONDITION --description 'Require value'
 complete --command fish_opt --long-option multiple-vals --description 'Store all values'
+complete --command fish_opt --short-option d --long-option delete --description 'Delete option from argv_opts'

--- a/share/completions/fish_opt.fish
+++ b/share/completions/fish_opt.fish
@@ -9,5 +9,5 @@ complete --command fish_opt --short-option l --long-option long --no-files --req
 complete --command fish_opt --long-option longonly --description 'Use only long option'
 complete --command fish_opt --short-option o --long-option optional-val -n $CONDITION --description 'Don\'t require value'
 complete --command fish_opt --short-option r --long-option required-val -n $CONDITION --description 'Require value'
-complete --command fish_opt --long-option multiple-vals --description 'Store all values'
+complete --command fish_opt --short-option m --long-option multiple-vals --description 'Store all values'
 complete --command fish_opt --short-option d --long-option delete --description 'Delete option from argv_opts'

--- a/share/completions/fish_opt.fish
+++ b/share/completions/fish_opt.fish
@@ -11,3 +11,4 @@ complete --command fish_opt --short-option o --long-option optional-val -n $COND
 complete --command fish_opt --short-option r --long-option required-val -n $CONDITION --description 'Require value'
 complete --command fish_opt --short-option m --long-option multiple-vals --description 'Store all values'
 complete --command fish_opt --short-option d --long-option delete --description 'Delete option from argv_opts'
+complete --command fish_opt --short-option v --long-option validate --require-parameter --description 'Fish script to validate option values'

--- a/share/completions/iwctl.fish
+++ b/share/completions/iwctl.fish
@@ -8,10 +8,10 @@ function __iwctl_filter -w iwctl
     # awk does not work on multiline entries, therefore we use string match,
     # which has the added benefit of filtering out the `No devices in ...` lines
 
-    argparse -i all-columns -- $argv
+    argparse -u all-columns -- $argv
 
     # remove color escape sequences
-    set -l results (iwctl $argv | string replace -ra '\e\[[\d;]+m' '')
+    set -l results (iwctl $argv_opts -- $argv | string replace -ra '\e\[[\d;]+m' '')
     # calculate column widths
     set -l headers $results[3]
     # We exploit the fact that all column labels will have >2 space to the left, and inside column labels there is always only one space.
@@ -38,7 +38,7 @@ function __iwctl_match_subcoms
 
     set argv (commandline -pxc)
     # iwctl allows to specify arguments for username, password, passphrase and dont-ask regardless of any following commands
-    argparse -i 'u/username=' 'p/password=' 'P/passphrase=' v/dont-ask -- $argv
+    argparse -u 'u/username=' 'p/password=' 'P/passphrase=' v/dont-ask -- $argv
     set argv $argv[2..]
 
     if test (count $argv) != (count $match)
@@ -55,7 +55,7 @@ end
 function __iwctl_connect
     set argv (commandline -pxc)
     # remove all options
-    argparse -i 'u/username=' 'p/password=' 'P/passphrase=' v/dont-ask -- $argv
+    argparse -u 'u/username=' 'p/password=' 'P/passphrase=' v/dont-ask -- $argv
     # station name should now be the third argument (`iwctl station <wlan>`)
     for network in (__iwctl_filter station $argv[3] get-networks rssi-dbms --all-columns)
         set network (string split \t -- $network)

--- a/share/completions/meson.fish
+++ b/share/completions/meson.fish
@@ -20,7 +20,7 @@ end
 function __fish_meson_builddir
     # Consider the value of -C option to detect the build directory
     set -l cmd (commandline -xpc)
-    argparse -i 'C=' -- $cmd
+    argparse -u 'C=' -- $cmd
     if set -q _flag_C
         echo $_flag_C
     else

--- a/share/completions/ninja.fish
+++ b/share/completions/ninja.fish
@@ -1,7 +1,7 @@
 function __fish_ninja
     set -l saved_args $argv
     set -l dir .
-    if argparse -i C/dir= -- (commandline -xpc)
+    if argparse -u C/dir= -- (commandline -xpc)
         command ninja -C$_flag_C $saved_args
     end
 end

--- a/share/completions/yadm.fish
+++ b/share/completions/yadm.fish
@@ -61,11 +61,13 @@ function __fish_complete_yadm_like_git
     set -l yadm_work_tree (yadm gitconfig --get core.worktree)
     set -l yadm_repo (yadm introspect repo)
 
-    argparse -i 'R-yadm-repo=' -- $cmdline 2>/dev/null
+    argparse -u 'R-yadm-repo=&' -- $cmdline 2>/dev/null
     if set -q _flag_yadm_repo
         set yadm_repo $_flag_yadm_repo
-        # argparse *always* sets $argv to remaining arguments after consuming specified options
-        set cmdline $argv
+        # argparse -u *always* sets $argv to remaining arguments after consuming all options,
+        # and it *always* sets $argv_opts to any specified non-& options and any unknown options
+        # (the -- is needed in case $argv originally contained a -- followed by arguments starting with a -)
+        set cmdline $argv_opts -- $argv
     end
 
     set -l git_wrapper_cmd "git --work-tree $yadm_work_tree --git-dir $yadm_repo $cmdline"

--- a/share/functions/__fish_complete_mysql.fish
+++ b/share/functions/__fish_complete_mysql.fish
@@ -1,5 +1,5 @@
 function __fish_mysql_query -a query
-    argparse -i 'u/user=' 'P/port=' 'h/host=' 'p/password=?' 'S/socket=' -- (commandline -px)
+    argparse -u 'u/user=' 'P/port=' 'h/host=' 'p/password=?' 'S/socket=' -- (commandline -px)
     set -l mysql_cmd mysql
     for flag in u P h S
         if set -q _flag_$flag

--- a/share/functions/__fish_seen_argument.fish
+++ b/share/functions/__fish_seen_argument.fish
@@ -1,5 +1,5 @@
 function __fish_seen_argument --description 'Check whether argument is used'
-    argparse --ignore-unknown 's/short=+' 'o/old=+' 'l/long=+' 'w/windows=+' -- $argv
+    argparse --move-unknown 's/short=+&' 'o/old=+&' 'l/long=+&' 'w/windows=+&' -- $argv
 
     set --local tokens (commandline --current-process --tokens-expanded --cut-at-cursor)
     set --erase tokens[1]
@@ -30,7 +30,7 @@ function __fish_seen_argument --description 'Check whether argument is used'
             end
         end
 
-        for raw_arg in $argv
+        for raw_arg in $argv_opts $argv
             if string match --quiet -- $t $raw_arg
                 return 0
             end

--- a/share/functions/fish_opt.fish
+++ b/share/functions/fish_opt.fish
@@ -11,9 +11,9 @@ end
 
 # The `fish_opt` command.
 function fish_opt -d 'Produce an option specification suitable for use with `argparse`.'
-    set -l options h/help 's/short=' 'l/long=' d/delete o/optional-val r/required-val
-    set options $options L-long-only M-multiple-vals
-    argparse -n fish_opt --max-args=0 --exclusive=r,o --exclusive=M,o $options -- $argv
+    set -l options h/help 's/short=' 'l/long=' d/delete o/optional-val r/required-val m/multiple-vals
+    set options $options L-long-only
+    argparse -n fish_opt --max-args=0 --exclusive=r,o $options -- $argv
     or return
 
     if set -q _flag_help
@@ -35,7 +35,9 @@ function fish_opt -d 'Produce an option specification suitable for use with `arg
         set opt_spec "$opt_spec$_flag_long"
     end
 
-    if set -q _flag_multiple_vals
+    if set -q _flag_multiple_vals && set -q _flag_optional_val
+        set opt_spec "$opt_spec=*"
+    else if set -q _flag_multiple_vals
         set opt_spec "$opt_spec=+"
     else if set -q _flag_required_val
         set opt_spec "$opt_spec="

--- a/share/functions/fish_opt.fish
+++ b/share/functions/fish_opt.fish
@@ -10,9 +10,6 @@ function __fish_opt_validate_args --no-scope-shadowing
     else if set -q _flag_long_only && not set -q _flag_long
         printf (_ "%s: The --long-only flag requires the --long flag\n") fish_opt >&2
         return 1
-    else if not set -q _flag_short && test 1 -eq (string length -- $_flag_long)
-        printf (_ "%s: The --long flag must be more than one character when no --short flag is provided\n") fish_opt >&2
-        return 1
     end
 
     return 0
@@ -33,7 +30,7 @@ function fish_opt -d 'Produce an option specification suitable for use with `arg
     or return
 
     if not set -q _flag_short
-        set opt_spec $_flag_long
+        set opt_spec "/$_flag_long"
     else if not set -q _flag_long
         set opt_spec $_flag_short
     else if set -q _flag_long_only

--- a/share/functions/fish_opt.fish
+++ b/share/functions/fish_opt.fish
@@ -11,7 +11,7 @@ end
 
 # The `fish_opt` command.
 function fish_opt -d 'Produce an option specification suitable for use with `argparse`.'
-    set -l options h/help 's/short=' 'l/long=' o/optional-val r/required-val
+    set -l options h/help 's/short=' 'l/long=' d/delete o/optional-val r/required-val
     set options $options L-long-only M-multiple-vals
     argparse -n fish_opt --max-args=0 --exclusive=r,o --exclusive=M,o $options -- $argv
     or return
@@ -41,6 +41,10 @@ function fish_opt -d 'Produce an option specification suitable for use with `arg
         set opt_spec "$opt_spec="
     else if set -q _flag_optional_val
         and set opt_spec "$opt_spec=?"
+    end
+
+    if set -q _flag_delete
+        set opt_spec "$opt_spec&"
     end
 
     echo $opt_spec

--- a/share/functions/fish_opt.fish
+++ b/share/functions/fish_opt.fish
@@ -1,6 +1,15 @@
 # This is a helper function for `fish_opt`. It does some basic validation of the arguments.
 function __fish_opt_validate_args --no-scope-shadowing
-    if set -q _flag_short && test 1 -ne (string length -- $_flag_short)
+    if not set -q _flag_validate && test (count $argv) -ne 0
+        printf (_ "%s: Extra non-option arguments were provided\n") fish_opt >&2
+        return 1
+    else if set -q _flag_validate && test (count $argv) -eq 0
+        printf (_ "%s: The --validate flag requires subsequent arguments\n") fish_opt >&2
+        return 1
+    else if set -q _flag_validate && not set -q _flag_multiple_vals && not set -q _flag_optional_val && not set -q _flag_required_val
+        printf (_ "%s: The --validate flag requires the --required-val, --optional-value, or --multiple-vals flag\n") fish_opt >&2
+        return 1
+    else if set -q _flag_short && test 1 -ne (string length -- $_flag_short)
         printf (_ "%s: The --short flag must be a single character\n") fish_opt >&2
         return 1
     else if not set -q _flag_short && not set -q _flag_long
@@ -17,8 +26,8 @@ end
 
 # The `fish_opt` command.
 function fish_opt -d 'Produce an option specification suitable for use with `argparse`.'
-    set -l options h/help 's/short=' 'l/long=' d/delete o/optional-val r/required-val m/multiple-vals long-only
-    argparse -n fish_opt --max-args=0 --exclusive=r,o $options -- $argv
+    set -l options h/help 's/short=' 'l/long=' d/delete o/optional-val r/required-val m/multiple-vals long-only v/validate
+    argparse -n fish_opt --stop-nonopt --exclusive=r,o $options -- $argv
     or return
 
     if set -q _flag_help
@@ -26,7 +35,7 @@ function fish_opt -d 'Produce an option specification suitable for use with `arg
         return 0
     end
 
-    __fish_opt_validate_args
+    __fish_opt_validate_args $argv
     or return
 
     if not set -q _flag_short
@@ -51,6 +60,10 @@ function fish_opt -d 'Produce an option specification suitable for use with `arg
 
     if set -q _flag_delete
         set opt_spec "$opt_spec&"
+    end
+
+    if set -q _flag_validate
+        set opt_spec "$opt_spec!$argv"
     end
 
     echo $opt_spec

--- a/src/bin/fish.rs
+++ b/src/bin/fish.rs
@@ -26,8 +26,8 @@ use fish::{
     builtins::{
         fish_indent, fish_key_reader,
         shared::{
-            BUILTIN_ERR_MISSING, BUILTIN_ERR_UNKNOWN, STATUS_CMD_ERROR, STATUS_CMD_OK,
-            STATUS_CMD_UNKNOWN,
+            BUILTIN_ERR_MISSING, BUILTIN_ERR_UNEXP_ARG, BUILTIN_ERR_UNKNOWN, STATUS_CMD_ERROR,
+            STATUS_CMD_OK, STATUS_CMD_UNKNOWN,
         },
     },
     common::{
@@ -253,7 +253,7 @@ fn fish_parse_opt(args: &mut [WString], opts: &mut FishCmdOpts) -> ControlFlow<i
     const PRINT_DEBUG_CATEGORIES_ARG: char = 2 as char;
     const PROFILE_STARTUP_ARG: char = 3 as char;
 
-    const SHORT_OPTS: &wstr = L!("+:hPilNnvc:C:p:d:f:D:o:");
+    const SHORT_OPTS: &wstr = L!("+hPilNnvc:C:p:d:f:D:o:");
     const LONG_OPTS: &[WOption<'static>] = &[
         wopt(L!("command"), RequiredArgument, 'c'),
         wopt(L!("init-command"), RequiredArgument, 'C'),
@@ -356,6 +356,13 @@ fn fish_parse_opt(args: &mut [WString], opts: &mut FishCmdOpts) -> ControlFlow<i
                 eprintf!(
                     "%ls\n",
                     wgettext_fmt!(BUILTIN_ERR_MISSING, "fish", args[w.wopt_index - 1])
+                );
+                return ControlFlow::Break(1);
+            }
+            ';' => {
+                eprintf!(
+                    "%ls\n",
+                    wgettext_fmt!(BUILTIN_ERR_UNEXP_ARG, "fish", args[w.wopt_index - 1])
                 );
                 return ControlFlow::Break(1);
             }

--- a/src/builtins/abbr.rs
+++ b/src/builtins/abbr.rs
@@ -453,7 +453,7 @@ pub fn abbr(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
     // Note the leading '-' causes wgetopter to return arguments in order, instead of permuting
     // them. We need this behavior for compatibility with pre-builtin abbreviations where options
     // could be given literally, for example `abbr e emacs -nw`.
-    const short_options: &wstr = L!("-:ac:f:r:seqgUh");
+    const short_options: &wstr = L!("-ac:f:r:seqgUh");
 
     const longopts: &[WOption] = &[
         wopt(L!("add"), ArgType::NoArgument, 'a'),
@@ -570,6 +570,10 @@ pub fn abbr(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
             }
             ':' => {
                 builtin_missing_argument(parser, streams, cmd, argv[w.wopt_index - 1], true);
+                return Err(STATUS_INVALID_ARGS);
+            }
+            ';' => {
+                builtin_unexpected_argument(parser, streams, cmd, argv[w.wopt_index - 1], true);
                 return Err(STATUS_INVALID_ARGS);
             }
             '?' => {

--- a/src/builtins/argparse.rs
+++ b/src/builtins/argparse.rs
@@ -59,6 +59,7 @@ struct ArgParseCmdOpts<'args> {
     name: WString,
     raw_exclusive_flags: Vec<&'args wstr>,
     args: Vec<&'args wstr>,
+    args_opts: Vec<&'args wstr>,
     options: HashMap<char, OptionSpec<'args>>,
     long_to_short_flag: HashMap<WString, char>,
     exclusive_flag_sets: Vec<Vec<char>>,
@@ -792,6 +793,7 @@ fn argparse_parse_flags<'args>(
                     // This allows reusing the same argv in multiple argparse calls,
                     // or just ignoring the error (e.g. in completions).
                     opts.args.push(args_read[w.wopt_index - 1]);
+                    w.argv_opts.pop();
                     // Work around weirdness with wgetopt, which crashes if we `continue` here.
                     if w.wopt_index == argc {
                         break;
@@ -816,6 +818,7 @@ fn argparse_parse_flags<'args>(
         };
         retval?;
     }
+    opts.args_opts = w.argv_opts;
 
     *optind = w.wopt_index;
     return Ok(SUCCESS);
@@ -901,6 +904,8 @@ fn set_argparse_result_vars(vars: &EnvStack, opts: &ArgParseCmdOpts) {
 
     let args = opts.args.iter().map(|&s| s.to_owned()).collect();
     vars.set(L!("argv"), EnvMode::LOCAL, args);
+    let args_opts = opts.args_opts.iter().map(|&s| s.to_owned()).collect();
+    vars.set(L!("argv_opts"), EnvMode::LOCAL, args_opts);
 }
 
 /// The argparse builtin. This is explicitly not compatible with the BSD or GNU version of this

--- a/src/builtins/argparse.rs
+++ b/src/builtins/argparse.rs
@@ -83,7 +83,7 @@ impl ArgParseCmdOpts<'_> {
     }
 }
 
-const SHORT_OPTIONS: &wstr = L!("+:hn:siux:N:X:");
+const SHORT_OPTIONS: &wstr = L!("+hn:siux:N:X:");
 const LONG_OPTIONS: &[WOption] = &[
     wopt(L!("stop-nonopt"), ArgType::NoArgument, 's'),
     wopt(L!("ignore-unknown"), ArgType::NoArgument, 'i'),
@@ -574,6 +574,16 @@ fn parse_cmd_opts<'args>(
                 );
                 return Err(STATUS_INVALID_ARGS);
             }
+            ';' => {
+                builtin_unexpected_argument(
+                    parser,
+                    streams,
+                    cmd,
+                    args[w.wopt_index - 1],
+                    /* print_hints */ false,
+                );
+                return Err(STATUS_INVALID_ARGS);
+            }
             '?' => {
                 builtin_unknown_option(parser, streams, cmd, args[w.wopt_index - 1], false);
                 return Err(STATUS_INVALID_ARGS);
@@ -858,7 +868,7 @@ fn argparse_parse_flags<'args>(
 
     // "+" means stop at nonopt, "-" means give nonoptions the option character code `1`, and don't
     // reorder.
-    let mut short_options = WString::from(if opts.stop_nonopt { L!("+:") } else { L!("-:") });
+    let mut short_options = WString::from(if opts.stop_nonopt { L!("+") } else { L!("-") });
     let mut long_options = vec![];
     populate_option_strings(opts, &mut short_options, &mut long_options);
 
@@ -868,6 +878,16 @@ fn argparse_parse_flags<'args>(
         let retval: BuiltinResult = match opt {
             ':' => {
                 builtin_missing_argument(
+                    parser,
+                    streams,
+                    &opts.name,
+                    args_read[w.wopt_index - 1],
+                    false,
+                );
+                Err(STATUS_INVALID_ARGS)
+            }
+            ';' => {
+                builtin_unexpected_argument(
                     parser,
                     streams,
                     &opts.name,

--- a/src/builtins/argparse.rs
+++ b/src/builtins/argparse.rs
@@ -248,6 +248,14 @@ fn parse_flag_modifiers<'args>(
     }
 
     if s.char_at(0) == '!' {
+        if opt_spec.arg_type == ArgType::NoArgument {
+            streams.err.append(wgettext_fmt!(
+                BUILTIN_ERR_INVALID_OPT_SPEC,
+                opts.name,
+                option_spec,
+                s.char_at(0)
+            ));
+        }
         s = s.slice_from(1);
         opt_spec.validation_command = s;
         // Move cursor to the end so we don't expect a long flag.

--- a/src/builtins/argparse.rs
+++ b/src/builtins/argparse.rs
@@ -364,10 +364,12 @@ fn parse_option_spec_sep<'args>(
             }
         }
         _ => {
-            // No short flag separator and no other modifiers, so this is a long only option.
+            // No short flag or separator, and no other modifiers, so this is a long only option.
             // Since getopt needs a wchar, we have a counter that we count up.
             opt_spec.short_flag_valid = false;
-            i -= 1;
+            if s.char_at(i - 1) != '/' {
+                i -= 1
+            }
             opt_spec.short_flag = char::from_u32(*counter).unwrap();
             *counter += 1;
         }
@@ -392,7 +394,8 @@ fn parse_option_spec<'args>(
     }
 
     let mut s = option_spec;
-    if !fish_iswalnum(s.char_at(0)) && s.char_at(0) != '#' {
+    if !fish_iswalnum(s.char_at(0)) && s.char_at(0) != '#' && !(s.char_at(0) == '/' && s.len() > 1)
+    {
         streams.err.append(wgettext_fmt!(
             "%ls: Short flag '%lc' invalid, must be alphanum or '#'\n",
             opts.name,

--- a/src/builtins/argparse.rs
+++ b/src/builtins/argparse.rs
@@ -234,6 +234,10 @@ fn parse_flag_modifiers<'args>(
                 s = s.slice_from(1);
                 (ArgType::RequiredArgument, true)
             }
+            '*' => {
+                s = s.slice_from(1);
+                (ArgType::OptionalArgument, true)
+            }
             _ => (ArgType::RequiredArgument, false),
         };
     }
@@ -858,7 +862,11 @@ fn handle_flag<'args>(
     }
 
     if opt_spec.accumulate_args {
-        opt_spec.vals.push(w.woptarg.unwrap().into());
+        if let Some(arg) = w.woptarg {
+            opt_spec.vals.push(arg.into());
+        } else {
+            opt_spec.vals.push(WString::new());
+        }
     } else {
         // We're depending on `next_opt()` to report that a mandatory value is missing if
         // `opt_spec->arg_type == ArgType::RequiredArgument` and thus return ':' so that we don't

--- a/src/builtins/argparse.rs
+++ b/src/builtins/argparse.rs
@@ -60,6 +60,7 @@ enum UnknownHandling {
 #[derive(Default)]
 struct ArgParseCmdOpts<'args> {
     unknown_handling: UnknownHandling,
+    strict_long_opts: bool,
     print_help: bool,
     stop_nonopt: bool,
     min_args: usize,
@@ -83,13 +84,14 @@ impl ArgParseCmdOpts<'_> {
     }
 }
 
-const SHORT_OPTIONS: &wstr = L!("+hn:siux:N:X:");
+const SHORT_OPTIONS: &wstr = L!("+hn:siux:SN:X:");
 const LONG_OPTIONS: &[WOption] = &[
     wopt(L!("stop-nonopt"), ArgType::NoArgument, 's'),
     wopt(L!("ignore-unknown"), ArgType::NoArgument, 'i'),
     wopt(L!("move-unknown"), ArgType::NoArgument, 'u'),
     wopt(L!("name"), ArgType::RequiredArgument, 'n'),
     wopt(L!("exclusive"), ArgType::RequiredArgument, 'x'),
+    wopt(L!("strict-longopts"), ArgType::NoArgument, 'S'),
     wopt(L!("help"), ArgType::NoArgument, 'h'),
     wopt(L!("min-args"), ArgType::RequiredArgument, 'N'),
     wopt(L!("max-args"), ArgType::RequiredArgument, 'X'),
@@ -532,6 +534,7 @@ fn parse_cmd_opts<'args>(
                     UnknownHandling::Move
                 }
             }
+            'S' => opts.strict_long_opts = true,
             // Just save the raw string here. Later, when we have all the short and long flag
             // definitions we'll parse these strings into a more useful data structure.
             'x' => opts.raw_exclusive_flags.push(w.woptarg.unwrap()),
@@ -873,6 +876,7 @@ fn argparse_parse_flags<'args>(
     populate_option_strings(opts, &mut short_options, &mut long_options);
 
     let mut w = WGetopter::new(&short_options, &long_options, args);
+    w.strict_long_opts = opts.strict_long_opts;
     while let Some((opt, longopt_idx)) = w.next_opt_indexed() {
         let is_long_flag = longopt_idx.is_some();
         let retval: BuiltinResult = match opt {

--- a/src/builtins/bind.rs
+++ b/src/builtins/bind.rs
@@ -407,7 +407,7 @@ fn parse_cmd_opts(
     streams: &mut IoStreams,
 ) -> BuiltinResult {
     let cmd = argv[0];
-    let short_options = L!(":aehkKfM:Lm:s");
+    let short_options = L!("aehkKfM:Lm:s");
     const long_options: &[WOption] = &[
         wopt(L!("all"), NoArgument, 'a'),
         wopt(L!("erase"), NoArgument, 'e'),
@@ -475,6 +475,10 @@ fn parse_cmd_opts(
             }
             ':' => {
                 builtin_missing_argument(parser, streams, cmd, argv[w.wopt_index - 1], true);
+                return Err(STATUS_INVALID_ARGS);
+            }
+            ';' => {
+                builtin_unexpected_argument(parser, streams, cmd, argv[w.wopt_index - 1], true);
                 return Err(STATUS_INVALID_ARGS);
             }
             '?' => {

--- a/src/builtins/block.rs
+++ b/src/builtins/block.rs
@@ -30,7 +30,7 @@ fn parse_options(
 ) -> Result<(Options, usize), ErrorCode> {
     let cmd = args[0];
 
-    const SHORT_OPTS: &wstr = L!(":eghl");
+    const SHORT_OPTS: &wstr = L!("eghl");
     const LONG_OPTS: &[WOption] = &[
         wopt(L!("erase"), ArgType::NoArgument, 'e'),
         wopt(L!("local"), ArgType::NoArgument, 'l'),
@@ -57,6 +57,10 @@ fn parse_options(
             }
             ':' => {
                 builtin_missing_argument(parser, streams, cmd, args[w.wopt_index - 1], false);
+                return Err(STATUS_INVALID_ARGS);
+            }
+            ';' => {
+                builtin_unexpected_argument(parser, streams, cmd, args[w.wopt_index - 1], false);
                 return Err(STATUS_INVALID_ARGS);
             }
             '?' => {

--- a/src/builtins/builtin.rs
+++ b/src/builtins/builtin.rs
@@ -12,7 +12,7 @@ pub fn r#builtin(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
     let print_hints = false;
     let mut opts: builtin_cmd_opts_t = Default::default();
 
-    const shortopts: &wstr = L!(":hnq");
+    const shortopts: &wstr = L!("hnq");
     const longopts: &[WOption] = &[
         wopt(L!("help"), ArgType::NoArgument, 'h'),
         wopt(L!("names"), ArgType::NoArgument, 'n'),
@@ -30,6 +30,16 @@ pub fn r#builtin(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
             }
             ':' => {
                 builtin_missing_argument(parser, streams, cmd, argv[w.wopt_index - 1], print_hints);
+                return Err(STATUS_INVALID_ARGS);
+            }
+            ';' => {
+                builtin_unexpected_argument(
+                    parser,
+                    streams,
+                    cmd,
+                    argv[w.wopt_index - 1],
+                    print_hints,
+                );
                 return Err(STATUS_INVALID_ARGS);
             }
             '?' => {

--- a/src/builtins/command.rs
+++ b/src/builtins/command.rs
@@ -14,7 +14,7 @@ pub fn r#command(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
     let print_hints = false;
     let mut opts: command_cmd_opts_t = Default::default();
 
-    const shortopts: &wstr = L!(":hasqv");
+    const shortopts: &wstr = L!("hasqv");
     const longopts: &[WOption] = &[
         wopt(L!("help"), ArgType::NoArgument, 'h'),
         wopt(L!("all"), ArgType::NoArgument, 'a'),
@@ -37,6 +37,16 @@ pub fn r#command(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
             }
             ':' => {
                 builtin_missing_argument(parser, streams, cmd, argv[w.wopt_index - 1], print_hints);
+                return Err(STATUS_INVALID_ARGS);
+            }
+            ';' => {
+                builtin_unexpected_argument(
+                    parser,
+                    streams,
+                    cmd,
+                    argv[w.wopt_index - 1],
+                    print_hints,
+                );
                 return Err(STATUS_INVALID_ARGS);
             }
             '?' => {

--- a/src/builtins/commandline.rs
+++ b/src/builtins/commandline.rs
@@ -269,7 +269,7 @@ pub fn commandline(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr])
 
     let mut override_buffer = None;
 
-    const short_options: &wstr = L!(":abijpctfxorhI:CBELSsP");
+    const short_options: &wstr = L!("abijpctfxorhI:CBELSsP");
     let long_options: &[WOption] = &[
         wopt(L!("append"), ArgType::NoArgument, 'a'),
         wopt(L!("insert"), ArgType::NoArgument, 'i'),
@@ -353,6 +353,10 @@ pub fn commandline(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr])
             }
             ':' => {
                 builtin_missing_argument(parser, streams, cmd, w.argv[w.wopt_index - 1], true);
+                return Err(STATUS_INVALID_ARGS);
+            }
+            ';' => {
+                builtin_unexpected_argument(parser, streams, cmd, w.argv[w.wopt_index - 1], true);
                 return Err(STATUS_INVALID_ARGS);
             }
             '?' => {

--- a/src/builtins/complete.rs
+++ b/src/builtins/complete.rs
@@ -239,7 +239,7 @@ pub fn complete(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) ->
     let mut preserve_order = false;
     let mut unescape_output = true;
 
-    const short_options: &wstr = L!(":a:c:p:s:l:o:d:fFrxeuAn:C::w:hk");
+    const short_options: &wstr = L!("a:c:p:s:l:o:d:fFrxeuAn:C::w:hk");
     const long_options: &[WOption] = &[
         wopt(L!("exclusive"), ArgType::NoArgument, 'x'),
         wopt(L!("no-files"), ArgType::NoArgument, 'f'),
@@ -380,6 +380,10 @@ pub fn complete(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) ->
             }
             ':' => {
                 builtin_missing_argument(parser, streams, cmd, argv[w.wopt_index - 1], true);
+                return Err(STATUS_INVALID_ARGS);
+            }
+            ';' => {
+                builtin_unexpected_argument(parser, streams, cmd, argv[w.wopt_index - 1], true);
                 return Err(STATUS_INVALID_ARGS);
             }
             '?' => {

--- a/src/builtins/contains.rs
+++ b/src/builtins/contains.rs
@@ -14,7 +14,7 @@ fn parse_options(
 ) -> Result<(Options, usize), ErrorCode> {
     let cmd = args[0];
 
-    const SHORT_OPTS: &wstr = L!("+:hi");
+    const SHORT_OPTS: &wstr = L!("+hi");
     const LONG_OPTS: &[WOption] = &[
         wopt(L!("help"), ArgType::NoArgument, 'h'),
         wopt(L!("index"), ArgType::NoArgument, 'i'),
@@ -29,6 +29,10 @@ fn parse_options(
             'i' => opts.print_index = true,
             ':' => {
                 builtin_missing_argument(parser, streams, cmd, args[w.wopt_index - 1], false);
+                return Err(STATUS_INVALID_ARGS);
+            }
+            ';' => {
+                builtin_unexpected_argument(parser, streams, cmd, args[w.wopt_index - 1], false);
                 return Err(STATUS_INVALID_ARGS);
             }
             '?' => {

--- a/src/builtins/echo.rs
+++ b/src/builtins/echo.rs
@@ -29,7 +29,7 @@ fn parse_options(
         return Err(STATUS_INVALID_ARGS);
     };
 
-    const SHORT_OPTS: &wstr = L!("+:Eens");
+    const SHORT_OPTS: &wstr = L!("+Eens");
     const LONG_OPTS: &[WOption] = &[];
 
     let mut opts = Options::default();
@@ -47,6 +47,9 @@ fn parse_options(
             ':' => {
                 builtin_missing_argument(parser, streams, cmd, args[w.wopt_index - 1], true);
                 return Err(STATUS_INVALID_ARGS);
+            }
+            ';' => {
+                panic!("unexpected option arguments are only possible with long options")
             }
             '?' => {
                 return Ok((oldopts, w.wopt_index - 1));

--- a/src/builtins/fish_key_reader.rs
+++ b/src/builtins/fish_key_reader.rs
@@ -212,6 +212,14 @@ fn parse_flags(
             'V' => {
                 *verbose = true;
             }
+            ';' => {
+                streams.err.append(wgettext_fmt!(
+                    BUILTIN_ERR_UNEXP_ARG,
+                    "fish_key_reader",
+                    w.argv[w.wopt_index - 1]
+                ));
+                return ControlFlow::Break(Err(STATUS_CMD_ERROR));
+            }
             '?' => {
                 streams.err.append(wgettext_fmt!(
                     BUILTIN_ERR_UNKNOWN,

--- a/src/builtins/function.rs
+++ b/src/builtins/function.rs
@@ -40,7 +40,7 @@ impl Default for FunctionCmdOpts {
 
 // This command is atypical in using the "-" (RETURN_IN_ORDER) option for flag parsing.
 // This is needed due to the semantics of the -a/--argument-names flag.
-const SHORT_OPTIONS: &wstr = L!("-:a:d:e:hj:p:s:v:w:SV:");
+const SHORT_OPTIONS: &wstr = L!("-a:d:e:hj:p:s:v:w:SV:");
 #[rustfmt::skip]
 const LONG_OPTIONS: &[WOption] = &[
     wopt(L!("description"), ArgType::RequiredArgument, 'd'),
@@ -217,6 +217,16 @@ fn parse_cmd_opts(
             }
             ':' => {
                 builtin_missing_argument(parser, streams, cmd, argv[w.wopt_index - 1], print_hints);
+                return STATUS_INVALID_ARGS;
+            }
+            ';' => {
+                builtin_unexpected_argument(
+                    parser,
+                    streams,
+                    cmd,
+                    argv[w.wopt_index - 1],
+                    print_hints,
+                );
                 return STATUS_INVALID_ARGS;
             }
             '?' => {

--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -49,7 +49,7 @@ impl Default for FunctionsCmdOpts<'_> {
 
 const NO_METADATA_SHORT: char = 2 as char;
 
-const SHORT_OPTIONS: &wstr = L!(":Ht:Dacd:ehnqv");
+const SHORT_OPTIONS: &wstr = L!("Ht:Dacd:ehnqv");
 #[rustfmt::skip]
 const LONG_OPTIONS: &[WOption] = &[
     wopt(L!("erase"), ArgType::NoArgument, 'e'),
@@ -99,6 +99,16 @@ fn parse_cmd_opts<'args>(
             }
             ':' => {
                 builtin_missing_argument(parser, streams, cmd, argv[w.wopt_index - 1], print_hints);
+                return Err(STATUS_INVALID_ARGS);
+            }
+            ';' => {
+                builtin_unexpected_argument(
+                    parser,
+                    streams,
+                    cmd,
+                    argv[w.wopt_index - 1],
+                    print_hints,
+                );
                 return Err(STATUS_INVALID_ARGS);
             }
             '?' => {

--- a/src/builtins/history.rs
+++ b/src/builtins/history.rs
@@ -66,7 +66,7 @@ struct HistoryCmdOpts {
 /// the non-flag subcommand form. While many of these flags are deprecated they must be
 /// supported at least until fish 3.0 and possibly longer to avoid breaking everyones
 /// config.fish and other scripts.
-const short_options: &wstr = L!(":CRcehmn:pt::z");
+const short_options: &wstr = L!("CRcehmn:pt::z");
 const longopts: &[WOption] = &[
     wopt(L!("prefix"), ArgType::NoArgument, 'p'),
     wopt(L!("contains"), ArgType::NoArgument, 'c'),
@@ -209,6 +209,10 @@ fn parse_cmd_opts(
             }
             ':' => {
                 builtin_missing_argument(parser, streams, cmd, argv[w.wopt_index - 1], true);
+                return Err(STATUS_INVALID_ARGS);
+            }
+            ';' => {
+                builtin_unexpected_argument(parser, streams, cmd, argv[w.wopt_index - 1], true);
                 return Err(STATUS_INVALID_ARGS);
             }
             '?' => {

--- a/src/builtins/jobs.rs
+++ b/src/builtins/jobs.rs
@@ -117,7 +117,7 @@ fn builtin_jobs_print(j: &Job, mode: JobsPrintMode, header: bool, streams: &mut 
     };
 }
 
-const SHORT_OPTIONS: &wstr = L!(":cghlpq");
+const SHORT_OPTIONS: &wstr = L!("cghlpq");
 const LONG_OPTIONS: &[WOption] = &[
     wopt(L!("command"), ArgType::NoArgument, 'c'),
     wopt(L!("group"), ArgType::NoArgument, 'g'),
@@ -164,6 +164,10 @@ pub fn jobs(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
             }
             ':' => {
                 builtin_missing_argument(parser, streams, cmd, argv[w.wopt_index - 1], true);
+                return Err(STATUS_INVALID_ARGS);
+            }
+            ';' => {
+                builtin_unexpected_argument(parser, streams, cmd, argv[w.wopt_index - 1], true);
                 return Err(STATUS_INVALID_ARGS);
             }
             '?' => {

--- a/src/builtins/math.rs
+++ b/src/builtins/math.rs
@@ -38,7 +38,7 @@ fn parse_cmd_opts(
 
     // This command is atypical in using the "+" (REQUIRE_ORDER) option for flag parsing.
     // This is needed because of the minus, `-`, operator in math expressions.
-    const SHORT_OPTS: &wstr = L!("+:hs:b:m:");
+    const SHORT_OPTS: &wstr = L!("+hs:b:m:");
     const LONG_OPTS: &[WOption] = &[
         wopt(L!("scale"), ArgType::RequiredArgument, 's'),
         wopt(L!("base"), ArgType::RequiredArgument, 'b'),
@@ -118,6 +118,16 @@ fn parse_cmd_opts(
             }
             ':' => {
                 builtin_missing_argument(parser, streams, cmd, args[w.wopt_index - 1], print_hints);
+                return Err(STATUS_INVALID_ARGS);
+            }
+            ';' => {
+                builtin_unexpected_argument(
+                    parser,
+                    streams,
+                    cmd,
+                    args[w.wopt_index - 1],
+                    print_hints,
+                );
                 return Err(STATUS_INVALID_ARGS);
             }
             '?' => {

--- a/src/builtins/path.rs
+++ b/src/builtins/path.rs
@@ -178,7 +178,7 @@ fn path_out(streams: &mut IoStreams, opts: &Options<'_>, s: impl AsRef<wstr>) {
 
 fn construct_short_opts(opts: &Options) -> WString {
     // All commands accept -z, -Z and -q
-    let mut short_opts = WString::from(":zZq");
+    let mut short_opts = WString::from("zZq");
     if opts.perms_valid {
         short_opts += L!("p:");
         short_opts += L!("rwx");
@@ -245,6 +245,17 @@ fn parse_opts<'args>(
             ':' => {
                 streams.err.append(L!("path ")); // clone of string_error
                 builtin_missing_argument(parser, streams, cmd, args_read[w.wopt_index - 1], false);
+                return Err(STATUS_INVALID_ARGS);
+            }
+            ';' => {
+                streams.err.append(L!("path ")); // clone of string_error
+                builtin_unexpected_argument(
+                    parser,
+                    streams,
+                    cmd,
+                    args_read[w.wopt_index - 1],
+                    false,
+                );
                 return Err(STATUS_INVALID_ARGS);
             }
             '?' => {

--- a/src/builtins/pwd.rs
+++ b/src/builtins/pwd.rs
@@ -25,6 +25,10 @@ pub fn pwd(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Buil
                 builtin_print_help(parser, streams, cmd);
                 return Ok(SUCCESS);
             }
+            ';' => {
+                builtin_unexpected_argument(parser, streams, cmd, argv[w.wopt_index - 1], false);
+                return Err(STATUS_INVALID_ARGS);
+            }
             '?' => {
                 builtin_unknown_option(parser, streams, cmd, argv[w.wopt_index - 1], false);
                 return Err(STATUS_INVALID_ARGS);

--- a/src/builtins/random.rs
+++ b/src/builtins/random.rs
@@ -14,7 +14,7 @@ pub fn random(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
     let argc = argv.len();
     let print_hints = false;
 
-    const shortopts: &wstr = L!("+:h");
+    const shortopts: &wstr = L!("+h");
     const longopts: &[WOption] = &[wopt(L!("help"), ArgType::NoArgument, 'h')];
 
     let mut w = WGetopter::new(shortopts, longopts, argv);
@@ -27,6 +27,16 @@ pub fn random(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
             }
             ':' => {
                 builtin_missing_argument(parser, streams, cmd, argv[w.wopt_index - 1], print_hints);
+                return Err(STATUS_INVALID_ARGS);
+            }
+            ';' => {
+                builtin_unexpected_argument(
+                    parser,
+                    streams,
+                    cmd,
+                    argv[w.wopt_index - 1],
+                    print_hints,
+                );
                 return Err(STATUS_INVALID_ARGS);
             }
             '?' => {

--- a/src/builtins/read.rs
+++ b/src/builtins/read.rs
@@ -63,7 +63,7 @@ impl Options {
     }
 }
 
-const SHORT_OPTIONS: &wstr = L!(":ac:d:fghiLln:p:sStuxzP:UR:L");
+const SHORT_OPTIONS: &wstr = L!("ac:d:fghiLln:p:sStuxzP:UR:L");
 const LONG_OPTIONS: &[WOption] = &[
     wopt(L!("array"), ArgType::NoArgument, 'a'),
     wopt(L!("command"), ArgType::RequiredArgument, 'c'),
@@ -183,6 +183,10 @@ fn parse_cmd_opts(
             }
             ':' => {
                 builtin_missing_argument(parser, streams, cmd, args[w.wopt_index - 1], true);
+                return Err(STATUS_INVALID_ARGS);
+            }
+            ';' => {
+                builtin_unexpected_argument(parser, streams, cmd, args[w.wopt_index - 1], true);
                 return Err(STATUS_INVALID_ARGS);
             }
             '?' => {

--- a/src/builtins/realpath.rs
+++ b/src/builtins/realpath.rs
@@ -15,7 +15,7 @@ struct Options {
     no_symlinks: bool,
 }
 
-const short_options: &wstr = L!("+:hs");
+const short_options: &wstr = L!("+hs");
 const long_options: &[WOption] = &[
     wopt(L!("no-symlinks"), NoArgument, 's'),
     wopt(L!("help"), NoArgument, 'h'),
@@ -38,6 +38,10 @@ fn parse_options(
             'h' => opts.print_help = true,
             ':' => {
                 builtin_missing_argument(parser, streams, cmd, args[w.wopt_index - 1], false);
+                return Err(STATUS_INVALID_ARGS);
+            }
+            ';' => {
+                builtin_unexpected_argument(parser, streams, cmd, args[w.wopt_index - 1], false);
                 return Err(STATUS_INVALID_ARGS);
             }
             '?' => {

--- a/src/builtins/return.rs
+++ b/src/builtins/return.rs
@@ -16,7 +16,7 @@ fn parse_options(
 ) -> ControlFlow<ErrorCode, (Options, usize)> {
     let cmd = args[0];
 
-    const SHORT_OPTS: &wstr = L!(":h");
+    const SHORT_OPTS: &wstr = L!("h");
     const LONG_OPTS: &[WOption] = &[wopt(L!("help"), ArgType::NoArgument, 'h')];
 
     let mut opts = Options::default();
@@ -28,6 +28,10 @@ fn parse_options(
             'h' => opts.print_help = true,
             ':' => {
                 builtin_missing_argument(parser, streams, cmd, args[w.wopt_index - 1], true);
+                return ControlFlow::Break(STATUS_INVALID_ARGS);
+            }
+            ';' => {
+                builtin_unexpected_argument(parser, streams, cmd, args[w.wopt_index - 1], true);
                 return ControlFlow::Break(STATUS_INVALID_ARGS);
             }
             '?' => {

--- a/src/builtins/set.rs
+++ b/src/builtins/set.rs
@@ -108,7 +108,7 @@ impl Options {
         // Variables used for parsing the argument list. This command is atypical in using the "+"
         // (REQUIRE_ORDER) option for flag parsing. This is not typical of most fish commands. It means
         // we stop scanning for flags when the first non-flag argument is seen.
-        const SHORT_OPTS: &wstr = L!("+:LSUaefghlnpqux");
+        const SHORT_OPTS: &wstr = L!("+LSUaefghlnpqux");
         const LONG_OPTS: &[WOption] = &[
             wopt(L!("export"), NoArgument, 'x'),
             wopt(L!("global"), NoArgument, 'g'),
@@ -165,6 +165,16 @@ impl Options {
                 }
                 ':' => {
                     builtin_missing_argument(parser, streams, cmd, args[w.wopt_index - 1], false);
+                    return Err(STATUS_INVALID_ARGS);
+                }
+                ';' => {
+                    builtin_unexpected_argument(
+                        parser,
+                        streams,
+                        cmd,
+                        args[w.wopt_index - 1],
+                        false,
+                    );
                     return Err(STATUS_INVALID_ARGS);
                 }
                 '?' => {

--- a/src/builtins/set_color.rs
+++ b/src/builtins/set_color.rs
@@ -86,6 +86,16 @@ pub fn set_color(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
                 // In future we change both to actually print an error.
                 return Err(STATUS_INVALID_ARGS);
             }
+            Err(UnexpectedOptArg(option_index)) => {
+                builtin_unexpected_argument(
+                    parser,
+                    streams,
+                    L!("set_color"),
+                    argv[option_index],
+                    true, /* print_hints */
+                );
+                return Err(STATUS_INVALID_ARGS);
+            }
             Err(UnknownColor(arg)) => {
                 streams
                     .err

--- a/src/builtins/status.rs
+++ b/src/builtins/status.rs
@@ -150,7 +150,7 @@ const IS_INTERACTIVE_JOB_CTRL_SHORT: char = '\x03';
 const IS_NO_JOB_CTRL_SHORT: char = '\x04';
 const IS_INTERACTIVE_READ_SHORT: char = '\x05';
 
-const SHORT_OPTIONS: &wstr = L!(":L:cbilfnhj:t");
+const SHORT_OPTIONS: &wstr = L!("L:cbilfnhj:t");
 const LONG_OPTIONS: &[WOption] = &[
     wopt(L!("help"), NoArgument, 'h'),
     wopt(L!("current-filename"), NoArgument, 'f'),
@@ -302,6 +302,10 @@ fn parse_cmd_opts(
             'h' => opts.print_help = true,
             ':' => {
                 builtin_missing_argument(parser, streams, cmd, args[w.wopt_index - 1], false);
+                return Err(STATUS_INVALID_ARGS);
+            }
+            ';' => {
+                builtin_unexpected_argument(parser, streams, cmd, args[w.wopt_index - 1], false);
                 return Err(STATUS_INVALID_ARGS);
             }
             '?' => {

--- a/src/builtins/string.rs
+++ b/src/builtins/string.rs
@@ -71,6 +71,17 @@ trait StringSubCommand<'args> {
                     );
                     return Err(STATUS_INVALID_ARGS);
                 }
+                ';' => {
+                    streams.err.append(L!("string ")); // clone of string_error
+                    builtin_unexpected_argument(
+                        parser,
+                        streams,
+                        cmd,
+                        args_read[w.wopt_index - 1],
+                        false,
+                    );
+                    return Err(STATUS_INVALID_ARGS);
+                }
                 '?' => {
                     string_unknown_option(parser, streams, cmd, args_read[w.wopt_index - 1]);
                     return Err(STATUS_INVALID_ARGS);

--- a/src/builtins/string/collect.rs
+++ b/src/builtins/string/collect.rs
@@ -11,7 +11,7 @@ impl StringSubCommand<'_> for Collect {
         wopt(L!("allow-empty"), NoArgument, 'a'),
         wopt(L!("no-trim-newlines"), NoArgument, 'N'),
     ];
-    const SHORT_OPTIONS: &'static wstr = L!(":Na");
+    const SHORT_OPTIONS: &'static wstr = L!("Na");
 
     fn parse_opt(&mut self, _n: &wstr, c: char, _arg: Option<&wstr>) -> Result<(), StringError> {
         match c {

--- a/src/builtins/string/escape.rs
+++ b/src/builtins/string/escape.rs
@@ -12,7 +12,7 @@ impl StringSubCommand<'_> for Escape {
         wopt(L!("no-quoted"), NoArgument, 'n'),
         wopt(L!("style"), RequiredArgument, NON_OPTION_CHAR),
     ];
-    const SHORT_OPTIONS: &'static wstr = L!(":n");
+    const SHORT_OPTIONS: &'static wstr = L!("n");
 
     fn parse_opt(&mut self, name: &wstr, c: char, arg: Option<&wstr>) -> Result<(), StringError> {
         match c {

--- a/src/builtins/string/join.rs
+++ b/src/builtins/string/join.rs
@@ -23,7 +23,7 @@ impl<'args> StringSubCommand<'args> for Join<'args> {
         wopt(L!("quiet"), NoArgument, 'q'),
         wopt(L!("no-empty"), NoArgument, 'n'),
     ];
-    const SHORT_OPTIONS: &'static wstr = L!(":qn");
+    const SHORT_OPTIONS: &'static wstr = L!("qn");
 
     fn parse_opt(&mut self, _n: &wstr, c: char, _arg: Option<&wstr>) -> Result<(), StringError> {
         match c {

--- a/src/builtins/string/length.rs
+++ b/src/builtins/string/length.rs
@@ -11,7 +11,7 @@ impl StringSubCommand<'_> for Length {
         wopt(L!("quiet"), NoArgument, 'q'),
         wopt(L!("visible"), NoArgument, 'V'),
     ];
-    const SHORT_OPTIONS: &'static wstr = L!(":qV");
+    const SHORT_OPTIONS: &'static wstr = L!("qV");
 
     fn parse_opt(&mut self, _n: &wstr, c: char, _arg: Option<&wstr>) -> Result<(), StringError> {
         match c {

--- a/src/builtins/string/match.rs
+++ b/src/builtins/string/match.rs
@@ -34,7 +34,7 @@ impl<'args> StringSubCommand<'args> for Match<'args> {
         wopt(L!("index"), NoArgument, 'n'),
         wopt(L!("max-matches"), RequiredArgument, 'm'),
     ];
-    const SHORT_OPTIONS: &'static wstr = L!(":aegivqrnm:");
+    const SHORT_OPTIONS: &'static wstr = L!("aegivqrnm:");
 
     fn parse_opt(&mut self, _n: &wstr, c: char, arg: Option<&wstr>) -> Result<(), StringError> {
         match c {

--- a/src/builtins/string/pad.rs
+++ b/src/builtins/string/pad.rs
@@ -26,7 +26,7 @@ impl StringSubCommand<'_> for Pad {
         wopt(L!("right"), NoArgument, 'r'),
         wopt(L!("width"), RequiredArgument, 'w'),
     ];
-    const SHORT_OPTIONS: &'static wstr = L!(":c:rw:");
+    const SHORT_OPTIONS: &'static wstr = L!("c:rw:");
 
     fn parse_opt(&mut self, name: &wstr, c: char, arg: Option<&wstr>) -> Result<(), StringError> {
         match c {

--- a/src/builtins/string/repeat.rs
+++ b/src/builtins/string/repeat.rs
@@ -15,7 +15,7 @@ impl StringSubCommand<'_> for Repeat {
         wopt(L!("quiet"), NoArgument, 'q'),
         wopt(L!("no-newline"), NoArgument, 'N'),
     ];
-    const SHORT_OPTIONS: &'static wstr = L!(":n:m:qN");
+    const SHORT_OPTIONS: &'static wstr = L!("n:m:qN");
 
     fn parse_opt(&mut self, name: &wstr, c: char, arg: Option<&wstr>) -> Result<(), StringError> {
         match c {

--- a/src/builtins/string/replace.rs
+++ b/src/builtins/string/replace.rs
@@ -26,7 +26,7 @@ impl<'args> StringSubCommand<'args> for Replace<'args> {
         wopt(L!("regex"), NoArgument, 'r'),
         wopt(L!("max-matches"), RequiredArgument, 'm'),
     ];
-    const SHORT_OPTIONS: &'static wstr = L!(":afiqrm:");
+    const SHORT_OPTIONS: &'static wstr = L!("afiqrm:");
 
     fn parse_opt(&mut self, _n: &wstr, c: char, arg: Option<&wstr>) -> Result<(), StringError> {
         match c {

--- a/src/builtins/string/shorten.rs
+++ b/src/builtins/string/shorten.rs
@@ -32,7 +32,7 @@ impl<'args> StringSubCommand<'args> for Shorten<'args> {
         wopt(L!("left"), NoArgument, 'l'),
         wopt(L!("quiet"), NoArgument, 'q'),
     ];
-    const SHORT_OPTIONS: &'static wstr = L!(":c:m:Nlq");
+    const SHORT_OPTIONS: &'static wstr = L!("c:m:Nlq");
 
     fn parse_opt(
         &mut self,

--- a/src/builtins/string/split.rs
+++ b/src/builtins/string/split.rs
@@ -110,7 +110,7 @@ impl<'args> StringSubCommand<'args> for Split<'args> {
         wopt(L!("fields"), RequiredArgument, 'f'),
         wopt(L!("allow-empty"), NoArgument, 'a'),
     ];
-    const SHORT_OPTIONS: &'static wstr = L!(":qrm:nf:a");
+    const SHORT_OPTIONS: &'static wstr = L!("qrm:nf:a");
 
     fn parse_opt(&mut self, name: &wstr, c: char, arg: Option<&wstr>) -> Result<(), StringError> {
         match c {

--- a/src/builtins/string/sub.rs
+++ b/src/builtins/string/sub.rs
@@ -17,7 +17,7 @@ impl StringSubCommand<'_> for Sub {
         wopt(L!("end"), RequiredArgument, 'e'),
         wopt(L!("quiet"), NoArgument, 'q'),
     ];
-    const SHORT_OPTIONS: &'static wstr = L!(":l:qs:e:");
+    const SHORT_OPTIONS: &'static wstr = L!("l:qs:e:");
 
     fn parse_opt(&mut self, name: &wstr, c: char, arg: Option<&wstr>) -> Result<(), StringError> {
         match c {

--- a/src/builtins/string/transform.rs
+++ b/src/builtins/string/transform.rs
@@ -7,7 +7,7 @@ pub struct Transform {
 
 impl StringSubCommand<'_> for Transform {
     const LONG_OPTIONS: &'static [WOption<'static>] = &[wopt(L!("quiet"), NoArgument, 'q')];
-    const SHORT_OPTIONS: &'static wstr = L!(":q");
+    const SHORT_OPTIONS: &'static wstr = L!("q");
     fn parse_opt(&mut self, _n: &wstr, c: char, _arg: Option<&wstr>) -> Result<(), StringError> {
         match c {
             'q' => self.quiet = true,

--- a/src/builtins/string/trim.rs
+++ b/src/builtins/string/trim.rs
@@ -26,7 +26,7 @@ impl<'args> StringSubCommand<'args> for Trim<'args> {
         wopt(L!("right"), NoArgument, 'r'),
         wopt(L!("quiet"), NoArgument, 'q'),
     ];
-    const SHORT_OPTIONS: &'static wstr = L!(":c:lrq");
+    const SHORT_OPTIONS: &'static wstr = L!("c:lrq");
 
     fn parse_opt(
         &mut self,

--- a/src/builtins/string/unescape.rs
+++ b/src/builtins/string/unescape.rs
@@ -14,7 +14,7 @@ impl StringSubCommand<'_> for Unescape {
         wopt(L!("no-quoted"), NoArgument, 'n'),
         wopt(L!("style"), RequiredArgument, NON_OPTION_CHAR),
     ];
-    const SHORT_OPTIONS: &'static wstr = L!(":n");
+    const SHORT_OPTIONS: &'static wstr = L!("n");
 
     fn parse_opt(&mut self, name: &wstr, c: char, arg: Option<&wstr>) -> Result<(), StringError> {
         match c {

--- a/src/builtins/type.rs
+++ b/src/builtins/type.rs
@@ -23,7 +23,7 @@ pub fn r#type(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
     let print_hints = false;
     let mut opts: type_cmd_opts_t = Default::default();
 
-    const shortopts: &wstr = L!(":hasftpPq");
+    const shortopts: &wstr = L!("hasftpPq");
     const longopts: &[WOption] = &[
         wopt(L!("help"), ArgType::NoArgument, 'h'),
         wopt(L!("all"), ArgType::NoArgument, 'a'),
@@ -52,6 +52,16 @@ pub fn r#type(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
             }
             ':' => {
                 builtin_missing_argument(parser, streams, cmd, argv[w.wopt_index - 1], print_hints);
+                return Err(STATUS_INVALID_ARGS);
+            }
+            ';' => {
+                builtin_unexpected_argument(
+                    parser,
+                    streams,
+                    cmd,
+                    argv[w.wopt_index - 1],
+                    print_hints,
+                );
                 return Err(STATUS_INVALID_ARGS);
             }
             '?' => {

--- a/src/builtins/ulimit.rs
+++ b/src/builtins/ulimit.rs
@@ -171,7 +171,7 @@ impl Default for Options {
 pub fn ulimit(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> BuiltinResult {
     let cmd = args[0];
 
-    const SHORT_OPTS: &wstr = L!(":HSabcdefilmnqrstuvwyKPTh");
+    const SHORT_OPTS: &wstr = L!("HSabcdefilmnqrstuvwyKPTh");
 
     const LONG_OPTS: &[WOption] = &[
         wopt(L!("all"), ArgType::NoArgument, 'a'),
@@ -235,6 +235,10 @@ pub fn ulimit(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
             }
             ':' => {
                 builtin_missing_argument(parser, streams, cmd, w.argv[w.wopt_index - 1], true);
+                return Err(STATUS_INVALID_ARGS);
+            }
+            ';' => {
+                builtin_unexpected_argument(parser, streams, cmd, w.argv[w.wopt_index - 1], true);
                 return Err(STATUS_INVALID_ARGS);
             }
             '?' => {

--- a/src/builtins/wait.rs
+++ b/src/builtins/wait.rs
@@ -140,7 +140,7 @@ pub fn wait(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
     let mut print_help = false;
     let print_hints = false;
 
-    const shortopts: &wstr = L!(":nh");
+    const shortopts: &wstr = L!("nh");
     const longopts: &[WOption] = &[
         wopt(L!("any"), ArgType::NoArgument, 'n'),
         wopt(L!("help"), ArgType::NoArgument, 'h'),
@@ -157,6 +157,16 @@ pub fn wait(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
             }
             ':' => {
                 builtin_missing_argument(parser, streams, cmd, argv[w.wopt_index - 1], print_hints);
+                return Err(STATUS_INVALID_ARGS);
+            }
+            ';' => {
+                builtin_unexpected_argument(
+                    parser,
+                    streams,
+                    cmd,
+                    argv[w.wopt_index - 1],
+                    print_hints,
+                );
                 return Err(STATUS_INVALID_ARGS);
             }
             '?' => {

--- a/src/text_face.rs
+++ b/src/text_face.rs
@@ -170,6 +170,7 @@ pub(crate) enum ParsedArgs<'argarray, 'args> {
 
 pub(crate) enum ParseError<'args> {
     MissingOptArg,
+    UnexpectedOptArg(usize),
     UnknownColor(&'args wstr),
     UnknownUnderlineStyle(&'args wstr),
     UnknownOption(usize),
@@ -180,7 +181,7 @@ pub(crate) fn parse_text_face_and_options<'argarray, 'args>(
     is_builtin: bool,
 ) -> Result<ParsedArgs<'argarray, 'args>, ParseError<'args>> {
     let builtin_extra_args = if is_builtin { 0 } else { "hc".len() };
-    let short_options = L!(":b:oidru::ch");
+    let short_options = L!("b:oidru::ch");
     let short_options = &short_options[..short_options.len() - builtin_extra_args];
     let long_options: &[WOption] = &[
         wopt(L!("background"), ArgType::RequiredArgument, 'b'),
@@ -260,6 +261,11 @@ pub(crate) fn parse_text_face_and_options<'argarray, 'args>(
             ':' => {
                 if is_builtin {
                     return Err(MissingOptArg);
+                }
+            }
+            ';' => {
+                if is_builtin {
+                    return Err(UnexpectedOptArg(w.wopt_index - 1));
                 }
             }
             '?' => {

--- a/src/wgetopt.rs
+++ b/src/wgetopt.rs
@@ -107,6 +107,8 @@ enum NextArgv {
     FoundOption,
 }
 
+use std::borrow::Cow;
+
 pub struct WGetopter<'opts, 'args, 'argarray> {
     /// List of arguments. Will not be resized, but can be modified.
     pub argv: &'argarray mut [&'args wstr],
@@ -141,7 +143,7 @@ pub struct WGetopter<'opts, 'args, 'argarray> {
     initialized: bool,
     /// This will be populated with the elements of the original args that were interpreted
     /// as options and arguments to options
-    pub argv_opts: Vec<&'args wstr>,
+    pub argv_opts: Vec<Cow<'args, wstr>>,
 }
 
 impl<'opts, 'args, 'argarray> WGetopter<'opts, 'args, 'argarray> {
@@ -307,7 +309,7 @@ impl<'opts, 'args, 'argarray> WGetopter<'opts, 'args, 'argarray> {
         }
 
         let opt = self.argv[self.wopt_index];
-        self.argv_opts.push(opt);
+        self.argv_opts.push(Cow::Borrowed(opt));
 
         // We've found an option, so we need to skip the initial punctuation.
         let skip = if !self.longopts.is_empty() && opt.char_at(1) == '-' {
@@ -373,7 +375,7 @@ impl<'opts, 'args, 'argarray> WGetopter<'opts, 'args, 'argarray> {
             } else {
                 // Consume the next element.
                 let val = self.argv[self.wopt_index];
-                self.argv_opts.push(val);
+                self.argv_opts.push(Cow::Borrowed(val));
                 self.woptarg = Some(val);
                 self.wopt_index += 1;
             }
@@ -403,7 +405,7 @@ impl<'opts, 'args, 'argarray> WGetopter<'opts, 'args, 'argarray> {
         } else if opt_found.arg_type == ArgType::RequiredArgument {
             if self.wopt_index < self.argv.len() {
                 let val = self.argv[self.wopt_index];
-                self.argv_opts.push(val);
+                self.argv_opts.push(Cow::Borrowed(val));
                 self.woptarg = Some(val);
                 self.wopt_index += 1;
             } else {

--- a/src/wgetopt.rs
+++ b/src/wgetopt.rs
@@ -59,9 +59,10 @@ enum Ordering {
 
 /// Indicates whether an option takes an argument, and whether that argument
 /// is optional.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ArgType {
     /// The option takes no arguments.
+    #[default]
     NoArgument,
     /// The option takes a required argument.
     RequiredArgument,

--- a/src/wgetopt.rs
+++ b/src/wgetopt.rs
@@ -490,6 +490,10 @@ impl<'opts, 'args, 'argarray> WGetopter<'opts, 'args, 'argarray> {
                 .as_char_slice()
                 .contains(&self.remaining_text.char_at(0))
         {
+            // Unknown option, assume remaining text is its argument
+            // (it needs to be saved somewhere for argparse, but we cant save it in
+            // self.remaining_text as that will break further parsing)
+            self.woptarg = Some(&self.remaining_text[1..]);
             self.remaining_text = empty_wstr();
             self.wopt_index += 1;
 

--- a/tests/checks/argparse.fish
+++ b/tests/checks/argparse.fish
@@ -639,5 +639,11 @@ begin
     # CHECK: argv_opts '-abv124'  '-abv125'  '-abv124'  '-vd3'
 end
 
+argparse a/alpha -- --banna=value
+# CHECKERR: argparse: --banna=value: unknown option
+# But this gives a better message
+argparse a/alpha -- --alpha=value --banna=value
+# CHECKERR: argparse: --alpha=value: option does not take an argument
+
 # Check that the argparse's are properly wrapped in begin blocks
 set -l

--- a/tests/checks/argparse.fish
+++ b/tests/checks/argparse.fish
@@ -645,5 +645,35 @@ argparse a/alpha -- --banna=value
 argparse a/alpha -- --alpha=value --banna=value
 # CHECKERR: argparse: --alpha=value: option does not take an argument
 
+# Check behaviour without -S/--strict-longopts option
+begin
+    argparse long valu=+ -- --lon -long -lon -valu=3 -valu 4 -val=3 -val 4
+    set -lL
+    # CHECK: _flag_long '--long'  '--long'  '--long'
+    # CHECK: _flag_valu '3'  '4'  '3'  '4'
+    # CHECK: argv
+    # CHECK: argv_opts '--lon'  '-long'  '-lon'  '-valu=3'  '-valu'  '4'  '-val=3'  '-val'  '4'
+    argparse amb ambig -- -am
+    # CHECKERR: argparse: -am: unknown option
+    argparse a ambig -- -ambig
+    # CHECKERR: argparse: -ambig: unknown option
+    argparse long -- -long3
+    # CHECKERR: argparse: -long3: unknown option
+end
+
+# Check behaviour with -S/--strict-longopts option
+begin
+    argparse -S long -- --lon
+    # CHECKERR: argparse: --lon: unknown option
+    argparse -S long -- -long
+    # CHECKERR: argparse: -long: unknown option
+    argparse --strict-longopts long -- -lon
+    # CHECKERR: argparse: -lon: unknown option
+    argparse -S value=+ -- -valu=3
+    # CHECKERR: argparse: -valu=3: unknown option
+    argparse --strict-longopts value=+ -- -valu 4
+    # CHECKERR: argparse: -valu: unknown option
+end
+
 # Check that the argparse's are properly wrapped in begin blocks
 set -l

--- a/tests/checks/argparse.fish
+++ b/tests/checks/argparse.fish
@@ -380,7 +380,7 @@ end
 
 begin
     # Moving unknown options
-    argparse --move-unknown h i -- -hoa -oia
+    argparse --move-unknown --unknown-arguments=optional h i -- -hoa -oia
     echo -- $argv
     #CHECK:
     echo -- $argv_opts
@@ -422,6 +422,48 @@ begin
     # CHECK: _flag_break -b
     # CHECK: argv
     # CHECK: argv_opts '-b kubectl get pods -l name=foo'
+end
+
+begin
+    # Checking unknown-arguments, with errors
+    argparse -i -U none -- --long=value
+    # CHECKERR: argparse: --long=value: option does not take an argument
+    argparse -i -U required -- -u
+    # CHECKERR: argparse: -u: option requires an argument
+    argparse -i -U required -- --long
+    # CHECKERR: argparse: --long: option requires an argument
+end
+
+begin
+    argparse -U none -i b= -- -abv=val in --long between -u
+    set -l
+    # CHECK: _flag_b v=val
+    # CHECK: argv '-a'  'in'  '--long'  'between'  '-u'
+    # CHECK: argv_opts -bv=val
+end
+
+begin
+    argparse -U none b= -- -abv in --long between -u
+    set -l
+    # CHECK: _flag_b v
+    # CHECK: argv 'in'  'between'
+    # CHECK: argv_opts '-abv'  '--long'  '-u'
+end
+
+begin
+    argparse -iU required b= -- -abv -b -b --long -b -u -b
+    set -l
+    # CHECK: _flag_b -b
+    # CHECK: argv '-abv'  '--long'  '-b'  '-u'  '-b'
+    # CHECK: argv_opts '-b'  '-b'
+end
+
+begin
+    argparse -uU required b= -- -abv -b -b --long -b -u -b
+    set -l
+    # CHECK: _flag_b -b
+    # CHECK: argv
+    # CHECK: argv_opts '-abv'  '-b'  '-b'  '--long'  '-b'  '-u'  '-b'
 end
 
 begin
@@ -580,6 +622,24 @@ begin
     #CHECKERR: argparse: An option spec must have at least a short or a long flag
     #CHECKERR: {{.*}}checks/argparse.fish (line {{\d+}}):
     #CHECKERR: argparse ''
+    #CHECKERR: ^
+    #CHECKERR: (Type 'help argparse' for related documentation)
+end
+
+begin
+    argparse -U
+    #CHECKERR: argparse: -U: option requires an argument
+    #CHECKERR: {{.*}}checks/argparse.fish (line {{\d+}}):
+    #CHECKERR: argparse -U
+    #CHECKERR: ^
+    #CHECKERR: (Type 'help argparse' for related documentation)
+end
+
+begin
+    argparse --unknown-arguments what --
+    #CHECKERR: argparse: Invalid --unknown-arguments value 'what'
+    #CHECKERR: {{.*}}checks/argparse.fish (line {{\d+}}):
+    #CHECKERR: argparse --unknown-arguments what --
     #CHECKERR: ^
     #CHECKERR: (Type 'help argparse' for related documentation)
 end

--- a/tests/checks/argparse.fish
+++ b/tests/checks/argparse.fish
@@ -31,6 +31,7 @@ begin
     # CHECK: 0
     set -l
     # CHECK: argv hello
+    # CHECK: argv_opts
 end
 
 # Invalid option specs
@@ -154,6 +155,7 @@ begin
     argparse h/help -- help
     set -l
     # CHECK: argv help
+    # CHECK: argv_opts
 end
 
 # Five args with two matching a flag
@@ -163,12 +165,13 @@ begin
     # CHECK: _flag_h '--help'  '-h'
     # CHECK: _flag_help '--help'  '-h'
     # CHECK: argv 'help'  'me'  'a lot more'
+    # CHECK: argv_opts '--help'  '-h'
 end
 
 # Required, optional, and multiple flags
 begin
     argparse h/help 'a/abc=' 'd/def=?' 'g/ghk=+' -- help --help me --ghk=g1 --abc=ABC --ghk g2 -d -g g3
-    set -l
+    set -lL
     # CHECK: _flag_a ABC
     # CHECK: _flag_abc ABC
     # CHECK: _flag_d
@@ -178,6 +181,7 @@ begin
     # CHECK: _flag_h --help
     # CHECK: _flag_help --help
     # CHECK: argv 'help'  'me'
+    # CHECK: argv_opts '--help'  '--ghk=g1'  '--abc=ABC'  '--ghk'  'g2'  '-d'  '-g'  'g3'
 end
 
 # --stop-nonopt works
@@ -189,6 +193,7 @@ begin
     # CHECK: _flag_h -h
     # CHECK: _flag_help -h
     # CHECK: argv 'non-opt'  'second non-opt'  '--help'
+    # CHECK: argv_opts '-a'  'A1'  '-h'  '--abc'  'A2'
 end
 
 # Implicit int flags work
@@ -197,6 +202,7 @@ begin
     set -l
     # CHECK: _flag_val 123
     # CHECK: argv 'abc'  'def'
+    # CHECK: argv_opts -123
 end
 begin
     argparse v/verbose '#-val' 't/token=' -- -123 a1 --token woohoo --234 -v a2 --verbose
@@ -207,6 +213,7 @@ begin
     # CHECK: _flag_val -234
     # CHECK: _flag_verbose '-v'  '--verbose'
     # CHECK: argv 'a1'  'a2'
+    # CHECK: argv_opts '-123'  '--token'  'woohoo'  '--234'  '-v'  '--verbose'
 end
 
 # Should be set to 987
@@ -216,6 +223,7 @@ begin
     # CHECK: _flag_m 987
     # CHECK: _flag_max 987
     # CHECK: argv 'argle'  'bargle'
+    # CHECK: argv_opts -987
 end
 
 # Should be set to 765
@@ -225,6 +233,7 @@ begin
     # CHECK: _flag_m 765
     # CHECK: _flag_max 765
     # CHECK: argv 'argle'  'bargle'
+    # CHECK: argv_opts '-987'  '--max'  '765'
 end
 
 # Bool short flag only
@@ -234,6 +243,7 @@ begin
     # CHECK: _flag_C -C
     # CHECK: _flag_v '-v'  '-v'
     # CHECK: argv 'arg1'  'arg2'
+    # CHECK: argv_opts '-C'  '-v'  '-v'
 end
 
 # Value taking short flag only
@@ -244,6 +254,7 @@ begin
     # CHECK: _flag_verbose '--verbose'  '-v'
     # CHECK: _flag_x arg2
     # CHECK: argv arg1
+    # CHECK: argv_opts '--verbose'  '-v'  '-x'  'arg2'
 end
 
 # Implicit int short flag only
@@ -254,6 +265,7 @@ begin
     # CHECK: _flag_verbose '-v'  '-v'  '-v'
     # CHECK: _flag_x 321
     # CHECK: argv 'argle'  'bargle'
+    # CHECK: argv_opts '-v'  '-v'  '-v'  '-x'  '321'
 end
 
 # Implicit int short flag only with custom validation passes
@@ -264,6 +276,7 @@ begin
     # CHECK: _flag_verbose '-v'  '-v'  '-v'
     # CHECK: _flag_x 499
     # CHECK: argv
+    # CHECK: argv_opts '-v'  '-v'  '-x'  '499'  '-v'
 end
 
 # Implicit int short flag only with custom validation fails
@@ -326,8 +339,10 @@ begin
     or echo unexpected argparse return status $status >&2
     # The unknown options are removed _entirely_.
     echo $argv
+    echo $argv_opts
     echo $_flag_a
     # CHECK: -t tango --wurst
+    # CHECK: -a alpha -b bravo -a aaaa
     # CHECK: alpha aaaa
 end
 
@@ -338,6 +353,7 @@ begin
     # CHECK: _flag_b -b
     # CHECK: _flag_break -b
     # CHECK: argv '-b kubectl get pods -l name=foo'
+    # CHECK: argv_opts
 end
 
 begin
@@ -346,7 +362,9 @@ begin
     printf '%s\n' $argv
     # CHECK: a
     # CHECK: b
+    printf '%s\n' $argv_opts
     # CHECK: -a
+    # CHECK: --alpha
 end
 
 begin
@@ -361,6 +379,7 @@ begin
     # CHECK: _flag_i 2
     # CHECK: _flag_o 3
     # CHECK: argv
+    # CHECK: argv_opts '-i'  '2'  '-o'  '3'
 end
 
 # long-only flags
@@ -370,6 +389,7 @@ begin
     # CHECK: _flag_foo --foo
     # CHECK: _flag_installed no
     # CHECK: argv
+    # CHECK: argv_opts '--installed=no'  '--foo'
 end
 
 begin
@@ -378,6 +398,7 @@ begin
     # CHECK: _flag_foo --foo
     # CHECK: _flag_installed 5
     # CHECK: argv
+    # CHECK: argv_opts '--installed=5'  '--foo'
 end
 
 begin
@@ -386,6 +407,7 @@ begin
     # CHECK: _flag_installed 5
     # CHECK: _flag_num 5
     # CHECK: argv
+    # CHECK: argv_opts '--installed=5'  '-5'
 end
 
 begin
@@ -498,6 +520,7 @@ begin
     argparse --ignore-unknown h i -- -hoa -oia
     echo -- $argv
     #CHECK: -hoa -oia
+    echo -- $argv_opts
     echo $_flag_h
     #CHECK: -h
     set -q _flag_i

--- a/tests/checks/argparse.fish
+++ b/tests/checks/argparse.fish
@@ -36,6 +36,7 @@ end
 
 # Invalid option specs
 argparse h-
+argparse /
 argparse +help
 argparse h/help:
 argparse h-help::
@@ -43,6 +44,11 @@ argparse h-help=x
 #CHECKERR: argparse: Invalid option spec 'h-' at char '-'
 #CHECKERR: {{.*}}checks/argparse.fish (line {{\d+}}):
 #CHECKERR: argparse h-
+#CHECKERR: ^
+#CHECKERR: (Type 'help argparse' for related documentation)
+#CHECKERR: argparse: Short flag '/' invalid, must be alphanum or '#'
+#CHECKERR: {{.*}}checks/argparse.fish (line {{\d+}}):
+#CHECKERR: argparse /
 #CHECKERR: ^
 #CHECKERR: (Type 'help argparse' for related documentation)
 #CHECKERR: argparse: Short flag '+' invalid, must be alphanum or '#'
@@ -504,7 +510,7 @@ end
 
 # long-only flags with one letter
 begin
-    argparse i-i= a-f -- --i=no --f
+    argparse i-i= /f -- --i=no --f
     set -l
     # CHECK: _flag_f --f
     # CHECK: _flag_i no
@@ -553,12 +559,6 @@ fish_opt -s h --long-only
 and echo unexpected status $status
 #CHECKERR: fish_opt: The --long-only flag requires the --long flag
 
-# One character long flag with no short isn't supported
-fish_opt -l h
-and echo unexpected status $status
-#CHECKERR: fish_opt: The --long flag must be more than one character when no --short flag is provided
-
-
 fish_opt -s help
 and echo unexpected status $status
 #CHECKERR: fish_opt: The --short flag must be a single character
@@ -584,7 +584,12 @@ or echo unexpected status $status
 # Long flag only
 fish_opt -l help
 or echo unexpected status $status
-#CHECK: help
+#CHECK: /help
+
+# One character long flag
+fish_opt -l h
+or echo unexpected status $status
+#CHECK: /h
 
 # Bool, short and long
 fish_opt --short h --long help
@@ -598,7 +603,7 @@ fish_opt --short h --long help --long-only
 # Required val and long
 fish_opt --long help -r
 or echo unexpected status $status
-#CHECK: help=
+#CHECK: /help=
 
 # Optional val, short and long valid, and delete
 fish_opt --short h -l help --optional-val --delete
@@ -623,7 +628,7 @@ or echo unexpected status $status
 # Repeated val and short
 fish_opt -ml help --long-only
 or echo unexpected status $status
-#CHECK: help=+
+#CHECK: /help=+
 
 # Repeated and optional val, short and long but short not valid
 fish_opt --short h -l help --long-only -mo

--- a/tests/checks/argparse.fish
+++ b/tests/checks/argparse.fish
@@ -347,13 +347,25 @@ begin
 end
 
 begin
+    # Ignoring unknown long options that share a character with a known short options
+    argparse -i o -- --long=value --long
+    or echo unexpected argparse return status $status >&2
+    set -l
+    # CHECK: argv '--long=value'  '--long'
+    # CHECK: argv_opts
+end
+
+begin
     # Check for crash when last option is unknown
+    # Note that because of the quotation marks, there is a single argument
+    # starting with the known short option '-b', and continuing with an unknown short option
+    # that starts with a space
     argparse -i b/break -- "-b kubectl get pods -l name=foo"
     set -l
     # CHECK: _flag_b -b
     # CHECK: _flag_break -b
-    # CHECK: argv '-b kubectl get pods -l name=foo'
-    # CHECK: argv_opts
+    # CHECK: argv '- kubectl get pods -l name=foo'
+    # CHECK: argv_opts -b
 end
 
 begin
@@ -519,8 +531,9 @@ end
 begin
     argparse --ignore-unknown h i -- -hoa -oia
     echo -- $argv
-    #CHECK: -hoa -oia
+    #CHECK: -oa -oia
     echo -- $argv_opts
+    #CHECK: -h
     echo $_flag_h
     #CHECK: -h
     set -q _flag_i

--- a/tests/checks/argparse.fish
+++ b/tests/checks/argparse.fish
@@ -572,7 +572,17 @@ and echo unexpected status $status
 # An unexpected arg not associated with a flag is an error
 fish_opt -s h -l help hello
 and echo unexpected status $status
-#CHECKERR: fish_opt: expected <= 0 arguments; got 1
+#CHECKERR: fish_opt: Extra non-option arguments were provided
+
+# A -v / --validate without any arguments is an error
+fish_opt -s h -l help -rv
+and echo unexpected status $status
+#CHECKERR: fish_opt: The --validate flag requires subsequent arguments
+
+# A -v / --validate for boolean options is an error
+fish_opt -s h -l help -v echo hello
+and echo unexpected status $status
+#CHECKERR: fish_opt: The --validate flag requires the --required-val, --optional-value, or --multiple-vals flag
 
 # Now verify that valid combinations of options produces the correct output.
 
@@ -615,20 +625,20 @@ fish_opt --short h -l help --optional-val --long-only
 or echo unexpected status $status
 #CHECK: h-help=?
 
-# Repeated val, short and long valid
-fish_opt --short h -l help --multiple-vals
+# Repeated val, short and long valid, with validate
+fish_opt --short h -l help --multiple-vals --validate _validate_int --max 500
 or echo unexpected status $status
-#CHECK: h/help=+
+#CHECK: h/help=+!_validate_int --max 500
 
 # Repeated and optional val, short and long valid
 fish_opt --short h -l help --optional-val -m
 or echo unexpected status $status
 #CHECK: h/help=*
 
-# Repeated val and short
-fish_opt -ml help --long-only
+# Repeated val and short, with validate
+fish_opt -ml help --long-only -v test \$_flag_value != "' '"
 or echo unexpected status $status
-#CHECK: /help=+
+#CHECK: /help=+!test $_flag_value != ' '
 
 # Repeated and optional val, short and long but short not valid
 fish_opt --short h -l help --long-only -mo

--- a/tests/checks/argparse.fish
+++ b/tests/checks/argparse.fish
@@ -679,6 +679,11 @@ begin
 end
 
 begin
+    argparse f!echo hello -- -f
+    #CHECKERR: argparse: Invalid option spec 'f!echo' at char '!'
+end
+
+begin
     argparse --ignore-unknown h i -- -hoa -oia
     echo -- $argv
     #CHECK: -oa -oia

--- a/tests/checks/bad-option.fish
+++ b/tests/checks/bad-option.fish
@@ -1,2 +1,2 @@
-#RUN: %fish -Z
-# CHECKERR: {{.*fish}}: {{unrecognized option: Z|invalid option -- '?Z'?|unknown option -- Z|illegal option -- Z|-Z: unknown option}}
+#RUN: %fish --interactive=value
+# CHECKERR: {{.*fish}}: --interactive=value: option does not take an argument

--- a/tests/checks/functions.fish
+++ b/tests/checks/functions.fish
@@ -229,3 +229,8 @@ functions --banana
 # CHECKERR: functions: --banana: unknown option
 echo $status
 # CHECK: 2
+
+functions --all=arg
+# CHECKERR: functions: --all=arg: option does not take an argument
+echo $status
+# CHECK: 2

--- a/tests/checks/line-number.fish
+++ b/tests/checks/line-number.fish
@@ -16,9 +16,12 @@ emit linenumber
 type --nonexistent-option-so-we-get-a-backtrace
 # CHECKERR: type: --nonexistent-option-so-we-get-a-backtrace: unknown option
 
+type --short=cd
+# CHECKERR: type: --short=cd: option does not take an argument
+
 function line-number
     status line-number
 end
 
 line-number
-# CHECK: 20
+# CHECK: 23

--- a/tests/checks/set_color.fish
+++ b/tests/checks/set_color.fish
@@ -13,6 +13,15 @@ string escape (set_color red reset yellow)
 string escape (set_color --background=reset)
 # CHECKERR: set_color: Unknown color 'reset'
 
+string escape (set_color --bold=red)
+# CHECKERR: set_color: --bold=red: option does not take an argument
+#CHECKERR: {{.*}}checks/set_color.fish (line {{\d+}}):
+#CHECKERR: set_color --bold=red
+#CHECKERR: ^
+#CHECKERR: in command substitution
+#CHECKERR: called on line {{\d+}} of file {{.*}}checks/set_color.fish
+#CHECKERR: (Type 'help set_color' for related documentation)
+
 string escape (set_color --bold red --background=normal)
 # CHECK: \e\[31m\e\[49m\e\[1m
 string escape (set_color --bold red --background=blue)


### PR DESCRIPTION
This pull request has many changes, mostly because I wanted to make a wrapper over an existing command that adds options to said command, and makes some changes to arguments.  However the original command has many options, so I didn't want to bother specifying them all manually to argparse, and then individually forward them over. Bassically, the motivation behind #6466. The first set of commits shown below address this use case.

However I got a bit carried away with various little things I noticed about `argparse` and `fish_opt`. So I've split everything up into individual commits, in case you want to reject some of my changes but not all of them. After each commit I ran `make fish_run_tests sphinx-docs`, and there weren't any test/doc failures (although some tests where marked as ignored/skipped).


The commits are roughly in order of how useful I think they are are.
Each commit gives more detail about the individual change, and why I made it. Moreover, the commits modify the  documentation, `doc_src/cmds/argparse.rst` and `doc_src/cmds/fish_opt.rst` with examples and detailed explanations of the new features.

Let me know if you think, or would like me to make any other `argparse`/`fish_opt` related changes. In particular, I'd be happy to write more examples for the documentation if you think that would be useful.

# Example
Together, the main commits 74cad9e02b82ebdd441eacb503929145ef66e7b1..807a5cbe4b261288e4e3409d9154abf8757adddb enables the following example (which is included in `doc_src/cmds/argparse.rst`). (See the diffs for those commits to see how each individual commit alters the example, the one shown below is the state at the end of all them):

```fish
function head
    # The following option is the only existing one to head that takes arguments
    # (we will forward it verbatim).
    set opt_spec n/lines=
    # --qwords is a new option, but --bytes is an existing one which we will modify below
    set opt_spec -a "qwords=&" "c/bytes=&"
    argparse --move-unknown --unknown-arguments=none $opt_spec -- $argv

    if set -q _flag_qwords
        # --qwords allows specifying the size in multiples of 8 bytes
        set -a argv_opts --bytes=(math $_flag_qwords \* 8)
    else if set -q _flag_bytes
        # Allows using a 'q' suffix, e.g. --bytes=4q to mean 4*8 bytes.
        if string match -r 'q$' -- $_flag_bytes
            set -a argv_opts --bytes=(math (string replace -r 'q$' '*8'))
        else
            # Keep the users settings
            set -a argv_opts --bytes=$_flag_bytes
        end

    end

    if (count $argv) -eq 0
        # Default to heading stderr (whereas head defaults to stdin)
        set argv /dev/stderr
    end

    # Call the real head with our modified options and arguments.
    command head $argv_opts -- $argv
end
```

The argparse call above saves all the options we do *not* want to process in `$argv_opts`. (The `--qwords` and `--bytes` options are *not* saved there as their option spec's end in a `~`). The code then processes the `--qwords` and `--bytes` options using the the `$_flag_OPTION` variables, and puts the transformed options in `$argv_opts` (which already contains all the original options, *other* than `--qwords` and `--bytes`).

Note that because the `argparse` call above uses `--move-unknown` and `--unknown-arguments=none`, we only need to tell it the arguments to `head` that take a value. This allows the wrapper script to accurately work out the *non*-option arguments (i.e. `$argv`, the filenames that `head` is to operate on). Using `--unknown-arguments=optional` and explicitly listing all the known options to `head` however would have the advantage that if `head` were to add new options, they could still be used with the wrapper script using the "stuck" form for arguments (e.g. `-o<arg>`, or `--opt=<arg>`).

Also note that if `--ignore-unknown` was used instead of `--move-unknown` the `command head $argv_opts -- $argv` line would incorrectly
parse unknown options to `head` as if they were file names, but removing the `--` would prevent users of the wrapper function from passing in filenames starting with `--` (as `head` would interpret them as options).