### PR TITLE
Fix  java_home version completion

### DIFF
--- a/share/completions/java_home.fish
+++ b/share/completions/java_home.fish
@@ -1,27 +1,10 @@
 function __fish_complete_macos_java_version
-    set -l xslt (mktemp)
-
-    printf '%s\n' \
-        '<?xml version="1.0" encoding="UTF-8"?>' \
-        '<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">' \
-        '  <xsl:output method="text" encoding="UTF-8"/>' \
-        '  <xsl:template match="/">' \
-        '    <xsl:for-each select="//dict">' \
-        '      <xsl:variable name="v"   select="string(key[.=\'JVMVersion\']/following-sibling::*[1])"/>' \
-        '      <xsl:variable name="a"   select="string(key[.=\'JVMArch\']/following-sibling::*[1])"/>' \
-        '      <xsl:variable name="n"   select="string(key[.=\'JVMName\']/following-sibling::*[1])"/>' \
-        '      <xsl:variable name="ven" select="string(key[.=\'JVMVendor\']/following-sibling::*[1])"/>' \
-        '      <xsl:value-of select="concat($v,\'&#9;\',$a,\' \',$n,\' by \',$ven)"/>' \
-        '      <xsl:text>&#10;</xsl:text>' \
-        '    </xsl:for-each>' \
-        '  </xsl:template>' \
-        '</xsl:stylesheet>' >$xslt
-
-    /usr/libexec/java_home -X | xsltproc $xslt -
+    set -l json (/usr/libexec/java_home -X|plutil -convert json -o - -)
+    osascript -l JavaScript -s o -e "JSON.parse('$json').map(e => `\${e.JVMVersion}\t\${e.JVMArch} \${e.JVMName} by \${e.JVMVendor}`).join('\n')"
 end
 
 function __fish_complete_macos_java_home_exec
-    # seperate the buffer into two parts
+    # separate the buffer into two parts
     # where the first used to get the JAVA_HOME
     # and the second is the subcommand to complete
     set -l cmds (string replace -a -r ' *java_home *' ''  (commandline) )

--- a/share/completions/java_home.fish
+++ b/share/completions/java_home.fish
@@ -1,6 +1,6 @@
 function __fish_complete_macos_java_version
     set -l json (/usr/libexec/java_home -X|plutil -convert json -o - -)
-    osascript -l JavaScript -s o -e "JSON.parse('$json').forEach(e => console.log(`\${e.JVMVersion}\t\${e.JVMArch} \${e.JVMName} by--exec \${e.JVMVendor}`))"
+    osascript -l JavaScript -s o -e "JSON.parse('$json').forEach(e => console.log(`\${e.JVMVersion}\t\${e.JVMArch} \${e.JVMName} by--exec \${e.JVMVendor}`))" 2>&1
 end
 
 function __fish_complete_macos_java_home_exec

--- a/share/completions/java_home.fish
+++ b/share/completions/java_home.fish
@@ -1,6 +1,6 @@
 function __fish_complete_macos_java_version
     set -l json (/usr/libexec/java_home -X|plutil -convert json -o - -)
-    osascript -l JavaScript -s o -e "JSON.parse('$json').forEach(e => console.log(`\${e.JVMVersion}\t\${e.JVMArch} \${e.JVMName} by--exec \${e.JVMVendor}`))" 2>&1
+    osascript -l JavaScript -s o -e "JSON.parse('$json').forEach(e => console.log(`\${e.JVMVersion}\t\${e.JVMArch} \${e.JVMName} by \${e.JVMVendor}`))" 2>&1
 end
 
 function __fish_complete_macos_java_home_exec

--- a/share/completions/java_home.fish
+++ b/share/completions/java_home.fish
@@ -1,10 +1,27 @@
 function __fish_complete_macos_java_version
-    set -l json (/usr/libexec/java_home -X|plutil -convert json -o - -)
-    osascript -l JavaScript -s o -e "JSON.parse('$json').forEach(e => console.log(`\${e.JVMVersion}\t\${e.JVMArch} \${e.JVMName} by \${e.JVMVendor}`))" 2>&1
+    set -l xslt (mktemp)
+
+    printf '%s\n' \
+        '<?xml version="1.0" encoding="UTF-8"?>' \
+        '<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">' \
+        '  <xsl:output method="text" encoding="UTF-8"/>' \
+        '  <xsl:template match="/">' \
+        '    <xsl:for-each select="//dict">' \
+        '      <xsl:variable name="v"   select="string(key[.=\'JVMVersion\']/following-sibling::*[1])"/>' \
+        '      <xsl:variable name="a"   select="string(key[.=\'JVMArch\']/following-sibling::*[1])"/>' \
+        '      <xsl:variable name="n"   select="string(key[.=\'JVMName\']/following-sibling::*[1])"/>' \
+        '      <xsl:variable name="ven" select="string(key[.=\'JVMVendor\']/following-sibling::*[1])"/>' \
+        '      <xsl:value-of select="concat($v,\'&#9;\',$a,\' \',$n,\' by \',$ven)"/>' \
+        '      <xsl:text>&#10;</xsl:text>' \
+        '    </xsl:for-each>' \
+        '  </xsl:template>' \
+        '</xsl:stylesheet>' >$xslt
+
+    /usr/libexec/java_home -X | xsltproc $xslt -
 end
 
 function __fish_complete_macos_java_home_exec
-    # separate the buffer into two parts
+    # seperate the buffer into two parts
     # where the first used to get the JAVA_HOME
     # and the second is the subcommand to complete
     set -l cmds (string replace -a -r ' *java_home *' ''  (commandline) )


### PR DESCRIPTION
## Description

fix `java_home` completion problems due to change of osascirpt default output behavior.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
