### PR TITLE
Remove useless comments

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -200,7 +200,6 @@ msgstr "%ls: %ls: ungültiger Unterbefehl\n"
 msgid "%ls: %ls: invalid variable name. See `help identifiers`\n"
 msgstr ""
 
-#
 #, c-format
 msgid "%ls: %ls: option does not take an argument\n"
 msgstr ""
@@ -409,7 +408,6 @@ msgstr ""
 msgid "%ls: Invalid --min-args value '%ls'\n"
 msgstr ""
 
-#
 #, c-format
 msgid "%ls: Invalid --unknown-arguments value '%ls'\n"
 msgstr ""
@@ -702,7 +700,6 @@ msgstr ""
 msgid "%ls: expected a numeric value"
 msgstr "%ls: Erwartete numerischen Wert"
 
-#
 #, c-format
 msgid "%ls: fish was not built with embedded files"
 msgstr ""
@@ -799,17 +796,14 @@ msgstr ""
 msgid "%s"
 msgstr ""
 
-#
 #, c-format
 msgid "%s %s: unrecognized feature '%ls'"
 msgstr ""
 
-#
 #, c-format
 msgid "%s and %s are mutually exclusive"
 msgstr ""
 
-#
 #, c-format
 msgid "%s could not read response to Primary Device Attribute query after waiting for %d seconds. This is often due to a missing feature in your terminal. See 'help terminal-compatibility' or 'man fish-terminal-compatibility'. This %s process will no longer wait for outstanding queries, which disables some optional features."
 msgstr ""
@@ -1117,7 +1111,6 @@ msgstr ""
 msgid "Failed to assign shell to its own process group"
 msgstr "Konnte Shell nicht einer eigenen Prozessgruppe zuweisen"
 
-#
 #, c-format
 msgid "Failed to set terminal mode (%s)"
 msgstr ""
@@ -1195,7 +1188,6 @@ msgstr "Illegale Instruktion"
 msgid "Incomplete escape sequence '%ls'"
 msgstr "Unvollständige Escapesequenz '%ls'"
 
-#
 msgid "Information request"
 msgstr ""
 
@@ -1522,7 +1514,6 @@ msgstr "Derzeit ausführende Funktion stoppen"
 msgid "Stop the innermost loop"
 msgstr "Innerste Schleife beenden"
 
-#
 msgid "Synchronized file access"
 msgstr ""
 
@@ -1710,7 +1701,6 @@ msgstr "Nicht passender Platzhalter"
 msgid "Unsupported use of '='. In fish, please use 'set %ls %ls'."
 msgstr ""
 
-#
 msgid "Unused signal"
 msgstr ""
 
@@ -1738,7 +1728,6 @@ msgstr ""
 msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
 msgstr ""
 
-#
 msgid "Virtual timer expired"
 msgstr ""
 

--- a/po/en.po
+++ b/po/en.po
@@ -198,7 +198,6 @@ msgstr ""
 msgid "%ls: %ls: invalid variable name. See `help identifiers`\n"
 msgstr ""
 
-#
 #, c-format
 msgid "%ls: %ls: option does not take an argument\n"
 msgstr ""
@@ -379,7 +378,6 @@ msgstr "%ls: Expected exactly two names (current function name, and new function
 msgid "%ls: Expected generic | variable | signal | exit | job-id for --handlers-type\n"
 msgstr ""
 
-#
 #, c-format
 msgid "%ls: Function '%ls' already exists. Cannot create copy of '%ls'\n"
 msgstr ""
@@ -408,7 +406,6 @@ msgstr ""
 msgid "%ls: Invalid --min-args value '%ls'\n"
 msgstr ""
 
-#
 #, c-format
 msgid "%ls: Invalid --unknown-arguments value '%ls'\n"
 msgstr ""
@@ -701,7 +698,6 @@ msgstr ""
 msgid "%ls: expected a numeric value"
 msgstr "%ls: expected a numeric value"
 
-#
 #, c-format
 msgid "%ls: fish was not built with embedded files"
 msgstr ""
@@ -798,17 +794,14 @@ msgstr ""
 msgid "%s"
 msgstr ""
 
-#
 #, c-format
 msgid "%s %s: unrecognized feature '%ls'"
 msgstr ""
 
-#
 #, c-format
 msgid "%s and %s are mutually exclusive"
 msgstr ""
 
-#
 #, c-format
 msgid "%s could not read response to Primary Device Attribute query after waiting for %d seconds. This is often due to a missing feature in your terminal. See 'help terminal-compatibility' or 'man fish-terminal-compatibility'. This %s process will no longer wait for outstanding queries, which disables some optional features."
 msgstr ""
