### PR TITLE
Fix release workflow syntax

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,12 @@
 name: Create a new release
 
-on: workflow_dispatch
-  inputs:
-    version:
-      description: 'Version to release (tag name)'
-      required: true
-      type: string
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (tag name)'
+        required: true
+        type: string
 
 permissions:
   contents: write


### PR DESCRIPTION
The previous version results in an immediate workflow failure due to a syntax error in the YAML. `workflow_dispatch` should be a dictionary key, with its value being another dictionary (whose only key is `inputs` at the moment).

Example of the failure: https://github.com/danielrainer/fish-shell/actions/runs/17924202509

Relevant docs: https://github.com/danielrainer/fish-shell/actions/runs/17924202509