### PR TITLE
Add a `-C/--center` option to string pad.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,7 @@ Deprecations and removed features
 Scripting improvements
 ----------------------
 - The ``psub`` command now allows combining ``--suffix`` with ``--fifo`` (:issue:`11729`).
+- The ``string pad`` command now has a ``-C/--center`` option.
 
 Interactive improvements
 ------------------------

--- a/doc_src/cmds/string-pad.rst
+++ b/doc_src/cmds/string-pad.rst
@@ -8,7 +8,7 @@ Synopsis
 
 .. synopsis::
 
-    string pad [-r | --right] [(-c | --char) CHAR] [(-w | --width) INTEGER]
+    string pad [-r | --right] [-C | --center] [(-c | --char) CHAR] [(-w | --width) INTEGER]
                [STRING ...]
 
 .. END SYNOPSIS
@@ -21,6 +21,8 @@ Description
 ``string pad`` extends each *STRING* to the given visible width by adding *CHAR* to the left. That means the width of all visible characters added together, excluding escape sequences and accounting for :envvar:`fish_emoji_width` and :envvar:`fish_ambiguous_width`. It is the amount of columns in a terminal the *STRING* occupies.
 
 The escape sequences reflect what fish knows about, and how it computes its output. Your terminal might support more escapes, or not support escape sequences that fish knows about.
+
+If **-C** or **--center** is given, add the padding to before and after the string. If it is impossible to perfectly center the result (because the required amount of padding is an odd number), extra padding will be added to the left, unless **--right** is also given.
 
 If **-r** or **--right** is given, add the padding after a string.
 

--- a/doc_src/cmds/string.rst
+++ b/doc_src/cmds/string.rst
@@ -18,7 +18,7 @@ Synopsis
                  [-g | --groups-only] [-r | --regex] [-n | --index]
                  [-q | --quiet] [-v | --invert]
                  PATTERN [STRING ...]
-    string pad [-r | --right] [(-c | --char) CHAR] [(-w | --width) INTEGER]
+    string pad [-r | --right] [-C | --center] [(-c | --char) CHAR] [(-w | --width) INTEGER]
                [STRING ...]
     string repeat [(-n | --count) COUNT] [(-m | --max) MAX] [-N | --no-newline]
                   [-q | --quiet] [STRING ...]

--- a/po/de.po
+++ b/po/de.po
@@ -40692,6 +40692,9 @@ msgstr ""
 msgid "Pacman log actions"
 msgstr ""
 
+msgid "Pad both left and right"
+msgstr ""
+
 msgid "Pad right instead of left"
 msgstr ""
 

--- a/po/en.po
+++ b/po/en.po
@@ -40688,6 +40688,9 @@ msgstr ""
 msgid "Pacman log actions"
 msgstr ""
 
+msgid "Pad both left and right"
+msgstr ""
+
 msgid "Pad right instead of left"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -40789,6 +40789,9 @@ msgstr ""
 msgid "Pacman log actions"
 msgstr ""
 
+msgid "Pad both left and right"
+msgstr ""
+
 msgid "Pad right instead of left"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -40684,6 +40684,9 @@ msgstr ""
 msgid "Pacman log actions"
 msgstr ""
 
+msgid "Pad both left and right"
+msgstr ""
+
 msgid "Pad right instead of left"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -40705,6 +40705,9 @@ msgstr ""
 msgid "Pacman log actions"
 msgstr ""
 
+msgid "Pad both left and right"
+msgstr ""
+
 msgid "Pad right instead of left"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -40687,6 +40687,9 @@ msgstr ""
 msgid "Pacman log actions"
 msgstr ""
 
+msgid "Pad both left and right"
+msgstr ""
+
 msgid "Pad right instead of left"
 msgstr ""
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -40687,6 +40687,9 @@ msgstr "将本地仓库中已有的文物装入捆绑, 用于上传请求"
 msgid "Pacman log actions"
 msgstr "Pacman 日志动作"
 
+msgid "Pad both left and right"
+msgstr ""
+
 msgid "Pad right instead of left"
 msgstr "右侧而不是左侧"
 

--- a/share/completions/string.fish
+++ b/share/completions/string.fish
@@ -54,6 +54,7 @@ complete -x -c string -n "test (count (commandline -xpc)) -ge 2" -n "contains --
 complete -f -c string -n "test (count (commandline -xpc)) -ge 2" -n "contains -- (commandline -xpc)[2] repeat" -s N -l no-newline -d "Remove newline"
 complete -f -c string -n "test (count (commandline -xpc)) -lt 2" -a pad
 complete -x -c string -n "test (count (commandline -xpc)) -ge 2" -n "contains -- (commandline -xpc)[2] pad" -s r -l right -d "Pad right instead of left"
