### PR TITLE
fish-git-prompt: add upstream diverged char option

### DIFF
--- a/doc_src/cmds/fish_git_prompt.rst
+++ b/doc_src/cmds/fish_git_prompt.rst
@@ -110,7 +110,7 @@ Variables used with ``showupstream`` (also implied by informative status):
 
 - ``$__fish_git_prompt_char_upstream_ahead`` (>, ↑) - the character for the commits this repository is ahead of upstream
 - ``$__fish_git_prompt_char_upstream_behind`` (<, ↓) - the character for the commits this repository is behind upstream
-- ``$__fish_git_prompt_char_upstream_diverged`` (<>) - the symbol if this repository is both ahead and behind upstream
+- ``$__fish_git_prompt_char_upstream_diverged`` (<>, ↓↑) - the symbol if this repository is both ahead and behind upstream
 - ``$__fish_git_prompt_char_upstream_equal`` (=) - the symbol if this repo is equal to upstream
 - ``$__fish_git_prompt_char_upstream_prefix`` ('')
 - ``$__fish_git_prompt_color_upstream``

--- a/share/functions/fish_git_prompt.fish
+++ b/share/functions/fish_git_prompt.fish
@@ -586,7 +586,7 @@ function __fish_git_prompt_validate_chars --description "fish_git_prompt helper,
     __fish_git_prompt_set_char __fish_git_prompt_char_untrackedfiles '%' '…'
     __fish_git_prompt_set_char __fish_git_prompt_char_upstream_ahead '>' '↑'
     __fish_git_prompt_set_char __fish_git_prompt_char_upstream_behind '<' '↓'
-    __fish_git_prompt_set_char __fish_git_prompt_char_upstream_diverged '<>'
+    __fish_git_prompt_set_char __fish_git_prompt_char_upstream_diverged '<>' '↓↑'
     __fish_git_prompt_set_char __fish_git_prompt_char_upstream_equal '='
     __fish_git_prompt_set_char __fish_git_prompt_char_upstream_prefix ''
 


### PR DESCRIPTION
## Description

Currently, `__fish_git_prompt_char_upstream_diverged` can only be set to a combination of `__fish_git_prompt_char_upstream_behind` and `__fish_git_prompt_char_upstream_ahead`s plain-text options (<>). Adding a combination of the less plain character options (↓↑) gives users more options.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Added less plain `__fish_git_prompt_char_upstream_diverged` option.
