### PR TITLE
Cleaned up, fixed bug, and added functionality to bind completions 

### DIFF
--- a/share/completions/bind.fish
+++ b/share/completions/bind.fish
@@ -1,46 +1,8 @@
-function __fish_bind_test1
-    set -l args
-    set -l use_keys no
-    for i in (commandline -pxc)
-        switch $i
-            case -k --k --ke --key
-                set use_keys yes
+set -l __fish_bind_optspecs M/mode= m/sets-mode= preset user s/silent a/all function-names list-modes e/erase
 
-            case "-*"
-
-            case "*"
-                set -a args $i
-        end
-    end
-
-    switch $use_keys
-        case yes
-            switch (count $args)
-                case 1
-                    return 0
-            end
-    end
-    return 1
-end
-
-function __fish_bind_test2
-    set -l args
-    for i in (commandline -pxc)
-        switch $i
-            case "-*"
-
-            case "*"
-                set -a args $i
-        end
-    end
-
-    switch (count $args)
-        case 2
-            return 0
-    end
-
-    return 1
-
+function __fish_bind_has_keys --inherit-variable __fish_bind_optspecs
+    argparse $_bind_opts -- $argv 2>/dev/null
+    test ( count $argv ) -ge 2 && return 0
 end
 
 complete -c bind -f
@@ -56,11 +18,10 @@ complete -c bind -s s -l silent -d 'Operate silently'
 complete -c bind -l preset -d 'Operate on preset bindings'
 complete -c bind -l user -d 'Operate on user bindings'
 
-complete -c bind -n __fish_bind_test2 -a '(bind --function-names)' -d 'Function name' -x
+complete -c bind -n '__fish_bind_has_keys (commandline -pcx)' -a '(bind --function-names)' -d 'Function name' -x
 
-function __fish_bind_complete
-    argparse M/mode= m/sets-mode= preset user s/silent \
-        a/all function-names list-modes e/erase -- (commandline -xpc)[2..] 2>/dev/null
+function __fish_bind_complete --inherit-variable __fish_bind_optspecs
+    argparse $__fish_bind_optspecs -- (commandline -xpc)[2..] 2>/dev/null
     or return 1
     set -l token (commandline -ct)
     if test (count $argv) = 0 && set -l prefix (string match -r -- '(.*,)?(ctrl-|alt-|shift-|super-)*' $token)


### PR DESCRIPTION
## Description

Since bind can take a series of functions in defining a keybinding, it didn't make sense to only provide completions for bind functions once. When I went to fix that, I saw the functions __fish_bind_test1 and __fish_bind_test2. The first isn't being used by anything I could see, so I removed it. 

The second one used iteration for counting args and discounting flags. Then used a switch/case block to check if there were 2 args which would be 'bind' and whatever key-combo. And it only checked if there were a total of 2. This means it fails after the first function is entered. If the commandline was  `bind -m MODE `, it would give the function completions along with the key completions. 

I went ahead and changed  the name of __fish_bind_test2 to be more descriptive. And just completely changed the function so it accounts for multiple functions and ignores counting bind's args/params.

Fixes issue #

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
