### PR TITLE
Consistently use `__fish_cache_sourced_completions`

### DIFF
--- a/share/completions/argocd.fish
+++ b/share/completions/argocd.fish
@@ -1,1 +1,2 @@
-argocd completion fish | source
+__fish_cache_sourced_completions argocd completion fish
+or argocd completion fish | source

--- a/share/completions/bws.fish
+++ b/share/completions/bws.fish
@@ -1,1 +1,2 @@
-bws completions fish | source
+__fish_cache_sourced_completions bws completions fish
+or bws completions fish | source

--- a/share/completions/cilium.fish
+++ b/share/completions/cilium.fish
@@ -1,1 +1,2 @@
-cilium completion fish 2>/dev/null | source
+__fish_cache_sourced_completions cilium completion fish 2>/dev/null
+or cilium completion fish 2>/dev/null | source

--- a/share/completions/cobra-cli.fish
+++ b/share/completions/cobra-cli.fish
@@ -1,1 +1,2 @@
-cobra-cli completion fish | source
+__fish_cache_sourced_completions cobra-cli completion fish
+or cobra-cli completion fish | source

--- a/share/completions/crc.fish
+++ b/share/completions/crc.fish
@@ -1,1 +1,2 @@
-crc completion fish | source
+__fish_cache_sourced_completions crc completion fish
+or crc completion fish | source

--- a/share/completions/cue.fish
+++ b/share/completions/cue.fish
@@ -1,1 +1,2 @@
-cue completion fish | source
+__fish_cache_sourced_completions cue completion fish
+or cue completion fish | source

--- a/share/completions/dagger.fish
+++ b/share/completions/dagger.fish
@@ -1,1 +1,2 @@
-dagger completion fish | source
+__fish_cache_sourced_completions dagger completion fish
+or dagger completion fish | source

--- a/share/completions/delta.fish
+++ b/share/completions/delta.fish
@@ -1,3 +1,4 @@
 # Older versions of delta do not have a --generate-completion option and will complain
 # to stderr but emit nothing to stdout, making it safe (but a no-op) to source.
-delta --generate-completion fish 2>/dev/null | source
+__fish_cache_sourced_completions delta --generate-completion fish 2>/dev/null
+or delta --generate-completion fish 2>/dev/null | source

--- a/share/completions/deno.fish
+++ b/share/completions/deno.fish
@@ -1,4 +1,5 @@
-deno completions fish | source
+__fish_cache_sourced_completions deno completions fish
+or deno completions fish | source
 
 # complete deno task
 complete -f -c deno -n "__fish_seen_subcommand_from task" -n "__fish_is_nth_token 2" -a "(NO_COLOR=1 deno task &| string match -rg '^- (\S*)')"

--- a/share/completions/devspace.fish
+++ b/share/completions/devspace.fish
@@ -1,1 +1,2 @@
-devspace completion fish 2>/dev/null | source
+__fish_cache_sourced_completions devspace completion fish 2>/dev/null
+or devspace completion fish 2>/dev/null | source

--- a/share/completions/doctl.fish
+++ b/share/completions/doctl.fish
@@ -1,1 +1,2 @@
-doctl completion fish | source
+__fish_cache_sourced_completions doctl completion fish
+or doctl completion fish | source

--- a/share/completions/exercism.fish
+++ b/share/completions/exercism.fish
@@ -1,1 +1,2 @@
-exercism completion fish | source
+__fish_cache_sourced_completions exercism completion fish
+or exercism completion fish | source

--- a/share/completions/flux.fish
+++ b/share/completions/flux.fish
@@ -1,1 +1,2 @@
 __fish_cache_sourced_completions flux completion fish 2>/dev/null
+or flux completion fish 2>/dev/null | source

--- a/share/completions/folderify.fish
+++ b/share/completions/folderify.fish
@@ -1,1 +1,2 @@
-folderify --completions fish | source
+__fish_cache_sourced_completions folderify --completions fish
+or folderify --completions fish | source

--- a/share/completions/glow.fish
+++ b/share/completions/glow.fish
@@ -1,1 +1,2 @@
-glow completion fish | source
+__fish_cache_sourced_completions glow completion fish
+or glow completion fish | source