@@ -912,7 +905,6 @@ msgstr "An error occurred while setting up pipe"
 msgid "Argument is not a number: '%ls'"
 msgstr ""
 
-#
 msgid "Await background process completion"
 msgstr ""
 
@@ -1117,7 +1109,6 @@ msgstr ""
 msgid "Failed to assign shell to its own process group"
 msgstr ""
 
-#
 #, c-format
 msgid "Failed to set terminal mode (%s)"
 msgstr ""
@@ -1521,7 +1512,6 @@ msgstr "Stop the currently evaluated function"
 msgid "Stop the innermost loop"
 msgstr "Stop the innermost loop"
 
-#
 msgid "Synchronized file access"
 msgstr ""
 
@@ -1736,7 +1726,6 @@ msgstr ""
 msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
 msgstr ""
 
-#
 msgid "Virtual timer expired"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -299,7 +299,6 @@ msgstr ""
 msgid "%ls: %ls: invalid variable name. See `help identifiers`\n"
 msgstr ""
 
-#
 #, c-format
 msgid "%ls: %ls: option does not take an argument\n"
 msgstr ""
@@ -480,7 +479,6 @@ msgstr "%ls : Exactement deux noms attendus (noms de fonctions actuel et projet
 msgid "%ls: Expected generic | variable | signal | exit | job-id for --handlers-type\n"
 msgstr ""
 
-#
 #, c-format
 msgid "%ls: Function '%ls' already exists. Cannot create copy of '%ls'\n"
 msgstr ""
@@ -509,7 +507,6 @@ msgstr "%ls : Valeur --max-args '%ls' invalide\n"
 msgid "%ls: Invalid --min-args value '%ls'\n"
 msgstr "%ls : Valeur --min-args '%ls' invalide\n"
 
-#
 #, c-format
 msgid "%ls: Invalid --unknown-arguments value '%ls'\n"
 msgstr ""
@@ -802,7 +799,6 @@ msgstr ""
 msgid "%ls: expected a numeric value"
 msgstr "%ls : valeur numérique attendue"
 
-#
 #, c-format
 msgid "%ls: fish was not built with embedded files"
 msgstr ""
@@ -899,17 +895,14 @@ msgstr ""
 msgid "%s"
 msgstr ""
 
-#
 #, c-format
 msgid "%s %s: unrecognized feature '%ls'"
 msgstr ""
 
-#
 #, c-format
 msgid "%s and %s are mutually exclusive"
 msgstr ""
 
-#
 #, c-format
 msgid "%s could not read response to Primary Device Attribute query after waiting for %d seconds. This is often due to a missing feature in your terminal. See 'help terminal-compatibility' or 'man fish-terminal-compatibility'. This %s process will no longer wait for outstanding queries, which disables some optional features."
 msgstr ""
@@ -1013,7 +1006,6 @@ msgstr "Une erreur est survenue lors du paramétrage du tube"
 msgid "Argument is not a number: '%ls'"
 msgstr ""
 
-#
 msgid "Await background process completion"
 msgstr ""
 
@@ -1218,7 +1210,6 @@ msgstr ""
 msgid "Failed to assign shell to its own process group"
 msgstr ""
 
-#
 #, c-format
 msgid "Failed to set terminal mode (%s)"
 msgstr ""
@@ -1622,7 +1613,6 @@ msgstr "Arrêter la fonction actuellement en évaluation"
 msgid "Stop the innermost loop"
 msgstr "Arrêter la boucle interne"
 
-#
 msgid "Synchronized file access"
 msgstr ""
 
@@ -1837,7 +1827,6 @@ msgstr "Les variables ne peuvent être placées entre crochets. Dans fish, veuil
 msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
 msgstr "Les variables ne peuvent être placées entre crochets. Dans fish, veuillez utiliser {$%ls}."
 
-#
 msgid "Virtual timer expired"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -194,7 +194,6 @@ msgstr ""
 msgid "%ls: %ls: invalid variable name. See `help identifiers`\n"
 msgstr ""
 
-#
 #, c-format
 msgid "%ls: %ls: option does not take an argument\n"
 msgstr ""
@@ -375,7 +374,6 @@ msgstr "%ls: Oczekiwano dokładnie dwóch nazw (nazwa obecnej funkcji i nazwa no
 msgid "%ls: Expected generic | variable | signal | exit | job-id for --handlers-type\n"
 msgstr ""
 
-#
 #, c-format
 msgid "%ls: Function '%ls' already exists. Cannot create copy of '%ls'\n"
 msgstr ""
@@ -404,7 +402,6 @@ msgstr ""
 msgid "%ls: Invalid --min-args value '%ls'\n"
 msgstr ""
 
