### PR TITLE
Extract messages without building default features

### DIFF
--- a/build_tools/fish_xgettext.fish
+++ b/build_tools/fish_xgettext.fish
@@ -27,7 +27,7 @@ begin
     else
         set rust_extraction_file (mktemp)
         # We need to build to ensure that the proc macro for extracting strings runs.
-        FISH_GETTEXT_EXTRACTION_FILE=$rust_extraction_file cargo check --features=gettext-extract
+        FISH_GETTEXT_EXTRACTION_FILE=$rust_extraction_file cargo check --no-default-features --features=gettext-extract
         or exit 1
     end
 


### PR DESCRIPTION
Default features are not needed for message extraction, so there is no need to spend any resources on them.

If a PO files contains a syntax error, extraction would fail if the `localize-messages` feature is active. This is undesirable, because it results in an unnecessary failure with worse error messages than if the `msgmerge` invocation of the `update_translations.fish` script fails.