### PR TITLE
Add cargo feature for enabling gettext extraction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ nix = { version = "0.30.1", default-features = false, features = [
 num-traits = "0.2.19"
 once_cell = "1.19.0"
 fish-printf = { path = "./printf", features = ["widestring"] }
-fish-gettext-extraction = { path = "./gettext-extraction" }
+fish-gettext-extraction = { path = "./gettext-extraction", optional = true }
 
 # Don't use the "getrandom" feature as it requires "getentropy" which was not
 # available on macOS < 10.12. We can enable "getrandom" when we raise the
@@ -95,6 +95,11 @@ path = "src/bin/fish_key_reader.rs"
 default = ["embed-data"]
 benchmark = []
 embed-data = ["dep:rust-embed"]
+# This feature is used to enable extracting messages from the source code for localization.
+# It only needs to be enabled if updating these messages (and the corresponding PO files) is
+# desired. This happens when running tests via `build_tools/check.sh` and when calling
+# `build_tools/update_translations.fish`, so there should not be a need to enable it manually.
+gettext-extract = ["dep:fish-gettext-extraction"]
 
 # The following features are auto-detected by the build-script and should not be enabled manually.
 asan = []

--- a/build.rs
+++ b/build.rs
@@ -82,6 +82,7 @@ fn main() {
     #[cfg(not(clippy))]
     rsconf::rebuild_if_paths_changed(&SPHINX_DOC_SOURCES);
 
+    #[cfg(feature = "gettext-extract")]
     rsconf::rebuild_if_env_changed("FISH_GETTEXT_EXTRACTION_FILE");
 
     cc::Build::new().file("src/libc.c").compile("flibc.a");

--- a/build_tools/check.sh
+++ b/build_tools/check.sh
@@ -38,7 +38,7 @@ repo_root="$(dirname "$0")/.."
 build_dir="${CARGO_TARGET_DIR:-$repo_root/target}/${target_triple}/debug"
 
 template_file=$(mktemp)
-FISH_GETTEXT_EXTRACTION_FILE=$template_file cargo build --workspace --all-targets
+FISH_GETTEXT_EXTRACTION_FILE=$template_file cargo build --workspace --all-targets --features=gettext-extract
 if $lint; then
     PATH="$build_dir:$PATH" "$repo_root/build_tools/style.fish" --all --check
     cargo clippy --workspace --all-targets

--- a/build_tools/fish_xgettext.fish
+++ b/build_tools/fish_xgettext.fish
@@ -27,7 +27,7 @@ begin
     else
         set rust_extraction_file (mktemp)
         # We need to build to ensure that the proc macro for extracting strings runs.
-        FISH_GETTEXT_EXTRACTION_FILE=$rust_extraction_file cargo check
+        FISH_GETTEXT_EXTRACTION_FILE=$rust_extraction_file cargo check --features=gettext-extract
         or exit 1
     end
 

--- a/build_tools/update_translations.fish
+++ b/build_tools/update_translations.fish
@@ -29,7 +29,7 @@
 # `FILE` must be the path to a gettext template file generated from our compilation process.
 # It can be obtained by running:
 #   set -l FILE (mktemp)
-#   FISH_GETTEXT_EXTRACTION_FILE=$FILE cargo check
+#   FISH_GETTEXT_EXTRACTION_FILE=$FILE cargo check --features=gettext-extract
 
 # The sort utility is locale-sensitive.
 # Ensure that sorting output is consistent by setting LC_ALL here.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,7 @@ pub mod wgetopt;
 pub mod widecharwidth;
 pub mod wildcard;
 
+#[cfg(feature = "gettext-extract")]
 pub extern crate fish_gettext_extraction;
 
 #[cfg(test)]

--- a/src/wutil/gettext.rs
+++ b/src/wutil/gettext.rs
@@ -173,11 +173,19 @@ impl std::fmt::Display for LocalizableString {
 /// The essential part is the invocation of the proc macro,
 /// which ensures that the string gets extracted for localization.
 #[macro_export]
+#[cfg(feature = "gettext-extract")]
 macro_rules! localizable_string {
     ($string:literal) => {
         $crate::wutil::gettext::LocalizableString::Static(widestring::utf32str!(
             fish_gettext_extraction::gettext_extract!($string)
         ))
+    };
+}
+#[macro_export]
+#[cfg(not(feature = "gettext-extract"))]
+macro_rules! localizable_string {
+    ($string:literal) => {
+        $crate::wutil::gettext::LocalizableString::Static(widestring::utf32str!($string))
     };
 }
 pub use localizable_string;


### PR DESCRIPTION
This allows having the proc macro crate as an optional dependency and speeds up compilation in situations where `FISH_GETTEXT_EXTRACTION_FILE` changes, such as the `build_tools/check.sh` script. Because we don't need to recompile on changes to the environment variable when the feature is disabled, cargo can reuse earlier compilation results instead of recompiling everything. This speeds up the compilation work in `build_tools/check.sh` when no changes were made which necessitate recompilation.
For such runs of `build_tools/check.sh`, these changes reduce the runtime on my system by about 10 seconds, from 70 to 60, approximately. The difference comes from the following two commands recompiling code without the changes in this commit, but not with them:
- `cargo test --doc --workspace`
- `cargo doc --workspace`