-#
 #, c-format
 msgid "%ls: Invalid --unknown-arguments value '%ls'\n"
 msgstr ""
@@ -697,7 +694,6 @@ msgstr ""
 msgid "%ls: expected a numeric value"
 msgstr "%ls: oczekiwano wartości liczbowej"
 
-#
 #, c-format
 msgid "%ls: fish was not built with embedded files"
 msgstr ""
@@ -794,17 +790,14 @@ msgstr ""
 msgid "%s"
 msgstr ""
 
-#
 #, c-format
 msgid "%s %s: unrecognized feature '%ls'"
 msgstr ""
 
-#
 #, c-format
 msgid "%s and %s are mutually exclusive"
 msgstr ""
 
-#
 #, c-format
 msgid "%s could not read response to Primary Device Attribute query after waiting for %d seconds. This is often due to a missing feature in your terminal. See 'help terminal-compatibility' or 'man fish-terminal-compatibility'. This %s process will no longer wait for outstanding queries, which disables some optional features."
 msgstr ""
@@ -908,7 +901,6 @@ msgstr ""
 msgid "Argument is not a number: '%ls'"
 msgstr ""
 
-#
 msgid "Await background process completion"
 msgstr ""
 
@@ -1113,7 +1105,6 @@ msgstr ""
 msgid "Failed to assign shell to its own process group"
 msgstr ""
 
-#
 #, c-format
 msgid "Failed to set terminal mode (%s)"
 msgstr ""
@@ -1517,7 +1508,6 @@ msgstr "Zatrzymaj obecnie używaną funkcję"
 msgid "Stop the innermost loop"
 msgstr ""
 
-#
 msgid "Synchronized file access"
 msgstr ""
 
@@ -1732,7 +1722,6 @@ msgstr "Zmienne nie mogą znajdować się w nawiasach. W fish używane jest \"$%
 msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
 msgstr "Zmienne nie mogą znajdować się w nawiasach. W fish używane jest {$%ls}."
 
-#
 msgid "Virtual timer expired"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -199,7 +199,6 @@ msgstr ""
 msgid "%ls: %ls: invalid variable name. See `help identifiers`\n"
 msgstr ""
 
-#
 #, c-format
 msgid "%ls: %ls: option does not take an argument\n"
 msgstr ""
@@ -380,7 +379,6 @@ msgstr "%ls: Esperava exatamente dois nomes (nome atual da função, e novo nome
 msgid "%ls: Expected generic | variable | signal | exit | job-id for --handlers-type\n"
 msgstr ""
 
-#
 #, c-format
 msgid "%ls: Function '%ls' already exists. Cannot create copy of '%ls'\n"
 msgstr ""
@@ -409,7 +407,6 @@ msgstr ""
 msgid "%ls: Invalid --min-args value '%ls'\n"
 msgstr ""
 
-#
 #, c-format
 msgid "%ls: Invalid --unknown-arguments value '%ls'\n"
 msgstr ""
@@ -702,7 +699,6 @@ msgstr ""
 msgid "%ls: expected a numeric value"
 msgstr "%ls: esperava valor numérico"
 
-#
 #, c-format
 msgid "%ls: fish was not built with embedded files"
 msgstr ""
@@ -799,17 +795,14 @@ msgstr ""
 msgid "%s"
 msgstr ""
 
-#
 #, c-format
 msgid "%s %s: unrecognized feature '%ls'"
 msgstr ""
 
-#
 #, c-format
 msgid "%s and %s are mutually exclusive"
 msgstr ""
 
-#
 #, c-format
 msgid "%s could not read response to Primary Device Attribute query after waiting for %d seconds. This is often due to a missing feature in your terminal. See 'help terminal-compatibility' or 'man fish-terminal-compatibility'. This %s process will no longer wait for outstanding queries, which disables some optional features."
 msgstr ""
@@ -913,7 +906,6 @@ msgstr "Ocorreu um erro ao preparar pipe"
 msgid "Argument is not a number: '%ls'"
 msgstr ""
 
-#
 msgid "Await background process completion"
 msgstr ""
 
@@ -1118,7 +1110,6 @@ msgstr ""
 msgid "Failed to assign shell to its own process group"
 msgstr ""
 
-#
 #, c-format
 msgid "Failed to set terminal mode (%s)"
 msgstr ""
@@ -1522,7 +1513,6 @@ msgstr "Pára a função em execução"
 msgid "Stop the innermost loop"
 msgstr "Pára o laço mais interno"
 
-#
 msgid "Synchronized file access"
 msgstr ""
 
@@ -1737,7 +1727,6 @@ msgstr ""
 msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
 msgstr ""
 
-#
 msgid "Virtual timer expired"
 msgstr ""
 
