### PR TITLE
Update pinned stable Rust to 1.89

### DIFF
--- a/.github/actions/rust-toolchain@stable/action.yml
+++ b/.github/actions/rust-toolchain@stable/action.yml
@@ -16,7 +16,7 @@ permissions:
 runs:
   using: "composite"
   steps:
-    - uses: dtolnay/rust-toolchain@1.88
+    - uses: dtolnay/rust-toolchain@1.89
       with:
         targets: ${{ inputs.targets }}
         components: ${{ inputs.components }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ asan = []
 tsan = []
 
 [workspace.lints]
+rust.mismatched_lifetime_syntaxes = "allow"
 rust.non_camel_case_types = "allow"
 rust.non_upper_case_globals = "allow"
 rust.unknown_lints = "allow"


### PR DESCRIPTION
Rust 1.89 introduces new lifetime-related lints:
https://github.com/rust-lang/rust/pull/138677

The current code results in warnings about lifetime syntax mismatches, e.g. in `fn kind(&self) -> Kind`, where the lifetime is elided in `&self` but hidden in `Kind`. We might want to address these issues in the code instead of disabling the warning. To prevent issues for unrelated development, the warning is enabled for now.

It is desirable to merge this quickly, since `build_tools/check.sh` fails if the pinned version in `.github/actions/rust-toolchain@stable/action.yml` is not the most recent stable version, which blocks running the checks for everyone.

This shows another reason why pinning stable Rust is problematic. Not only is a PR like this one required every 6 weeks, but with the current setup it also prevents running the checks, even for code completely unrelated to any changes in the new version. I hope we can improve that before 1.90 is released as stable.