### PR TITLE
xgettext: remove `--strict` flag from msguniq

### DIFF
--- a/build_tools/fish_xgettext.fish
+++ b/build_tools/fish_xgettext.fish
@@ -41,7 +41,7 @@ begin
     mark_section tier1-from-rust
 
     # Get rid of duplicates and sort.
-    msguniq --no-wrap --strict --sort-output $rust_extraction_file
+    msguniq --no-wrap --sort-output $rust_extraction_file
     or exit 1
 
     if not set -l --query _flag_use_existing_template


### PR DESCRIPTION
As with `msgmerge`, this introduces unwanted empty comment lines above `#, c-format`
lines. We don't need this strict formatting, so we get rid of the flag and the associated empty comment lines.