### PR TITLE
Refactor PO section marking

### DIFF
--- a/build_tools/fish_xgettext.fish
+++ b/build_tools/fish_xgettext.fish
@@ -31,7 +31,15 @@ begin
         or exit 1
     end
 
-    echo '# fish-section-tier1-from-rust'
+    function mark_section
+        set -l section_name $argv[1]
+        echo 'msgid "fish-section-'$section_name'"'
+        echo 'msgstr ""'
+        echo ''
+    end
+
+    mark_section tier1-from-rust
+
     # Get rid of duplicates and sort.
     msguniq --no-wrap --strict --sort-output $rust_extraction_file
     or exit 1
@@ -77,13 +85,13 @@ begin
         # This regex handles explicit requests to translate a message. These are more important to translate
         # than messages which should be implicitly translated.
         set -l explicit_regex '.*\( *_ (([\'"]).+?(?<!\\\\)\\2) *\).*'
-        echo "# fish-section-$tier-from-script-explicitly-added"
+        mark_section "$tier-from-script-explicitly-added"
         extract_fish_script_messages_impl $explicit_regex $argv
 
         # This regex handles descriptions for `complete` and `function` statements. These messages are not
         # particularly important to translate. Hence the "implicit" label.
         set -l implicit_regex '^(?:\s|and |or )*(?:complete|function).*? (?:-d|--description) (([\'"]).+?(?<!\\\\)\\2).*'
-        echo "# fish-section-$tier-from-script-implicitly-added"
+        mark_section "$tier-from-script-implicitly-added"
         extract_fish_script_messages_impl $implicit_regex $argv
     end
 

--- a/po/de.po
+++ b/po/de.po
@@ -1,4 +1,4 @@
-# fish-note-sections: Translations are divided into sections, each starting with a fish-section-* comment.
+# fish-note-sections: Translations are divided into sections, each starting with a fish-section-* pseudo-message.
 # fish-note-sections: The first few sections are more important.
 # fish-note-sections: Ignore the tier3 sections unless you have a lot of time.
 # translation of de.po to deutsch
@@ -21,6 +21,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.5\n"
 
+msgid "fish-section-tier1-from-rust"
+msgstr ""
+
 msgid ""
 "\n"
 "   PID  Command\n"
@@ -29,7 +32,6 @@ msgstr ""
 "   PID  Befehl\n"
 
 #, c-format
-# fish-section-tier1-from-rust
 msgid " (%ls)\n"
 msgstr " (%ls)\n"
 
@@ -1891,7 +1893,9 @@ msgstr "unbegrenzt\n"
 msgid "|& is not valid. In fish, use &| to pipe both stdout and stderr."
 msgstr "|& ist ungültig. In fish, nutze &| um stdout und stderr gleichzeitig zu pipen"
 
-# fish-section-tier1-from-script-explicitly-added
+msgid "fish-section-tier1-from-script-explicitly-added"
+msgstr ""
+
 msgid "%ls: %ls: expected %d arguments; got %d\\n"
 msgstr ""
 
@@ -2114,7 +2118,9 @@ msgstr "oder die Datei war leer"
 msgid "python executable not found"
 msgstr ""
 
-# fish-section-tier1-from-script-implicitly-added
+msgid "fish-section-tier1-from-script-implicitly-added"
+msgstr ""
+
 msgid "# comments"
 msgstr ""
 
@@ -3816,7 +3822,12 @@ msgstr ""
 msgid "~ expansion"
 msgstr ""
 
-# fish-section-tier3-from-script-implicitly-added
+msgid "fish-section-tier3-from-script-explicitly-added"
+msgstr ""
+
+msgid "fish-section-tier3-from-script-implicitly-added"
+msgstr ""
+
 msgid " "
 msgstr ""
 

--- a/po/en.po
+++ b/po/en.po
@@ -1,4 +1,4 @@
-# fish-note-sections: Translations are divided into sections, each starting with a fish-section-* comment.
+# fish-note-sections: Translations are divided into sections, each starting with a fish-section-* pseudo-message.
 # fish-note-sections: The first few sections are more important.
 # fish-note-sections: Ignore the tier3 sections unless you have a lot of time.
 # SOME DESCRIPTIVE TITLE.
