### PR TITLE
Variadic and strict `function` `--argument-names`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -53,6 +53,7 @@ Scripting improvements
 - ``argparse`` option specifiers for long only options can now start with ``/``, allowing the definition of long options with a single letter (withouht the ``/``, an option with a single letter is always interpreted as a short flag). Due to this change, the ``--long-only`` option to ``fish_opt`` is now no longer necessary and is deprecated.
 - ``fish_opt`` now has a ``-v`` / ``--validate`` option you can use to give a fish script to validate values of the option.
 - The ``string pad`` command now has a ``-C/--center`` option.
+- The last parameter in a function's ``-a``/``--argument-names`` list can now end in ``...``, indicating that it should collect all remaining arguments.
 
 Interactive improvements
 ------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -53,7 +53,7 @@ Scripting improvements
 - ``argparse`` option specifiers for long only options can now start with ``/``, allowing the definition of long options with a single letter (withouht the ``/``, an option with a single letter is always interpreted as a short flag). Due to this change, the ``--long-only`` option to ``fish_opt`` is now no longer necessary and is deprecated.
 - ``fish_opt`` now has a ``-v`` / ``--validate`` option you can use to give a fish script to validate values of the option.
 - The ``string pad`` command now has a ``-C/--center`` option.
-- The last parameter in a function's ``-a``/``--argument-names`` list can now end in ``...``, indicating that it should collect all remaining arguments.
+- A single parameter in a function's ``-a``/``--argument-names`` list can now end in ``...``, indicating that it will collect as many arguments as possible.
 
 Interactive improvements
 ------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -54,6 +54,7 @@ Scripting improvements
 - ``fish_opt`` now has a ``-v`` / ``--validate`` option you can use to give a fish script to validate values of the option.
 - The ``string pad`` command now has a ``-C/--center`` option.
 - A single parameter in a function's ``-a``/``--argument-names`` list can now end in ``...``, indicating that it will collect as many arguments as possible.
+- Add a ``-A``/``--strict-argument-names`` to the ``function`` builtin, this is like the existing ``-a``/``--argument-names`` options, but it reports an error if the given number of arguments doesn't agree with the argument names.
 
 Interactive improvements
 ------------------------

--- a/doc_src/cmds/function.rst
+++ b/doc_src/cmds/function.rst
@@ -27,6 +27,13 @@ The following options are available:
 
     See the :ref:`Argument Names Caveats <argument_names_caveats>` section below for what happens when the number of arguments passed differs from the number of argument *NAMES*.
 
+**-A** *NAMES* or **--strict-argument-names** *NAMES*
+    This behaves like like ``-a`` / ``--argument-names``, except that calling the function with an incorrect number of arguments will print an error, return 2, and not execute the body of the function.
+    If none of the given *NAMES* use a ``...``, this error will trigger when the number of actual arguments does not equal the number of *NAMES*.
+    Otherwise, (if ``...`` was used) the error will trigger if the number of actual arguments is *less* than the number *NAMES* minus 1.
+
+    Unlike the ``-a``/``--argument-names`` option, the given *NAMES* list can be empty, in which case an error will be generated if the function is called with a non-empty list of arguments.
+
 **-d** *DESCRIPTION* or **--description** *DESCRIPTION*
     A description of what the function does, suitable as a completion description.
 
@@ -153,7 +160,9 @@ The ``-a`` / ``--argument-names`` flag does *not* validate the number of argumen
     #    x 1
     #    y
 
-Similarly, if none of the argument names end in ``...``, any extra arguments are ignored, but they are still accessible in ``$argv``. Continuing the previous example:
+In contrast, if the ``-A`` / ``--strict-argument-names`` option where used instead, the above call to ``two`` would produce an error.
+
+Similarly, if ``-a`` / ``--argument-names`` is used and none of the argument names end in ``...``, any extra arguments are ignored, but they are still accessible in ``$argv``. Continuing the previous example:
 
 ::
 
@@ -162,6 +171,8 @@ Similarly, if none of the argument names end in ``...``, any extra arguments are
     #    argv '1'  '2'  '3'
     #    x 1
     #    y 2
+
+Using ``-A`` / ``--strict-argument-names`` will make the above call to ``two`` an error.
 
 If on the other hand the last argument name does end in ``...``, any extra arguments are stored in that variable. For example:
 
@@ -175,6 +186,8 @@ If on the other hand the last argument name does end in ``...``, any extra argum
     #    argv '1'  '2'  '3'
     #    x 1
     #    y '2'  '3'
+
+The same behaviour occurs with the ``-A`` / ``--strict-argument-names`` option.
 
 If the argument named with a ``...`` is not the last, then if possible, it will leave enough arguments for the subsequent argument names. For example:
 
@@ -202,6 +215,8 @@ The argument with a ``...`` is however set to the empty list if there are not en
     #    x
     #    y 1
     #    z
+
+However, with the ``-A`` / ``--strict-argument-names`` option, the above call to ``more_or_two`` would produce an error.
 
 Notes
 -----

--- a/doc_src/cmds/function.rst
+++ b/doc_src/cmds/function.rst
@@ -21,7 +21,7 @@ A function is a list of commands that will be executed when the name of the func
 The following options are available:
 
 **-a** *NAMES* or **--argument-names** *NAMES*
-    Has to be the last option. Assigns the value of successive command-line arguments to the names given in *NAMES* (separated by space). These are the same arguments given in :envvar:`argv`, and are still available there. See also :ref:`Argument Handling <variables-argv>`.
+    Assigns the value of successive command-line arguments to the names given in *NAMES* (separated by space). These are the same arguments given in :envvar:`argv`, and are still available there. See also :ref:`Argument Handling <variables-argv>`.
 
 **-d** *DESCRIPTION* or **--description** *DESCRIPTION*
     A description of what the function does, suitable as a completion description.

--- a/doc_src/cmds/function.rst
+++ b/doc_src/cmds/function.rst
@@ -23,6 +23,8 @@ The following options are available:
 **-a** *NAMES* or **--argument-names** *NAMES*
     Assigns the value of successive command-line arguments to the names given in *NAMES* (separated by spaces). These are the same arguments given in :envvar:`argv`, and are still available there (unless ``--inherit-variable argv`` was used or one of the given *NAMES* is ``argv``). See also :ref:`Argument Handling <variables-argv>`.
 
+    See the :ref:`Argument Names Caveats <argument_names_caveats>` section below for what happens when the number of arguments passed differs from the number of argument *NAMES*.
+
 **-d** *DESCRIPTION* or **--description** *DESCRIPTION*
     A description of what the function does, suitable as a completion description.
 
@@ -74,8 +76,6 @@ Example
 
 will run the ``ls`` command, using the ``-l`` option, while passing on any additional files and switches to ``ls``.
 
-
-
 ::
 
     function debug -a name val
@@ -99,8 +99,6 @@ will run the ``ls`` command, using the ``-l`` option, while passing on any addit
 
 will create a ``debug`` command to print chosen variables to `stderr`.
 
-
-
 ::
 
     function mkdir -d "Create a directory and set CWD"
@@ -120,7 +118,6 @@ will create a ``debug`` command to print chosen variables to `stderr`.
 This will run the ``mkdir`` command, and if it is successful, change the current working directory to the one just created.
 
 
-
 ::
 
     function notify
@@ -136,6 +133,33 @@ This will run the ``mkdir`` command, and if it is successful, change the current
 
 This will beep when the most recent job completes.
 
+.. _argument_names_caveats:
+
+Argument Names Caveats
+----------------------
+
+The ``-a`` / ``--argument-names`` flag does *not* validate the number of arguments passed: if an argument is missing the corresponding variable will be assigned to an empty list. For example:
+
+::
+
+    function two -a x y
+        set -l
+    end
+    two 1
+    # prints:
+    #    argv 1
+    #    x 1
+    #    y
+
+Similarly any extra arguments are ignored, but they are still accessible in ``$argv``. Continuing the previous example:
+
+::
+
+    two 1 2 3
+    # prints:
+    #    argv '1'  '2'  '3'
+    #    x 1
+    #    y 2
 
 Notes
 -----

--- a/doc_src/cmds/function.rst
+++ b/doc_src/cmds/function.rst
@@ -22,8 +22,8 @@ The following options are available:
 
 **-a** *NAMES* or **--argument-names** *NAMES*
     Assigns the value of successive command-line arguments to the names given in *NAMES* (separated by spaces). These are the same arguments given in :envvar:`argv`, and are still available there (unless ``--inherit-variable argv`` was used or one of the given *NAMES* is ``argv``). See also :ref:`Argument Handling <variables-argv>`.
-    
-    The last name given can end in ``...``, in which case all remaining arguments are saved in a variable with that name (excluding the ``...`` part).
+
+    A single argument name given can end in ``...``, in which case a variable number of arguments are saved in a variable with that name (excluding the ``...`` part), as many as possible whilst still leaving arguments for each of the other named arguments. If this cannot be done (because the number of arguments is smaller than the number of argument names), the argument with a ``...`` is set to the empty list, and the other arguments are asigned values as if the ``...`` one was not there.
 
     See the :ref:`Argument Names Caveats <argument_names_caveats>` section below for what happens when the number of arguments passed differs from the number of argument *NAMES*.
 
