### PR TITLE
allow `psub --fifo --suffix ...`

### DIFF
--- a/share/functions/psub.fish
+++ b/share/functions/psub.fish
@@ -1,5 +1,5 @@
 function psub --description "Read from stdin into a file and output the filename. Remove the file when the command that called psub exits."
-    set -l options -x 'f,F' -x 'F,s' h/help f/file F/fifo 's/suffix=' T-testing
+    set -l options -x 'f,F' h/help f/file F/fifo 's/suffix=' T-testing
     argparse -n psub --max-args=0 $options -- $argv
     or return
 

--- a/tests/checks/psub.fish
+++ b/tests/checks/psub.fish
@@ -49,6 +49,17 @@ else
 end
 #CHECK: psub filename ends with .cc
 
+# Fifo is allowed to have a suffix as well
+# hack: the background write that psub performs may block
+# until someone opens the fifo for reading. So make sure we
+# actually read it.
+if cat (echo foo | psub -F -s .cc | string match -e -r '\.fifo\.cc$') >/dev/null
+    echo 'psub pipe name ends with .cc'
+else
+    echo 'psub pipe name does not end with .cc'
+end
+#CHECK: psub pipe name ends with .cc
+
 set -l filename (echo foo | psub -s .fish)
 if test -e (dirname $filename)
     echo 'psub directory was not deleted'


### PR DESCRIPTION
## Description

Prior to 8f22def8f7b71fb9855d435e99d624bc89d1e8d9, this was allowed, and there's been a codepath for it since before the switch to argparse. Seems to work fine from personal use, and added a test case to make sure.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
