### PR TITLE
Remove `Optional` annotation

### DIFF
--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -268,7 +268,7 @@ class TestPass:
     arg: str
     duration_ms: int
 
-    def __init__(self, arg: str, duration_ms: Optional[int]):
+    def __init__(self, arg: str, duration_ms: int):
         self.arg = arg
         self.duration_ms = duration_ms
 


### PR DESCRIPTION
The is inconsistent with the type annotation of `TestPass.duration_ms`. The function is only called with `duration_ms` as an int, so there is no need to declare it `Optional`.