@@ -153,7 +153,7 @@ The ``-a`` / ``--argument-names`` flag does *not* validate the number of argumen
     #    x 1
     #    y
 
-Similarly, if the last argument name doesn't end in ``...``, any extra arguments are ignored, but they are still accessible in ``$argv``. Continuing the previous example:
+Similarly, if none of the argument names end in ``...``, any extra arguments are ignored, but they are still accessible in ``$argv``. Continuing the previous example:
 
 ::
 
@@ -176,6 +176,32 @@ If on the other hand the last argument name does end in ``...``, any extra argum
     #    x 1
     #    y '2'  '3'
 
+If the argument named with a ``...`` is not the last, then if possible, it will leave enough arguments for the subsequent argument names. For example:
+
+::
+
+    function more_or_one -a x... y
+        set -l
+    end
+    more_or_one 1 2 3
+    # prints:
+    #    argv '1'  '2'  '3'
+    #    x '1'  '2'
+    #    y 3
+
+The argument with a ``...`` is however set to the empty list if there are not enough arguments to satisfy all the argument names. For example:
+
+::
+
+    function more_or_two -a x... y z
+        set -l
+    end
+    more_or_two 1
+    # prints:
+    #    argv 1
+    #    x
+    #    y 1
+    #    z
 
 Notes
 -----

--- a/doc_src/cmds/function.rst
+++ b/doc_src/cmds/function.rst
@@ -22,6 +22,8 @@ The following options are available:
 
 **-a** *NAMES* or **--argument-names** *NAMES*
     Assigns the value of successive command-line arguments to the names given in *NAMES* (separated by spaces). These are the same arguments given in :envvar:`argv`, and are still available there (unless ``--inherit-variable argv`` was used or one of the given *NAMES* is ``argv``). See also :ref:`Argument Handling <variables-argv>`.
+    
+    The last name given can end in ``...``, in which case all remaining arguments are saved in a variable with that name (excluding the ``...`` part).
 
     See the :ref:`Argument Names Caveats <argument_names_caveats>` section below for what happens when the number of arguments passed differs from the number of argument *NAMES*.
 
@@ -151,7 +153,7 @@ The ``-a`` / ``--argument-names`` flag does *not* validate the number of argumen
     #    x 1
     #    y
 
-Similarly any extra arguments are ignored, but they are still accessible in ``$argv``. Continuing the previous example:
+Similarly, if the last argument name doesn't end in ``...``, any extra arguments are ignored, but they are still accessible in ``$argv``. Continuing the previous example:
 
 ::
 
@@ -160,6 +162,20 @@ Similarly any extra arguments are ignored, but they are still accessible in ``$a
     #    argv '1'  '2'  '3'
     #    x 1
     #    y 2
+
+If on the other hand the last argument name does end in ``...``, any extra arguments are stored in that variable. For example:
+
+::
+
+    function one_or_more -a x y...
+        set -l
+    end
+    one_or_more 1 2 3
+    # prints:
+    #    argv '1'  '2'  '3'
+    #    x 1
+    #    y '2'  '3'
+
 
 Notes
 -----

--- a/doc_src/cmds/function.rst
+++ b/doc_src/cmds/function.rst
@@ -21,7 +21,7 @@ A function is a list of commands that will be executed when the name of the func
 The following options are available:
 
 **-a** *NAMES* or **--argument-names** *NAMES*
-    Assigns the value of successive command-line arguments to the names given in *NAMES* (separated by space). These are the same arguments given in :envvar:`argv`, and are still available there. See also :ref:`Argument Handling <variables-argv>`.
+    Assigns the value of successive command-line arguments to the names given in *NAMES* (separated by spaces). These are the same arguments given in :envvar:`argv`, and are still available there (unless ``--inherit-variable argv`` was used or one of the given *NAMES* is ``argv``). See also :ref:`Argument Handling <variables-argv>`.
 
 **-d** *DESCRIPTION* or **--description** *DESCRIPTION*
     A description of what the function does, suitable as a completion description.

--- a/po/de.po
+++ b/po/de.po
@@ -241,6 +241,11 @@ msgstr ""
 msgid "%ls: '%ls' is not a valid process id\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: --argument-names and --strict-argument-names cannot be mixed"
+msgstr ""
+
 #, c-format
 msgid "%ls: --command cannot be combined with --position command"
 msgstr ""
@@ -728,6 +733,16 @@ msgstr ""
 #, c-format
 msgid "%ls: function name required"
 msgstr "%ls: Brauche Funktionsnamen"
+
+#
+#, c-format
+msgid "%ls: function requires at least %d arguments, but %d where supplied"
+msgstr ""
+
+#
+#, c-format
+msgid "%ls: function requires exactly %d arguments, but %d where supplied"
+msgstr ""
 
 #, c-format
 msgid "%ls: given %d indexes but %d values\n"

--- a/po/de.po
+++ b/po/de.po
@@ -654,6 +654,11 @@ msgstr "%ls: Warnung: Option '%ls' wurde entfernt und wird nun ignoriert"
 msgid "%ls: `set --show` does not allow slices with the var names\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: argument names '%ls...' and '%ls...' both end in '...'\n"
+msgstr ""
+
 #, c-format
 msgid "%ls: array index out of bounds\n"
 msgstr ""
@@ -812,11 +817,6 @@ msgstr ""
 
 #, c-format
 msgid "%ls: variable '%ls' is read-only\n"
-msgstr ""
-
-#
-#, c-format
-msgid "%ls: variadic argument name '%ls' must be the final one\n"
 msgstr ""
 
 #, c-format

--- a/po/de.po
+++ b/po/de.po
@@ -814,6 +814,11 @@ msgstr ""
 msgid "%ls: variable '%ls' is read-only\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: variadic argument name '%ls' must be the final one\n"
+msgstr ""
+
 #, c-format
 msgid "%lsand %lu more rows"
 msgstr "%lsund %lu mehr Zeilen"

--- a/po/de.po
+++ b/po/de.po
@@ -686,6 +686,11 @@ msgstr ""
 msgid "%ls: column %ls exceeds line length\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: duplicate variable '%ls' in --argument-names\n"
+msgstr ""
+
 #, c-format
 msgid "%ls: exclusive flag '%ls' is not valid\n"
 msgstr "%ls: Exklusive option '%ls' ist ungültig\n"
@@ -794,6 +799,16 @@ msgstr ""
 #, c-format
 msgid "%ls: value not completely converted (can't convert '%ls')"
 msgstr "%ls: Wert nicht vollständig konvertiert (kann '%ls' nicht konvertieren)"
+
+#
+#, c-format
+msgid "%ls: variable '%ls' is inherited multiple times\n"
+msgstr ""
+
+#
+#, c-format
+msgid "%ls: variable '%ls' is passed to both --argument-names and --inherit-variable\n"
+msgstr ""
 
 #, c-format
 msgid "%ls: variable '%ls' is read-only\n"

--- a/po/en.po
+++ b/po/en.po
@@ -652,6 +652,11 @@ msgstr ""
 msgid "%ls: `set --show` does not allow slices with the var names\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: argument names '%ls...' and '%ls...' both end in '...'\n"
+msgstr ""
+
 #, c-format
 msgid "%ls: array index out of bounds\n"
 msgstr ""
@@ -810,11 +815,6 @@ msgstr ""
 
 #, c-format
 msgid "%ls: variable '%ls' is read-only\n"
-msgstr ""
-
-#
-#, c-format
-msgid "%ls: variadic argument name '%ls' must be the final one\n"
 msgstr ""
 
 #, c-format

--- a/po/en.po
+++ b/po/en.po
@@ -684,6 +684,11 @@ msgstr ""
 msgid "%ls: column %ls exceeds line length\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: duplicate variable '%ls' in --argument-names\n"
+msgstr ""
+
 #, c-format
 msgid "%ls: exclusive flag '%ls' is not valid\n"
 msgstr ""
@@ -791,6 +796,16 @@ msgstr ""
 
 #, c-format
 msgid "%ls: value not completely converted (can't convert '%ls')"
+msgstr ""
+
+#
+#, c-format
+msgid "%ls: variable '%ls' is inherited multiple times\n"
+msgstr ""
+
+#
+#, c-format
+msgid "%ls: variable '%ls' is passed to both --argument-names and --inherit-variable\n"
 msgstr ""
 
 #, c-format

--- a/po/en.po
+++ b/po/en.po
@@ -239,6 +239,11 @@ msgstr ""
 msgid "%ls: '%ls' is not a valid process id\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: --argument-names and --strict-argument-names cannot be mixed"
+msgstr ""
+
 #, c-format
 msgid "%ls: --command cannot be combined with --position command"
 msgstr ""
@@ -725,6 +730,16 @@ msgstr ""
 
 #, c-format
 msgid "%ls: function name required"