@@ -21,13 +21,15 @@ msgstr ""
 "X-Poedit-Basepath: /home/david/src/fish-shell\n"
 "X-Generator: Poedit 1.8.11\n"
 
+msgid "fish-section-tier1-from-rust"
+msgstr ""
+
 msgid ""
 "\n"
 "   PID  Command\n"
 msgstr ""
 
 #, c-format
-# fish-section-tier1-from-rust
 msgid " (%ls)\n"
 msgstr ""
 
@@ -1889,7 +1891,9 @@ msgstr ""
 msgid "|& is not valid. In fish, use &| to pipe both stdout and stderr."
 msgstr ""
 
-# fish-section-tier1-from-script-explicitly-added
+msgid "fish-section-tier1-from-script-explicitly-added"
+msgstr ""
+
 msgid "%ls: %ls: expected %d arguments; got %d\\n"
 msgstr ""
 
@@ -2112,7 +2116,9 @@ msgstr ""
 msgid "python executable not found"
 msgstr ""
 
-# fish-section-tier1-from-script-implicitly-added
+msgid "fish-section-tier1-from-script-implicitly-added"
+msgstr ""
+
 msgid "# comments"
 msgstr ""
 
@@ -3814,7 +3820,12 @@ msgstr ""
 msgid "~ expansion"
 msgstr ""
 
-# fish-section-tier3-from-script-implicitly-added
+msgid "fish-section-tier3-from-script-explicitly-added"
+msgstr ""
+
+msgid "fish-section-tier3-from-script-implicitly-added"
+msgstr ""
+
 msgid " "
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,4 +1,4 @@
-# fish-note-sections: Translations are divided into sections, each starting with a fish-section-* comment.
+# fish-note-sections: Translations are divided into sections, each starting with a fish-section-* pseudo-message.
 # fish-note-sections: The first few sections are more important.
 # fish-note-sections: Ignore the tier3 sections unless you have a lot of time.
 # translation of fr.po to Français
@@ -120,6 +120,9 @@ msgstr ""
 "X-Generator: Gtranslator 2.91.7\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
+msgid "fish-section-tier1-from-rust"
+msgstr ""
+
 msgid ""
 "\n"
 "   PID  Command\n"
@@ -128,7 +131,6 @@ msgstr ""
 "   PID Commande\n"
 
 #, c-format
-# fish-section-tier1-from-rust
 msgid " (%ls)\n"
 msgstr ""
 
@@ -1990,7 +1992,9 @@ msgstr ""
 msgid "|& is not valid. In fish, use &| to pipe both stdout and stderr."
 msgstr ""
 
-# fish-section-tier1-from-script-explicitly-added
+msgid "fish-section-tier1-from-script-explicitly-added"
+msgstr ""
+
 msgid "%ls: %ls: expected %d arguments; got %d\\n"
 msgstr ""
 
@@ -2213,7 +2217,9 @@ msgstr "ou le fichier était vide"
 msgid "python executable not found"
 msgstr "Exécutable python introuvable"
 
-# fish-section-tier1-from-script-implicitly-added
+msgid "fish-section-tier1-from-script-implicitly-added"
+msgstr ""
+
 msgid "# comments"
 msgstr ""
 
@@ -3915,7 +3921,12 @@ msgstr ""
 msgid "~ expansion"
 msgstr ""
 
-# fish-section-tier3-from-script-implicitly-added
+msgid "fish-section-tier3-from-script-explicitly-added"
+msgstr ""
+
+msgid "fish-section-tier3-from-script-implicitly-added"
+msgstr ""
+
 msgid " "
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -1,4 +1,4 @@
-# fish-note-sections: Translations are divided into sections, each starting with a fish-section-* comment.
+# fish-note-sections: Translations are divided into sections, each starting with a fish-section-* pseudo-message.
 # fish-note-sections: The first few sections are more important.
 # fish-note-sections: Ignore the tier3 sections unless you have a lot of time.
 # Translation of fish in Polish