@@ -19604,11 +19593,6 @@ msgstr ""
 msgid "Do not list files that match the given pattern"
 msgstr ""
 
-# Notas:
-# Adicionar nota
-#
-# Caminhos:
-# share/functions/__fish_complete_ls.fish:49
 msgid "Do not list implied entries matching specified shell pattern"
 msgstr "Não lista entradas com o padrão especificado"
 
@@ -26017,11 +26001,6 @@ msgstr ""
 msgid "File is on filesystem of specified type"
 msgstr ""
 
-# Notas:
-# Adicionar nota
-#
-# Caminhos:
-# share/functions/__fish_complete_ls.fish:49
 msgid "File is symlink matching specified case insensitive pattern"
 msgstr ""
 
@@ -36558,12 +36537,6 @@ msgstr ""
 msgid "Machine-readable description of custom origin"
 msgstr ""
 
-# Notas:
-# Adicionar nota
-#
-# Caminhos:
-# proc.cpp:1279
-# proc.cpp:1305
 msgid "Mail address to send alerts to"
 msgstr ""
 
@@ -46062,12 +46035,6 @@ msgstr ""
 msgid "Process last file first"
 msgstr ""
 
-# Notas:
-# Adicionar nota
-#
-# Caminhos:
-# proc.cpp:1279
-# proc.cpp:1305
 msgid "Process log file"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -195,7 +195,6 @@ msgstr ""
 msgid "%ls: %ls: invalid variable name. See `help identifiers`\n"
 msgstr ""
 
-#
 #, c-format
 msgid "%ls: %ls: option does not take an argument\n"
 msgstr ""
@@ -376,7 +375,6 @@ msgstr ""
 msgid "%ls: Expected generic | variable | signal | exit | job-id for --handlers-type\n"
 msgstr ""
 
-#
 #, c-format
 msgid "%ls: Function '%ls' already exists. Cannot create copy of '%ls'\n"
 msgstr ""
@@ -405,7 +403,6 @@ msgstr ""
 msgid "%ls: Invalid --min-args value '%ls'\n"
 msgstr ""
 
-#
 #, c-format
 msgid "%ls: Invalid --unknown-arguments value '%ls'\n"
 msgstr ""
@@ -698,7 +695,6 @@ msgstr ""
 msgid "%ls: expected a numeric value"
 msgstr ""
 
-#
 #, c-format
 msgid "%ls: fish was not built with embedded files"
 msgstr ""
@@ -795,17 +791,14 @@ msgstr ""
 msgid "%s"
 msgstr ""
 
-#
 #, c-format
 msgid "%s %s: unrecognized feature '%ls'"
 msgstr ""
 
-#
 #, c-format
 msgid "%s and %s are mutually exclusive"
 msgstr ""
 
-#
 #, c-format
 msgid "%s could not read response to Primary Device Attribute query after waiting for %d seconds. This is often due to a missing feature in your terminal. See 'help terminal-compatibility' or 'man fish-terminal-compatibility'. This %s process will no longer wait for outstanding queries, which disables some optional features."
 msgstr ""
@@ -909,7 +902,6 @@ msgstr "Ett fel inträffade under skapandet av ett rör"
 msgid "Argument is not a number: '%ls'"
 msgstr ""
 
-#
 msgid "Await background process completion"
 msgstr ""
 
@@ -1114,7 +1106,6 @@ msgstr ""
 msgid "Failed to assign shell to its own process group"
 msgstr ""
 
-#
 #, c-format
 msgid "Failed to set terminal mode (%s)"
 msgstr ""
@@ -1518,7 +1509,6 @@ msgstr "Avbryt den nuvarande funktionen"
 msgid "Stop the innermost loop"
 msgstr "Avbryt den innersta loopen"
 
-#
 msgid "Synchronized file access"
 msgstr ""
 
@@ -1733,7 +1723,6 @@ msgstr ""
 msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
 msgstr ""
 
-#
 msgid "Virtual timer expired"
 msgstr ""
 
@@ -2069,14 +2058,12 @@ msgstr ""
 msgid "Too many args for cd command"
 msgstr ""
 
-#
 msgid "Type %shelp%s for instructions on how to use fish"
 msgstr "Skriv %shelp%s för instruktioner om hur man använder fish"
 
 msgid "Warning: the file containing this function has not been saved. Changes may be lost when fish is closed."
 msgstr ""
 
-#
 msgid "Welcome to fish, the friendly interactive shell"
 msgstr "Välkommen till fish, det vänliga interaktiva skalet"
 


### PR DESCRIPTION
Most of them have been added automatically for no good reason.

Also remove outdated comments referring to source locations in pt_BR.po.