+msgstr ""
+
+#
+#, c-format
+msgid "%ls: function requires at least %d arguments, but %d where supplied"
+msgstr ""
+
+#
+#, c-format
+msgid "%ls: function requires exactly %d arguments, but %d where supplied"
 msgstr ""
 
 #, c-format

--- a/po/en.po
+++ b/po/en.po
@@ -812,6 +812,11 @@ msgstr ""
 msgid "%ls: variable '%ls' is read-only\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: variadic argument name '%ls' must be the final one\n"
+msgstr ""
+
 #, c-format
 msgid "%lsand %lu more rows"
 msgstr "%lsand %lu more rows"

--- a/po/fr.po
+++ b/po/fr.po
@@ -340,6 +340,11 @@ msgstr "%ls : '%ls' est un nom de variable invalide\n"
 msgid "%ls: '%ls' is not a valid process id\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: --argument-names and --strict-argument-names cannot be mixed"
+msgstr ""
+
 #, c-format
 msgid "%ls: --command cannot be combined with --position command"
 msgstr ""
@@ -826,6 +831,16 @@ msgstr ""
 
 #, c-format
 msgid "%ls: function name required"
+msgstr ""
+
+#
+#, c-format
+msgid "%ls: function requires at least %d arguments, but %d where supplied"
+msgstr ""
+
+#
+#, c-format
+msgid "%ls: function requires exactly %d arguments, but %d where supplied"
 msgstr ""
 
 #, c-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -913,6 +913,11 @@ msgstr ""
 msgid "%ls: variable '%ls' is read-only\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: variadic argument name '%ls' must be the final one\n"
+msgstr ""
+
 #, c-format
 msgid "%lsand %lu more rows"
 msgstr "%lset %lu lignes de plus"

--- a/po/fr.po
+++ b/po/fr.po
@@ -753,6 +753,11 @@ msgstr ""
 msgid "%ls: `set --show` does not allow slices with the var names\n"
 msgstr "%ls : `set --show` n’autorise pas de tranches avec les noms des variables\n"
 
+#
+#, c-format
+msgid "%ls: argument names '%ls...' and '%ls...' both end in '...'\n"
+msgstr ""
+
 #, c-format
 msgid "%ls: array index out of bounds\n"
 msgstr ""
@@ -911,11 +916,6 @@ msgstr ""
 
 #, c-format
 msgid "%ls: variable '%ls' is read-only\n"
-msgstr ""
-
-#
-#, c-format
-msgid "%ls: variadic argument name '%ls' must be the final one\n"
 msgstr ""
 
 #, c-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -785,6 +785,11 @@ msgstr ""
 msgid "%ls: column %ls exceeds line length\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: duplicate variable '%ls' in --argument-names\n"
+msgstr ""
+
 #, c-format
 msgid "%ls: exclusive flag '%ls' is not valid\n"
 msgstr "%ls : le sémaphore exclusif '%ls' est invalide\n"
@@ -892,6 +897,16 @@ msgstr ""
 
 #, c-format
 msgid "%ls: value not completely converted (can't convert '%ls')"
+msgstr ""
+
+#
+#, c-format
+msgid "%ls: variable '%ls' is inherited multiple times\n"
+msgstr ""
+
+#
+#, c-format
+msgid "%ls: variable '%ls' is passed to both --argument-names and --inherit-variable\n"
 msgstr ""
 
 #, c-format

--- a/po/pl.po
+++ b/po/pl.po
@@ -648,6 +648,11 @@ msgstr ""
 msgid "%ls: `set --show` does not allow slices with the var names\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: argument names '%ls...' and '%ls...' both end in '...'\n"
+msgstr ""
+
 #, c-format
 msgid "%ls: array index out of bounds\n"
 msgstr ""
@@ -806,11 +811,6 @@ msgstr ""
 
 #, c-format
 msgid "%ls: variable '%ls' is read-only\n"
-msgstr ""
-
-#
-#, c-format
-msgid "%ls: variadic argument name '%ls' must be the final one\n"
 msgstr ""
 
 #, c-format

--- a/po/pl.po
+++ b/po/pl.po
@@ -680,6 +680,11 @@ msgstr ""
 msgid "%ls: column %ls exceeds line length\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: duplicate variable '%ls' in --argument-names\n"
+msgstr ""
+
 #, c-format
 msgid "%ls: exclusive flag '%ls' is not valid\n"
 msgstr ""
@@ -787,6 +792,16 @@ msgstr ""
 
 #, c-format
 msgid "%ls: value not completely converted (can't convert '%ls')"
+msgstr ""
+
+#
+#, c-format
+msgid "%ls: variable '%ls' is inherited multiple times\n"
+msgstr ""
+
+#
+#, c-format
+msgid "%ls: variable '%ls' is passed to both --argument-names and --inherit-variable\n"
 msgstr ""
 
 #, c-format

--- a/po/pl.po
+++ b/po/pl.po
@@ -235,6 +235,11 @@ msgstr ""
 msgid "%ls: '%ls' is not a valid process id\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: --argument-names and --strict-argument-names cannot be mixed"
+msgstr ""
+
 #, c-format
 msgid "%ls: --command cannot be combined with --position command"
 msgstr ""
@@ -721,6 +726,16 @@ msgstr ""
 
 #, c-format
 msgid "%ls: function name required"
+msgstr ""
+
+#
+#, c-format
+msgid "%ls: function requires at least %d arguments, but %d where supplied"
+msgstr ""
+
+#
+#, c-format
+msgid "%ls: function requires exactly %d arguments, but %d where supplied"
 msgstr ""
 
 #, c-format

--- a/po/pl.po
+++ b/po/pl.po
@@ -808,6 +808,11 @@ msgstr ""
 msgid "%ls: variable '%ls' is read-only\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: variadic argument name '%ls' must be the final one\n"
+msgstr ""
+
 #, c-format
 msgid "%lsand %lu more rows"
 msgstr "%lsand %lu więcej rzędów"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -653,6 +653,11 @@ msgstr ""
 msgid "%ls: `set --show` does not allow slices with the var names\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: argument names '%ls...' and '%ls...' both end in '...'\n"
+msgstr ""
+
 #, c-format
 msgid "%ls: array index out of bounds\n"
 msgstr ""
@@ -811,11 +816,6 @@ msgstr ""
 
 #, c-format
 msgid "%ls: variable '%ls' is read-only\n"
-msgstr ""
-
-#
-#, c-format
-msgid "%ls: variadic argument name '%ls' must be the final one\n"
 msgstr ""
 
 #, c-format

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -813,6 +813,11 @@ msgstr ""
 msgid "%ls: variable '%ls' is read-only\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: variadic argument name '%ls' must be the final one\n"
+msgstr ""
+
 #, c-format
 msgid "%lsand %lu more rows"
 msgstr "%lse mais %lu linhas"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -240,6 +240,11 @@ msgstr "%ls: '%ls' não é um identificador de tarefa válido\n"
 msgid "%ls: '%ls' is not a valid process id\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: --argument-names and --strict-argument-names cannot be mixed"
+msgstr ""
+
 #, c-format
 msgid "%ls: --command cannot be combined with --position command"
 msgstr ""
@@ -726,6 +731,16 @@ msgstr ""
 
 #, c-format
 msgid "%ls: function name required"
+msgstr ""
+
+#
+#, c-format
+msgid "%ls: function requires at least %d arguments, but %d where supplied"
+msgstr ""
+
+#
+#, c-format
+msgid "%ls: function requires exactly %d arguments, but %d where supplied"
 msgstr ""
 
 #, c-format

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -685,6 +685,11 @@ msgstr ""
 msgid "%ls: column %ls exceeds line length\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: duplicate variable '%ls' in --argument-names\n"
+msgstr ""
+
 #, c-format
 msgid "%ls: exclusive flag '%ls' is not valid\n"
 msgstr ""
@@ -792,6 +797,16 @@ msgstr ""
 
 #, c-format
 msgid "%ls: value not completely converted (can't convert '%ls')"
+msgstr ""
+
+#
+#, c-format
+msgid "%ls: variable '%ls' is inherited multiple times\n"
+msgstr ""
+
+#
+#, c-format
+msgid "%ls: variable '%ls' is passed to both --argument-names and --inherit-variable\n"
 msgstr ""
 
 #, c-format

--- a/po/sv.po
+++ b/po/sv.po
@@ -236,6 +236,11 @@ msgstr ""
 msgid "%ls: '%ls' is not a valid process id\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: --argument-names and --strict-argument-names cannot be mixed"
+msgstr ""
+
 #, c-format
 msgid "%ls: --command cannot be combined with --position command"
 msgstr ""
@@ -722,6 +727,16 @@ msgstr ""
 
 #, c-format
 msgid "%ls: function name required"
+msgstr ""
+
+#
+#, c-format
+msgid "%ls: function requires at least %d arguments, but %d where supplied"
+msgstr ""
+
+#
+#, c-format
+msgid "%ls: function requires exactly %d arguments, but %d where supplied"
 msgstr ""
 
 #, c-format

