### PR TITLE
Check exit status of `msgfmt`

### DIFF
--- a/crates/gettext-maps/build.rs
+++ b/crates/gettext-maps/build.rs
@@ -97,6 +97,12 @@ fn embed_localizations(cache_dir: &Path) {
                     .arg(&po_file_path)
                     .output()
                     .unwrap();
+                if !output.status.success() {
+                    panic!(
+                        "msgfmt failed:\n{}",
+                        String::from_utf8(output.stderr).unwrap()
+                    );
+                }
                 let mo_data = output.stdout;
 
                 // Extract map from MO data.


### PR DESCRIPTION
Prior to this, when `msgfmt` failed, this would be detected indirectly by the parser, which would then panic due to it input being empty.

Explicit checking allows us to properly display `msgfmt`'s error message.