### PR TITLE
Censor variable completions

### DIFF
--- a/doc_src/interactive.rst
+++ b/doc_src/interactive.rst
@@ -56,6 +56,15 @@ It also provides a large number of program specific scripted completions. Most o
 
 You can also write your own completions or install some you got from someone else. For that, see :ref:`Writing your own completions <completion-own>`.
 
+.. envvar:: fish_censor_vars
+    A list of glob patterns for variable names whose values should be censored in completion descriptions.
+    If a variable name matches one of these patterns, its value will be replaced with ``[censored]`` in the completion description.
+    This is useful for preventing accidental exposure of sensitive information like API keys or tokens during tab completion.
+
+    Example: to censor variables ending with ``_TOKEN`` or containing ``SECRET``::
+
+        set -g fish_censor_vars '*_TOKEN' '*_SECRET*'
+
 Completion scripts are loaded on demand, like :ref:`functions are <syntax-function-autoloading>`. The difference is the ``$fish_complete_path`` :ref:`list <variables-lists>` is used instead of ``$fish_function_path``. Typically you can drop new completions in ~/.config/fish/completions/name-of-command.fish and fish will find them automatically.
 
 .. _color:

--- a/po/de.po
+++ b/po/de.po
@@ -1722,6 +1722,10 @@ msgstr "Benutzerdefiniertes Signal 2"
 msgid "Variable: %ls"
 msgstr "Variable: %ls"
 
+#
+msgid "Variable: [censored]"
+msgstr ""
+
 #, c-format
 msgid "Variables cannot be bracketed. In fish, please use \"$%ls\"."
 msgstr ""

--- a/po/en.po
+++ b/po/en.po
@@ -1718,6 +1718,10 @@ msgstr "User defined signal 2"
 msgid "Variable: %ls"
 msgstr "Variable: %ls"
 
+#
+msgid "Variable: [censored]"
+msgstr ""
+
 #, c-format
 msgid "Variables cannot be bracketed. In fish, please use \"$%ls\"."
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -1819,6 +1819,10 @@ msgstr "Signal défini par l'utilisateur 2"
 msgid "Variable: %ls"
 msgstr "Variable : %ls"
 
+#
+msgid "Variable: [censored]"
+msgstr ""
+
 #, c-format
 msgid "Variables cannot be bracketed. In fish, please use \"$%ls\"."
 msgstr "Les variables ne peuvent être placées entre crochets. Dans fish, veuillez utiliser \"$%ls\"."

--- a/po/pl.po
+++ b/po/pl.po
@@ -1714,6 +1714,10 @@ msgstr "Sygnał zdefiniowany przez użytkownika 2"
 msgid "Variable: %ls"
 msgstr "Zmienna: %ls"
 
+#
+msgid "Variable: [censored]"
+msgstr ""
+
 #, c-format
 msgid "Variables cannot be bracketed. In fish, please use \"$%ls\"."
 msgstr "Zmienne nie mogą znajdować się w nawiasach. W fish używane jest \"$%ls\"."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1719,6 +1719,10 @@ msgstr "Sinal definido pelo usuário 2"
 msgid "Variable: %ls"
 msgstr "Variável: %ls"
 
+#
+msgid "Variable: [censored]"
+msgstr ""
+
 #, c-format
 msgid "Variables cannot be bracketed. In fish, please use \"$%ls\"."
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -1715,6 +1715,10 @@ msgstr "Användardefinerad signal 2"
 msgid "Variable: %ls"
 msgstr "Variabel: %ls"
 
+#
+msgid "Variable: [censored]"
+msgstr ""
+
 #, c-format
 msgid "Variables cannot be bracketed. In fish, please use \"$%ls\"."
 msgstr ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1714,6 +1714,10 @@ msgstr ""
 msgid "Variable: %ls"
 msgstr "变量:%ls"
 
+#
+msgid "Variable: [censored]"
+msgstr ""
+
 #, c-format
 msgid "Variables cannot be bracketed. In fish, please use \"$%ls\"."
 msgstr ""

--- a/src/complete.rs
+++ b/src/complete.rs
@@ -1682,8 +1682,23 @@ impl<'ctx> Completer<'ctx> {
                         continue;
                     };
 
-                    let value = expand_escape_variable(&var);
-                    desc = sprintf!(*COMPLETE_VAR_DESC_VAL, value);
+                    let censored = if let Some(censor_patterns) =
+                        self.ctx.vars().get(L!("fish_censor_vars"))
+                    {
+                        censor_patterns.as_list().iter().any(|pattern| {
+                            let wc = crate::parse_util::parse_util_unescape_wildcards(pattern);
+                            wildcard_match(&env_name, wc, false)
+                        })
+                    } else {
+                        false
+                    };
+
+                    if censored {
+                        desc = wgettext!("Variable: [censored]").to_owned();
+                    } else {
+                        let value = expand_escape_variable(&var);
+                        desc = sprintf!(*COMPLETE_VAR_DESC_VAL, value);
+                    }
                 }
             }
 