--- a/po/sv.po
+++ b/po/sv.po
@@ -809,6 +809,11 @@ msgstr ""
 msgid "%ls: variable '%ls' is read-only\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: variadic argument name '%ls' must be the final one\n"
+msgstr ""
+
 #, c-format
 msgid "%lsand %lu more rows"
 msgstr "%lsoch %lu rader till"

--- a/po/sv.po
+++ b/po/sv.po
@@ -681,6 +681,11 @@ msgstr ""
 msgid "%ls: column %ls exceeds line length\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: duplicate variable '%ls' in --argument-names\n"
+msgstr ""
+
 #, c-format
 msgid "%ls: exclusive flag '%ls' is not valid\n"
 msgstr ""
@@ -788,6 +793,16 @@ msgstr ""
 
 #, c-format
 msgid "%ls: value not completely converted (can't convert '%ls')"
+msgstr ""
+
+#
+#, c-format
+msgid "%ls: variable '%ls' is inherited multiple times\n"
+msgstr ""
+
+#
+#, c-format
+msgid "%ls: variable '%ls' is passed to both --argument-names and --inherit-variable\n"
 msgstr ""
 
 #, c-format

--- a/po/sv.po
+++ b/po/sv.po
@@ -649,6 +649,11 @@ msgstr ""
 msgid "%ls: `set --show` does not allow slices with the var names\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: argument names '%ls...' and '%ls...' both end in '...'\n"
+msgstr ""
+
 #, c-format
 msgid "%ls: array index out of bounds\n"
 msgstr ""
@@ -807,11 +812,6 @@ msgstr ""
 
 #, c-format
 msgid "%ls: variable '%ls' is read-only\n"
-msgstr ""
-
-#
-#, c-format
-msgid "%ls: variadic argument name '%ls' must be the final one\n"
 msgstr ""
 
 #, c-format

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -646,6 +646,11 @@ msgstr "%ls: 警告: 选项 '%ls' 已被删除, 现在被忽略"
 msgid "%ls: `set --show` does not allow slices with the var names\n"
 msgstr "%ls: `set --show` 不支持使用带有变量名称的切片\n"
 
+#
+#, c-format
+msgid "%ls: argument names '%ls...' and '%ls...' both end in '...'\n"
+msgstr ""
+
 #, c-format
 msgid "%ls: array index out of bounds\n"
 msgstr ""
@@ -804,11 +809,6 @@ msgstr ""
 
 #, c-format
 msgid "%ls: variable '%ls' is read-only\n"
-msgstr ""
-
-#
-#, c-format
-msgid "%ls: variadic argument name '%ls' must be the final one\n"
 msgstr ""
 
 #, c-format

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -806,6 +806,11 @@ msgstr ""
 msgid "%ls: variable '%ls' is read-only\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: variadic argument name '%ls' must be the final one\n"
+msgstr ""
+
 #, c-format
 msgid "%lsand %lu more rows"
 msgstr "%lsand %lu 更多行数"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -233,6 +233,11 @@ msgstr "%ls: '%ls' 不是有效任务说明符\n"
 msgid "%ls: '%ls' is not a valid process id\n"
 msgstr "%ls: '%ls' 不是一个有效的进程 id\n"
 
+#
+#, c-format
+msgid "%ls: --argument-names and --strict-argument-names cannot be mixed"
+msgstr ""
+
 #, c-format
 msgid "%ls: --command cannot be combined with --position command"
 msgstr ""
@@ -720,6 +725,16 @@ msgstr ""
 #, c-format
 msgid "%ls: function name required"
 msgstr "%ls: 函数名称是必须的"
+
+#
+#, c-format
+msgid "%ls: function requires at least %d arguments, but %d where supplied"
+msgstr ""
+
+#
+#, c-format
+msgid "%ls: function requires exactly %d arguments, but %d where supplied"
+msgstr ""
 
 #, c-format
 msgid "%ls: given %d indexes but %d values\n"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -678,6 +678,11 @@ msgstr "%ls: 无法同时path 和 unpath\n"
 msgid "%ls: column %ls exceeds line length\n"
 msgstr ""
 
+#
+#, c-format
+msgid "%ls: duplicate variable '%ls' in --argument-names\n"
+msgstr ""
+
 #, c-format
 msgid "%ls: exclusive flag '%ls' is not valid\n"
 msgstr "%ls: 排他性标志 '%ls' 无效\n"
@@ -786,6 +791,16 @@ msgstr "%ls: 对-i的用法 --silent 已贬值. 请使用 - s 或 --silent 代�
 #, c-format
 msgid "%ls: value not completely converted (can't convert '%ls')"
 msgstr "%ls: 数值未完全转换( 无法转换 '%ls' )"
+
+#
+#, c-format
+msgid "%ls: variable '%ls' is inherited multiple times\n"
+msgstr ""
+
+#
+#, c-format
+msgid "%ls: variable '%ls' is passed to both --argument-names and --inherit-variable\n"
+msgstr ""
 
 #, c-format
 msgid "%ls: variable '%ls' is read-only\n"

--- a/src/builtins/function.rs
+++ b/src/builtins/function.rs
@@ -77,7 +77,7 @@ fn parse_cmd_opts(
     argv: &mut [&wstr],
     parser: &Parser,
     streams: &mut IoStreams,
-) -> c_int {
+) -> BuiltinResult {
     let cmd = L!("function");
     let print_hints = false;
     let mut handling_named_arguments = false;
@@ -98,7 +98,7 @@ fn parse_cmd_opts(
                             cmd,
                             woptarg
                         ));
-                        return STATUS_INVALID_ARGS;
+                        return Err(STATUS_INVALID_ARGS);
                     }
                     opts.named_arguments.push(woptarg);
                 } else {
@@ -107,7 +107,7 @@ fn parse_cmd_opts(
                         cmd,
                         woptarg
                     ));
-                    return STATUS_INVALID_ARGS;
+                    return Err(STATUS_INVALID_ARGS);
                 }
             }
             'd' => {
@@ -120,7 +120,7 @@ fn parse_cmd_opts(
                         cmd,
                         w.woptarg.unwrap()
                     ));
-                    return STATUS_INVALID_ARGS;
+                    return Err(STATUS_INVALID_ARGS);
                 };
                 opts.events.push(EventDescription::Signal { signal });
             }
@@ -130,7 +130,7 @@ fn parse_cmd_opts(
                     streams
                         .err
                         .append(wgettext_fmt!(BUILTIN_ERR_VARNAME, cmd, name));
-                    return STATUS_INVALID_ARGS;
+                    return Err(STATUS_INVALID_ARGS);
                 }
                 opts.events.push(EventDescription::Variable { name });
             }
@@ -152,7 +152,7 @@ fn parse_cmd_opts(
                             "%ls: calling job for event handler not found",
                             cmd
                         ));
-                        return STATUS_INVALID_ARGS;
+                        return Err(STATUS_INVALID_ARGS);
                     }
                     e = EventDescription::CallerExit { caller_id };
                 } else if opt == 'p' && woptarg == "%self" {
@@ -165,7 +165,7 @@ fn parse_cmd_opts(
                             cmd,
                             woptarg
                         ));
-                        return STATUS_INVALID_ARGS;
+                        return Err(STATUS_INVALID_ARGS);
                     };
                     if opt == 'p' {
                         e = EventDescription::ProcessExit { pid: Pid::new(pid) };
@@ -191,7 +191,7 @@ fn parse_cmd_opts(
                         cmd,
                         name
                     ));
-                    return STATUS_INVALID_ARGS;
+                    return Err(STATUS_INVALID_ARGS);
                 }
                 handling_named_arguments = true;
                 opts.named_arguments.push(name);
@@ -208,7 +208,7 @@ fn parse_cmd_opts(
                     streams
                         .err
                         .append(wgettext_fmt!(BUILTIN_ERR_VARNAME, cmd, woptarg));
-                    return STATUS_INVALID_ARGS;
+                    return Err(STATUS_INVALID_ARGS);
                 }
                 opts.inherit_vars.push(woptarg.to_owned());
             }