@@ -17,13 +17,15 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 "X-Generator: GlotPress/2.2.2\n"
 
+msgid "fish-section-tier1-from-rust"
+msgstr ""
+
 msgid ""
 "\n"
 "   PID  Command\n"
 msgstr ""
 
 #, c-format
-# fish-section-tier1-from-rust
 msgid " (%ls)\n"
 msgstr ""
 
@@ -1885,7 +1887,9 @@ msgstr ""
 msgid "|& is not valid. In fish, use &| to pipe both stdout and stderr."
 msgstr ""
 
-# fish-section-tier1-from-script-explicitly-added
+msgid "fish-section-tier1-from-script-explicitly-added"
+msgstr ""
+
 msgid "%ls: %ls: expected %d arguments; got %d\\n"
 msgstr ""
 
@@ -2108,7 +2112,9 @@ msgstr ""
 msgid "python executable not found"
 msgstr ""
 
-# fish-section-tier1-from-script-implicitly-added
+msgid "fish-section-tier1-from-script-implicitly-added"
+msgstr ""
+
 msgid "# comments"
 msgstr ""
 
@@ -3810,7 +3816,12 @@ msgstr ""
 msgid "~ expansion"
 msgstr ""
 
-# fish-section-tier3-from-script-implicitly-added
+msgid "fish-section-tier3-from-script-explicitly-added"
+msgstr ""
+
+msgid "fish-section-tier3-from-script-implicitly-added"
+msgstr ""
+
 msgid " "
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1,4 +1,4 @@
-# fish-note-sections: Translations are divided into sections, each starting with a fish-section-* comment.
+# fish-note-sections: Translations are divided into sections, each starting with a fish-section-* pseudo-message.
 # fish-note-sections: The first few sections are more important.
 # fish-note-sections: Ignore the tier3 sections unless you have a lot of time.
 # Portuguese translations for fish package.
@@ -22,13 +22,15 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 1.8.4\n"
 
+msgid "fish-section-tier1-from-rust"
+msgstr ""
+
 msgid ""
 "\n"
 "   PID  Command\n"
 msgstr ""
 
 #, c-format
-# fish-section-tier1-from-rust
 msgid " (%ls)\n"
 msgstr ""
 
@@ -1890,7 +1892,9 @@ msgstr ""
 msgid "|& is not valid. In fish, use &| to pipe both stdout and stderr."
 msgstr ""
 
-# fish-section-tier1-from-script-explicitly-added
+msgid "fish-section-tier1-from-script-explicitly-added"
+msgstr ""
+
 msgid "%ls: %ls: expected %d arguments; got %d\\n"
 msgstr ""
 
@@ -2113,7 +2117,9 @@ msgstr ""
 msgid "python executable not found"
 msgstr "executável python não encontrado"
 
-# fish-section-tier1-from-script-implicitly-added
+msgid "fish-section-tier1-from-script-implicitly-added"
+msgstr ""
+
 msgid "# comments"
 msgstr ""
 
@@ -3815,7 +3821,12 @@ msgstr ""
 msgid "~ expansion"
 msgstr ""
 
-# fish-section-tier3-from-script-implicitly-added
+msgid "fish-section-tier3-from-script-explicitly-added"
+msgstr ""
+
+msgid "fish-section-tier3-from-script-implicitly-added"
+msgstr ""
+
 msgid " "
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -1,4 +1,4 @@
-# fish-note-sections: Translations are divided into sections, each starting with a fish-section-* comment.
+# fish-note-sections: Translations are divided into sections, each starting with a fish-section-* pseudo-message.
 # fish-note-sections: The first few sections are more important.
 # fish-note-sections: Ignore the tier3 sections unless you have a lot of time.
 # Copyright © 2006
@@ -18,13 +18,15 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+msgid "fish-section-tier1-from-rust"
+msgstr ""
+
 msgid ""
 "\n"
 "   PID  Command\n"
 msgstr ""
 
 #, c-format
