### PR TITLE
completions/help: correct the spelling of "redirection"

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -3035,7 +3035,7 @@ msgstr ""
 msgid "802.1p priority to set"
 msgstr ""
 
-msgid "< and > redirectoins"
+msgid "< and > redirections"
 msgstr ""
 
 msgid "<CMD> Command to execute"

--- a/po/en.po
+++ b/po/en.po
@@ -3031,7 +3031,7 @@ msgstr ""
 msgid "802.1p priority to set"
 msgstr ""
 
-msgid "< and > redirectoins"
+msgid "< and > redirections"
 msgstr ""
 
 msgid "<CMD> Command to execute"

--- a/po/fr.po
+++ b/po/fr.po
@@ -3132,7 +3132,7 @@ msgstr ""
 msgid "802.1p priority to set"
 msgstr ""
 
-msgid "< and > redirectoins"
+msgid "< and > redirections"
 msgstr ""
 
 msgid "<CMD> Command to execute"

--- a/po/pl.po
+++ b/po/pl.po
@@ -3027,7 +3027,7 @@ msgstr ""
 msgid "802.1p priority to set"
 msgstr ""
 
-msgid "< and > redirectoins"
+msgid "< and > redirections"
 msgstr ""
 
 msgid "<CMD> Command to execute"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -3032,7 +3032,7 @@ msgstr ""
 msgid "802.1p priority to set"
 msgstr ""
 
-msgid "< and > redirectoins"
+msgid "< and > redirections"
 msgstr ""
 
 msgid "<CMD> Command to execute"

--- a/po/sv.po
+++ b/po/sv.po
@@ -3030,7 +3030,7 @@ msgstr ""
 msgid "802.1p priority to set"
 msgstr ""
 
-msgid "< and > redirectoins"
+msgid "< and > redirections"
 msgstr ""
 
 msgid "<CMD> Command to execute"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -3030,8 +3030,8 @@ msgstr "64 位散列"
 msgid "802.1p priority to set"
 msgstr ""
 
-msgid "< and > redirectoins"
-msgstr "<和 > 重定向线"
+msgid "< and > redirections"
+msgstr ""
 
 msgid "<CMD> Command to execute"
 msgstr ""

--- a/share/completions/help.fish
+++ b/share/completions/help.fish
@@ -122,7 +122,7 @@ complete -c help -x -a exporting-variables -d "What set -x does"
 complete -c help -x -a functions -d "How to define functions"
 complete -c help -x -a home-directory-expansion -d "~ expansion"
 complete -c help -x -a index-range-expansion -d "var[x..y] slices"
-complete -c help -x -a input-output-redirection -d "< and > redirectoins"
+complete -c help -x -a input-output-redirection -d "< and > redirections"
 complete -c help -x -a lists -d "Variables with multiple elements"
 complete -c help -x -a loops-and-blocks -d "while, for and begin"
 complete -c help -x -a more-on-universal-variables


### PR DESCRIPTION
## Description

Correct the spelling of "redirection" in `share/completions/help.fish`.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
