### PR TITLE
Fix webconfig

### DIFF
--- a/share/tools/web_config/webconfig.py
+++ b/share/tools/web_config/webconfig.py
@@ -263,6 +263,10 @@ def parse_color(color_str):
             ) -> str:
                 if comp.startswith(long_opt):
                     c = comp[len(long_opt) :]
+                    if c[0] == "=":
+                        # There was a = between the long option and the value.
+                        # i.e. support also --background=red, not just --background red
+                        c = c[1:]
                     parsed_c = parse_one_color(c)
                     # We prefer the unparsed version - if it says "brgreen", we use brgreen,
                     # instead of 00ff00

--- a/share/tools/web_config/webconfig.py
+++ b/share/tools/web_config/webconfig.py
@@ -229,7 +229,7 @@ def parse_color(color_str):
     background_color = ""
     underline_color = ""
     bold = False
-    underline = False
+    underline = None
     italics = False
     dim = False
     reverse = False


### PR DESCRIPTION
## Description

Not sure since when, but I just used web_config to refresh my color theme and discovered that it generates some error as universal values.

This MR fix the 2 issues I got:

- the new underline style behavior make the default False value to be translated to `--underline=False`, which makes set_color not really happy
- a probably more old mistake was inside the parse_opt function, which did not support long options separated from their value with an = sign (i.e. `--background=red` instead of `--background red`), causing the = sign to be kept as part of the color value, leading after translation to universal variable to a wrong double = sign: `--background==red`.

Fixes issue #

## TODOs:

- [X] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed (I may be wrong but I think web_config does not have any test)
- [X] User-visible changes noted in CHANGELOG.rst (not sure we should document a fix?)