### PR TITLE
Respect Git canonical config for untracked files

### DIFF
--- a/doc_src/cmds/fish_git_prompt.rst
+++ b/doc_src/cmds/fish_git_prompt.rst
@@ -33,11 +33,11 @@ Boolean options (those which enable or disable something) understand "1", "yes" 
 - ``$__fish_git_prompt_show_informative_status`` or the git option ``bash.showInformativeStatus`` can be set to 1, true or yes to enable the "informative" display, which will show a large amount of information - the number of dirty files, unpushed/unpulled commits, and more.
   In large repositories, this can take a lot of time, so you may wish to disable it in these repositories with  ``git config --local bash.showInformativeStatus false``. It also changes the characters the prompt uses to less plain ones (``✚`` instead of ``*`` for the dirty state for example) , and if you are only interested in that, set ``$__fish_git_prompt_use_informative_chars`` instead.
 
-  Because counting untracked files requires a lot of time, the number of untracked files is only shown if enabled via ``$__fish_git_prompt_showuntrackedfiles`` or the git option ``bash.showUntrackedFiles``.
+  Because counting untracked files requires a lot of time, the number of untracked files is only shown if enabled via ``$__fish_git_prompt_showuntrackedfiles`` or the git option ``status.showUntrackedFiles``.
 
 - ``$__fish_git_prompt_showdirtystate`` or the git option ``bash.showDirtyState`` can be set to 1, true or yes to show if the repository is "dirty", i.e. has uncommitted changes.
 
-- ``$__fish_git_prompt_showuntrackedfiles`` or the git option ``bash.showUntrackedFiles`` can be set to 1, true or yes to show if the repository has untracked files (that aren't ignored).
+- ``$__fish_git_prompt_showuntrackedfiles`` or the git option ``status.showUntrackedFiles`` can be set to 1, true or yes to show if the repository has untracked files (that aren't ignored).
 
 - ``$__fish_git_prompt_showupstream`` can be set to a list of values to determine how changes between HEAD and upstream are shown:
 

--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -1170,10 +1170,10 @@ complete -c git -n '__fish_git_using_command add' -l ignore-errors -d 'Ignore er
 complete -c git -n '__fish_git_using_command add' -l ignore-missing -d 'Check if any of the given files would be ignored'
 # Renames also show up as untracked + deleted, and to get git to show it as a rename _both_ need to be added.
 # However, we can't do that as it is two tokens, so we don't need renamed here.
-complete -f -c git -n '__fish_git_using_command add; and test "$(__fish_git config --get bash.showUntrackedFiles)" != 0' -a '(__fish_git_files modified untracked deleted unmerged modified-staged-deleted)'
+complete -f -c git -n '__fish_git_using_command add; and test "$(__fish_git config --type bool --get status.showUntrackedFiles)" != false' -a '(__fish_git_files modified untracked deleted unmerged modified-staged-deleted)'
 # If we have so many files that you disable untrackedfiles, let's add file completions,
 # to avoid slurping megabytes of git output.
-complete -F -c git -n '__fish_git_using_command add; and test "$(__fish_git config --get bash.showUntrackedFiles)" = 0' -a '(__fish_git_files modified deleted unmerged modified-staged-deleted)'
+complete -F -c git -n '__fish_git_using_command add; and test "$(__fish_git config --type bool --get status.showUntrackedFiles)" = false' -a '(__fish_git_files modified deleted unmerged modified-staged-deleted)'
 
 ### am
 complete -c git -n __fish_git_needs_command -a am -d 'Apply patches from a mailbox'


### PR DESCRIPTION
## Description

The git completion was not respecting git config for ignoring untracked files.

I am using something called `yadm` to track my dotfiles in a bare git repository. What `yadm` is doesn't really matter, as it just setup GIT environment variable and configs under hood. I'll demonstrates the same principle with raw git:

This shows that it's showing my dotfiles status
<img width="2132" height="362" alt="Screenshot 2025-08-06 104720" src="https://github.com/user-attachments/assets/16e1321f-1950-4e7f-a091-9537f532b5c2" />

By default it setup the git config variable to NOT show untracked files. This in-turns creates issues when <TAB> completing `add`: 
<img width="2825" height="394" alt="Screenshot 2025-08-06 104805" src="https://github.com/user-attachments/assets/e409d9eb-b375-4b49-8750-a9a3a490f99d" />
(notice the > 300K files)

Now, you can see that the git config is setup correctly:
<img width="2484" height="131" alt="Screenshot 2025-08-06 105002" src="https://github.com/user-attachments/assets/9a5cb1db-8bfa-4d04-b203-9d6625cfa528" />

where its using the option here: https://git-scm.com/docs/git-config
<img width="1181" height="512" alt="image" src="https://github.com/user-attachments/assets/fa8b3187-3a71-4b89-b2cc-553455686dd5" />

(BTW, noticing how the current behaviour is actually the `all` behaviour of including files within untracked folders)


-----------------------

The behaviour after this PR:

<img width="1947" height="129" alt="Screenshot 2025-08-06 105848" src="https://github.com/user-attachments/assets/8e912a27-5a2a-4b35-8aa5-fe1d3e4ad838" />

-------------

## Discussion

Regarding the previous `bash.showUntrackedFiles` option: I was able to find traces of it in the git source repo, and apparently I think it used to be a contrib module for completion:

https://github.com/search?q=repo%3Agit%2Fgit%20bash.showUntrackedFiles&type=code

But i reckon we should now use the canonical git config option?

https://github.com/search?q=repo%3Agit%2Fgit+status.showUntrackedFiles&type=code


## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
