### PR TITLE
webconfig: Replace str.stripprefix with str.removeprefix

### DIFF
--- a/share/tools/web_config/webconfig.py
+++ b/share/tools/web_config/webconfig.py
@@ -243,11 +243,11 @@ def parse_color(color_str):
         elif comp == "--underline" or comp == "-u":
             underline = "single"
         elif comp.startswith("--underline="):
-            underline = comp.stripprefix("--underline=")
+            underline = comp.removeprefix("--underline=")
         elif comp.startswith(
             "-u"
         ):  # Multiple short options like "-rucurly" are not yet supported.
-            underline = comp.stripprefix("-u")
+            underline = comp.removeprefix("-u")
         elif comp == "--italics" or comp == "-i":
             italics = True
         elif comp == "--dim" or comp == "-d":


### PR DESCRIPTION
## Description

After playing around with web config, I got the following traceback:

```
Exception occurred during processing of request from ('::ffff:127.0.0.1', 47492, 0, 0)
Traceback (most recent call last):
  File "/usr/lib/python3.13/socketserver.py", line 697, in process_request_thread
    self.finish_request(request, client_address)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/socketserver.py", line 362, in finish_request
    self.RequestHandlerClass(request, client_address, self)
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/http/server.py", line 672, in __init__
    super().__init__(*args, **kwargs)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/socketserver.py", line 766, in __init__
    self.handle()
    ~~~~~~~~~~~^^
  File "/usr/lib/python3.13/http/server.py", line 436, in handle
    self.handle_one_request()
    ~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/http/server.py", line 424, in handle_one_request
    method()
    ~~~~~~^^
  File "/usr/share/fish/tools/web_config/webconfig.py", line 1215, in do_GET
    curcolors, curinfo = self.do_get_colors()
                         ~~~~~~~~~~~~~~~~~~^^
  File "/usr/share/fish/tools/web_config/webconfig.py", line 880, in do_get_colors
    data.update(parse_color(color_value))
                ~~~~~~~~~~~^^^^^^^^^^^^^
  File "/usr/share/fish/tools/web_config/webconfig.py", line 248, in parse_color
    underline = comp.stripprefix("--underline=")
                ^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'stripprefix'
```

str.stripprefix doesn't exist in Python:
https://docs.python.org/3/library/stdtypes.html#str.removeprefix

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