@@ -217,7 +217,7 @@ fn parse_cmd_opts(
             }
             ':' => {
                 builtin_missing_argument(parser, streams, cmd, argv[w.wopt_index - 1], print_hints);
-                return STATUS_INVALID_ARGS;
+                return Err(STATUS_INVALID_ARGS);
             }
             ';' => {
                 builtin_unexpected_argument(
@@ -227,11 +227,11 @@ fn parse_cmd_opts(
                     argv[w.wopt_index - 1],
                     print_hints,
                 );
-                return STATUS_INVALID_ARGS;
+                return Err(STATUS_INVALID_ARGS);
             }
             '?' => {
                 builtin_unknown_option(parser, streams, cmd, argv[w.wopt_index - 1], print_hints);
-                return STATUS_INVALID_ARGS;
+                return Err(STATUS_INVALID_ARGS);
             }
             other => {
                 panic!("Unexpected retval from WGetopter: {}", other);
@@ -240,7 +240,7 @@ fn parse_cmd_opts(
     }
 
     *optind = w.wopt_index;
-    STATUS_CMD_OK
+    Ok(SUCCESS)
 }
 
 fn validate_function_name(
@@ -248,13 +248,13 @@ fn validate_function_name(
     function_name: &mut WString,
     cmd: &wstr,
     streams: &mut IoStreams,
-) -> c_int {
+) -> BuiltinResult {
     if argv.len() < 2 {
         // This is currently impossible but let's be paranoid.
         streams
             .err
             .append(wgettext_fmt!("%ls: function name required", cmd));
-        return STATUS_INVALID_ARGS;
+        return Err(STATUS_INVALID_ARGS);
     }
     *function_name = argv[1].to_owned();
     if !valid_func_name(function_name) {
@@ -263,7 +263,7 @@ fn validate_function_name(
             cmd,
             function_name,
         ));
-        return STATUS_INVALID_ARGS;
+        return Err(STATUS_INVALID_ARGS);
     }
     if parser_keywords_is_reserved(function_name) {
         streams.err.append(wgettext_fmt!(
@@ -271,9 +271,9 @@ fn validate_function_name(
             cmd,
             function_name
         ));
-        return STATUS_INVALID_ARGS;
+        return Err(STATUS_INVALID_ARGS);
     }
-    STATUS_CMD_OK
+    Ok(SUCCESS)
 }
 
 /// Define a function. Calls into `function.rs` to perform the heavy lifting of defining a
@@ -284,7 +284,7 @@ pub fn function(
     streams: &mut IoStreams,
     c_args: &mut [&wstr],
     func_node: NodeRef<BlockStatement>,
-) -> c_int {
+) -> BuiltinResult {
     // The wgetopt function expects 'function' as the first argument. Make a new vec with
     // that property. This is needed because this builtin has a different signature than the other
     // builtins.
@@ -295,22 +295,16 @@ pub fn function(
 
     // A valid function name has to be the first argument.
     let mut function_name = WString::new();
-    let mut retval = validate_function_name(argv, &mut function_name, cmd, streams);
-    if retval != STATUS_CMD_OK {
-        return retval;
-    }
+    validate_function_name(argv, &mut function_name, cmd, streams)?;
     let argv = &mut argv[1..];
 
     let mut opts = FunctionCmdOpts::default();
     let mut optind = 0;
-    retval = parse_cmd_opts(&mut opts, &mut optind, argv, parser, streams);
-    if retval != STATUS_CMD_OK {
-        return retval;
-    }
+    parse_cmd_opts(&mut opts, &mut optind, argv, parser, streams)?;
 
     if opts.print_help {
         builtin_print_error_trailer(parser, streams.err, cmd);
-        return STATUS_CMD_OK;
+        return Ok(SUCCESS);
     }
 
     if argv.len() != optind {
@@ -321,7 +315,7 @@ pub fn function(
                     streams
                         .err
                         .append(wgettext_fmt!(BUILTIN_ERR_VARNAME, cmd, arg));
-                    return STATUS_INVALID_ARGS;
+                    return Err(STATUS_INVALID_ARGS);
                 }
                 opts.named_arguments.push(arg.to_owned());
             }
@@ -331,7 +325,7 @@ pub fn function(
                 cmd,
                 argv[optind],
             ));
-            return STATUS_INVALID_ARGS;
+            return Err(STATUS_INVALID_ARGS);
         }
     }
 
@@ -356,7 +350,7 @@ pub fn function(
             streams
                 .err
                 .append(wgettext_fmt!(BUILTIN_ERR_VARNAME, cmd, named));
-            return STATUS_INVALID_ARGS;
+            return Err(STATUS_INVALID_ARGS);
         }
     }
 
@@ -411,5 +405,5 @@ pub fn function(
         }
     }
 
-    STATUS_CMD_OK
+    Ok(SUCCESS)
 }