--- a/share/completions/helm.fish
+++ b/share/completions/helm.fish
@@ -1,1 +1,2 @@
-helm completion fish 2>/dev/null | source
+__fish_cache_sourced_completions helm completion fish 2>/dev/null
+or helm completion fish 2>/dev/null | source

--- a/share/completions/hubble.fish
+++ b/share/completions/hubble.fish
@@ -1,1 +1,2 @@
-hubble completion fish 2>/dev/null | source
+__fish_cache_sourced_completions hubble completion fish 2>/dev/null
+or hubble completion fish 2>/dev/null | source

--- a/share/completions/istioctl.fish
+++ b/share/completions/istioctl.fish
@@ -1,1 +1,2 @@
-istioctl completion fish | source
+__fish_cache_sourced_completions istioctl completion fish
+or istioctl completion fish | source

--- a/share/completions/k9s.fish
+++ b/share/completions/k9s.fish
@@ -1,1 +1,2 @@
-k9s completion fish 2>/dev/null | source
+__fish_cache_sourced_completions k9s completion fish 2>/dev/null
+or k9s completion fish 2>/dev/null | source

--- a/share/completions/kind.fish
+++ b/share/completions/kind.fish
@@ -1,2 +1,3 @@
 # kind (Kubernetes in Docker)
-kind completion fish | source
+__fish_cache_sourced_completions kind completion fish
+or kind completion fish | source

--- a/share/completions/kmutil.fish
+++ b/share/completions/kmutil.fish
@@ -7,5 +7,6 @@
 #        kmutil -h
 
 if test "$(command -s kmutil)" = /usr/bin/kmutil
-    command kmutil --generate-completion-script=fish | source
+    __fish_cache_sourced_completions kmutil --generate-completion-script=fish
+    or command kmutil --generate-completion-script=fish | source
 end

--- a/share/completions/kops.fish
+++ b/share/completions/kops.fish
@@ -1,1 +1,2 @@
-kops completion fish 2>/dev/null | source
+__fish_cache_sourced_completions kops completion fish 2>/dev/null
+or kops completion fish 2>/dev/null | source

--- a/share/completions/kubebuilder.fish
+++ b/share/completions/kubebuilder.fish
@@ -1,1 +1,2 @@
-kubebuilder completion fish | source
+__fish_cache_sourced_completions kubebuilder completion fish
+or kubebuilder completion fish | source

--- a/share/completions/kubectl.fish
+++ b/share/completions/kubectl.fish
@@ -1,1 +1,2 @@
-kubectl completion fish 2>/dev/null | source
+__fish_cache_sourced_completions kubectl completion fish 2>/dev/null
+or kubectl completion fish 2>/dev/null | source

--- a/share/completions/kustomize.fish
+++ b/share/completions/kustomize.fish
@@ -1,1 +1,2 @@
 __fish_cache_sourced_completions kustomize completion fish 2>/dev/null
+or kustomize completion fish 2>/dev/null | source

--- a/share/completions/minikube.fish
+++ b/share/completions/minikube.fish
@@ -1,1 +1,2 @@
-minikube completion fish 2>/dev/null | source
+__fish_cache_sourced_completions minikube completion fish 2>/dev/null
+or minikube completion fish 2>/dev/null | source

--- a/share/completions/oc.fish
+++ b/share/completions/oc.fish
@@ -1,1 +1,2 @@
-oc completion fish | source
+__fish_cache_sourced_completions oc completion fish
+or oc completion fish | source

--- a/share/completions/op.fish
+++ b/share/completions/op.fish
@@ -1,1 +1,2 @@
-op completion fish | source
+__fish_cache_sourced_completions op completion fish
+or op completion fish | source

--- a/share/completions/pulumi.fish
+++ b/share/completions/pulumi.fish
@@ -1,1 +1,4 @@
-PULUMI_SKIP_UPDATE_CHECK=true pulumi completion fish | source
+set -lx PULUMI_SKIP_UPDATE_CHECK true
+
+__fish_cache_sourced_completions pulumi completion fish
+or pulumi completion fish | source

