### PR TITLE
More printf cleanup

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -909,6 +909,10 @@ msgstr "Fehler beim Einrichten der Pipe aufgetreten"
 msgid "Argument is not a number: '%ls'"
 msgstr "Argument ist keine Zahl: '%ls'"
 
+#
+msgid "Argument type does not match conversion character"
+msgstr ""
+
 msgid "Await background process completion"
 msgstr "Auf den Abschluss von Hintergrundprozessen warten"
 
@@ -917,6 +921,10 @@ msgstr ""
 
 msgid "Backgrounded commands can not be used as conditionals"
 msgstr "Hintergrundbefehle können nicht als Bedingungen benutzt werden"
+
+#
+msgid "Bad format string"
+msgstr ""
 
 msgid "Bad system call"
 msgstr "Fehlerhafter Systemaufruf"
@@ -1138,6 +1146,11 @@ msgstr "Erzwungene Beendigung"
 msgid "Forced stop"
 msgstr "Erzwungener Stopp"
 
+#
+#, c-format
+msgid "Formatter error: %s"
+msgstr ""
+
 msgid "Generate random number"
 msgstr "Zufallszahl generieren"
 
@@ -1274,6 +1287,10 @@ msgstr "Unausgeglichene Klammern"
 
 msgid "Mismatched parenthesis"
 msgstr "Unausgeglichene Klammer"
+
+#
+msgid "Missing argument"
+msgstr ""
 
 msgid "Missing closing parenthesis"
 msgstr "Fehlende schließende Klammer"

--- a/po/en.po
+++ b/po/en.po
@@ -907,6 +907,10 @@ msgstr "An error occurred while setting up pipe"
 msgid "Argument is not a number: '%ls'"
 msgstr ""
 
+#
+msgid "Argument type does not match conversion character"
+msgstr ""
+
 msgid "Await background process completion"
 msgstr ""
 
@@ -915,6 +919,10 @@ msgstr ""
 
 msgid "Backgrounded commands can not be used as conditionals"
 msgstr "Backgrounded commands can not be used as conditionals"
+
+#
+msgid "Bad format string"
+msgstr ""
 
 msgid "Bad system call"
 msgstr "Bad system call"
@@ -1136,6 +1144,11 @@ msgstr "Forced quit"
 msgid "Forced stop"
 msgstr "Forced stop"
 
+#
+#, c-format
+msgid "Formatter error: %s"
+msgstr ""
+
 msgid "Generate random number"
 msgstr "Generate random number"
 
@@ -1271,6 +1284,10 @@ msgid "Mismatched braces"
 msgstr ""
 
 msgid "Mismatched parenthesis"
+msgstr ""
+
+#
+msgid "Missing argument"
 msgstr ""
 
 msgid "Missing closing parenthesis"

--- a/po/fr.po
+++ b/po/fr.po
@@ -1008,6 +1008,10 @@ msgstr "Une erreur est survenue lors du paramétrage du tube"
 msgid "Argument is not a number: '%ls'"
 msgstr ""
 
+#
+msgid "Argument type does not match conversion character"
+msgstr ""
+
 msgid "Await background process completion"
 msgstr ""
 
@@ -1016,6 +1020,10 @@ msgstr ""
 
 msgid "Backgrounded commands can not be used as conditionals"
 msgstr "Les commandes en arrière-plan ne peuvent être utilisées comme des conditionnelles"
+
+#
+msgid "Bad format string"
+msgstr ""
 
 msgid "Bad system call"
 msgstr "Mauvais appel système"
@@ -1237,6 +1245,11 @@ msgstr "Forcé à quitter"
 msgid "Forced stop"
 msgstr "Arrêt forcé"
 
+#
+#, c-format
+msgid "Formatter error: %s"
+msgstr ""
+
 msgid "Generate random number"
 msgstr "Génère un nombre aléatoire"
 
@@ -1372,6 +1385,10 @@ msgid "Mismatched braces"
 msgstr ""
 
 msgid "Mismatched parenthesis"
+msgstr ""
+
+#
+msgid "Missing argument"
 msgstr ""
 
 msgid "Missing closing parenthesis"

--- a/po/pl.po
+++ b/po/pl.po
@@ -903,6 +903,10 @@ msgstr ""
 msgid "Argument is not a number: '%ls'"
 msgstr ""
 
+#
+msgid "Argument type does not match conversion character"
+msgstr ""
+
 msgid "Await background process completion"
 msgstr ""
 
@@ -910,6 +914,10 @@ msgid "Background IO thread events"
 msgstr ""
 
 msgid "Backgrounded commands can not be used as conditionals"
+msgstr ""
+
+#
+msgid "Bad format string"
 msgstr ""
 
 msgid "Bad system call"
@@ -1132,6 +1140,11 @@ msgstr "Przymusowe wyjście"
 msgid "Forced stop"
 msgstr "Wymuszono zatrzymanie"
 
+#
+#, c-format
+msgid "Formatter error: %s"
+msgstr ""
+
 msgid "Generate random number"
 msgstr "Zwróć losową liczbę"
 
@@ -1267,6 +1280,10 @@ msgid "Mismatched braces"
 msgstr ""
 
 msgid "Mismatched parenthesis"
+msgstr ""
+
+#
+msgid "Missing argument"
 msgstr ""
 
 msgid "Missing closing parenthesis"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -908,6 +908,10 @@ msgstr "Ocorreu um erro ao preparar pipe"
 msgid "Argument is not a number: '%ls'"
 msgstr ""
 
