### PR TITLE
completions/systemctl: Handle --boot-loader-entry and --boot-loader-menu

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -7630,6 +7630,12 @@ msgstr ""
 msgid "Boolean as the value for the given key"
 msgstr ""
 
+msgid "Boot into a specific boot loader entry on next boot"
+msgstr ""
+
+msgid "Boot into boot loader menu on next boot"
+msgstr ""
+
 msgid "Boot manager display label (Default: Linux)"
 msgstr ""
 

--- a/po/en.po
+++ b/po/en.po
@@ -7626,6 +7626,12 @@ msgstr ""
 msgid "Boolean as the value for the given key"
 msgstr ""
 
+msgid "Boot into a specific boot loader entry on next boot"
+msgstr ""
+
+msgid "Boot into boot loader menu on next boot"
+msgstr ""
+
 msgid "Boot manager display label (Default: Linux)"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7727,6 +7727,12 @@ msgstr ""
 msgid "Boolean as the value for the given key"
 msgstr ""
 
+msgid "Boot into a specific boot loader entry on next boot"
+msgstr ""
+
+msgid "Boot into boot loader menu on next boot"
+msgstr ""
+
 msgid "Boot manager display label (Default: Linux)"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7622,6 +7622,12 @@ msgstr ""
 msgid "Boolean as the value for the given key"
 msgstr ""
 
+msgid "Boot into a specific boot loader entry on next boot"
+msgstr ""
+
+msgid "Boot into boot loader menu on next boot"
+msgstr ""
+
 msgid "Boot manager display label (Default: Linux)"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7627,6 +7627,12 @@ msgstr ""
 msgid "Boolean as the value for the given key"
 msgstr ""
 
+msgid "Boot into a specific boot loader entry on next boot"
+msgstr ""
+
+msgid "Boot into boot loader menu on next boot"
+msgstr ""
+
 msgid "Boot manager display label (Default: Linux)"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7625,6 +7625,12 @@ msgstr ""
 msgid "Boolean as the value for the given key"
 msgstr ""
 
+msgid "Boot into a specific boot loader entry on next boot"
+msgstr ""
+
+msgid "Boot into boot loader menu on next boot"
+msgstr ""
+
 msgid "Boot manager display label (Default: Linux)"
 msgstr ""
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -7625,6 +7625,12 @@ msgstr "粗体字体"
 msgid "Boolean as the value for the given key"
 msgstr "布尔为给定密钥的值"
 
+msgid "Boot into a specific boot loader entry on next boot"
+msgstr ""
+
+msgid "Boot into boot loader menu on next boot"
+msgstr ""
+
 msgid "Boot manager display label (Default: Linux)"
 msgstr "Boot 管理器显示标签( 默认: Linux)"
 

--- a/share/completions/systemctl.fish
+++ b/share/completions/systemctl.fish
@@ -94,3 +94,9 @@ if test $systemd_version -gt 219 2>/dev/null
     complete -f -c systemctl -l now -n "__fish_seen_subcommand_from enable" -d "Also start unit"
     complete -f -c systemctl -l now -n "__fish_seen_subcommand_from disable mask" -d "Also stop unit"
 end
+
+# New options since systemd 242
+if test $systemd_version -ge 242 2>/dev/null
+    complete -x -c systemctl -l boot-loader-entry -n "__fish_seen_subcommand_from halt poweroff reboot" -d "Boot into a specific boot loader entry on next boot" -a "(systemctl --boot-loader-entry=help --no-legend --no-pager 2>/dev/null)"
+    complete -x -c systemctl -l boot-loader-menu -n "__fish_seen_subcommand_from halt poweroff reboot" -d "Boot into boot loader menu on next boot"
+end


### PR DESCRIPTION
## Description

systemd 242 added two new options to `halt`, `poweroff`, and `reboot`:

    --boot-loader-entry: Reboot to a specific boot loader entry
    --boot-loader-menu: Reboot into boot loader menu with specified timeout

Add these to the `systemctl` completion so that it is easy to interactively select available entries.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