--- a/tests/pexpects/censor_env_vars.py
+++ b/tests/pexpects/censor_env_vars.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+import pexpect
+import re
+from pexpect_helper import SpawnedProc
+
+def strip_ansi(s):
+    return re.sub(r'\x1b\].*?\x07|\x1b\[?[0-9;]*[A-Za-z]', '', s)
+
+def normalize_line(line):
+    return re.sub(r'\s+', ' ', line.replace('\t', ' ').strip())
+
+sp = SpawnedProc()
+send, sendline, sleep, expect_prompt, expect_re, expect_str = (
+    sp.send,
+    sp.sendline,
+    sp.sleep,
+    sp.expect_prompt,
+    sp.expect_re,
+    sp.expect_str,
+)
+expect_prompt(timeout=5)
+# SETUP: Reset shell state and set up environment
+sendline("bind --erase --all")
+expect_prompt(timeout=5)
+sendline("set -e -g fish_key_bindings fish_prompt")
+expect_prompt(timeout=5)
+sendline("set TERM xterm")
+expect_prompt(timeout=5)
+sendline(r"bind ! 'commandline \"\"'")
+expect_prompt(timeout=5)
+sendline("set -g fish_pager_completion_threshold 1")
+expect_prompt(timeout=5)
+sendline("set -gx MY_SUPER_SECRET 'secret_value'")
+expect_prompt(timeout=5)
+sendline("set -gx MY_OTHER_SECRET 'another_secret'")
+expect_prompt(timeout=5)
+sendline("set -gx MY_PUBLIC_VALUE 'public_value'")
+expect_prompt(timeout=5)
+sendline("set -gx MY_OTHER_VALUE 'other_value'")
+expect_prompt(timeout=5)
+sendline("set -gx MY_NORMAL_VAR 'normal_value'")
+expect_prompt(timeout=5)
+sendline("set -g fish_censor_vars '*_SECRET' MY_PUBLIC_VALUE")
+expect_prompt(timeout=5)
+# ACTION: Trigger variable completions with a single tab
+send("echo $MY_\t")
+sleep(0.05)
+try:
+    sp.spawn.expect(pexpect.TIMEOUT, timeout=0.5)
+except pexpect.TIMEOUT:
+    pass
+# VERIFY: Check pager output for censored and non-censored variables
+stripped_output = strip_ansi(sp.spawn.before)
+lines = [normalize_line(line) for line in stripped_output.splitlines() if line.strip() and '(Variable:' in line]
+expected_patterns = [
+    "$MY_SUPER_SECRET (Variable: [censored])",
+    "$MY_OTHER_SECRET (Variable: [censored])",
+    "$MY_PUBLIC_VALUE (Variable: [censored])",
+    "$MY_OTHER_VALUE (Variable: other_value)",
+    "$MY_NORMAL_VAR (Variable: normal_value)"
+]
+censored_super_secret = False
+censored_other_secret = False
+censored_public = False
+non_censored_other = False
+non_censored_normal = False
+for line in lines:
+    if "$MY_SUPER_SECRET" in line:
+        assert "(Variable: [censored])" in line, f"Censored description not found in line: {line}"
+        censored_super_secret = True
+        print(f"DEBUG: Censored MY_SUPER_SECRET match found in line: {line}")
+    if "$MY_OTHER_SECRET" in line:
+        assert "(Variable: [censored])" in line, f"Censored description not found in line: {line}"
+        censored_other_secret = True
+        print(f"DEBUG: Censored MY_OTHER_SECRET match found in line: {line}")
+    if "$MY_PUBLIC_VALUE" in line:
+        assert "(Variable: [censored])" in line, f"Censored description not found in line: {line}"
+        censored_public = True
+        print(f"DEBUG: Censored MY_PUBLIC_VALUE match found in line: {line}")
+    if "$MY_OTHER_VALUE" in line:
+        assert "(Variable: other_value)" in line, f"Non-censored description not found in line: {line}"
+        non_censored_other = True
+        print(f"DEBUG: Non-censored MY_OTHER_VALUE match found in line: {line}")
+    if "$MY_NORMAL_VAR" in line:
+        assert "(Variable: normal_value)" in line, f"Non-censored description not found in line: {line}"
+        non_censored_normal = True
+        print(f"DEBUG: Non-censored MY_NORMAL_VAR match found in line: {line}")
+assert censored_super_secret, "Censored variable $MY_SUPER_SECRET not found in output"
+assert censored_other_secret, "Censored variable $MY_OTHER_SECRET not found in output"
+assert censored_public, "Censored variable $MY_PUBLIC_VALUE not found in output"
+assert non_censored_other, "Non-censored variable $MY_OTHER_VALUE not found in output"
+assert non_censored_normal, "Non-censored variable $MY_NORMAL_VAR not found in output"
+# CLEANUP: Dismiss pager and clear command line
+send("q")
+sleep(0.5)
+send("\x03")
+sleep(0.1)
+send("\r")
+sleep(0.1)
+send("!")
+expect_prompt(timeout=5)
+sendline("set -e fish_pager_completion_threshold MY_SUPER_SECRET MY_OTHER_SECRET MY_PUBLIC_VALUE MY_OTHER_VALUE MY_NORMAL_VAR fish_censor_vars")
+expect_prompt(timeout=5)


### PR DESCRIPTION
## Description

This pull request introduces a new feature to prevent sensitive environment variable values from being displayed in completion suggestions.

A new global environment variable, fish_censor_vars, is introduced. It can be set to a list of glob patterns (e.g., *_TOKEN, *_SECRET*). Any variable name matching one of these patterns will have its value replaced with [censored] in the completion description. This helps to avoid accidental exposure of secrets like API keys or tokens when using tab completion in a public setting.

For example:
`set -g fish_censor_vars '*_TOKEN' '*_SECRET*'`

## Screenshots
(In these shots, I'm pressing the Tab key at the end of `MY_`)

This:
<img width="623" height="291" alt="image" src="https://github.com/user-attachments/assets/1f9b22ed-a8f8-45be-80f2-5a00dd548505" />

Becomes this:
<img width="655" height="331" alt="image" src="https://github.com/user-attachments/assets/f62e2e44-ca0b-4b43-a6a5-82765d249275" />




This change also includes updates to the localization files to make the new `Variable: [censored]` string available for translation by the community.

Fixes issue # (N/A)

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