--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -419,11 +419,8 @@ pub fn functions(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -
         let mut def = WString::new();
 
         if !comment.is_empty() {
-            def.push_utfstr(&sprintf!(
-                "# %ls\n%ls",
-                comment,
-                props.annotated_definition(arg)
-            ));
+            let defy = props.annotated_definition(arg);
+            def.push_utfstr(&sprintf!("# %ls\n%ls", comment, defy,));
         } else {
             def = props.annotated_definition(arg);
         }

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -947,7 +947,11 @@ fn function_prepare_environment(
     // 2. inherited variables
     // 3. argv
 
+    let mut overwrite_argv = false;
     for (idx, named_arg) in props.named_arguments.iter().enumerate() {
+        if named_arg == L!("argv") {
+            overwrite_argv = true
+        };
         if idx < argv.len() {
             vars.set_one(named_arg, EnvMode::LOCAL | EnvMode::USER, argv[idx].clone());
         } else {
@@ -956,10 +960,15 @@ fn function_prepare_environment(
     }
 
     for (key, value) in &*props.inherit_vars {
+        if key == L!("argv") {
+            overwrite_argv = true
+        };
         vars.set(key, EnvMode::LOCAL | EnvMode::USER, value.clone());
     }
 
-    vars.set_argv(argv);
+    if !overwrite_argv {
+        vars.set_argv(argv);
+    }
     fb
 }
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -27,6 +27,9 @@ pub struct FunctionProperties {
     /// List of all named arguments for this function.
     pub named_arguments: Vec<WString>,
 
+    /// Does the last element of named_arguments end in ...?
+    pub variadic: bool,
+
     /// Description of the function.
     pub description: LocalizableString,
 
@@ -478,6 +481,9 @@ impl FunctionProperties {
             sprintf!(=> &mut out, " --argument-names");
             for name in named {
                 sprintf!(=> &mut out, " %ls", name);
+            }
+            if self.variadic {
+                sprintf!(=> &mut out, "...");
             }
         }
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -27,6 +27,9 @@ pub struct FunctionProperties {
     /// List of all named arguments for this function.
     pub named_arguments: Vec<WString>,
 
+    /// Whether to give an error if the function is called with an incorrect number of arguments
+    pub strict_arity: bool,
+
     /// The index of the named_arguments that ends in ...
     pub variadic: Option<usize>,
 
@@ -477,8 +480,12 @@ impl FunctionProperties {
         }
 
         let named = &self.named_arguments;
-        if !named.is_empty() {
-            sprintf!(=> &mut out, " --argument-names");
+        if !named.is_empty() || self.strict_arity {
+            sprintf!(=> &mut out, if self.strict_arity {
+                " --strict-argument-names"
+            } else {
+                " --argument-names"
+            });
             for (idx, name) in named.iter().enumerate() {
                 sprintf!(=> &mut out, " %ls", name);
                 if self.variadic == Some(idx) {

--- a/src/function.rs
+++ b/src/function.rs
@@ -475,8 +475,9 @@ impl FunctionProperties {
 
         let named = &self.named_arguments;
         if !named.is_empty() {
+            sprintf!(=> &mut out, " --argument-names");
             for name in named {
-                sprintf!(=> &mut out, " --argument-names %ls", name);
+                sprintf!(=> &mut out, " %ls", name);
             }
         }
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -27,8 +27,8 @@ pub struct FunctionProperties {
     /// List of all named arguments for this function.
     pub named_arguments: Vec<WString>,
 
-    /// Does the last element of named_arguments end in ...?
-    pub variadic: bool,
+    /// The index of the named_arguments that ends in ...
+    pub variadic: Option<usize>,
 
     /// Description of the function.
     pub description: LocalizableString,
@@ -479,11 +479,11 @@ impl FunctionProperties {
         let named = &self.named_arguments;
         if !named.is_empty() {
             sprintf!(=> &mut out, " --argument-names");
-            for name in named {
+            for (idx, name) in named.iter().enumerate() {
                 sprintf!(=> &mut out, " %ls", name);
-            }
-            if self.variadic {
-                sprintf!(=> &mut out, "...");
+                if self.variadic == Some(idx) {
+                    sprintf!(=> &mut out, "...");
+                }
             }
         }
 

--- a/src/parse_execution.rs
+++ b/src/parse_execution.rs
@@ -1279,7 +1279,9 @@ impl<'a> ExecutionContext<'a> {
             &mut streams,
             &mut shim_arguments,
             NodeRef::new(Arc::clone(self.pstree()), statement),
-        );
+        )
+        .err()
+        .unwrap_or(STATUS_CMD_OK);
 
         ctx.parser().libdata_mut().status_count += 1;
         ctx.parser().set_last_statuses(Statuses::just(err_code));

--- a/tests/checks/function-definition.fish
+++ b/tests/checks/function-definition.fish
@@ -8,7 +8,7 @@ end
 
 functions stuff
 #CHECK: # Defined in {{.*}}
-#CHECK: function stuff --argument-names a --argument-names b --argument-names c
+#CHECK: function stuff --argument-names a b c
 #CHECK:    # This is a comment
 #CHECK:    echo stuff
 #CHECK:    # This is another comment
@@ -26,10 +26,10 @@ end
 functions commenting
 #CHECK: # Defined in {{.*}}
 #CHECK: function commenting
-#CHECK:     
+#CHECK:
 #CHECK:     # line 2
-#CHECK:     
+#CHECK:
 #CHECK:     # line 4
-#CHECK:     
+#CHECK:
 #CHECK:     echo Bye bye says line 6
 #CHECK: end

--- a/tests/checks/function.fish
+++ b/tests/checks/function.fish
@@ -208,3 +208,59 @@ function outer
 end
 outer 1 2 3
 #CHECK: 1 2 3
+
+# Check for errors with duplicate names
+set var 1
+function bad -a var var -V var
+    echo $var
+end
+#CHECKERR: {{.*}}checks/function.fish (line {{\d+}}): function: variable 'var' is passed to both --argument-names and --inherit-variable
+#CHECKERR: function bad -a var var -V var
+#CHECKERR: ^
+bad 2
+#CHECKERR: fish: Unknown command: bad
+#CHECKERR: {{.*}}checks/function.fish (line {{\d+}}):
+#CHECKERR: bad 2
+#CHECKERR: ^~^
+
+
+echo START>&2
+#CHECKERR: START
+
+function bad -V var -a var
+    echo $var
+end
+#CHECKERR: {{.*}}checks/function.fish (line {{\d+}}): function: variable 'var' is passed to both --argument-names and --inherit-variable
+#CHECKERR: function bad -V var -a var
+#CHECKERR: ^
+bad 3
+#CHECKERR: fish: Unknown command: bad
+#CHECKERR: {{.*}}checks/function.fish (line {{\d+}}):
+#CHECKERR: bad 3
+#CHECKERR: ^~^
+
+function bad -a var var -V not_var
+    echo $var
+end
+#CHECKERR: {{.*}}checks/function.fish (line {{\d+}}): function: duplicate variable 'var' in --argument-names
+#CHECKERR: function bad -a var var -V not_var
+#CHECKERR: ^
+bad 4
+#CHECKERR: fish: Unknown command: bad
+#CHECKERR: {{.*}}checks/function.fish (line {{\d+}}):
+#CHECKERR: bad 4
+#CHECKERR: ^~^
+
+function bad -V var -V var
+    echo $var
+end
+#CHECKERR: {{.*}}checks/function.fish (line {{\d+}}): function: variable 'var' is inherited multiple times
+#CHECKERR: function bad -V var -V var
+#CHECKERR: ^
+bad 5
+#CHECKERR: fish: Unknown command: bad
+#CHECKERR: {{.*}}checks/function.fish (line {{\d+}}):
+#CHECKERR: bad 5
+#CHECKERR: ^~^
+
+exit 0

--- a/tests/checks/function.fish
+++ b/tests/checks/function.fish
@@ -108,16 +108,16 @@ test "$name3[3..-1]" = "$name3a[3..-1]"; and echo "3 = 3a"
 # Test the first two lines.
 string join \n -- $name1[1..2]
 #CHECK: # Defined in {{(?:(?!, copied).)*}}
-#CHECK: function name1 --argument-names arg1 --argument-names arg2
+#CHECK: function name1 --argument-names arg1 arg2
 string join \n -- $name1a[1..2]
 #CHECK: # Defined in {{.*}}, copied in {{.*}}
-#CHECK: function name1a --argument-names arg1 --argument-names arg2
+#CHECK: function name1a --argument-names arg1 arg2
 string join \n -- $name3[1..2]
 #CHECK: # Defined in {{(?:(?!, copied).)*}}
-#CHECK: function name3 --argument-names arg1 --argument-names arg2
+#CHECK: function name3 --argument-names arg1 arg2
 string join \n -- $name3a[1..2]
 #CHECK: # Defined in {{.*}}, copied in {{.*}}
-#CHECK: function name3a --argument-names arg1 --argument-names arg2
+#CHECK: function name3a --argument-names arg1 arg2
 
 function test
     echo banana

--- a/tests/checks/function.fish
+++ b/tests/checks/function.fish
@@ -401,3 +401,217 @@ type dotty
 # CHECK: function dotty --argument-names x y z...
 # CHECK:     set -l
 # CHECK: end
+
+# Tests for --strict-argument-names
+function strict -A
+    set -l
+end
+strict 1; test $status -eq 2 || echo WRONG
+
+# CHECKERR: error: strict: function requires exactly 0 arguments, but 1 where supplied
+strict; test $status -eq 0 || echo WRONG
+# CHECK: argv
+functions strict
+# CHECK: # Defined in {{.*}}checks/function.fish @ line {{\d+}}
+# CHECK: function strict --strict-argument-names
+# CHECK:     set -l
+# CHECK: end
+type strict
+# CHECK: strict is a function with definition
+# CHECK: # Defined in {{.*}}checks/function.fish @ line {{\d+}}
+# CHECK: function strict --strict-argument-names
+# CHECK:     set -l
+# CHECK: end
+
+function bad -a
+    set -l
+end
+#CHECKERR: {{.*}}checks/function.fish (line {{\d+}}): function: -a: option requires an argument
+#CHECKERR: function bad -a
+#CHECKERR: ^
+not functions -q bad || echo "function should not exist"
+
+function strict -A -A # This is the same as -A, this could be made into an error though
+    set -l
+end
+strict 1; test $status -eq 2 || echo WRONG
+# CHECKERR: error: strict: function requires exactly 0 arguments, but 1 where supplied
+strict; test $status -eq 0 || echo WRONG
+# CHECK: argv
+functions strict
+# CHECK: # Defined in {{.*}}checks/function.fish @ line {{\d+}}
+# CHECK: function strict --strict-argument-names
+# CHECK:     set -l
+# CHECK: end
+type strict
+# CHECK: strict is a function with definition
+# CHECK: # Defined in {{.*}}checks/function.fish @ line {{\d+}}
+# CHECK: function strict --strict-argument-names
+# CHECK:     set -l
+# CHECK: end
+
+function bad -a -a
+    set -l
+end
+#CHECKERR: {{.*}}checks/function.fish (line {{\d+}}): function: -a: invalid variable name. See `help identifiers`
+#CHECKERR: function bad -a -a
+#CHECKERR: ^
+not functions -q bad || echo "function should not exist"
+
+function strict -AA # This is the same as -A A, not -A -A
+    set -l
+end
+strict; test $status -eq 2 || echo WRONG
+# CHECKERR: error: strict: function requires exactly 1 arguments, but 0 where supplied
+strict 1; test $status -eq 0 || echo WRONG
+# CHECK: A 1
+# CHECK: argv 1
+strict 1 2 3; test $status -eq 2 || echo WRONG
+# CHECKERR: error: strict: function requires exactly 1 arguments, but 3 where supplied
+functions strict
+# CHECK: # Defined in {{.*}}checks/function.fish @ line {{\d+}}
+# CHECK: function strict --strict-argument-names A
+# CHECK:     set -l
+# CHECK: end
+type strict
+# CHECK: strict is a function with definition
+# CHECK: # Defined in {{.*}}checks/function.fish @ line {{\d+}}
+# CHECK: function strict --strict-argument-names A
+# CHECK:     set -l
+# CHECK: end
+
+function non_strict -aa # This is the same as -a a, not -a -a
+    set -l
+end
+non_strict; test $status -eq 0 || echo WRONG
+# CHECK: a
+# CHECK: argv
+non_strict 1; test $status -eq 0 || echo WRONG
+# CHECK: a 1
+# CHECK: argv 1
+non_strict 1 2 3; test $status -eq 0 || echo WRONG
+# CHECK: a 1
+# CHECK: argv '1'  '2'  '3'
+functions non_strict
+# CHECK: # Defined in {{.*}}checks/function.fish @ line {{\d+}}
+# CHECK: function non_strict --argument-names a
+# CHECK:     set -l
+# CHECK: end
+type non_strict
+# CHECK: non_strict is a function with definition
+# CHECK: # Defined in {{.*}}checks/function.fish @ line {{\d+}}
+# CHECK: function non_strict --argument-names a
+# CHECK:     set -l
+# CHECK: end
+
+function strict --strict-argument-names x y -A z # This is the same as -A x y z
+    set -l
+end
+strict; test $status -eq 2 || echo WRONG
+# CHECKERR: error: strict: function requires exactly 3 arguments, but 0 where supplied
+strict 1 2 3; test $status -eq 0 || echo WRONG
+# CHECK: argv '1'  '2'  '3'
+# CHECK: x 1
+# CHECK: y 2
+# CHECK: z 3
+functions strict
+# CHECK: # Defined in {{.*}}checks/function.fish @ line {{\d+}}
+# CHECK: function strict --strict-argument-names x y z
+# CHECK:     set -l
+# CHECK: end
+type strict
+# CHECK: strict is a function with definition
+# CHECK: # Defined in {{.*}}checks/function.fish @ line {{\d+}}
+# CHECK: function strict --strict-argument-names x y z
+# CHECK:     set -l
+# CHECK: end
+
+function bad --strict-argument-names x y -a z
+    set -l
+end
+#CHECKERR: {{.*}}checks/function.fish (line {{\d+}}): function: --argument-names and --strict-argument-names cannot be mixed
+#CHECKERR: function bad --strict-argument-names x y -a z
+#CHECKERR: ^
+not functions -q bad || echo "function should not exist"
+
+function bad --argument-names x y -A z
+    set -l
+end
+#CHECKERR: {{.*}}checks/function.fish (line {{\d+}}): function: --argument-names and --strict-argument-names cannot be mixed
+#CHECKERR: function bad --argument-names x y -A z
+#CHECKERR: ^
+not functions -q bad || echo "function should not exist"
+
+# Tests for --strict-argument-names with ...
+function strict -A x...
+    set -l
+end
+strict; test $status -eq 0 || echo WRONG
+# CHECK: argv
+# CHECK: x
+strict 1; test $status -eq 0 || echo WRONG
+# CHECK: argv 1
+# CHECK: x 1
+strict 1 2 3; test $status -eq 0 || echo WRONG
+# CHECK: argv '1'  '2'  '3'
+# CHECK: x '1'  '2'  '3'
+functions strict
+# CHECK: # Defined in {{.*}}checks/function.fish @ line {{\d+}}
+# CHECK: function strict --strict-argument-names x...
+# CHECK:     set -l
+# CHECK: end
+type strict
+# CHECK: strict is a function with definition
+# CHECK: # Defined in {{.*}}checks/function.fish @ line {{\d+}}
+# CHECK: function strict --strict-argument-names x...
+# CHECK:     set -l
+# CHECK: end
+
+function strict -A x y...
+    set -l
+end
+strict; test $status -eq 2 || echo WRONG
+# CHECKERR: error: strict: function requires at least 1 arguments, but 0 where supplied
+strict 1; test $status -eq 0 || echo WRONG
+# CHECK: argv 1
+# CHECK: x 1
+# CHECK: y
+strict 1 2 3; test $status -eq 0 || echo WRONG
+# CHECK: argv '1'  '2'  '3'
+# CHECK: x 1
+# CHECK: y '2'  '3'
+functions strict
+# CHECK: # Defined in {{.*}}checks/function.fish @ line {{\d+}}
+# CHECK: function strict --strict-argument-names x y...
+# CHECK:     set -l
+# CHECK: end
+type strict
+# CHECK: strict is a function with definition
+# CHECK: # Defined in {{.*}}checks/function.fish @ line {{\d+}}
+# CHECK: function strict --strict-argument-names x y...
+# CHECK:     set -l
+# CHECK: end
+
+function strict -A x y... z
+    set -l
+end
+strict; test $status -eq 2 || echo WRONG
+# CHECKERR: error: strict: function requires at least 2 arguments, but 0 where supplied
+strict 1; test $status -eq 2 || echo WRONG
+# CHECKERR: error: strict: function requires at least 2 arguments, but 1 where supplied
+strict 1 2 3; test $status -eq 0 || echo WRONG
+# CHECK: argv '1'  '2'  '3'
+# CHECK: x 1
+# CHECK: y 2
+# CHECK: z 3
+functions strict
+# CHECK: # Defined in {{.*}}checks/function.fish @ line {{\d+}}
+# CHECK: function strict --strict-argument-names x y... z
+# CHECK:     set -l
+# CHECK: end
+type strict
+# CHECK: strict is a function with definition
+# CHECK: # Defined in {{.*}}checks/function.fish @ line {{\d+}}
+# CHECK: function strict --strict-argument-names x y... z
+# CHECK:     set -l
+# CHECK: end

--- a/tests/checks/function.fish
+++ b/tests/checks/function.fish
@@ -263,4 +263,111 @@ bad 5
 #CHECKERR: bad 5
 #CHECKERR: ^~^
 
-exit 0
+# Tests for ... in argument names
+function dotty -a x y... -a z...
+    set -l
+end
+#CHECKERR: {{.*}}checks/function.fish (line {{\d+}}): function: variadic argument name 'y' must be the final one
+#CHECKERR: function dotty -a x y... -a z...
+#CHECKERR: ^
+dotty 1 2 3 4
+#CHECKERR: fish: Unknown command: dotty
+#CHECKERR: {{.*}}checks/function.fish (line {{\d+}}):
+#CHECKERR: dotty 1 2 3 4
+#CHECKERR: ^~~~^
+
+function dotty -a x...
+    set -l
+end
+dotty
+#CHECK: argv
+#CHECK: x
+dotty 1
+#CHECK: argv 1
+#CHECK: x 1
+dotty 1 2
+#CHECK: argv '1'  '2'
+#CHECK: x '1'  '2'
+dotty 1 2 3
+#CHECK: argv '1'  '2'  '3'
+#CHECK: x '1'  '2'  '3'
+dotty 1 2 3 4 5
+#CHECK: argv '1'  '2'  '3'  '4'  '5'
+#CHECK: x '1'  '2'  '3'  '4'  '5'
+functions dotty
+# CHECK: # Defined in {{.*}}checks/function.fish @ line {{\d+}}
+# CHECK: function dotty --argument-names x...
+# CHECK:     set -l
+# CHECK: end
+type dotty
+# CHECK: dotty is a function with definition
+# CHECK: # Defined in {{.*}}checks/function.fish @ line {{\d+}}
+# CHECK: function dotty --argument-names x...
+# CHECK:     set -l
+# CHECK: end
+
+functions -e dotty
+
+function dotty -a x... y z
+    set -l
+end
+#CHECKERR: {{.*}}checks/function.fish (line {{\d+}}): function: variadic argument name 'x' must be the final one
+#CHECKERR: function dotty -a x... y z
+#CHECKERR: ^
+dotty 1 2 3 4
+#CHECKERR: fish: Unknown command: dotty
+#CHECKERR: {{.*}}checks/function.fish (line {{\d+}}):
+#CHECKERR: dotty 1 2 3 4
+#CHECKERR: ^~~~^
+
+function dotty -a x y... z
+    set -l
+end
+#CHECKERR: {{.*}}checks/function.fish (line {{\d+}}): function: variadic argument name 'y' must be the final one
+#CHECKERR: function dotty -a x y... z
+#CHECKERR: ^
+dotty 1 2 3 4
+#CHECKERR: fish: Unknown command: dotty
+#CHECKERR: {{.*}}checks/function.fish (line {{\d+}}):
+#CHECKERR: dotty 1 2 3 4
+#CHECKERR: ^~~~^
+
+function dotty -a x y z...
+    set -l
+end
+dotty
+#CHECK: argv
+#CHECK: x
+#CHECK: y
+#CHECK: z
+dotty 1
+# CHECK: argv 1
+# CHECK: x 1
+# CHECK: y
+# CHECK: z
+dotty 1 2
+# CHECK: argv '1'  '2'
+# CHECK: x 1
+# CHECK: y 2
+# CHECK: z
+dotty 1 2 3
+# CHECK: argv '1'  '2'  '3'
+# CHECK: x 1
+# CHECK: y 2
+# CHECK: z 3
+dotty 1 2 3 4 5
+# CHECK: argv '1'  '2'  '3'  '4'  '5'
+# CHECK: x 1
+# CHECK: y 2
+# CHECK: z '3'  '4'  '5'
+functions dotty
+# CHECK: # Defined in {{.*}}checks/function.fish @ line {{\d+}}
+# CHECK: function dotty --argument-names x y z...
+# CHECK:     set -l
+# CHECK: end
+type dotty
+# CHECK: dotty is a function with definition
+# CHECK: # Defined in {{.*}}checks/function.fish @ line {{\d+}}
+# CHECK: function dotty --argument-names x y z...
+# CHECK:     set -l
+# CHECK: end

--- a/tests/checks/function.fish
+++ b/tests/checks/function.fish
@@ -186,4 +186,25 @@ function foo; echo before; end
 foo (functions --erase foo)
 # CHECKERR: error: Unknown function 'foo'
 
-exit 0
+
+# Tests the --argument-names and --inherit-variable can overwrite argv
+function t --argument-names a argv c
+    echo $argv
+end
+t 1 2 3
+#CHECK: 2
+
+function t -a argv
+    echo $argv
+end
+t 1 2 3
+#CHECK: 1
+
+function outer
+    function inner -v argv -V argv
+        echo $argv
+    end
+    set -gx argv 4 5 6
+end
+outer 1 2 3
+#CHECK: 1 2 3


### PR DESCRIPTION
This pull request adds two new features (as discussed in issue #11728):
1. A *single* argument name in a `function`s `-a`/`--argument-names` list can end in `...`, the variable (with the `...` removed) will be set to a list containing as many arguments as possible, whilst still leaving arguments to be assigned to the rest of the parameters.
2. A new `-A`/`--strict-argument-names` option is added that works like `-a`/`--argument-names`, but you will get an error if you use the function with an incorrect number of arguments.

I also 'fixed' a few strange related behaviours that I noticed (see below).

I've documented everything and added test cases, however there is one bug (in my last commit): the error message produced by `-A` cannot be redirected away, e.g.:
```fish
function foo -A arg; end
foo &>/dev/null # Still prints an error message
```
However, this is consistent with the behaviour of calling a non-existent function/command.
Please let me know if you have any idea how to fix this.

# Details
Copied from the documentation for `function`, with changed behaviour in bold:

* `-a NAMES` or `--argument-names NAMES`
    Assigns the value of successive command-line arguments to the names given in *NAMES* (separated by spaces). These are the same arguments given in `argv`, and are still available there **(unless `--inherit-variable argv` was used or one of the given *NAMES* is `argv`)**. See also *Argument Handling*.

    **A single argument name given can end in `...`, in which case a variable number of arguments are saved in a variable with that name (excluding the `...` part), as many as possible whilst still leaving arguments for each of the other named arguments. If this cannot be done (because the number of arguments is smaller than the number of argument names), the argument with a `...` is set to the empty list, and the other arguments are asigned values as if the `...` one was not there.**

    See the *Argument Names Caveats* section below for what happens when the number of arguments passed differs from the number of argument *NAMES*.

*  `-A NAMES` or `--strict-argument-names NAMES`
    **This behaves like like `-a` / `--argument-names`, except that calling the function with an incorrect number of arguments will print an error, return 2, and not execute the body of the function.
    If none of the given *NAMES* use a `...`, this error will trigger when the number of actual arguments does not equal the number of *NAMES*.
    Otherwise, (if `...` was used) the error will trigger if the number of actual arguments is *less* than the number *NAMES* minus 1.**

    **Unlike the `-a`/`--argument-names` option, the given *NAMES* list can be empty, in which case an error will be generated if the function is called with a non-empty list of arguments.**

### Argument Names Caveats
**(this section is new, but some of it describes existing behaviour)**

The `-a` / `--argument-names` flag does *not* validate the number of arguments passed: if an argument is missing the corresponding variable will be assigned to an empty list. For example:

```fish
function two -a x y
    set -l
end
two 1
# prints:
#    argv 1
#    x 1
#    y
```

**In contrast, if the `-A` / `--strict-argument-names` option where used instead, the above call to `two` would produce an error.**

Similarly, if `-a` / `--argument-names` is used and none of the argument names end in `...`, any extra arguments are ignored, but they are still accessible in `$argv`. Continuing the previous example:

```fish
two 1 2 3
# prints:
#    argv '1'  '2'  '3'
#    x 1
#    y 2
```

**Using `-A` / `--strict-argument-names` will make the above call to `two` an error.**

**If on the other hand the last argument name does end in `...`, any extra arguments are stored in that variable. For example:**

```fish
function one_or_more -a x y...
    set -l
end
one_or_more 1 2 3
# prints:
#    argv '1'  '2'  '3'
#    x 1
#    y '2'  '3'
```

**The same behaviour occurs with the `-A` / `--strict-argument-names` option.**

**If the argument named with a `...` is not the last, then if possible, it will leave enough arguments for the subsequent argument names. For example:**

```fish
function more_or_one -a x... y
    set -l
end
more_or_one 1 2 3
# prints:
#    argv '1'  '2'  '3'
#    x '1'  '2'
#    y 3
```

**The argument with a `...` is however set to the empty list if there are not enough arguments to satisfy all the argument names. For example:**

```fish
function more_or_two -a x... y z
    set -l
end
more_or_two 1
# prints:
#    argv 1
#    x
#    y 1
#    z
```

**However, with the `-A` / `--strict-argument-names` option, the above call to `more_or_two` would produce an error.**

# The Commits
This first group of changes are not necessary for the rest of the functionality, so I'm happy to remove them if you don't like them:
1. f7f60b307f632224c5a9b7760b849e05b3571881  Use idiomatic Rust error handling for function builtin.
    > This simply does the same thing as #10948, but for the function builtin.
2. 6a7667dcf1cc6a9ff79f62e9cc1bf0dabd017113 Output function argument-names in one group.
    > This makes it so that printing a function definition will only use one
    > --argument-names group, instead of one for argument name.
    > For example, "function foo -a x y; ..." will print with "function foo
    > --argument-names x y" instead of "function foo --argument-names x
    > --argument-names y", which is very bizarre.
    > 
    > Moreover, the documentation no longer says that argument-names "Has to 
    > be the last option.". This sentence appears to have been introduced in 
    > error by pull #10524, since the ability to have options afterwards was 
    > deliberately added by pull #6188.

3. cd8c938f37464a8e02fbcfa968cf732b07cab8e9 Allow overwriting argv with function -a and -V
    > Previously, if you called a function parameter 'argv', within the body
    > of the function, argv would be set to *all* the arguments to the
    > function, and not the one indicated by the parameter name.
    > The same behaviour happened if you inherited a variable named 'argv'.
    > Both behaviours were quite surprising, so this commit makes things more
    > obvious, although they could alternatively simply be made errors.
4. c813ea2f4fdef3d52a4718a3446644ce93b48993 Prohibit duplicate variable names with function -a and -V options
    > It is now an error to use the same variable name twice with
    > --inherit-variable and/pr --argument-names.
    > The previous behaviour was:
    >     1. duplicate --inherit-variable's worked as if you only inherited
    >     the variable once
    >     2. Later --argument-names override earlier ones
    >     3. An --inherit-variable overrides an --argument-names
    > Thus this change is backwards incompatible, however, such duplicate
    > names are not useful and where likely unintentional, and none of the
    > test cases were depending on the old behaviour.
    > 
    > (I do note that there was code written to specifically remove any
    > duplicate --inherit-variable's, but the only difference this made was
    > that the duplicates wouldn't be displayed by the functions or type
    > builtin. This seems to have been done to preserve the prior behaviour
    > when it was a HashMap.)
    
The next commit adds a section to the documentation that the remaining commits add to:

5. 4ee163de274559c794afb97a9fede2f34820c63e Added more documentation for function --argument-names
    > Specifically, this adds a section to the "function" builtin
    > documentation explaining what happens when you call a function defined
    > with --argument-names, but with a different number of arguments than
    > argument-names.
    
6. 6ad3d9e5ea6514ff3e31c14c5471acbdc8c1e69b Allow variadic function --argument-names 
    > Specifically, this allows the last --argument-names in a function
    > definition to be suffixed with ... This causes any leftover arguments in
    > argv to be appended to the affixed variable name.
    > 
    > The documentation has been updating giving details on how different
    > numbers of argument names and argv elements are reconciled, with and
    > without the new ...

7. 181c8f9b9941733fdd8dcfab52dafa2589e9fa59 Do not require the variadic --argument-names to be the last one **(note: I made this a seperate commit in case it's too strange/useless)**
    > This commit makes it so that an argument-name ending with a ...
    > in a function's --argument-names list is not required to be the last.
    > There can still only be one such argument name.
    > The idea is that a '...' argument name will consume as many arguments
    > from argv as possible, whilst still leaving one argument for each normal
    > argument name (if possible).

8. 25a79d4e9958bef5505f2ab3855ae85ebc6b1c00 Add an -A/--strict-argument-names option to function 
    > 
    > The new -A/--strict-argument-names option behave like the existing
    > -a/--argument-names option to function, but with the following
    > differences:
    >   - If none of the argument names contains a ... suffix, it will be
    >   an error to call the function with a different number of arguments
    >   compared to the number of argument names.
    >   - If one of the argument names does contain a ... suffix, it will
    >   be an error to call it with less arguments, than non-... argument
    >   names.
    >   - it cannot be used together with -a/--argument-names (e.g.
    >   function f -A x -A y, and function f -a x -a y are allowed, but
    >   function f -A x -a y is not.)
    >   - It can be used without any argument argument names
    >   (e.g. function f -A), indicating that the function takes no arguments.
    > 
    > An error is produced as follows:
    >     - An error message of the following form is printed to stderr:
    > error: <name>: function requires exactly <n> arguments, but <m> where supplied
    >     - The function is not called
    >     - A status code of 2 is returned (similarly to other builtins
    >     when you provide them with an incorrect number/format of arguments)
    > 
    > Note that the error message is printed *before* the function is called,
    > so any redirections on the function call statement are not applied,
    > this is a bug that should be fixed.
    > 
    > This new feature fixes #11728.

# Future Stuff
If this pull request is accepted, I would like to add:
* Add `-a`/`--argument-names` and `-A`/`--strict-argument-names` to `argparse` (although I note similar suggestions were previously rejected in #5778 and #5946, but they didn't include my new `...` feature).
* Add `-m`/`--multiple` and `-M`/`--strict-multiple` to `set` (fixing #11457), that would be similar to `-a` and `-A`, the usage would be:
    ```fish
    set <options> -m <var>... -- <values>
    ```
    Where `<options>` are any existing set options that make sense. Each `<var>` part could be anything that set currently supports (e.g. `foo[1 3]`), or a name followed by `...`.

So let me know if you think any of my changes would not be suitable for `argparse` or `set`.