### PR TITLE
Skip sending OSC7 sequences when running inside SSH session

### DIFF
--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -173,9 +173,8 @@ end" >$__fish_config_dir/config.fish
         if set -q KONSOLE_VERSION
             set host ''
         end
-        if [ "$TERM" = dumb ]
-            return
-        end
+        # Skip if running over SSH or in a dumb terminal
+        set -q SSH_TTY; or test "$TERM" = dumb; and return
         printf \e\]7\;file://%s%s\a $host (string escape --style=url -- $PWD)
     end
     __fish_update_cwd_osc # Run once because we might have already inherited a PWD from an old tab


### PR DESCRIPTION
## Description

Fixes an issue that affects at least Apple Terminal when connecting to a remote server that runs fish over ssh. Fish emits an OSC7 sequence signaling the current working directory in the server and as the path is not valid on the client a question mark is shown over the icon in the Terminal title bar.

Fixes issue #11777.

## TODOs:
- [X] Changed `__fish_update_cwd_osc` in `__fish_config_interactive.fish` to skip on `SSH_TTY`.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst

P.S.: I am unsure if there is some platform where this behaviour is actually supported and this change would break some valid use-case there (?). 
