### PR TITLE
Refactor history file appending

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -696,6 +696,7 @@ impl HistoryImpl {
         }
 
         flush_to_file(&mut buffer, locked_history_file.get_mut(), 0)?;
+        locked_history_file.get().sync_all()?;
         self.first_unwritten_new_item_index = new_first_index;
 
         // Since we just modified the file, update our history_file_id to match its current state

--- a/src/history.rs
+++ b/src/history.rs
@@ -711,7 +711,7 @@ impl HistoryImpl {
         // write.
         // We don't update `self.file_contents` since we only appended to the file, and everything we
         // appended remains in our new_items
-        self.history_file_id = file_id;
+        self.history_file_id = file_id_for_file(locked_history_file.get());
 
         drop(locked_history_file);
 


### PR DESCRIPTION
## Description

- Fix file id not being set correctly.
- Call `write_all` at most once.
- Call `fsync` after data is written.

The main motivation for these changes is to hopefully eliminate some cases leading to corruption in the history file (#10300). My very limited testing did not encounter any corruption using this code so far, but very frequent corruption using 07ff4e7df065e97a008b1b2995169bd61219662e and other recent commits without the changes contained in this PR. Being reasonably confident that the corruption issues are resolved for me would require at least several months of testing, but I think these changes make sense even if the corruption issue is unaffected.