+complete -x -c string -n "test (count (commandline -xpc)) -ge 2" -n "contains -- (commandline -xpc)[2] pad" -s r -l center -d "Pad both left and right"
 complete -x -c string -n "test (count (commandline -xpc)) -ge 2" -n "contains -- (commandline -xpc)[2] pad" -s c -l char -x -d "Character to use for padding"
 complete -x -c string -n "test (count (commandline -xpc)) -ge 2" -n "contains -- (commandline -xpc)[2] pad" -s w -l width -x -d "Integer width of the result, default is maximum width of inputs"
 complete -f -c string -n "test (count (commandline -xpc)) -lt 2" -a shorten

--- a/src/builtins/string/pad.rs
+++ b/src/builtins/string/pad.rs
@@ -5,6 +5,7 @@ pub struct Pad {
     char_to_pad: char,
     pad_char_width: usize,
     pad_from: Direction,
+    center: bool,
     width: usize,
 }
 
@@ -14,6 +15,7 @@ impl Default for Pad {
             char_to_pad: ' ',
             pad_char_width: 1,
             pad_from: Direction::Left,
+            center: false,
             width: 0,
         }
     }
@@ -24,9 +26,10 @@ impl StringSubCommand<'_> for Pad {
         // FIXME docs say `--char`, there was no long_opt with `--char` in C++
         wopt(L!("chars"), RequiredArgument, 'c'),
         wopt(L!("right"), NoArgument, 'r'),
+        wopt(L!("center"), NoArgument, 'C'),
         wopt(L!("width"), RequiredArgument, 'w'),
     ];
-    const SHORT_OPTIONS: &'static wstr = L!(":c:rw:");
+    const SHORT_OPTIONS: &'static wstr = L!(":c:rCw:");
 
     fn parse_opt(&mut self, name: &wstr, c: char, arg: Option<&wstr>) -> Result<(), StringError> {
         match c {
@@ -55,6 +58,7 @@ impl StringSubCommand<'_> for Pad {
                     .try_into()
                     .map_err(|_| invalid_args!("%ls: Invalid width value '%ls'\n", name, arg))?
             }
+            'C' => self.center = true,
             _ => return Err(StringError::UnknownOption),
         }
         return Ok(());
@@ -83,21 +87,22 @@ impl StringSubCommand<'_> for Pad {
         for (input, width) in inputs {
             use std::iter::repeat;
 
-            let pad = (pad_width - width) / self.pad_char_width;
-            let remaining_width = (pad_width - width) % self.pad_char_width;
-            let mut padded: WString = match self.pad_from {
-                Direction::Left => repeat(self.char_to_pad)
-                    .take(pad)
-                    .chain(repeat(' ').take(remaining_width))
-                    .chain(input.chars())
-                    .collect(),
-                Direction::Right => input
-                    .chars()
-                    .chain(repeat(' ').take(remaining_width))
-                    .chain(repeat(self.char_to_pad).take(pad))
-                    .collect(),
+            let total_pad = pad_width - width;
+            let (left_pad, right_pad) = match (self.pad_from, self.center) {
+                (Direction::Left, false) => (total_pad, 0),
+                (Direction::Right, false) => (0, total_pad),
+                (Direction::Left, true) => (total_pad - total_pad / 2, total_pad / 2),
+                (Direction::Right, true) => (total_pad / 2, total_pad - total_pad / 2),
             };
 
+            let chars = |w| repeat(self.char_to_pad).take(w / self.pad_char_width);
+            let spaces = |w| repeat(' ').take(w % self.pad_char_width);
+            let mut padded: WString = chars(left_pad)
+                .chain(spaces(left_pad))
+                .chain(input.chars())
+                .chain(spaces(right_pad))
+                .chain(chars(right_pad))
+                .collect();
             if print_trailing_newline {
                 padded.push('\n');
             }


### PR DESCRIPTION
## Description
This adds two really obvious feature that I was surprised was missing.
Bassically `string pad --center` will centre your strings (with some extra padding on the left if perfect centring isn't possible, and `string padd -center --right` will add the extra padding on the right).

"Fixes" issue #8282.

On a related note, I noticed that `string repeat` and `string shorten` have a `-N/--no-newline` option. Is there a reason that these are the only string subcommands with it? It would make sense for all of them except `string collect` and `string length`. The same effect can be achieved though by piping to string collect. I can add this option to all the string commands, it should be a quick change.

## TODOs:
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
