### PR TITLE
`npm install` completions: add `--save-peer` flag

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -52261,6 +52261,9 @@ msgstr ""
 msgid "Save to optionalDependencies"
 msgstr ""
 
+msgid "Save to peerDependencies"
+msgstr ""
+
 msgid "Save which profiles are active"
 msgstr ""
 

--- a/po/en.po
+++ b/po/en.po
@@ -52257,6 +52257,9 @@ msgstr ""
 msgid "Save to optionalDependencies"
 msgstr ""
 
+msgid "Save to peerDependencies"
+msgstr ""
+
 msgid "Save which profiles are active"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -52358,6 +52358,9 @@ msgstr ""
 msgid "Save to optionalDependencies"
 msgstr ""
 
+msgid "Save to peerDependencies"
+msgstr ""
+
 msgid "Save which profiles are active"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -52253,6 +52253,9 @@ msgstr ""
 msgid "Save to optionalDependencies"
 msgstr ""
 
+msgid "Save to peerDependencies"
+msgstr ""
+
 msgid "Save which profiles are active"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -52280,6 +52280,9 @@ msgstr ""
 msgid "Save to optionalDependencies"
 msgstr ""
 
+msgid "Save to peerDependencies"
+msgstr ""
+
 msgid "Save which profiles are active"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -52256,6 +52256,9 @@ msgstr ""
 msgid "Save to optionalDependencies"
 msgstr ""
 
+msgid "Save to peerDependencies"
+msgstr ""
+
 msgid "Save which profiles are active"
 msgstr ""
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -52256,6 +52256,9 @@ msgstr "保存到不依赖"
 msgid "Save to optionalDependencies"
 msgstr "保存到可选 依赖关系"
 
+msgid "Save to peerDependencies"
+msgstr ""
+
 msgid "Save which profiles are active"
 msgstr "保存哪些配置文件活动"
 

--- a/share/completions/npm.fish
+++ b/share/completions/npm.fish
@@ -414,6 +414,7 @@ for c in install add i in ins inst insta instal isnt isnta isntal isntall instal
     complete -f -c npm -n "__fish_npm_using_command $c" -s P -l save-prod -d 'Save to dependencies'
     complete -f -c npm -n "__fish_npm_using_command $c" -s D -l save-dev -d 'Save to devDependencies'
     complete -f -c npm -n "__fish_npm_using_command $c" -s O -l save-optional -d 'Save to optionalDependencies'
+    complete -f -c npm -n "__fish_npm_using_command $c" -l save-peer -d 'Save to peerDependencies'
     complete -f -c npm -n "__fish_npm_using_command $c" -s B -l save-bundle -d 'Also save to bundleDependencies'
     complete -f -c npm -n "__fish_npm_using_command $c" -s E -l save-exact -d 'Save dependency with exact version'
     complete -f -c npm -n "__fish_npm_using_command $c" -s g -l global -d 'Install package globally'


### PR DESCRIPTION
It's unclear if there is a short flag, since `npm install --help` does not list all short flags (e.g. `-O` is supported but not listed). So this just adds the long flag.