+#
+msgid "Argument type does not match conversion character"
+msgstr ""
+
 msgid "Await background process completion"
 msgstr ""
 
@@ -915,6 +919,10 @@ msgid "Background IO thread events"
 msgstr ""
 
 msgid "Backgrounded commands can not be used as conditionals"
+msgstr ""
+
+#
+msgid "Bad format string"
 msgstr ""
 
 msgid "Bad system call"
@@ -1137,6 +1145,11 @@ msgstr "Saída forçada"
 msgid "Forced stop"
 msgstr "Parada forçada"
 
+#
+#, c-format
+msgid "Formatter error: %s"
+msgstr ""
+
 msgid "Generate random number"
 msgstr "Gera um número aleatório"
 
@@ -1272,6 +1285,10 @@ msgid "Mismatched braces"
 msgstr ""
 
 msgid "Mismatched parenthesis"
+msgstr ""
+
+#
+msgid "Missing argument"
 msgstr ""
 
 msgid "Missing closing parenthesis"

--- a/po/sv.po
+++ b/po/sv.po
@@ -904,6 +904,10 @@ msgstr "Ett fel inträffade under skapandet av ett rör"
 msgid "Argument is not a number: '%ls'"
 msgstr ""
 
+#
+msgid "Argument type does not match conversion character"
+msgstr ""
+
 msgid "Await background process completion"
 msgstr ""
 
@@ -911,6 +915,10 @@ msgid "Background IO thread events"
 msgstr ""
 
 msgid "Backgrounded commands can not be used as conditionals"
+msgstr ""
+
+#
+msgid "Bad format string"
 msgstr ""
 
 msgid "Bad system call"
@@ -1133,6 +1141,11 @@ msgstr "Tvingad avslutning"
 msgid "Forced stop"
 msgstr "Tvingad att stoppa"
 
+#
+#, c-format
+msgid "Formatter error: %s"
+msgstr ""
+
 msgid "Generate random number"
 msgstr "Generera ett slumptal"
 
@@ -1268,6 +1281,10 @@ msgid "Mismatched braces"
 msgstr ""
 
 msgid "Mismatched parenthesis"
+msgstr ""
+
+#
+msgid "Missing argument"
 msgstr ""
 
 msgid "Missing closing parenthesis"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -930,6 +930,10 @@ msgstr "设置管道时出错"
 msgid "Argument is not a number: '%ls'"
 msgstr "参数不是数字：'%ls'"
 
+#
+msgid "Argument type does not match conversion character"
+msgstr ""
+
 msgid "Await background process completion"
 msgstr "等待后台进程完成"
 
@@ -938,6 +942,10 @@ msgstr "后台 IO 线程事件"
 
 msgid "Backgrounded commands can not be used as conditionals"
 msgstr "后台命令不能用作条件"
+
+#
+msgid "Bad format string"
+msgstr ""
 
 msgid "Bad system call"
 msgstr "错误的系统调用"
@@ -1162,6 +1170,11 @@ msgstr "强制退出"
 msgid "Forced stop"
 msgstr "强制停止"
 
+#
+#, c-format
+msgid "Formatter error: %s"
+msgstr ""
+
 msgid "Generate random number"
 msgstr "生成随机数"
 
@@ -1298,6 +1311,10 @@ msgstr "大括号不匹配"
 
 msgid "Mismatched parenthesis"
 msgstr "括号不匹配"
+
+#
+msgid "Missing argument"
+msgstr ""
 
 msgid "Missing closing parenthesis"
 msgstr "缺少收尾括号"

--- a/src/builtins/printf.rs
+++ b/src/builtins/printf.rs
@@ -444,7 +444,7 @@ impl<'a, 'b> builtin_printf_state_t<'a, 'b> {
                     let mut continue_looking_for_flags = true;
                     while continue_looking_for_flags {
                         match f.char_at(0) {
-                            'I' | '\'' => {
+                            '\'' => {
                                 modify_allowed_format_specifiers(&mut ok, "aAceEosxX", false);
                             }
 

--- a/src/builtins/printf.rs
+++ b/src/builtins/printf.rs
@@ -240,10 +240,16 @@ impl<'a, 'b> builtin_printf_state_t<'a, 'b> {
     }
 
     fn handle_sprintf_error(&mut self, err: fish_printf::Error) {
-        match err {
-            fish_printf::Error::Overflow => self.fatal_error(wgettext!("Number out of range")),
-            _ => panic!("unhandled error: {err:?}"),
-        }
+        use fish_printf::Error::*;
+        let msg = match err {
+            BadFormatString => wgettext!("Bad format string").into(),
+            MissingArg => wgettext!("Missing argument").into(),
+            ExtraArg => wgettext!("Too many arguments").into(),
+            BadArgType => wgettext!("Argument type does not match conversion character").into(),
+            Overflow => wgettext!("Number out of range").into(),
+            Fmt(error) => wgettext_fmt!("Formatter error: %s", format!("{error:?}")),
+        };
+        self.fatal_error(&msg);
     }
 
     /// Evaluate a printf conversion specification.


### PR DESCRIPTION
This time, there are some behavioral changes. The `I` flag change is very minor, and mostly useful for people looking at the code, to avoid suggesting that it's supported when it's not.

The important changes here are to avoid panicking when `sprintf_locale` fails. The `printf` implementation parses the format string before calling `sprintf_locale` which includes some error handling, but it is a bad idea to assume that it catches all errors `sprintf_locale` might encounter. Crashing fish because of an invalid `printf` invocation is unreasonable, so stop doing that and instead print an error message.
