### PR TITLE
path.rs: fix build on ARM / POWER on FreeBSD

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -695,7 +695,7 @@ pub fn path_remoteness(path: &wstr) -> DirRemoteness {
     #[cfg(not(any(target_os = "linux", cygwin)))]
     {
         fn remoteness_via_statfs<StatFS, Flags>(
-            statfn: unsafe extern "C" fn(*const i8, *mut StatFS) -> libc::c_int,
+            statfn: unsafe extern "C" fn(*const libc::c_char, *mut StatFS) -> libc::c_int,
             flagsfn: fn(&StatFS) -> Flags,
             is_local_flag: u64,
             path: &std::ffi::CStr,


### PR DESCRIPTION
```
error[E0308]: mismatched types
   --> src/path.rs:749:13
    |
748 |         let remoteness = remoteness_via_statfs(
    |                          --------------------- arguments to this function are incorrect
749 |             libc::statfs,
    |             ^^^^^^^^^^^^ expected fn pointer, found fn item
    |
    = note: expected fn pointer `unsafe extern "C" fn(*const i8, _) -> _`
                  found fn item `unsafe extern "C" fn(*const u8, _) -> _ {libc::statfs}`
note: function defined here
   --> src/path.rs:712:12
    |
712 |         fn remoteness_via_statfs<StatFS, Flags>(
    |            ^^^^^^^^^^^^^^^^^^^^^
713 |             statfn: unsafe extern "C" fn(*const i8, *mut StatFS) -> libc::c_int,
    |             -------------------------------------------------------------------

error[E0308]: mismatched types
   --> src/path.rs:725:34
    |
725 |             if unsafe { (statfn)(path.as_ptr(), buf.as_mut_ptr()) } < 0 {
    |                         -------- ^^^^^^^^^^^^^ expected `*const i8`, found `*const u8`
    |                         |
    |                         arguments to this function are incorrect
    |
    = note: expected raw pointer `*const i8`
               found raw pointer `*const u8`

For more information about this error, try `rustc --explain E0308`. error: could not compile `fish` (lib) due to 2 previous errors

```
## Description

Many architectures, e.g. ARM or POWER use unsigned char by default.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
