### PR TITLE
Solve latent build_tools/check.sh failures without rust-toolchain.toml for now

### DIFF
--- a/.github/actions/rust-toolchain@oldest-supported/action.yml
+++ b/.github/actions/rust-toolchain@oldest-supported/action.yml
@@ -20,5 +20,3 @@ runs:
       with:
         targets: ${{ inputs.targets }}
         components: ${{ inputs.components}}
-    - run: rm rust-toolchain.toml
-      shell: sh

--- a/.github/actions/rust-toolchain@stable/action.yml
+++ b/.github/actions/rust-toolchain@stable/action.yml
@@ -16,10 +16,7 @@ permissions:
 runs:
   using: "composite"
   steps:
-    # also update in rust-toolchain.toml
-    - uses: dtolnay/rust-toolchain@1.89.0
+    - uses: dtolnay/rust-toolchain@1.89
       with:
         targets: ${{ inputs.targets }}
         components: ${{ inputs.components }}
-    - run: rm rust-toolchain.toml
-      shell: sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,6 @@ jobs:
         # Ensure that fish is available as an executable.
         PATH="$PWD/build:$PATH" build_tools/update_translations.fish --no-mo
         # Show diff output. Fail if there is any.
-        git restore --worktree rust-toolchain.toml
         git --no-pager diff --exit-code || { echo 'There are uncommitted changes after regenerating the gettext PO files. Make sure to update them via `build_tools/update_translations.fish --no-mo` after changing source files.'; exit 1; }
 
   ubuntu-32bit-static-pcre2:
@@ -88,7 +87,6 @@ jobs:
         # ASAN uses `cargo build -Zbuild-std` which requires the rust-src component
         # this is comma-separated
         components: rust-src
-    - run: rm rust-toolchain.toml
     - name: Install deps
       run: |
         sudo apt install gettext libpcre2-dev python3-pexpect tmux

--- a/build_tools/check.sh
+++ b/build_tools/check.sh
@@ -29,25 +29,13 @@ cleanup () {
 
 trap cleanup EXIT INT TERM HUP
 
-repo_root="$(dirname "$0")/.."
-build_dir="${CARGO_TARGET_DIR:-$repo_root/target}/${target_triple}/debug"
-
-if $lint && command -v rustup >/dev/null && rustup show active-toolchain | grep -q ^stable-; then
-    # Check that stable is up-to-date
-    if rustup check | grep ^stable- | grep 'Update available'; then
-        exit 1
-    fi
-    # Same in CI.
-    rust_version=$(rustc --version | cut -d' ' -f2)
-    rust_version=${rust_version%.*}
-    grep -q "\bdtolnay/rust-toolchain@$rust_version\b" \
-        "$repo_root/.github/actions/rust-toolchain@stable/action.yml"
-fi
-
 if $lint; then
     export RUSTFLAGS="--deny=warnings ${RUSTFLAGS}"
     export RUSTDOCFLAGS="--deny=warnings ${RUSTDOCFLAGS}"
 fi
+
+repo_root="$(dirname "$0")/.."
+build_dir="${CARGO_TARGET_DIR:-$repo_root/target}/${target_triple}/debug"
 
 template_file=$(mktemp)
 FISH_GETTEXT_EXTRACTION_FILE=$template_file cargo build --workspace --all-targets

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-# also update in .github/actions/rust-toolchain@stable/action.yml
-channel = "1.89.0"


### PR DESCRIPTION
d8fc4c17ec1 Revert "build_tools/check.sh: check that stable rust is up-to-date"

<details>

As reported in #11711 and #11712, the update-checks make check.sh automatically
fail every 6 weeks, so it pressures people into updating Rust, and (what's
worse), updating fish's pinned Rust version, even when that's not relevant
to their intent (which is to run `clippy -Dwarnings` and all other checks).

The update-checks were added as a "temporary" solution to make sure that
our pinned version doesn't lag too far behind stable, which gives us an
opportunity to fix new warnings before most contributors see them.

As suggested in #11584, reasonable solutions might be either of:
1. stop pinning stable Rust and rely on beta-nightlies to fix CI failures early
2. use renovatebot or similar to automate Rust updates

Until then, remove the update check to reduce friction.
I'll still run it on my machine.

This reverts commit 6d061daa917d84d9e479ab9132393d692f7ad13d.

</details>

2a99b86a3a5 Revert "Add rust-toolchain.toml"

<details>

By default, we make every rustup user use our pinned version.  This might
not be ideal at this point, for two reasons:
1. we don't have automatic Rust updates yet (see the parent commit),
   so this might unnecessarily install an old version. As a contributor,
   this feels irritating (newer versions are usually strictly better).
2. it will use more bandwidth and perhaps other resources during "git-bisect"
   scenarios
3. somehow rustup will download things redundantly; it will download "1.89.0"
   and "stable" even if they are identical. The user will need to clean
   those up at some point, even if the didn't add them explicitly.

See also
https://github.com/fish-shell/fish-shell/pull/11712#issuecomment-3165388330

Part of the motivation for rust-toolchain.toml is probably the regular
(every 6 weeks) failures due to the update check, which has been removed in
the parent commit.

The other motivation ("fix the issue of local compiles running into lint
warnings from newer compilers") is a fair point but I think we should rather
fix warnings quickly.

Let's remove rust-toolchain.toml again until we have more agreement on what
we should do.

This reverts commits
* f806d35af82 (Ignore rust-toolchain.toml in CI, 2025-08-07)
* 9714b982623 (Explicitly use fully qualified rust version numbers, 2025-08-07)
* 921aaa07868 (Add rust-toolchain.toml, 2025-08-07)

</details>