-# fish-section-tier1-from-rust
 msgid " (%ls)\n"
 msgstr ""
 
@@ -1886,7 +1888,9 @@ msgstr ""
 msgid "|& is not valid. In fish, use &| to pipe both stdout and stderr."
 msgstr ""
 
-# fish-section-tier1-from-script-explicitly-added
+msgid "fish-section-tier1-from-script-explicitly-added"
+msgstr ""
+
 msgid "%ls: %ls: expected %d arguments; got %d\\n"
 msgstr ""
 
@@ -2109,7 +2113,9 @@ msgstr ""
 msgid "python executable not found"
 msgstr ""
 
-# fish-section-tier1-from-script-implicitly-added
+msgid "fish-section-tier1-from-script-implicitly-added"
+msgstr ""
+
 msgid "# comments"
 msgstr ""
 
@@ -3811,7 +3817,12 @@ msgstr ""
 msgid "~ expansion"
 msgstr ""
 
-# fish-section-tier3-from-script-implicitly-added
+msgid "fish-section-tier3-from-script-explicitly-added"
+msgstr ""
+
+msgid "fish-section-tier3-from-script-implicitly-added"
+msgstr ""
+
 msgid " "
 msgstr ""
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1,4 +1,4 @@
-# fish-note-sections: Translations are divided into sections, each starting with a fish-section-* comment.
+# fish-note-sections: Translations are divided into sections, each starting with a fish-section-* pseudo-message.
 # fish-note-sections: The first few sections are more important.
 # fish-note-sections: Ignore the tier3 sections unless you have a lot of time.
 #
@@ -42,6 +42,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.7\n"
 
+msgid "fish-section-tier1-from-rust"
+msgstr ""
+
 msgid ""
 "\n"
 "   PID  Command\n"
@@ -50,7 +53,6 @@ msgstr ""
 "   PID  命令\n"
 
 #, c-format
-# fish-section-tier1-from-rust
 msgid " (%ls)\n"
 msgstr " (%ls)\n"
 
@@ -1918,7 +1920,9 @@ msgstr "无限制\n"
 msgid "|& is not valid. In fish, use &| to pipe both stdout and stderr."
 msgstr "|& 无效。在 fish 中，用 &| 来同时管道链接 stdout 和 stderr。"
 
-# fish-section-tier1-from-script-explicitly-added
+msgid "fish-section-tier1-from-script-explicitly-added"
+msgstr ""
+
 msgid "%ls: %ls: expected %d arguments; got %d\\n"
 msgstr "%ls: %ls: 期望 %d 个参数；收到 %d 个\\n"
 
@@ -2141,7 +2145,9 @@ msgstr "或文件为空"
 msgid "python executable not found"
 msgstr "找不到 python 可执行文件"
 
-# fish-section-tier1-from-script-implicitly-added
+msgid "fish-section-tier1-from-script-implicitly-added"
+msgstr ""
+
 msgid "# comments"
 msgstr "# 注释"
 
@@ -3843,7 +3849,12 @@ msgstr "{a,b} 大括号展开"
 msgid "~ expansion"
 msgstr "~ 展开"
 
-# fish-section-tier3-from-script-implicitly-added
+msgid "fish-section-tier3-from-script-explicitly-added"
+msgstr ""
+
+msgid "fish-section-tier3-from-script-implicitly-added"
+msgstr ""
+
 msgid " "
 msgstr " "
 


### PR DESCRIPTION
Use msgids to mark sections. In the PO format, comments are associated
with specific messages, which does not match the semantics for section
markers.
Furthermore, comments are not preserved by `msgmerge`, which required
quite convoluted handling to copy them over from the template.
By using msgids to mark sections, this problem is avoided.

This convoluted handling was also used for header comments. Header
comments are now handled in a simpler way. There is a fixed prefix,
identifying these comments, as well as a list variable containing the
lines which should be put into the header. When a PO file is generated,
all existing lines starting with the prefix are deleted, the and the
current version of the lines is prepended to the file.

This is on top of #11843.