--- a/share/completions/shortcuts.fish
+++ b/share/completions/shortcuts.fish
@@ -6,7 +6,8 @@
 
 # checking the path is as expected is about as far as we're going with validation
 if test "$(command -s shortcuts)" = /usr/bin/shortcuts
-    command shortcuts --generate-completion-script=fish | source
+    __fish_cache_sourced_completions shortcuts --generate-completion-script=fish
+    or command shortcuts --generate-completion-script=fish | source
 end
 
 # output is like: 

--- a/share/completions/spago.fish
+++ b/share/completions/spago.fish
@@ -1,7 +1,8 @@
 # fish completion for spago, PureScript package manager and build tool
 # version v0.16.0
 
-spago --fish-completion-script (command -v spago) | source
+__fish_cache_sourced_completions spago --fish-completion-script (command -v spago)
+or spago --fish-completion-script (command -v spago) | source
 
 function __fish_spago_is_arg_n --argument-names n
     test $n -eq (count (string match -v -- '-*' (commandline -pxc)))

--- a/share/completions/stack.fish
+++ b/share/completions/stack.fish
@@ -1,3 +1,4 @@
 # Completion for 'stack' haskell build tool (http://haskellstack.org)
 
-stack --fish-completion-script stack | source
+__fish_cache_sourced_completions stack --fish-completion-script stack
+or stack --fish-completion-script stack | source

--- a/share/completions/starship.fish
+++ b/share/completions/starship.fish
@@ -1,1 +1,2 @@
-starship completions fish | source
+__fish_cache_sourced_completions starship completions fish
+or starship completions fish | source

--- a/share/completions/tailscale.fish
+++ b/share/completions/tailscale.fish
@@ -1,1 +1,2 @@
-tailscale completion fish | source
+__fish_cache_sourced_completions tailscale completion fish
+or tailscale completion fish | source

--- a/share/completions/tex-fmt.fish
+++ b/share/completions/tex-fmt.fish
@@ -1,1 +1,2 @@
-tex-fmt --completion fish | source
+__fish_cache_sourced_completions tex-fmt --completion fish
+or tex-fmt --completion fish | source

--- a/share/completions/uv.fish
+++ b/share/completions/uv.fish
@@ -1,1 +1,2 @@
-uv --generate-shell-completion fish | source
+__fish_cache_sourced_completions uv --generate-shell-completion fish
+or uv --generate-shell-completion fish | source

--- a/share/completions/uvx.fish
+++ b/share/completions/uvx.fish
@@ -1,1 +1,2 @@
-uvx --generate-shell-completion fish | source
+__fish_cache_sourced_completions uvx --generate-shell-completion fish
+or uvx --generate-shell-completion fish | source

--- a/share/completions/volta.fish
+++ b/share/completions/volta.fish
@@ -1,1 +1,2 @@
-volta completions fish 2>/dev/null | source
+__fish_cache_sourced_completions volta completions fish 2>/dev/null
+or volta completions fish 2>/dev/null | source

--- a/share/completions/warp-cli.fish
+++ b/share/completions/warp-cli.fish
@@ -1,1 +1,2 @@
-warp-cli generate-completions fish | source
+__fish_cache_sourced_completions warp-cli generate-completions fish
+or warp-cli generate-completions fish | source

--- a/share/completions/xcodes.fish
+++ b/share/completions/xcodes.fish
@@ -1,1 +1,2 @@
-xcodes --generate-completion-script fish | source
+__fish_cache_sourced_completions xcodes --generate-completion-script fish
+or xcodes --generate-completion-script fish | source


### PR DESCRIPTION
## Description

Just wanted to ensure all fish's generated completions benefit from being cached. Found using

```console
rg -l '\| source' share/completions | xargs rg --files-without-match __fish_cache_sourced_completions | sort
```

A few completions were a little more complicated so I've left those as TODOs ([`gh`](https://github.com/fish-shell/fish-shell/blob/master/share/completions/gh.fish), [`jj`](https://github.com/fish-shell/fish-shell/blob/master/share/completions/jj.fish), [`rclone`](https://github.com/fish-shell/fish-shell/blob/master/share/completions/rclone.fish))

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
