### PR TITLE
Printf remove length modifier support

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -343,7 +343,7 @@ command-line and graphical user interface programs. For simple use, you can use 
 
 Open up the PO file, for example ``po/sv.po``, and you'll see something like::
 
-    msgid "%ls: No suitable job\n"
+    msgid "%s: No suitable job\n"
     msgstr ""
 
 The ``msgid`` here is the "name" of the string to translate, typically the English string to translate.
@@ -351,10 +351,10 @@ The second line (``msgstr``) is where your translation goes.
 
 For example::
 
-    msgid "%ls: No suitable job\n"
-    msgstr "%ls: Inget passande jobb\n"
+    msgid "%s: No suitable job\n"
+    msgstr "%s: Inget passande jobb\n"
 
-Any ``%s`` / ``%ls`` or ``%d`` are placeholders that fish will use for formatting at runtime. It is important that they match - the translated string should have the same placeholders in the same order.
+Any ``%s`` or ``%d`` are placeholders that fish will use for formatting at runtime. It is important that they match - the translated string should have the same placeholders in the same order.
 
 Also any escaped characters, like that ``\n`` newline at the end, should be kept so the translation has the same behavior.
 
@@ -381,7 +381,7 @@ macros:
 
 ::
 
-    streams.out.append(wgettext_fmt!("%ls: There are no jobs\n", argv[0]));
+    streams.out.append(wgettext_fmt!("%s: There are no jobs\n", argv[0]));
 
 All messages in fish script must be enclosed in single or double quote
 characters for our message extraction script to find them.

--- a/po/de.po
+++ b/po/de.po
@@ -32,8 +32,8 @@ msgstr ""
 "   PID  Befehl\n"
 
 #, c-format
-msgid " (%ls)\n"
-msgstr " (%ls)\n"
+msgid " (%s)\n"
+msgstr " (%s)\n"
 
 msgid " (read-only)\n"
 msgstr " (screibgeschützt)\n"
@@ -42,8 +42,8 @@ msgid " a path variable"
 msgstr " eine Pfadvariable"
 
 #, c-format
-msgid " with arguments '%ls'"
-msgstr "mit den Parametern '%ls'"
+msgid " with arguments '%s'"
+msgstr "mit den Parametern '%s'"
 
 msgid " with definition"
 msgstr " mit Definition"
@@ -55,16 +55,16 @@ msgid "$$ is not the pid. In fish, please use $fish_pid."
 msgstr ""
 
 #, c-format
-msgid "$%lc is not a valid variable in fish."
+msgid "$%c is not a valid variable in fish."
 msgstr ""
 
 #, c-format
-msgid "$%ls: originally inherited as |%ls|\n"
-msgstr "$%ls: Ursprünglich geerbt als |%ls|\n"
+msgid "$%s: originally inherited as |%s|\n"
+msgstr "$%s: Ursprünglich geerbt als |%s|\n"
 
 #, c-format
-msgid "$%ls: set in %ls scope, %ls,%ls with %d elements"
-msgstr "$%ls: Gesetzt in Geltungsbereich '%ls', %ls,%ls mit %d Elementen"
+msgid "$%s: set in %s scope, %s,%s with %d elements"
+msgstr "$%s: Gesetzt in Geltungsbereich '%s', %s,%s mit %d Elementen"
 
 msgid "$* is not supported. In fish, please use $argv."
 msgstr ""
@@ -79,728 +79,52 @@ msgid "$status is not valid as a command. See `help conditions`"
 msgstr "$status ist kein gültiger Befehl. Siehe `help conditions`"
 
 #, c-format
-msgid "%.*ls: invalid conversion specification"
-msgstr "%.*ls: Ungültige Umwandlungsspezifikation"
-
-#, c-format
-msgid "%ls"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: Abbreviation %ls already exists, cannot rename %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: Abbreviation '%ls' cannot have spaces in the word\n"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: Name cannot be empty\n"
-msgstr "%ls %ls: Name darf nicht leer sein\n"
-
-#, c-format
-msgid "%ls %ls: No abbreviation named %ls\n"
-msgstr "%ls %ls: Keine Abkürzung namens %ls\n"
-
-#, c-format
-msgid "%ls %ls: Requires at least two arguments\n"
-msgstr "%ls %ls: Erfordert mindestens zwei Argumente\n"
-
-#, c-format
-msgid "%ls %ls: Requires exactly two arguments\n"
-msgstr "%ls %ls: Erfordert genau zwei Argumente\n"
-
-#, c-format
-msgid "%ls %ls: Unexpected argument -- '%ls'\n"
-msgstr "%ls %ls: Unerwartetes Argument - '%ls'\n"
-
-#, c-format
-msgid "%ls (line %d): "
-msgstr "%ls (Zeile %d): "
-
-#, c-format
-msgid "%ls (line %lu): "
-msgstr "%ls (Zeile %lu): "
-
-#, c-format
-msgid "%ls is %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls is a builtin\n"
-msgstr ""
-
-#, c-format
-msgid "%ls is a function"
-msgstr "%ls ist eine Funktion"
-
-#, c-format
-msgid "%ls, version %s"
-msgstr ""
-
-#, c-format
-msgid "%ls: %*ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls %ls: options cannot be used together\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: cannot overwrite read-only variable"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: cannot use reserved keyword as function name"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: contains a syntax error\n"
-msgstr "%ls: %ls: enthält einen Syntaxfehler\n"
-
-#, c-format
-msgid "%ls: %ls: expected %d arguments; got %d\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid base value\n"
-msgstr "%ls: %ls: ungültiger Basiswert\n"
-
-#, c-format
-msgid "%ls: %ls: invalid function name"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid integer\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid mode\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid mode name. See `help identifiers`\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid process id"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid scale\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid subcommand\n"
-msgstr "%ls: %ls: ungültiger Unterbefehl\n"
-
-#, c-format
-msgid "%ls: %ls: invalid variable name. See `help identifiers`\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: option does not take an argument\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: option requires an argument\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: subcommand takes no options\n"
-msgstr "%ls: %ls: Unterbefehl nimmt keine Optionen an\n"
-
-#, c-format
-msgid "%ls: %ls: unexpected positional argument"
-msgstr "%ls: %ls: unerwartetes Positionsargument"
-
-#, c-format
-msgid "%ls: %ls: unknown option\n"
-msgstr "%ls: %ls: unbekannte Option\n"
-
-#, c-format
-msgid "%ls: '%ls' is a broken symbolic link to '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: '%ls' is not a directory\n"
-msgstr "%ls: '%ls' ist kein Verzeichnis\n"
-
-#, c-format
-msgid "%ls: '%ls' is not a job\n"
-msgstr "%ls: '%ls' ist kein Job\n"
-
-#, c-format
-msgid "%ls: '%ls' is not a valid job id\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: '%ls' is not a valid job specifier\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: '%ls' is not a valid process id\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: --command cannot be combined with --position command"
-msgstr ""
-
-#, c-format
-msgid "%ls: --function option requires --add\n"
-msgstr "%ls: Option --function braucht --add\n"
-
-#, c-format
-msgid "%ls: --position option requires --add\n"
-msgstr "%ls: Option --position erfordert --add\n"
-
-#, c-format
-msgid "%ls: --regex option requires --add\n"
-msgstr "%ls: Option --regex erfordert --add\n"
-
-#, c-format
-msgid "%ls: --set-cursor argument cannot be empty\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: --set-cursor option requires --add\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: -l requires a non-empty string\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: -o requires a non-empty string\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: -s requires a non-empty string\n"
-msgstr "%ls: -s erfordert eine nicht-leere Zeichenkette\n"
-
-#, c-format
-msgid "%ls: Ambiguous job\n"
-msgstr "%ls: Mehrdeutiger Job\n"
-
-#, c-format
-msgid "%ls: An option spec must have at least a short or a long flag\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Argument '%ls' is out of range\n"
-msgstr "%ls: Argument '%ls' ist außerhalb des Definitionsbereichs\n"
-
-#, c-format
-msgid "%ls: Can not specify scope when removing block\n"
-msgstr "%ls: Bei Blocklöschung kann kein Geltungsbereich angegeben werden\n"
-
-#, c-format
-msgid "%ls: Can't put job %d, '%ls' to foreground because it is not under job control\n"
-msgstr "%ls: Kann job %d, '%ls' nicht in den Vordergrund schicken weil er nicht der Jobsteuerung unterliegt\n"
-
-#, c-format
-msgid "%ls: Can't put job %s, '%ls' to background because it is not under job control\n"
-msgstr "%ls: Kann job %s, '%ls' nicht in den Hintergrund schicken weil er nicht der Jobsteuerung unterliegt\n"
-
-#, c-format
-msgid "%ls: Cannot combine options %ls\n"
-msgstr "%ls: Kann Optionen %ls nicht kombinieren\n"
-
-#, c-format
-msgid "%ls: Cannot specify multiple positions\n"
-msgstr "%ls: Mehrere Positionen können nicht gleichzeitig angegeben werden\n"
-
-#, c-format
-msgid "%ls: Cannot specify multiple regex patterns\n"
-msgstr "%ls: Maximal ein regulärer Ausdruck erlaubt\n"
-
-#, c-format
-msgid "%ls: Cannot specify multiple set-cursor options\n"
-msgstr "%ls: Maximal eine set-cursor-Option erlaubt\n"
-
-#, c-format
-msgid "%ls: Cannot use --append or --prepend when assigning to a slice"
-msgstr ""
-
-#, c-format
-msgid "%ls: Command not valid at an interactive prompt\n"
-msgstr "%ls: Kann nicht am Prompt verwendet werden\n"
-
-#, c-format
-msgid "%ls: Could not find '%ls'\n"
-msgstr "%ls: Konnte '%ls' nicht finden\n"
-
-#, c-format
-msgid "%ls: Could not find a job with process id '%d'\n"
-msgstr "%ls: Konnte keinen Job mit Prozess-ID '%d' finden\n"
-
-#, c-format
-msgid "%ls: Could not find child processes with the name '%ls'\n"
-msgstr "%ls: Kein Kindprozess namens '%ls' gefunden\n"
-
-#, c-format
-msgid "%ls: Could not find home directory\n"
-msgstr "%ls: Konnte Heimordner nicht finden\n"
-
-#, c-format
-msgid "%ls: Could not find job '%d'\n"
-msgstr "%ls: Job '%d' nicht gefunden\n"
-
-#, c-format
-msgid "%ls: Did you mean `set %ls %ls`?"
-msgstr "%ls: Meintest du `set %ls %ls`?"
-
-#, c-format
-msgid "%ls: Empty directory '%ls' does not exist\n"
-msgstr "%ls: Leerer Ordnerpfad '%ls' existiert nicht\n"
-
-#, c-format
-msgid "%ls: Error encountered while sourcing file '%ls':\n"
-msgstr "%ls: Fehler beim Einladen von '%ls':\n"
-
-#, c-format
-msgid "%ls: Error while reading file '%ls'\n"
-msgstr "%ls: Fehler beim Lesen der Datei '%ls'\n"
-
-#, c-format
-msgid "%ls: Expected at least one argument"
-msgstr ""
-
-#, c-format
-msgid "%ls: Expected exactly one function name\n"
-msgstr "%ls: Erwartete genau einen Funktionsnamen\n"
-
-#, c-format
-msgid "%ls: Expected exactly two names (current function name, and new function name)\n"
-msgstr "%ls: Erwartete exakt zwei Namen (aktuellen und neuen Funktionsnamen)\n"
-
-#, c-format
-msgid "%ls: Expected generic | variable | signal | exit | job-id for --handlers-type\n"
-msgstr "%ls: Erwartete generic | variable | signal | exit | job-id für --handlers-type\n"
-
-#, c-format
-msgid "%ls: Function '%ls' already exists. Cannot create copy of '%ls'\n"
-msgstr "%ls: Funktion '%ls' existiert schon. Konnte '%ls' nicht kopieren\n"
-
-#, c-format
-msgid "%ls: Function '%ls' does not exist\n"
-msgstr "%ls: Funktion '%ls' existiert nicht\n"
-
-#, c-format
-msgid "%ls: Illegal function name '%ls'\n"
-msgstr "%ls: Ungültiger Funktionsname '%ls'\n"
-
-#, c-format
-msgid "%ls: Implicit int flag '%lc' already defined\n"
-msgstr "%ls: Implizite Zahloption '%lc' ist schon definiert\n"
-
-#, c-format
-msgid "%ls: Implicit int short flag '%lc' does not allow modifiers like '%lc'\n"
-msgstr "%ls: Implizite Zahloption '%lc' darf keine Modifikatoren wie '%lc' haben\n"
-
-#, c-format
-msgid "%ls: Invalid --max-args value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid --min-args value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid --unknown-arguments value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid count value '%ls'\n"
-msgstr "%ls: Ungültiger 'count'-Wert '%ls'\n"
-
-#, c-format
-msgid "%ls: Invalid end value '%ls'\n"
-msgstr "%ls: Ungültiger 'end'-Wert '%ls'\n"
-
-#, c-format
-msgid "%ls: Invalid escape style '%ls'\n"
-msgstr "%ls: Ungültiger Escape-Stil '%ls'\n"
-
-#, c-format
-msgid "%ls: Invalid fields value '%ls'\n"
-msgstr "%ls: Ungültiger 'fields'-Wert '%ls'\n"
-
-#, c-format
-msgid "%ls: Invalid function name: %ls\n"
-msgstr "%ls: Ungültiger Funktionsname: %ls\n"
-
-#, c-format
-msgid "%ls: Invalid index starting at '%ls'\n"
-msgstr "%ls: Ungültiger Index ab '%ls'\n"
-
-#, c-format
-msgid "%ls: Invalid job control mode '%ls'\n"
-msgstr "%ls: Ungültiger Jobkontrollmodus '%ls'\n"
-
-#, c-format
-msgid "%ls: Invalid length value '%ls'\n"
-msgstr "%ls: Ungültiger Längenwert '%ls'\n"
-
-#, c-format
-msgid "%ls: Invalid level value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid limit '%ls'\n"
-msgstr "%ls: Ungültiges Limit '%ls'\n"
-
-#, c-format
-msgid "%ls: Invalid max matches value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid max value '%ls'\n"
-msgstr "%ls: Ungültiger Maximalwert '%ls'\n"
-
-#, c-format
-msgid "%ls: Invalid option spec '%ls' at char '%lc'\n"
-msgstr "%ls: Ungültige Options-Spezifikation '%ls' bei Zeichen '%lc'\n"
-
-#, c-format
-msgid "%ls: Invalid padding character of width zero '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid permission '%ls'\n"
-msgstr "%ls: Ungültiger Rechtewert '%ls'\n"
-
-#, c-format
-msgid "%ls: Invalid position '%ls'\n"
-msgstr "%ls: Ungültige Position '%ls'\n"
-
-#, c-format
-msgid "%ls: Invalid range value for field '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid sort key '%ls'\n"
-msgstr "%ls: Ungültiger Sortierschlüssel '%ls'\n"
-
-#, c-format
-msgid "%ls: Invalid start value '%ls'\n"
-msgstr "%ls: Ungültiger Startwert '%ls'\n"
-
-#, c-format
-msgid "%ls: Invalid state\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid style value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid token '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid type '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid width value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Key not specified\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Long flag '%ls' already defined\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Missing -- separator\n"
-msgstr "%ls: Fehlendes '--'-Trennzeichen\n"
-
-#, c-format
-msgid "%ls: New limit cannot be an empty string\n"
-msgstr "%ls: Neues Limit darf keine leere Zeichenkette sein\n"
-
-#, c-format
-msgid "%ls: No binding found for key '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: No binding found for key sequence '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: No blocks defined\n"
-msgstr "%ls: Keine Blöcke definiert\n"
-
-#, c-format
-msgid "%ls: No suitable job: %d\n"
-msgstr "%ls: Kein passender Job: %d\n"
-
-#, c-format
-msgid "%ls: No suitable job: %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Not inside of loop\n"
-msgstr "%ls: Nicht innerhalb einer Schleife\n"
-
-#, c-format
-msgid "%ls: Options %ls and %ls cannot be used together\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Padding should be a character '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Permission denied: '%ls'\n"
-msgstr "%ls: Berechtigung verweigert: '%ls'\n"
-
-#, c-format
-msgid "%ls: Regular expression compile error: %ls\n"
-msgstr "%ls: Fehler beim Kompilieren von regulärem Ausdruck: %ls\n"
-
-#, c-format
-msgid "%ls: Regular expression substitute error: %ls\n"
-msgstr "%ls: Fehler beim Ersetzen von regulärem Ausdruck: %ls\n"
-
-#, c-format
-msgid "%ls: Resource limit not available on this operating system\n"
-msgstr "%ls: Ressourcenlimit ist auf diesem Betriebssystem nicht verfügbar\n"
-
-#, c-format
-msgid "%ls: STEP must be a positive integer\n"
-msgstr "%ls: STEP muss eine positive Ganzzahl sein\n"
-
-#, c-format
-msgid "%ls: Short flag '%lc' already defined\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Short flag '%lc' invalid, must be alphanum or '#'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: The directory '%ls' does not exist\n"
-msgstr "%ls: Das Verzeichnis '%ls' existiert nicht\n"
-
-#, c-format
-msgid "%ls: The variable '%ls' does not exist\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: There are no jobs\n"
-msgstr "%ls: Es gibt keine Jobs\n"
-
-#, c-format
-msgid "%ls: There are no suitable jobs\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Too many levels of symbolic links: '%ls'\n"
-msgstr "%ls: Zu viele Ebenen von symbolischen Links: '%ls'\n"
-
-#, c-format
-msgid "%ls: Too many long-only options\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Tried to change the read-only variable '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Tried to modify the special variable '%ls' to an invalid value\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Tried to modify the special variable '%ls' with the wrong scope\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Unknown color '%ls'\n"
-msgstr "%ls: Unbekannte Farbe '%ls'\n"
-
-#, c-format
-msgid "%ls: Unknown error trying to locate directory '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Unknown input function '%ls'"
-msgstr ""
-
-#, c-format
-msgid "%ls: Unknown signal '%ls'"
-msgstr "%ls: Unbekanntes Signal '%ls'"
-
-#, c-format
-msgid "%ls: Warning: Option '%ls' was removed and is now ignored"
-msgstr "%ls: Warnung: Option '%ls' wurde entfernt und wird nun ignoriert"
-
-#, c-format
-msgid "%ls: `set --show` does not allow slices with the var names\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: array index out of bounds\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: called with no arguments. This will be an error in future."
-msgstr ""
-
-#, c-format
-msgid "%ls: called with one argument. This will return false in future."
-msgstr ""
-
-#, c-format
-msgid "%ls: calling job for event handler not found"
-msgstr "%ls: Aufrufender Job für Eventhandler nicht gefunden"
-
-#, c-format
-msgid "%ls: can't merge history in private mode\n"
-msgstr "%ls: Kann Verlauf im privaten Modus nicht zusammenfügen\n"
-
-#, c-format
-msgid "%ls: cannot both export and unexport\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: cannot both path and unpath\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: column %ls exceeds line length\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: exclusive flag '%ls' is not valid\n"
-msgstr "%ls: Exklusive Option '%ls' ist ungültig\n"
-
-#, c-format
-msgid "%ls: exclusive flag string '%ls' is not valid\n"
-msgstr "%ls: Exklusive Option '%ls' ist ungültig\n"
-
-#, c-format
-msgid "%ls: expected %d arguments; got %d\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: expected <= %d arguments; got %d\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: expected >= %d arguments; got %d\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: expected a numeric value"
-msgstr "%ls: Erwartete numerischen Wert"
-
-#, c-format
-msgid "%ls: fish was not built with embedded files"
-msgstr ""
-
-#, c-format
-msgid "%ls: given %d indexes but %d values\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: invalid option combination\n"
-msgstr "%ls: ungültige Optionskombination\n"
-
-#, c-format
-msgid "%ls: invalid option combination, %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: invalid underline style: %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: job %d ('%ls') was stopped and has been signalled to continue.\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: line/column index starts at 1"
-msgstr ""
-
-#, c-format
-msgid "%ls: missing argument\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: missing filename argument or input redirection\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: missing subcommand\n"
-msgstr "%ls: fehlender Unterbefehl\n"
-
-#, c-format
-msgid "%ls: nothing to choose from\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: realpath failed: %s\n"
-msgstr "%ls: realpath fehlgeschlagen: %s\n"
-
-#, c-format
-msgid "%ls: scope can be only one of: universal function global local\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: stdin is closed\n"
-msgstr "%ls: stdin ist geschlossen\n"
-
-#, c-format
-msgid "%ls: successfully set universal '%ls'; but a global by that name shadows it\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: the -k/--key syntax is no longer supported. See `bind --help` and `bind --key-names`\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: there is no line %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: too many arguments\n"
-msgstr "%ls: zu viele Argumente\n"
-
-#, c-format
-msgid "%ls: usage of -i for --silent is deprecated. Please use -s or --silent instead.\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: value not completely converted (can't convert '%ls')"
-msgstr "%ls: Wert nicht vollständig konvertiert (kann '%ls' nicht konvertieren)"
-
-#, c-format
-msgid "%ls: variable '%ls' is read-only\n"
-msgstr ""
-
-#, c-format
-msgid "%lsand %lu more rows"
-msgstr "%lsund %lu weitere Zeilen"
-
-#, c-format
-msgid "%lu\n"
-msgstr ""
+msgid "%.*s: invalid conversion specification"
+msgstr "%.*s: Ungültige Umwandlungsspezifikation"
 
 #, c-format
 msgid "%s"
 msgstr ""
 
 #, c-format
-msgid "%s %s: unrecognized feature '%ls'"
+msgid "%s %s: Abbreviation %s already exists, cannot rename %s\n"
 msgstr ""
+
+#, c-format
+msgid "%s %s: Abbreviation '%s' cannot have spaces in the word\n"
+msgstr ""
+
+#, c-format
+msgid "%s %s: Name cannot be empty\n"
+msgstr "%s %s: Name darf nicht leer sein\n"
+
+#, c-format
+msgid "%s %s: No abbreviation named %s\n"
+msgstr "%s %s: Keine Abkürzung namens %s\n"
+
+#, c-format
+msgid "%s %s: Requires at least two arguments\n"
+msgstr "%s %s: Erfordert mindestens zwei Argumente\n"
+
+#, c-format
+msgid "%s %s: Requires exactly two arguments\n"
+msgstr "%s %s: Erfordert genau zwei Argumente\n"
+
+#, c-format
+msgid "%s %s: Unexpected argument -- '%s'\n"
+msgstr "%s %s: Unerwartetes Argument - '%s'\n"
+
+#, c-format
+msgid "%s %s: unrecognized feature '%s'"
+msgstr ""
+
+#, c-format
+msgid "%s (line %d): "
+msgstr "%s (Zeile %d): "
+
+#, c-format
+msgid "%s (line %u): "
+msgstr "%s (Zeile %u): "
 
 #, c-format
 msgid "%s and %s are mutually exclusive"
@@ -811,12 +135,680 @@ msgid "%s could not read response to Primary Device Attribute query after waitin
 msgstr ""
 
 #, c-format
+msgid "%s is %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s is a builtin\n"
+msgstr ""
+
+#, c-format
+msgid "%s is a function"
+msgstr "%s ist eine Funktion"
+
+#, c-format
 msgid "%s, version %s"
 msgstr ""
 
 #, c-format
 msgid "%s, version %s\n"
 msgstr "%s, version %s\n"
+
+#, c-format
+msgid "%s: %*s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s %s: options cannot be used together\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: cannot overwrite read-only variable"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: cannot use reserved keyword as function name"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: contains a syntax error\n"
+msgstr "%s: %s: enthält einen Syntaxfehler\n"
+
+#, c-format
+msgid "%s: %s: expected %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid base value\n"
+msgstr "%s: %s: ungültiger Basiswert\n"
+
+#, c-format
+msgid "%s: %s: invalid function name"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid integer\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid mode\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid mode name. See `help identifiers`\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid process id"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid scale\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid subcommand\n"
+msgstr "%s: %s: ungültiger Unterbefehl\n"
+
+#, c-format
+msgid "%s: %s: invalid variable name. See `help identifiers`\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: option does not take an argument\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: option requires an argument\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: subcommand takes no options\n"
+msgstr "%s: %s: Unterbefehl nimmt keine Optionen an\n"
+
+#, c-format
+msgid "%s: %s: unexpected positional argument"
+msgstr "%s: %s: unerwartetes Positionsargument"
+
+#, c-format
+msgid "%s: %s: unknown option\n"
+msgstr "%s: %s: unbekannte Option\n"
+
+#, c-format
+msgid "%s: '%s' is a broken symbolic link to '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: '%s' is not a directory\n"
+msgstr "%s: '%s' ist kein Verzeichnis\n"
+
+#, c-format
+msgid "%s: '%s' is not a job\n"
+msgstr "%s: '%s' ist kein Job\n"
+
+#, c-format
+msgid "%s: '%s' is not a valid job id\n"
+msgstr ""
+
+#, c-format
+msgid "%s: '%s' is not a valid job specifier\n"
+msgstr ""
+
+#, c-format
+msgid "%s: '%s' is not a valid process id\n"
+msgstr ""
+
+#, c-format
+msgid "%s: --command cannot be combined with --position command"
+msgstr ""
+
+#, c-format
+msgid "%s: --function option requires --add\n"
+msgstr "%s: Option --function braucht --add\n"
+
+#, c-format
+msgid "%s: --position option requires --add\n"
+msgstr "%s: Option --position erfordert --add\n"
+
+#, c-format
+msgid "%s: --regex option requires --add\n"
+msgstr "%s: Option --regex erfordert --add\n"
+
+#, c-format
+msgid "%s: --set-cursor argument cannot be empty\n"
+msgstr ""
+
+#, c-format
+msgid "%s: --set-cursor option requires --add\n"
+msgstr ""
+
+#, c-format
+msgid "%s: -l requires a non-empty string\n"
+msgstr ""
+
+#, c-format
+msgid "%s: -o requires a non-empty string\n"
+msgstr ""
+
+#, c-format
+msgid "%s: -s requires a non-empty string\n"
+msgstr "%s: -s erfordert eine nicht-leere Zeichenkette\n"
+
+#, c-format
+msgid "%s: Ambiguous job\n"
+msgstr "%s: Mehrdeutiger Job\n"
+
+#, c-format
+msgid "%s: An option spec must have at least a short or a long flag\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Argument '%s' is out of range\n"
+msgstr "%s: Argument '%s' ist außerhalb des Definitionsbereichs\n"
+
+#, c-format
+msgid "%s: Can not specify scope when removing block\n"
+msgstr "%s: Bei Blocklöschung kann kein Geltungsbereich angegeben werden\n"
+
+#, c-format
+msgid "%s: Can't put job %d, '%s' to foreground because it is not under job control\n"
+msgstr "%s: Kann job %d, '%s' nicht in den Vordergrund schicken weil er nicht der Jobsteuerung unterliegt\n"
+
+#, c-format
+msgid "%s: Can't put job %s, '%s' to background because it is not under job control\n"
+msgstr "%s: Kann job %s, '%s' nicht in den Hintergrund schicken weil er nicht der Jobsteuerung unterliegt\n"
+
+#, c-format
+msgid "%s: Cannot combine options %s\n"
+msgstr "%s: Kann Optionen %s nicht kombinieren\n"
+
+#, c-format
+msgid "%s: Cannot specify multiple positions\n"
+msgstr "%s: Mehrere Positionen können nicht gleichzeitig angegeben werden\n"
+
+#, c-format
+msgid "%s: Cannot specify multiple regex patterns\n"
+msgstr "%s: Maximal ein regulärer Ausdruck erlaubt\n"
+
+#, c-format
+msgid "%s: Cannot specify multiple set-cursor options\n"
+msgstr "%s: Maximal eine set-cursor-Option erlaubt\n"
+
+#, c-format
+msgid "%s: Cannot use --append or --prepend when assigning to a slice"
+msgstr ""
+
+#, c-format
+msgid "%s: Command not valid at an interactive prompt\n"
+msgstr "%s: Kann nicht am Prompt verwendet werden\n"
+
+#, c-format
+msgid "%s: Could not find '%s'\n"
+msgstr "%s: Konnte '%s' nicht finden\n"
+
+#, c-format
+msgid "%s: Could not find a job with process id '%d'\n"
+msgstr "%s: Konnte keinen Job mit Prozess-ID '%d' finden\n"
+
+#, c-format
+msgid "%s: Could not find child processes with the name '%s'\n"
+msgstr "%s: Kein Kindprozess namens '%s' gefunden\n"
+
+#, c-format
+msgid "%s: Could not find home directory\n"
+msgstr "%s: Konnte Heimordner nicht finden\n"
+
+#, c-format
+msgid "%s: Could not find job '%d'\n"
+msgstr "%s: Job '%d' nicht gefunden\n"
+
+#, c-format
+msgid "%s: Did you mean `set %s %s`?"
+msgstr "%s: Meintest du `set %s %s`?"
+
+#, c-format
+msgid "%s: Empty directory '%s' does not exist\n"
+msgstr "%s: Leerer Ordnerpfad '%s' existiert nicht\n"
+
+#, c-format
+msgid "%s: Error encountered while sourcing file '%s':\n"
+msgstr "%s: Fehler beim Einladen von '%s':\n"
+
+#, c-format
+msgid "%s: Error while reading file '%s'\n"
+msgstr "%s: Fehler beim Lesen der Datei '%s'\n"
+
+#, c-format
+msgid "%s: Expected at least one argument"
+msgstr ""
+
+#, c-format
+msgid "%s: Expected exactly one function name\n"
+msgstr "%s: Erwartete genau einen Funktionsnamen\n"
+
+#, c-format
+msgid "%s: Expected exactly two names (current function name, and new function name)\n"
+msgstr "%s: Erwartete exakt zwei Namen (aktuellen und neuen Funktionsnamen)\n"
+
+#, c-format
+msgid "%s: Expected generic | variable | signal | exit | job-id for --handlers-type\n"
+msgstr "%s: Erwartete generic | variable | signal | exit | job-id für --handlers-type\n"
+
+#, c-format
+msgid "%s: Function '%s' already exists. Cannot create copy of '%s'\n"
+msgstr "%s: Funktion '%s' existiert schon. Konnte '%s' nicht kopieren\n"
+
+#, c-format
+msgid "%s: Function '%s' does not exist\n"
+msgstr "%s: Funktion '%s' existiert nicht\n"
+
+#, c-format
+msgid "%s: Illegal function name '%s'\n"
+msgstr "%s: Ungültiger Funktionsname '%s'\n"
+
+#, c-format
+msgid "%s: Implicit int flag '%c' already defined\n"
+msgstr "%s: Implizite Zahloption '%c' ist schon definiert\n"
+
+#, c-format
+msgid "%s: Implicit int short flag '%c' does not allow modifiers like '%c'\n"
+msgstr "%s: Implizite Zahloption '%c' darf keine Modifikatoren wie '%c' haben\n"
+
+#, c-format
+msgid "%s: Invalid --max-args value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid --min-args value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid --unknown-arguments value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid count value '%s'\n"
+msgstr "%s: Ungültiger 'count'-Wert '%s'\n"
+
+#, c-format
+msgid "%s: Invalid end value '%s'\n"
+msgstr "%s: Ungültiger 'end'-Wert '%s'\n"
+
+#, c-format
+msgid "%s: Invalid escape style '%s'\n"
+msgstr "%s: Ungültiger Escape-Stil '%s'\n"
+
+#, c-format
+msgid "%s: Invalid fields value '%s'\n"
+msgstr "%s: Ungültiger 'fields'-Wert '%s'\n"
+
+#, c-format
+msgid "%s: Invalid function name: %s\n"
+msgstr "%s: Ungültiger Funktionsname: %s\n"
+
+#, c-format
+msgid "%s: Invalid index starting at '%s'\n"
+msgstr "%s: Ungültiger Index ab '%s'\n"
+
+#, c-format
+msgid "%s: Invalid job control mode '%s'\n"
+msgstr "%s: Ungültiger Jobkontrollmodus '%s'\n"
+
+#, c-format
+msgid "%s: Invalid length value '%s'\n"
+msgstr "%s: Ungültiger Längenwert '%s'\n"
+
+#, c-format
+msgid "%s: Invalid level value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid limit '%s'\n"
+msgstr "%s: Ungültiges Limit '%s'\n"
+
+#, c-format
+msgid "%s: Invalid max matches value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid max value '%s'\n"
+msgstr "%s: Ungültiger Maximalwert '%s'\n"
+
+#, c-format
+msgid "%s: Invalid option spec '%s' at char '%c'\n"
+msgstr "%s: Ungültige Options-Spezifikation '%s' bei Zeichen '%c'\n"
+
+#, c-format
+msgid "%s: Invalid padding character of width zero '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid permission '%s'\n"
+msgstr "%s: Ungültiger Rechtewert '%s'\n"
+
+#, c-format
+msgid "%s: Invalid position '%s'\n"
+msgstr "%s: Ungültige Position '%s'\n"
+
+#, c-format
+msgid "%s: Invalid range value for field '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid sort key '%s'\n"
+msgstr "%s: Ungültiger Sortierschlüssel '%s'\n"
+
+#, c-format
+msgid "%s: Invalid start value '%s'\n"
+msgstr "%s: Ungültiger Startwert '%s'\n"
+
+#, c-format
+msgid "%s: Invalid state\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid style value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid token '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid type '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid width value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Key not specified\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Long flag '%s' already defined\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Missing -- separator\n"
+msgstr "%s: Fehlendes '--'-Trennzeichen\n"
+
+#, c-format
+msgid "%s: New limit cannot be an empty string\n"
+msgstr "%s: Neues Limit darf keine leere Zeichenkette sein\n"
+
+#, c-format
+msgid "%s: No binding found for key '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: No binding found for key sequence '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: No blocks defined\n"
+msgstr "%s: Keine Blöcke definiert\n"
+
+#, c-format
+msgid "%s: No suitable job: %d\n"
+msgstr "%s: Kein passender Job: %d\n"
+
+#, c-format
+msgid "%s: No suitable job: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Not inside of loop\n"
+msgstr "%s: Nicht innerhalb einer Schleife\n"
+
+#, c-format
+msgid "%s: Options %s and %s cannot be used together\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Padding should be a character '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Permission denied: '%s'\n"
+msgstr "%s: Berechtigung verweigert: '%s'\n"
+
+#, c-format
+msgid "%s: Regular expression compile error: %s\n"
+msgstr "%s: Fehler beim Kompilieren von regulärem Ausdruck: %s\n"
+
+#, c-format
+msgid "%s: Regular expression substitute error: %s\n"
+msgstr "%s: Fehler beim Ersetzen von regulärem Ausdruck: %s\n"
+
+#, c-format
+msgid "%s: Resource limit not available on this operating system\n"
+msgstr "%s: Ressourcenlimit ist auf diesem Betriebssystem nicht verfügbar\n"
+
+#, c-format
+msgid "%s: STEP must be a positive integer\n"
+msgstr "%s: STEP muss eine positive Ganzzahl sein\n"
+
+#, c-format
+msgid "%s: Short flag '%c' already defined\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Short flag '%c' invalid, must be alphanum or '#'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: The directory '%s' does not exist\n"
+msgstr "%s: Das Verzeichnis '%s' existiert nicht\n"
+
+#, c-format
+msgid "%s: The variable '%s' does not exist\n"
+msgstr ""
+
+#, c-format
+msgid "%s: There are no jobs\n"
+msgstr "%s: Es gibt keine Jobs\n"
+
+#, c-format
+msgid "%s: There are no suitable jobs\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Too many levels of symbolic links: '%s'\n"
+msgstr "%s: Zu viele Ebenen von symbolischen Links: '%s'\n"
+
+#, c-format
+msgid "%s: Too many long-only options\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Tried to change the read-only variable '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Tried to modify the special variable '%s' to an invalid value\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Tried to modify the special variable '%s' with the wrong scope\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Unknown color '%s'\n"
+msgstr "%s: Unbekannte Farbe '%s'\n"
+
+#, c-format
+msgid "%s: Unknown error trying to locate directory '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Unknown input function '%s'"
+msgstr ""
+
+#, c-format
+msgid "%s: Unknown signal '%s'"
+msgstr "%s: Unbekanntes Signal '%s'"
+
+#, c-format
+msgid "%s: Warning: Option '%s' was removed and is now ignored"
+msgstr "%s: Warnung: Option '%s' wurde entfernt und wird nun ignoriert"
+
+#, c-format
+msgid "%s: `set --show` does not allow slices with the var names\n"
+msgstr ""
+
+#, c-format
+msgid "%s: array index out of bounds\n"
+msgstr ""
+
+#, c-format
+msgid "%s: called with no arguments. This will be an error in future."
+msgstr ""
+
+#, c-format
+msgid "%s: called with one argument. This will return false in future."
+msgstr ""
+
+#, c-format
+msgid "%s: calling job for event handler not found"
+msgstr "%s: Aufrufender Job für Eventhandler nicht gefunden"
+
+#, c-format
+msgid "%s: can't merge history in private mode\n"
+msgstr "%s: Kann Verlauf im privaten Modus nicht zusammenfügen\n"
+
+#, c-format
+msgid "%s: cannot both export and unexport\n"
+msgstr ""
+
+#, c-format
+msgid "%s: cannot both path and unpath\n"
+msgstr ""
+
+#, c-format
+msgid "%s: column %s exceeds line length\n"
+msgstr ""
+
+#, c-format
+msgid "%s: exclusive flag '%s' is not valid\n"
+msgstr "%s: Exklusive Option '%s' ist ungültig\n"
+
+#, c-format
+msgid "%s: exclusive flag string '%s' is not valid\n"
+msgstr "%s: Exklusive Option '%s' ist ungültig\n"
+
+#, c-format
+msgid "%s: expected %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%s: expected <= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%s: expected >= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%s: expected a numeric value"
+msgstr "%s: Erwartete numerischen Wert"
+
+#, c-format
+msgid "%s: fish was not built with embedded files"
+msgstr ""
+
+#, c-format
+msgid "%s: given %d indexes but %d values\n"
+msgstr ""
+
+#, c-format
+msgid "%s: invalid option combination\n"
+msgstr "%s: ungültige Optionskombination\n"
+
+#, c-format
+msgid "%s: invalid option combination, %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: invalid underline style: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: job %d ('%s') was stopped and has been signalled to continue.\n"
+msgstr ""
+
+#, c-format
+msgid "%s: line/column index starts at 1"
+msgstr ""
+
+#, c-format
+msgid "%s: missing argument\n"
+msgstr ""
+
+#, c-format
+msgid "%s: missing filename argument or input redirection\n"
+msgstr ""
+
+#, c-format
+msgid "%s: missing subcommand\n"
+msgstr "%s: fehlender Unterbefehl\n"
+
+#, c-format
+msgid "%s: nothing to choose from\n"
+msgstr ""
+
+#, c-format
+msgid "%s: realpath failed: %s\n"
+msgstr "%s: realpath fehlgeschlagen: %s\n"
+
+#, c-format
+msgid "%s: scope can be only one of: universal function global local\n"
+msgstr ""
+
+#, c-format
+msgid "%s: stdin is closed\n"
+msgstr "%s: stdin ist geschlossen\n"
+
+#, c-format
+msgid "%s: successfully set universal '%s'; but a global by that name shadows it\n"
+msgstr ""
+
+#, c-format
+msgid "%s: the -k/--key syntax is no longer supported. See `bind --help` and `bind --key-names`\n"
+msgstr ""
+
+#, c-format
+msgid "%s: there is no line %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: too many arguments\n"
+msgstr "%s: zu viele Argumente\n"
+
+#, c-format
+msgid "%s: usage of -i for --silent is deprecated. Please use -s or --silent instead.\n"
+msgstr ""
+
+#, c-format
+msgid "%s: value not completely converted (can't convert '%s')"
+msgstr "%s: Wert nicht vollständig konvertiert (kann '%s' nicht konvertieren)"
+
+#, c-format
+msgid "%s: variable '%s' is read-only\n"
+msgstr ""
+
+#, c-format
+msgid "%sand %u more rows"
+msgstr "%sund %u weitere Zeilen"
+
+#, c-format
+msgid "%u\n"
+msgstr ""
 
 msgid "'break' while not inside of loop"
 msgstr ""
@@ -843,15 +835,15 @@ msgid "'}' does not take arguments. Did you forget a ';'?"
 msgstr ""
 
 #, c-format
-msgid "(Type 'help %ls' for related documentation)\n"
-msgstr "(Nutze 'help %ls' für entsprechende Dokumentation)\n"
+msgid "(Type 'help %s' for related documentation)\n"
+msgstr "(Nutze 'help %s' für entsprechende Dokumentation)\n"
 
 msgid "(no matches)"
 msgstr "(keine Treffer)"
 
 #, c-format
-msgid ", copied in %ls @ line %d"
-msgstr ", kopiert in %ls, Zeile %d"
+msgid ", copied in %s @ line %d"
+msgstr ", kopiert in %s, Zeile %d"
 
 msgid ", copied interactively"
 msgstr ", interaktiv kopiert"
@@ -887,8 +879,8 @@ msgid "Abbreviation expansion"
 msgstr ""
 
 #, c-format
-msgid "Abbreviation: %ls"
-msgstr "Abkürzung: %ls"
+msgid "Abbreviation: %s"
+msgstr "Abkürzung: %s"
 
 msgid "Abort"
 msgstr "Abbruch"
@@ -906,8 +898,8 @@ msgid "An error occurred while setting up pipe"
 msgstr "Fehler beim Einrichten der Pipe aufgetreten"
 
 #, c-format
-msgid "Argument is not a number: '%ls'"
-msgstr "Argument ist keine Zahl: '%ls'"
+msgid "Argument is not a number: '%s'"
+msgstr "Argument ist keine Zahl: '%s'"
 
 msgid "Await background process completion"
 msgstr "Auf den Abschluss von Hintergrundprozessen warten"
@@ -1008,8 +1000,8 @@ msgid "Define a new function"
 msgstr "Neue Funktion definieren"
 
 #, c-format
-msgid "Defined in %ls @ line %d"
-msgstr "Definiert in %ls, Zeile %d"
+msgid "Defined in %s @ line %d"
+msgstr "Definiert in %s, Zeile %d"
 
 msgid "Defined interactively"
 msgstr "Interaktiv definiert"
@@ -1038,8 +1030,8 @@ msgid "Error when renaming file: %s"
 msgstr ""
 
 #, c-format
-msgid "Error while reading file %ls\n"
-msgstr "Fehler beim Lesen der Datei %ls\n"
+msgid "Error while reading file %s\n"
+msgstr "Fehler beim Lesen der Datei %s\n"
 
 msgid "Errors reported by exec (on by default)"
 msgstr ""
@@ -1072,20 +1064,16 @@ msgid "Expansion produced too many results"
 msgstr "Erweiterung produzierte zu viele Ergebnisse"
 
 #, c-format
-msgid "Expected %ls, but found %ls"
-msgstr "Erwartete %ls, aber fand %ls"
+msgid "Expected %s, but found %s"
+msgstr "Erwartete %s, aber fand %s"
 
 #, c-format
-msgid "Expected %s, but found %ls"
-msgstr ""
+msgid "Expected a command, but found %s"
+msgstr "Erwartete einen Befehl, aber fand %s"
 
 #, c-format
-msgid "Expected a command, but found %ls"
-msgstr "Erwartete einen Befehl, aber fand %ls"
-
-#, c-format
-msgid "Expected a string, but found %ls"
-msgstr "Erwartete Zeichenkette, aber fand %ls"
+msgid "Expected a string, but found %s"
+msgstr "Erwartete Zeichenkette, aber fand %s"
 
 msgid "Expected a string, but found a redirection"
 msgstr "Erwartete einen String, fand aber eine Umlenkung"
@@ -1097,7 +1085,7 @@ msgstr ""
 msgid ""
 "Expected file path to read/write for -w:\n"
 "\n"
-" $ %ls -w foo.fish"
+" $ %s -w foo.fish"
 msgstr ""
 
 #, c-format
@@ -1169,33 +1157,33 @@ msgid "History performance measurements"
 msgstr ""
 
 #, c-format
-msgid "History session ID '%ls' is not a valid variable name. Falling back to `%ls`."
-msgstr "Verlaufs-ID '%ls' ist kein gültiger Variablenname. Nutze `%ls`."
+msgid "History session ID '%s' is not a valid variable name. Falling back to `%s`."
+msgstr "Verlaufs-ID '%s' ist kein gültiger Variablenname. Nutze `%s`."
 
 #, c-format
-msgid "Home for %ls"
-msgstr "Heimordner für %ls"
+msgid "Home for %s"
+msgstr "Heimordner für %s"
 
 msgid "I/O on asynchronous file descriptor is possible"
 msgstr "E/A auf asynchronem Dateideskriptor ist möglich"
 
 #, c-format
-msgid "Illegal file descriptor in redirection '%ls'"
+msgid "Illegal file descriptor in redirection '%s'"
 msgstr ""
 
 msgid "Illegal instruction"
 msgstr "Illegale Instruktion"
 
 #, c-format
-msgid "Incomplete escape sequence '%ls'"
-msgstr "Unvollständige Escapesequenz '%ls'"
+msgid "Incomplete escape sequence '%s'"
+msgstr "Unvollständige Escapesequenz '%s'"
 
 msgid "Information request"
 msgstr ""
 
 #, c-format
-msgid "Integer %lld in '%ls' followed by non-digit"
-msgstr "Ganzzahl %lld in '%ls' gefolgt von nicht-Ziffer"
+msgid "Integer %d in '%s' followed by non-digit"
+msgstr "Ganzzahl %d in '%s' gefolgt von nicht-Ziffer"
 
 msgid "Internal (non-forked) process events"
 msgstr ""
@@ -1216,31 +1204,31 @@ msgid "Invalid input/output redirection"
 msgstr "Ungültige Eingabe-/Ausgabe-Umlenkung"
 
 #, c-format
-msgid "Invalid number: %ls"
-msgstr "Ungültige Zahl: %ls"
+msgid "Invalid number: %s"
+msgstr "Ungültige Zahl: %s"
 
 #, c-format
-msgid "Invalid redirection target: %ls"
-msgstr "Ungültiges Umleitungsziel: %ls"
+msgid "Invalid redirection target: %s"
+msgstr "Ungültiges Umleitungsziel: %s"
 
 #, c-format
-msgid "Invalid redirection: %ls"
-msgstr "Ungültige Umleitung: %ls"
+msgid "Invalid redirection: %s"
+msgstr "Ungültige Umleitung: %s"
 
 #, c-format
-msgid "Invalid token '%ls'"
-msgstr "Ungültiger Token '%ls'"
+msgid "Invalid token '%s'"
+msgstr "Ungültiger Token '%s'"
 
 #, c-format
-msgid "Items %lu to %lu of %lu"
+msgid "Items %u to %u of %u"
 msgstr ""
 
 msgid "Job\tGroup\t"
 msgstr "Job\tGruppe\t"
 
 #, c-format
-msgid "Job control: %ls\n"
-msgstr "Jobsteuerung: %ls\n"
+msgid "Job control: %s\n"
+msgstr "Jobsteuerung: %s\n"
 
 msgid "Jobs being executed"
 msgstr ""
@@ -1279,7 +1267,7 @@ msgid "Missing closing parenthesis"
 msgstr "Fehlende schließende Klammer"
 
 #, c-format
-msgid "Missing end to balance this %ls"
+msgid "Missing end to balance this %s"
 msgstr ""
 
 msgid "Missing hexadecimal number in Unicode escape"
@@ -1289,7 +1277,7 @@ msgid "Missing operator"
 msgstr ""
 
 #, c-format
-msgid "Modification of read-only variable \"%ls\" is not allowed\n"
+msgid "Modification of read-only variable \"%s\" is not allowed\n"
 msgstr ""
 
 msgid "Negate exit status of job"
@@ -1302,7 +1290,7 @@ msgid "No TTY for interactive shell (tcgetpgrp failed)"
 msgstr "Kein TTY für interaktive Shell (tcgetpgrp schlug fehl)"
 
 #, c-format
-msgid "No matches for wildcard '%ls'. See `help wildcards-globbing`."
+msgid "No matches for wildcard '%s'. See `help wildcards-globbing`."
 msgstr ""
 
 msgid "Not a function"
@@ -1346,12 +1334,12 @@ msgid "Perform a set of commands multiple times"
 msgstr "Eine Befehlsfolge mehrmals ausführen"
 
 #, c-format
-msgid "Please set $%ls to a directory where you have write access."
-msgstr "Bitte setzen sie $%ls auf ein Verzeichnis in das sie schreiben können."
+msgid "Please set $%s to a directory where you have write access."
+msgstr "Bitte setzen sie $%s auf ein Verzeichnis in das sie schreiben können."
 
 #, c-format
-msgid "Please set the %ls or HOME environment variable before starting fish."
-msgstr "Bitte setzen sie %ls oder die HOME Umgebungsvariable bevor sie fish starten."
+msgid "Please set the %s or HOME environment variable before starting fish."
+msgstr "Bitte setzen sie %s oder die HOME Umgebungsvariable bevor sie fish starten."
 
 msgid "Polite quit request"
 msgstr "Höfliche Beendigungsanforderung"
@@ -1415,12 +1403,12 @@ msgid "Rendering the command line"
 msgstr ""
 
 #, c-format
-msgid "Requested redirection to '%ls', which is not a valid file descriptor"
-msgstr "Umleitung zu '%ls' angefordert, dies ist aber kein gültiger Dateideskriptor"
+msgid "Requested redirection to '%s', which is not a valid file descriptor"
+msgstr "Umleitung zu '%s' angefordert, dies ist aber kein gültiger Dateideskriptor"
 
 #, c-format
-msgid "Result too large: %ls"
-msgstr "Ergebnis zu groß: %ls"
+msgid "Result too large: %s"
+msgstr "Ergebnis zu groß: %s"
 
 msgid "Return a successful result"
 msgstr "Ein erfolgreiches Resultat zurückgeben"
@@ -1453,11 +1441,11 @@ msgid "Searching/using paths"
 msgstr ""
 
 #, c-format
-msgid "Send job %d (%ls) to foreground\n"
+msgid "Send job %d (%s) to foreground\n"
 msgstr ""
 
 #, c-format
-msgid "Send job %s '%ls' to background\n"
+msgid "Send job %s '%s' to background\n"
 msgstr ""
 
 msgid "Send job to background"
@@ -1535,11 +1523,11 @@ msgid "Test a condition"
 msgstr "Teste eine Bedingung"
 
 #, c-format
-msgid "The '%ls' command can not be used immediately after a backgrounded job"
-msgstr "Der Befehl '%ls' kann nicht direkt nach einem Hintergrundjob aufgerufen werden"
+msgid "The '%s' command can not be used immediately after a backgrounded job"
+msgstr "Der Befehl '%s' kann nicht direkt nach einem Hintergrundjob aufgerufen werden"
 
 #, c-format
-msgid "The '%ls' command can not be used in a pipeline"
+msgid "The '%s' command can not be used in a pipeline"
 msgstr ""
 
 msgid "The 'time' command may only be at the beginning of a pipeline"
@@ -1562,8 +1550,8 @@ msgid "The expanded command was empty."
 msgstr ""
 
 #, c-format
-msgid "The function '%ls' calls itself immediately, which would result in an infinite loop."
-msgstr "Die Funktion '%ls' ruft sich sofort selbst auf. Dies wäre eine Endlosschleife."
+msgid "The function '%s' calls itself immediately, which would result in an infinite loop."
+msgstr "Die Funktion '%s' ruft sich sofort selbst auf. Dies wäre eine Endlosschleife."
 
 msgid "The interactive reader/input system"
 msgstr ""
@@ -1602,22 +1590,22 @@ msgid "Trying to print invalid output"
 msgstr ""
 
 #, c-format
-msgid "Unable to create temporary file '%ls': %s"
+msgid "Unable to create temporary file '%s': %s"
 msgstr ""
 
 msgid "Unable to evaluate string substitution"
 msgstr ""
 
 #, c-format
-msgid "Unable to expand variable name '%ls'"
+msgid "Unable to expand variable name '%s'"
 msgstr ""
 
 #, c-format
-msgid "Unable to locate %ls directory derived from $%ls: '%ls'."
-msgstr "Konnte Verzeichnis %ls abgeleitet von %ls nicht finden: '%ls'."
+msgid "Unable to locate %s directory derived from $%s: '%s'."
+msgstr "Konnte Verzeichnis %s abgeleitet von %s nicht finden: '%s'."
 
 #, c-format
-msgid "Unable to locate the %ls directory."
+msgid "Unable to locate the %s directory."
 msgstr ""
 
 #, c-format
@@ -1665,23 +1653,23 @@ msgid "Unknown"
 msgstr "Unbekannt"
 
 #, c-format
-msgid "Unknown builtin '%ls'"
-msgstr "Unbekannter interner Befehl '%ls'"
+msgid "Unknown builtin '%s'"
+msgstr "Unbekannter interner Befehl '%s'"
 
 msgid "Unknown command"
 msgstr "Unbekannter Befehl"
 
 #, c-format
-msgid "Unknown command. '%ls' exists but is not an executable file."
-msgstr "Befehl nicht gefunden. '%ls' existiert, ist aber keine ausführbare Datei."
+msgid "Unknown command. '%s' exists but is not an executable file."
+msgstr "Befehl nicht gefunden. '%s' existiert, ist aber keine ausführbare Datei."
 
 #, c-format
-msgid "Unknown command. A component of '%ls' is not a directory."
-msgstr "Befehl nicht gefunden. Eine Komponente von '%ls' ist kein Verzeichnis."
+msgid "Unknown command. A component of '%s' is not a directory."
+msgstr "Befehl nicht gefunden. Eine Komponente von '%s' ist kein Verzeichnis."
 
 #, c-format
-msgid "Unknown command. A component of '%ls' is not a directory. Check your $PATH."
-msgstr "Befehl nicht gefunden. Ein Element von '%ls' ist kein Verzeichnis. Überprüfe deinen $PATH"
+msgid "Unknown command. A component of '%s' is not a directory. Check your $PATH."
+msgstr "Befehl nicht gefunden. Ein Element von '%s' ist kein Verzeichnis. Überprüfe deinen $PATH"
 
 msgid "Unknown command:"
 msgstr "Befehl nicht gefunden:"
@@ -1693,14 +1681,14 @@ msgid "Unknown function"
 msgstr "Unbekannte Funktion"
 
 #, c-format
-msgid "Unknown function '%ls'"
-msgstr "Unbekannte Funktion '%ls'"
+msgid "Unknown function '%s'"
+msgstr "Unbekannte Funktion '%s'"
 
 msgid "Unmatched wildcard"
 msgstr "Nicht passender Platzhalter"
 
 #, c-format
-msgid "Unsupported use of '='. In fish, please use 'set %ls %ls'."
+msgid "Unsupported use of '='. In fish, please use 'set %s %s'."
 msgstr ""
 
 msgid "Unused signal"
@@ -1719,15 +1707,15 @@ msgid "User defined signal 2"
 msgstr "Benutzerdefiniertes Signal 2"
 
 #, c-format
-msgid "Variable: %ls"
-msgstr "Variable: %ls"
+msgid "Variable: %s"
+msgstr "Variable: %s"
 
 #, c-format
-msgid "Variables cannot be bracketed. In fish, please use \"$%ls\"."
+msgid "Variables cannot be bracketed. In fish, please use \"$%s\"."
 msgstr ""
 
 #, c-format
-msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
+msgid "Variables cannot be bracketed. In fish, please use {$%s}."
 msgstr ""
 
 msgid "Virtual timer expired"
@@ -1758,15 +1746,15 @@ msgid "autoloading"
 msgstr ""
 
 #, c-format
-msgid "builtin %ls: %ls: %s\n"
-msgstr "builtin %ls: %ls: %s\n"
+msgid "builtin %s: %s: %s\n"
+msgstr "builtin %s: %s: %s\n"
 
 #, c-format
-msgid "builtin %ls: Invalid arg: %ls\n"
-msgstr "builtin %ls: Ungültiges argument: %ls\n"
+msgid "builtin %s: Invalid arg: %s\n"
+msgstr "builtin %s: Ungültiges argument: %s\n"
 
 #, c-format
-msgid "builtin %ls: realpath failed: %s\n"
+msgid "builtin %s: realpath failed: %s\n"
 msgstr ""
 
 msgid "builtin history delete --exact requires --case-sensitive\n"
@@ -1817,33 +1805,33 @@ msgstr "Datei"
 
 #, c-format
 msgid ""
-"fish: %ls: missing man page\n"
+"fish: %s: missing man page\n"
 "Documentation may not be installed.\n"
-"`help %ls` will show an online version\n"
+"`help %s` will show an online version\n"
 msgstr ""
 
 #, c-format
-msgid "from sourcing file %ls\n"
-msgstr "aus der Quelldatei %ls\n"
+msgid "from sourcing file %s\n"
+msgstr "aus der Quelldatei %s\n"
 
 msgid "in command substitution\n"
 msgstr "in der Befehlsersetzung\n"
 
 #, c-format
-msgid "in event handler: %ls\n"
-msgstr "im Ereignis-Handler: %ls\n"
+msgid "in event handler: %s\n"
+msgstr "im Ereignis-Handler: %s\n"
 
 #, c-format
-msgid "in function '%ls'"
-msgstr "in der Funktion '%ls'"
+msgid "in function '%s'"
+msgstr "in der Funktion '%s'"
 
 #, c-format
-msgid "invalid field width: %ls"
-msgstr "Ungültige Feldlänge: %ls"
+msgid "invalid field width: %s"
+msgstr "Ungültige Feldlänge: %s"
 
 #, c-format
-msgid "invalid precision: %ls"
-msgstr "Ungültige Genauigkeitsangabe: %ls"
+msgid "invalid precision: %s"
+msgstr "Ungültige Genauigkeitsangabe: %s"
 
 msgid "missing hexadecimal number in escape"
 msgstr "fehlende Hexadezimal-Zahl in Escapesequenz"
@@ -1857,8 +1845,8 @@ msgid "or press ctrl-%c or ctrl-%c twice in a row."
 msgstr ""
 
 #, c-format
-msgid "rows %lu to %lu of %lu"
-msgstr "Zeilen %lu bis %lu von %lu"
+msgid "rows %u to %u of %u"
+msgstr "Zeilen %u bis %u von %u"
 
 msgid "running"
 msgstr "aktiv"
@@ -1870,14 +1858,14 @@ msgid "stopped"
 msgstr "gestoppt"
 
 #, c-format
-msgid "switch: Expected at most one argument, got %lu\n"
-msgstr "switch: Erwartet höchstens einen Parameter, aber %lu angegeben\n"
+msgid "switch: Expected at most one argument, got %u\n"
+msgstr "switch: Erwartet höchstens einen Parameter, aber %u angegeben\n"
 
 msgid "symlink"
 msgstr ""
 
 #, c-format
-msgid "ulimit: Permission denied when changing resource of type '%ls'\n"
+msgid "ulimit: Permission denied when changing resource of type '%s'\n"
 msgstr ""
 
 msgid "unexported"
@@ -1896,16 +1884,13 @@ msgstr "|& ist ungültig. In fish, nutze &| um stdout und stderr gleichzeitig zu
 msgid "fish-section-tier1-from-script-explicitly-added"
 msgstr ""
 
-msgid "%ls: %ls: expected %d arguments; got %d\\n"
-msgstr ""
-
-msgid "%ls: %ls: subcommand takes no options\\n"
-msgstr ""
-
-msgid "%ls: Expected at least %d args, got only %d\\n"
-msgstr ""
-
 msgid "%s: %s is an array variable. Use %svared%s %s[n]%s to edit the n:th element of %s\\n"
+msgstr ""
+
+msgid "%s: %s: expected %d arguments; got %d\\n"
+msgstr ""
+
+msgid "%s: %s: subcommand takes no options\\n"
 msgstr ""
 
 msgid "%s: Could not create configuration directory '%s'\\n"
@@ -1915,6 +1900,9 @@ msgid "%s: Could not find a web browser.\\n"
 msgstr ""
 
 msgid "%s: Directory stack is empty…\\n"
+msgstr ""
+
+msgid "%s: Expected at least %d args, got only %d\\n"
 msgstr ""
 
 msgid "%s: Expected exactly one argument, got %s.\\n\\nSynopsis:\\n\\t%svared%s VARIABLE\\n"

--- a/po/en.po
+++ b/po/en.po
@@ -30,7 +30,7 @@ msgid ""
 msgstr ""
 
 #, c-format
-msgid " (%ls)\n"
+msgid " (%s)\n"
 msgstr ""
 
 msgid " (read-only)\n"
@@ -40,7 +40,7 @@ msgid " a path variable"
 msgstr ""
 
 #, c-format
-msgid " with arguments '%ls'"
+msgid " with arguments '%s'"
 msgstr ""
 
 msgid " with definition"
@@ -53,15 +53,15 @@ msgid "$$ is not the pid. In fish, please use $fish_pid."
 msgstr ""
 
 #, c-format
-msgid "$%lc is not a valid variable in fish."
-msgstr "$%lc is not a valid variable in fish."
+msgid "$%c is not a valid variable in fish."
+msgstr "$%c is not a valid variable in fish."
 
 #, c-format
-msgid "$%ls: originally inherited as |%ls|\n"
+msgid "$%s: originally inherited as |%s|\n"
 msgstr ""
 
 #, c-format
-msgid "$%ls: set in %ls scope, %ls,%ls with %d elements"
+msgid "$%s: set in %s scope, %s,%s with %d elements"
 msgstr ""
 
 msgid "$* is not supported. In fish, please use $argv."
@@ -77,728 +77,52 @@ msgid "$status is not valid as a command. See `help conditions`"
 msgstr ""
 
 #, c-format
-msgid "%.*ls: invalid conversion specification"
-msgstr "%.*ls: invalid conversion specification"
-
-#, c-format
-msgid "%ls"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: Abbreviation %ls already exists, cannot rename %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: Abbreviation '%ls' cannot have spaces in the word\n"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: Name cannot be empty\n"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: No abbreviation named %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: Requires at least two arguments\n"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: Requires exactly two arguments\n"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: Unexpected argument -- '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls (line %d): "
-msgstr "%ls (line %d): "
-
-#, c-format
-msgid "%ls (line %lu): "
-msgstr "%ls (line %lu): "
-
-#, c-format
-msgid "%ls is %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls is a builtin\n"
-msgstr ""
-
-#, c-format
-msgid "%ls is a function"
-msgstr ""
-
-#, c-format
-msgid "%ls, version %s"
-msgstr ""
-
-#, c-format
-msgid "%ls: %*ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls %ls: options cannot be used together\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: cannot overwrite read-only variable"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: cannot use reserved keyword as function name"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: contains a syntax error\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: expected %d arguments; got %d\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid base value\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid function name"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid integer\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid mode\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid mode name. See `help identifiers`\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid process id"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid scale\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid subcommand\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid variable name. See `help identifiers`\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: option does not take an argument\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: option requires an argument\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: subcommand takes no options\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: unexpected positional argument"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: unknown option\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: '%ls' is a broken symbolic link to '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: '%ls' is not a directory\n"
-msgstr "%ls: “%ls” is not a directory\n"
-
-#, c-format
-msgid "%ls: '%ls' is not a job\n"
-msgstr "%ls: “%ls” is not a job\n"
-
-#, c-format
-msgid "%ls: '%ls' is not a valid job id\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: '%ls' is not a valid job specifier\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: '%ls' is not a valid process id\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: --command cannot be combined with --position command"
-msgstr ""
-
-#, c-format
-msgid "%ls: --function option requires --add\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: --position option requires --add\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: --regex option requires --add\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: --set-cursor argument cannot be empty\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: --set-cursor option requires --add\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: -l requires a non-empty string\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: -o requires a non-empty string\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: -s requires a non-empty string\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Ambiguous job\n"
-msgstr "%ls: Ambiguous job\n"
-
-#, c-format
-msgid "%ls: An option spec must have at least a short or a long flag\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Argument '%ls' is out of range\n"
-msgstr "%ls: Argument “%ls” is out of range\n"
-
-#, c-format
-msgid "%ls: Can not specify scope when removing block\n"
-msgstr "%ls: Can not specify scope when removing block\n"
-
-#, c-format
-msgid "%ls: Can't put job %d, '%ls' to foreground because it is not under job control\n"
-msgstr "%ls: Can't put job %d, “%ls” to foreground because it is not under job control\n"
-
-#, c-format
-msgid "%ls: Can't put job %s, '%ls' to background because it is not under job control\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Cannot combine options %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Cannot specify multiple positions\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Cannot specify multiple regex patterns\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Cannot specify multiple set-cursor options\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Cannot use --append or --prepend when assigning to a slice"
-msgstr ""
-
-#, c-format
-msgid "%ls: Command not valid at an interactive prompt\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Could not find '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Could not find a job with process id '%d'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Could not find child processes with the name '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Could not find home directory\n"
-msgstr "%ls: Could not find home directory\n"
-
-#, c-format
-msgid "%ls: Could not find job '%d'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Did you mean `set %ls %ls`?"
-msgstr ""
-
-#, c-format
-msgid "%ls: Empty directory '%ls' does not exist\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Error encountered while sourcing file '%ls':\n"
-msgstr "%ls: Error encountered while sourcing file “%ls”:\n"
-
-#, c-format
-msgid "%ls: Error while reading file '%ls'\n"
-msgstr "%ls: Error while reading file “%ls”\n"
-
-#, c-format
-msgid "%ls: Expected at least one argument"
-msgstr ""
-
-#, c-format
-msgid "%ls: Expected exactly one function name\n"
-msgstr "%ls: Expected exactly one function name\n"
-
-#, c-format
-msgid "%ls: Expected exactly two names (current function name, and new function name)\n"
-msgstr "%ls: Expected exactly two names (current function name, and new function name)\n"
-
-#, c-format
-msgid "%ls: Expected generic | variable | signal | exit | job-id for --handlers-type\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Function '%ls' already exists. Cannot create copy of '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Function '%ls' does not exist\n"
-msgstr "%ls: Function “%ls” does not exist\n"
-
-#, c-format
-msgid "%ls: Illegal function name '%ls'\n"
-msgstr "%ls: Illegal function name “%ls”\n"
-
-#, c-format
-msgid "%ls: Implicit int flag '%lc' already defined\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Implicit int short flag '%lc' does not allow modifiers like '%lc'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid --max-args value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid --min-args value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid --unknown-arguments value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid count value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid end value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid escape style '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid fields value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid function name: %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid index starting at '%ls'\n"
-msgstr "%ls: Invalid index starting at “%ls”\n"
-
-#, c-format
-msgid "%ls: Invalid job control mode '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid length value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid level value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid limit '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid max matches value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid max value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid option spec '%ls' at char '%lc'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid padding character of width zero '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid permission '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid position '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid range value for field '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid sort key '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid start value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid state\n"
-msgstr "%ls: Invalid state\n"
-
-#, c-format
-msgid "%ls: Invalid style value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid token '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid type '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid width value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Key not specified\n"
-msgstr "%ls: Key not specified\n"
-
-#, c-format
-msgid "%ls: Long flag '%ls' already defined\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Missing -- separator\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: New limit cannot be an empty string\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: No binding found for key '%ls'\n"
-msgstr "%ls: No binding found for key “%ls”\n"
-
-#, c-format
-msgid "%ls: No binding found for key sequence '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: No blocks defined\n"
-msgstr "%ls: No blocks defined\n"
-
-#, c-format
-msgid "%ls: No suitable job: %d\n"
-msgstr "%ls: No suitable job: %d\n"
-
-#, c-format
-msgid "%ls: No suitable job: %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Not inside of loop\n"
-msgstr "%ls: Not inside of loop\n"
-
-#, c-format
-msgid "%ls: Options %ls and %ls cannot be used together\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Padding should be a character '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Permission denied: '%ls'\n"
-msgstr "%ls: Permission denied: “%ls”\n"
-
-#, c-format
-msgid "%ls: Regular expression compile error: %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Regular expression substitute error: %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Resource limit not available on this operating system\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: STEP must be a positive integer\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Short flag '%lc' already defined\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Short flag '%lc' invalid, must be alphanum or '#'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: The directory '%ls' does not exist\n"
-msgstr "%ls: The directory “%ls” does not exist\n"
-
-#, c-format
-msgid "%ls: The variable '%ls' does not exist\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: There are no jobs\n"
-msgstr "%ls: There are no jobs\n"
-
-#, c-format
-msgid "%ls: There are no suitable jobs\n"
-msgstr "%ls: There are no suitable jobs\n"
-
-#, c-format
-msgid "%ls: Too many levels of symbolic links: '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Too many long-only options\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Tried to change the read-only variable '%ls'\n"
-msgstr "%ls: Tried to change the read-only variable “%ls”\n"
-
-#, c-format
-msgid "%ls: Tried to modify the special variable '%ls' to an invalid value\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Tried to modify the special variable '%ls' with the wrong scope\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Unknown color '%ls'\n"
-msgstr "%ls: Unknown color “%ls”\n"
-
-#, c-format
-msgid "%ls: Unknown error trying to locate directory '%ls'\n"
-msgstr "%ls: Unknown error trying to locate directory “%ls”\n"
-
-#, c-format
-msgid "%ls: Unknown input function '%ls'"
-msgstr ""
-
-#, c-format
-msgid "%ls: Unknown signal '%ls'"
-msgstr ""
-
-#, c-format
-msgid "%ls: Warning: Option '%ls' was removed and is now ignored"
-msgstr ""
-
-#, c-format
-msgid "%ls: `set --show` does not allow slices with the var names\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: array index out of bounds\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: called with no arguments. This will be an error in future."
-msgstr ""
-
-#, c-format
-msgid "%ls: called with one argument. This will return false in future."
-msgstr ""
-
-#, c-format
-msgid "%ls: calling job for event handler not found"
-msgstr ""
-
-#, c-format
-msgid "%ls: can't merge history in private mode\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: cannot both export and unexport\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: cannot both path and unpath\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: column %ls exceeds line length\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: exclusive flag '%ls' is not valid\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: exclusive flag string '%ls' is not valid\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: expected %d arguments; got %d\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: expected <= %d arguments; got %d\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: expected >= %d arguments; got %d\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: expected a numeric value"
-msgstr "%ls: expected a numeric value"
-
-#, c-format
-msgid "%ls: fish was not built with embedded files"
-msgstr ""
-
-#, c-format
-msgid "%ls: given %d indexes but %d values\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: invalid option combination\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: invalid option combination, %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: invalid underline style: %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: job %d ('%ls') was stopped and has been signalled to continue.\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: line/column index starts at 1"
-msgstr ""
-
-#, c-format
-msgid "%ls: missing argument\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: missing filename argument or input redirection\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: missing subcommand\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: nothing to choose from\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: realpath failed: %s\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: scope can be only one of: universal function global local\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: stdin is closed\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: successfully set universal '%ls'; but a global by that name shadows it\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: the -k/--key syntax is no longer supported. See `bind --help` and `bind --key-names`\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: there is no line %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: too many arguments\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: usage of -i for --silent is deprecated. Please use -s or --silent instead.\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: value not completely converted (can't convert '%ls')"
-msgstr ""
-
-#, c-format
-msgid "%ls: variable '%ls' is read-only\n"
-msgstr ""
-
-#, c-format
-msgid "%lsand %lu more rows"
-msgstr "%lsand %lu more rows"
-
-#, c-format
-msgid "%lu\n"
-msgstr ""
+msgid "%.*s: invalid conversion specification"
+msgstr "%.*s: invalid conversion specification"
 
 #, c-format
 msgid "%s"
 msgstr ""
 
 #, c-format
-msgid "%s %s: unrecognized feature '%ls'"
+msgid "%s %s: Abbreviation %s already exists, cannot rename %s\n"
 msgstr ""
+
+#, c-format
+msgid "%s %s: Abbreviation '%s' cannot have spaces in the word\n"
+msgstr ""
+
+#, c-format
+msgid "%s %s: Name cannot be empty\n"
+msgstr ""
+
+#, c-format
+msgid "%s %s: No abbreviation named %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s %s: Requires at least two arguments\n"
+msgstr ""
+
+#, c-format
+msgid "%s %s: Requires exactly two arguments\n"
+msgstr ""
+
+#, c-format
+msgid "%s %s: Unexpected argument -- '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s %s: unrecognized feature '%s'"
+msgstr ""
+
+#, c-format
+msgid "%s (line %d): "
+msgstr "%s (line %d): "
+
+#, c-format
+msgid "%s (line %u): "
+msgstr "%s (line %u): "
 
 #, c-format
 msgid "%s and %s are mutually exclusive"
@@ -809,12 +133,680 @@ msgid "%s could not read response to Primary Device Attribute query after waitin
 msgstr ""
 
 #, c-format
+msgid "%s is %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s is a builtin\n"
+msgstr ""
+
+#, c-format
+msgid "%s is a function"
+msgstr ""
+
+#, c-format
 msgid "%s, version %s"
 msgstr ""
 
 #, c-format
 msgid "%s, version %s\n"
 msgstr "%s, version %s\n"
+
+#, c-format
+msgid "%s: %*s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s %s: options cannot be used together\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: cannot overwrite read-only variable"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: cannot use reserved keyword as function name"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: contains a syntax error\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: expected %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid base value\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid function name"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid integer\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid mode\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid mode name. See `help identifiers`\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid process id"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid scale\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid subcommand\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid variable name. See `help identifiers`\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: option does not take an argument\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: option requires an argument\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: subcommand takes no options\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: unexpected positional argument"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: unknown option\n"
+msgstr ""
+
+#, c-format
+msgid "%s: '%s' is a broken symbolic link to '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: '%s' is not a directory\n"
+msgstr "%s: “%s” is not a directory\n"
+
+#, c-format
+msgid "%s: '%s' is not a job\n"
+msgstr "%s: “%s” is not a job\n"
+
+#, c-format
+msgid "%s: '%s' is not a valid job id\n"
+msgstr ""
+
+#, c-format
+msgid "%s: '%s' is not a valid job specifier\n"
+msgstr ""
+
+#, c-format
+msgid "%s: '%s' is not a valid process id\n"
+msgstr ""
+
+#, c-format
+msgid "%s: --command cannot be combined with --position command"
+msgstr ""
+
+#, c-format
+msgid "%s: --function option requires --add\n"
+msgstr ""
+
+#, c-format
+msgid "%s: --position option requires --add\n"
+msgstr ""
+
+#, c-format
+msgid "%s: --regex option requires --add\n"
+msgstr ""
+
+#, c-format
+msgid "%s: --set-cursor argument cannot be empty\n"
+msgstr ""
+
+#, c-format
+msgid "%s: --set-cursor option requires --add\n"
+msgstr ""
+
+#, c-format
+msgid "%s: -l requires a non-empty string\n"
+msgstr ""
+
+#, c-format
+msgid "%s: -o requires a non-empty string\n"
+msgstr ""
+
+#, c-format
+msgid "%s: -s requires a non-empty string\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Ambiguous job\n"
+msgstr "%s: Ambiguous job\n"
+
+#, c-format
+msgid "%s: An option spec must have at least a short or a long flag\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Argument '%s' is out of range\n"
+msgstr "%s: Argument “%s” is out of range\n"
+
+#, c-format
+msgid "%s: Can not specify scope when removing block\n"
+msgstr "%s: Can not specify scope when removing block\n"
+
+#, c-format
+msgid "%s: Can't put job %d, '%s' to foreground because it is not under job control\n"
+msgstr "%s: Can't put job %d, “%s” to foreground because it is not under job control\n"
+
+#, c-format
+msgid "%s: Can't put job %s, '%s' to background because it is not under job control\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Cannot combine options %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Cannot specify multiple positions\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Cannot specify multiple regex patterns\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Cannot specify multiple set-cursor options\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Cannot use --append or --prepend when assigning to a slice"
+msgstr ""
+
+#, c-format
+msgid "%s: Command not valid at an interactive prompt\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Could not find '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Could not find a job with process id '%d'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Could not find child processes with the name '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Could not find home directory\n"
+msgstr "%s: Could not find home directory\n"
+
+#, c-format
+msgid "%s: Could not find job '%d'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Did you mean `set %s %s`?"
+msgstr ""
+
+#, c-format
+msgid "%s: Empty directory '%s' does not exist\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Error encountered while sourcing file '%s':\n"
+msgstr "%s: Error encountered while sourcing file “%s”:\n"
+
+#, c-format
+msgid "%s: Error while reading file '%s'\n"
+msgstr "%s: Error while reading file “%s”\n"
+
+#, c-format
+msgid "%s: Expected at least one argument"
+msgstr ""
+
+#, c-format
+msgid "%s: Expected exactly one function name\n"
+msgstr "%s: Expected exactly one function name\n"
+
+#, c-format
+msgid "%s: Expected exactly two names (current function name, and new function name)\n"
+msgstr "%s: Expected exactly two names (current function name, and new function name)\n"
+
+#, c-format
+msgid "%s: Expected generic | variable | signal | exit | job-id for --handlers-type\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Function '%s' already exists. Cannot create copy of '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Function '%s' does not exist\n"
+msgstr "%s: Function “%s” does not exist\n"
+
+#, c-format
+msgid "%s: Illegal function name '%s'\n"
+msgstr "%s: Illegal function name “%s”\n"
+
+#, c-format
+msgid "%s: Implicit int flag '%c' already defined\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Implicit int short flag '%c' does not allow modifiers like '%c'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid --max-args value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid --min-args value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid --unknown-arguments value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid count value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid end value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid escape style '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid fields value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid function name: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid index starting at '%s'\n"
+msgstr "%s: Invalid index starting at “%s”\n"
+
+#, c-format
+msgid "%s: Invalid job control mode '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid length value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid level value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid limit '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid max matches value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid max value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid option spec '%s' at char '%c'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid padding character of width zero '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid permission '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid position '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid range value for field '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid sort key '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid start value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid state\n"
+msgstr "%s: Invalid state\n"
+
+#, c-format
+msgid "%s: Invalid style value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid token '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid type '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid width value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Key not specified\n"
+msgstr "%s: Key not specified\n"
+
+#, c-format
+msgid "%s: Long flag '%s' already defined\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Missing -- separator\n"
+msgstr ""
+
+#, c-format
+msgid "%s: New limit cannot be an empty string\n"
+msgstr ""
+
+#, c-format
+msgid "%s: No binding found for key '%s'\n"
+msgstr "%s: No binding found for key “%s”\n"
+
+#, c-format
+msgid "%s: No binding found for key sequence '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: No blocks defined\n"
+msgstr "%s: No blocks defined\n"
+
+#, c-format
+msgid "%s: No suitable job: %d\n"
+msgstr "%s: No suitable job: %d\n"
+
+#, c-format
+msgid "%s: No suitable job: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Not inside of loop\n"
+msgstr "%s: Not inside of loop\n"
+
+#, c-format
+msgid "%s: Options %s and %s cannot be used together\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Padding should be a character '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Permission denied: '%s'\n"
+msgstr "%s: Permission denied: “%s”\n"
+
+#, c-format
+msgid "%s: Regular expression compile error: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Regular expression substitute error: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Resource limit not available on this operating system\n"
+msgstr ""
+
+#, c-format
+msgid "%s: STEP must be a positive integer\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Short flag '%c' already defined\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Short flag '%c' invalid, must be alphanum or '#'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: The directory '%s' does not exist\n"
+msgstr "%s: The directory “%s” does not exist\n"
+
+#, c-format
+msgid "%s: The variable '%s' does not exist\n"
+msgstr ""
+
+#, c-format
+msgid "%s: There are no jobs\n"
+msgstr "%s: There are no jobs\n"
+
+#, c-format
+msgid "%s: There are no suitable jobs\n"
+msgstr "%s: There are no suitable jobs\n"
+
+#, c-format
+msgid "%s: Too many levels of symbolic links: '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Too many long-only options\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Tried to change the read-only variable '%s'\n"
+msgstr "%s: Tried to change the read-only variable “%s”\n"
+
+#, c-format
+msgid "%s: Tried to modify the special variable '%s' to an invalid value\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Tried to modify the special variable '%s' with the wrong scope\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Unknown color '%s'\n"
+msgstr "%s: Unknown color “%s”\n"
+
+#, c-format
+msgid "%s: Unknown error trying to locate directory '%s'\n"
+msgstr "%s: Unknown error trying to locate directory “%s”\n"
+
+#, c-format
+msgid "%s: Unknown input function '%s'"
+msgstr ""
+
+#, c-format
+msgid "%s: Unknown signal '%s'"
+msgstr ""
+
+#, c-format
+msgid "%s: Warning: Option '%s' was removed and is now ignored"
+msgstr ""
+
+#, c-format
+msgid "%s: `set --show` does not allow slices with the var names\n"
+msgstr ""
+
+#, c-format
+msgid "%s: array index out of bounds\n"
+msgstr ""
+
+#, c-format
+msgid "%s: called with no arguments. This will be an error in future."
+msgstr ""
+
+#, c-format
+msgid "%s: called with one argument. This will return false in future."
+msgstr ""
+
+#, c-format
+msgid "%s: calling job for event handler not found"
+msgstr ""
+
+#, c-format
+msgid "%s: can't merge history in private mode\n"
+msgstr ""
+
+#, c-format
+msgid "%s: cannot both export and unexport\n"
+msgstr ""
+
+#, c-format
+msgid "%s: cannot both path and unpath\n"
+msgstr ""
+
+#, c-format
+msgid "%s: column %s exceeds line length\n"
+msgstr ""
+
+#, c-format
+msgid "%s: exclusive flag '%s' is not valid\n"
+msgstr ""
+
+#, c-format
+msgid "%s: exclusive flag string '%s' is not valid\n"
+msgstr ""
+
+#, c-format
+msgid "%s: expected %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%s: expected <= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%s: expected >= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%s: expected a numeric value"
+msgstr "%s: expected a numeric value"
+
+#, c-format
+msgid "%s: fish was not built with embedded files"
+msgstr ""
+
+#, c-format
+msgid "%s: given %d indexes but %d values\n"
+msgstr ""
+
+#, c-format
+msgid "%s: invalid option combination\n"
+msgstr ""
+
+#, c-format
+msgid "%s: invalid option combination, %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: invalid underline style: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: job %d ('%s') was stopped and has been signalled to continue.\n"
+msgstr ""
+
+#, c-format
+msgid "%s: line/column index starts at 1"
+msgstr ""
+
+#, c-format
+msgid "%s: missing argument\n"
+msgstr ""
+
+#, c-format
+msgid "%s: missing filename argument or input redirection\n"
+msgstr ""
+
+#, c-format
+msgid "%s: missing subcommand\n"
+msgstr ""
+
+#, c-format
+msgid "%s: nothing to choose from\n"
+msgstr ""
+
+#, c-format
+msgid "%s: realpath failed: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: scope can be only one of: universal function global local\n"
+msgstr ""
+
+#, c-format
+msgid "%s: stdin is closed\n"
+msgstr ""
+
+#, c-format
+msgid "%s: successfully set universal '%s'; but a global by that name shadows it\n"
+msgstr ""
+
+#, c-format
+msgid "%s: the -k/--key syntax is no longer supported. See `bind --help` and `bind --key-names`\n"
+msgstr ""
+
+#, c-format
+msgid "%s: there is no line %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: too many arguments\n"
+msgstr ""
+
+#, c-format
+msgid "%s: usage of -i for --silent is deprecated. Please use -s or --silent instead.\n"
+msgstr ""
+
+#, c-format
+msgid "%s: value not completely converted (can't convert '%s')"
+msgstr ""
+
+#, c-format
+msgid "%s: variable '%s' is read-only\n"
+msgstr ""
+
+#, c-format
+msgid "%sand %u more rows"
+msgstr "%sand %u more rows"
+
+#, c-format
+msgid "%u\n"
+msgstr ""
 
 msgid "'break' while not inside of loop"
 msgstr ""
@@ -841,14 +833,14 @@ msgid "'}' does not take arguments. Did you forget a ';'?"
 msgstr ""
 
 #, c-format
-msgid "(Type 'help %ls' for related documentation)\n"
+msgid "(Type 'help %s' for related documentation)\n"
 msgstr ""
 
 msgid "(no matches)"
 msgstr "(no matches)"
 
 #, c-format
-msgid ", copied in %ls @ line %d"
+msgid ", copied in %s @ line %d"
 msgstr ""
 
 msgid ", copied interactively"
@@ -885,7 +877,7 @@ msgid "Abbreviation expansion"
 msgstr ""
 
 #, c-format
-msgid "Abbreviation: %ls"
+msgid "Abbreviation: %s"
 msgstr ""
 
 msgid "Abort"
@@ -904,7 +896,7 @@ msgid "An error occurred while setting up pipe"
 msgstr "An error occurred while setting up pipe"
 
 #, c-format
-msgid "Argument is not a number: '%ls'"
+msgid "Argument is not a number: '%s'"
 msgstr ""
 
 msgid "Await background process completion"
@@ -1006,7 +998,7 @@ msgid "Define a new function"
 msgstr "Define a new function"
 
 #, c-format
-msgid "Defined in %ls @ line %d"
+msgid "Defined in %s @ line %d"
 msgstr ""
 
 msgid "Defined interactively"
@@ -1036,8 +1028,8 @@ msgid "Error when renaming file: %s"
 msgstr ""
 
 #, c-format
-msgid "Error while reading file %ls\n"
-msgstr "Error while reading file %ls\n"
+msgid "Error while reading file %s\n"
+msgstr "Error while reading file %s\n"
 
 msgid "Errors reported by exec (on by default)"
 msgstr ""
@@ -1070,19 +1062,15 @@ msgid "Expansion produced too many results"
 msgstr ""
 
 #, c-format
-msgid "Expected %ls, but found %ls"
+msgid "Expected %s, but found %s"
 msgstr ""
 
 #, c-format
-msgid "Expected %s, but found %ls"
+msgid "Expected a command, but found %s"
 msgstr ""
 
 #, c-format
-msgid "Expected a command, but found %ls"
-msgstr ""
-
-#, c-format
-msgid "Expected a string, but found %ls"
+msgid "Expected a string, but found %s"
 msgstr ""
 
 msgid "Expected a string, but found a redirection"
@@ -1095,7 +1083,7 @@ msgstr ""
 msgid ""
 "Expected file path to read/write for -w:\n"
 "\n"
-" $ %ls -w foo.fish"
+" $ %s -w foo.fish"
 msgstr ""
 
 #, c-format
@@ -1167,32 +1155,32 @@ msgid "History performance measurements"
 msgstr ""
 
 #, c-format
-msgid "History session ID '%ls' is not a valid variable name. Falling back to `%ls`."
+msgid "History session ID '%s' is not a valid variable name. Falling back to `%s`."
 msgstr ""
 
 #, c-format
-msgid "Home for %ls"
-msgstr "Home for %ls"
+msgid "Home for %s"
+msgstr "Home for %s"
 
 msgid "I/O on asynchronous file descriptor is possible"
 msgstr "I/O on asynchronous file descriptor is possible"
 
 #, c-format
-msgid "Illegal file descriptor in redirection '%ls'"
-msgstr "Illegal file descriptor in redirection “%ls”"
+msgid "Illegal file descriptor in redirection '%s'"
+msgstr "Illegal file descriptor in redirection “%s”"
 
 msgid "Illegal instruction"
 msgstr "Illegal instruction"
 
 #, c-format
-msgid "Incomplete escape sequence '%ls'"
+msgid "Incomplete escape sequence '%s'"
 msgstr ""
 
 msgid "Information request"
 msgstr "Information request"
 
 #, c-format
-msgid "Integer %lld in '%ls' followed by non-digit"
+msgid "Integer %d in '%s' followed by non-digit"
 msgstr ""
 
 msgid "Internal (non-forked) process events"
@@ -1214,31 +1202,31 @@ msgid "Invalid input/output redirection"
 msgstr "Invalid input/output redirection"
 
 #, c-format
-msgid "Invalid number: %ls"
+msgid "Invalid number: %s"
 msgstr ""
 
 #, c-format
-msgid "Invalid redirection target: %ls"
-msgstr "Invalid redirection target: %ls"
+msgid "Invalid redirection target: %s"
+msgstr "Invalid redirection target: %s"
 
 #, c-format
-msgid "Invalid redirection: %ls"
+msgid "Invalid redirection: %s"
 msgstr ""
 
 #, c-format
-msgid "Invalid token '%ls'"
+msgid "Invalid token '%s'"
 msgstr ""
 
 #, c-format
-msgid "Items %lu to %lu of %lu"
+msgid "Items %u to %u of %u"
 msgstr ""
 
 msgid "Job\tGroup\t"
 msgstr "Job\tGroup\t"
 
 #, c-format
-msgid "Job control: %ls\n"
-msgstr "Job control: %ls\n"
+msgid "Job control: %s\n"
+msgstr "Job control: %s\n"
 
 msgid "Jobs being executed"
 msgstr ""
@@ -1277,7 +1265,7 @@ msgid "Missing closing parenthesis"
 msgstr ""
 
 #, c-format
-msgid "Missing end to balance this %ls"
+msgid "Missing end to balance this %s"
 msgstr ""
 
 msgid "Missing hexadecimal number in Unicode escape"
@@ -1287,7 +1275,7 @@ msgid "Missing operator"
 msgstr ""
 
 #, c-format
-msgid "Modification of read-only variable \"%ls\" is not allowed\n"
+msgid "Modification of read-only variable \"%s\" is not allowed\n"
 msgstr ""
 
 msgid "Negate exit status of job"
@@ -1300,7 +1288,7 @@ msgid "No TTY for interactive shell (tcgetpgrp failed)"
 msgstr "No TTY for interactive shell (tcgetpgrp failed)"
 
 #, c-format
-msgid "No matches for wildcard '%ls'. See `help wildcards-globbing`."
+msgid "No matches for wildcard '%s'. See `help wildcards-globbing`."
 msgstr ""
 
 msgid "Not a function"
@@ -1344,11 +1332,11 @@ msgid "Perform a set of commands multiple times"
 msgstr "Perform a set of commands multiple times"
 
 #, c-format
-msgid "Please set $%ls to a directory where you have write access."
+msgid "Please set $%s to a directory where you have write access."
 msgstr ""
 
 #, c-format
-msgid "Please set the %ls or HOME environment variable before starting fish."
+msgid "Please set the %s or HOME environment variable before starting fish."
 msgstr ""
 
 msgid "Polite quit request"
@@ -1413,11 +1401,11 @@ msgid "Rendering the command line"
 msgstr ""
 
 #, c-format
-msgid "Requested redirection to '%ls', which is not a valid file descriptor"
-msgstr "Requested redirection to “%ls”, which is not a valid file descriptor"
+msgid "Requested redirection to '%s', which is not a valid file descriptor"
+msgstr "Requested redirection to “%s”, which is not a valid file descriptor"
 
 #, c-format
-msgid "Result too large: %ls"
+msgid "Result too large: %s"
 msgstr ""
 
 msgid "Return a successful result"
@@ -1451,11 +1439,11 @@ msgid "Searching/using paths"
 msgstr ""
 
 #, c-format
-msgid "Send job %d (%ls) to foreground\n"
+msgid "Send job %d (%s) to foreground\n"
 msgstr ""
 
 #, c-format
-msgid "Send job %s '%ls' to background\n"
+msgid "Send job %s '%s' to background\n"
 msgstr ""
 
 msgid "Send job to background"
@@ -1533,12 +1521,12 @@ msgid "Test a condition"
 msgstr "Test a condition"
 
 #, c-format
-msgid "The '%ls' command can not be used immediately after a backgrounded job"
-msgstr "The “%ls” command can not be used immediately after a backgrounded job"
+msgid "The '%s' command can not be used immediately after a backgrounded job"
+msgstr "The “%s” command can not be used immediately after a backgrounded job"
 
 #, c-format
-msgid "The '%ls' command can not be used in a pipeline"
-msgstr "The “%ls” command can not be used in a pipeline"
+msgid "The '%s' command can not be used in a pipeline"
+msgstr "The “%s” command can not be used in a pipeline"
 
 msgid "The 'time' command may only be at the beginning of a pipeline"
 msgstr ""
@@ -1560,8 +1548,8 @@ msgid "The expanded command was empty."
 msgstr ""
 
 #, c-format
-msgid "The function '%ls' calls itself immediately, which would result in an infinite loop."
-msgstr "The function “%ls” calls itself immediately, which would result in an infinite loop."
+msgid "The function '%s' calls itself immediately, which would result in an infinite loop."
+msgstr "The function “%s” calls itself immediately, which would result in an infinite loop."
 
 msgid "The interactive reader/input system"
 msgstr ""
@@ -1600,23 +1588,23 @@ msgid "Trying to print invalid output"
 msgstr ""
 
 #, c-format
-msgid "Unable to create temporary file '%ls': %s"
+msgid "Unable to create temporary file '%s': %s"
 msgstr ""
 
 msgid "Unable to evaluate string substitution"
 msgstr ""
 
 #, c-format
-msgid "Unable to expand variable name '%ls'"
-msgstr "Unable to expand variable name “%ls”"
+msgid "Unable to expand variable name '%s'"
+msgstr "Unable to expand variable name “%s”"
 
 #, c-format
-msgid "Unable to locate %ls directory derived from $%ls: '%ls'."
+msgid "Unable to locate %s directory derived from $%s: '%s'."
 msgstr ""
 
 #, c-format
-msgid "Unable to locate the %ls directory."
-msgstr "Unable to locate the %ls directory."
+msgid "Unable to locate the %s directory."
+msgstr "Unable to locate the %s directory."
 
 #, c-format
 msgid "Unable to read input file: %s"
@@ -1663,22 +1651,22 @@ msgid "Unknown"
 msgstr "Unknown"
 
 #, c-format
-msgid "Unknown builtin '%ls'"
-msgstr "Unknown builtin “%ls”"
+msgid "Unknown builtin '%s'"
+msgstr "Unknown builtin “%s”"
 
 msgid "Unknown command"
 msgstr ""
 
 #, c-format
-msgid "Unknown command. '%ls' exists but is not an executable file."
+msgid "Unknown command. '%s' exists but is not an executable file."
 msgstr ""
 
 #, c-format
-msgid "Unknown command. A component of '%ls' is not a directory."
+msgid "Unknown command. A component of '%s' is not a directory."
 msgstr ""
 
 #, c-format
-msgid "Unknown command. A component of '%ls' is not a directory. Check your $PATH."
+msgid "Unknown command. A component of '%s' is not a directory. Check your $PATH."
 msgstr ""
 
 msgid "Unknown command:"
@@ -1691,14 +1679,14 @@ msgid "Unknown function"
 msgstr ""
 
 #, c-format
-msgid "Unknown function '%ls'"
-msgstr "Unknown function “%ls”"
+msgid "Unknown function '%s'"
+msgstr "Unknown function “%s”"
 
 msgid "Unmatched wildcard"
 msgstr ""
 
 #, c-format
-msgid "Unsupported use of '='. In fish, please use 'set %ls %ls'."
+msgid "Unsupported use of '='. In fish, please use 'set %s %s'."
 msgstr ""
 
 msgid "Unused signal"
@@ -1717,15 +1705,15 @@ msgid "User defined signal 2"
 msgstr "User defined signal 2"
 
 #, c-format
-msgid "Variable: %ls"
-msgstr "Variable: %ls"
+msgid "Variable: %s"
+msgstr "Variable: %s"
 
 #, c-format
-msgid "Variables cannot be bracketed. In fish, please use \"$%ls\"."
+msgid "Variables cannot be bracketed. In fish, please use \"$%s\"."
 msgstr ""
 
 #, c-format
-msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
+msgid "Variables cannot be bracketed. In fish, please use {$%s}."
 msgstr ""
 
 msgid "Virtual timer expired"
@@ -1756,15 +1744,15 @@ msgid "autoloading"
 msgstr ""
 
 #, c-format
-msgid "builtin %ls: %ls: %s\n"
+msgid "builtin %s: %s: %s\n"
 msgstr ""
 
 #, c-format
-msgid "builtin %ls: Invalid arg: %ls\n"
+msgid "builtin %s: Invalid arg: %s\n"
 msgstr ""
 
 #, c-format
-msgid "builtin %ls: realpath failed: %s\n"
+msgid "builtin %s: realpath failed: %s\n"
 msgstr ""
 
 msgid "builtin history delete --exact requires --case-sensitive\n"
@@ -1815,33 +1803,33 @@ msgstr "file"
 
 #, c-format
 msgid ""
-"fish: %ls: missing man page\n"
+"fish: %s: missing man page\n"
 "Documentation may not be installed.\n"
-"`help %ls` will show an online version\n"
+"`help %s` will show an online version\n"
 msgstr ""
 
 #, c-format
-msgid "from sourcing file %ls\n"
-msgstr "from sourcing file %ls\n"
+msgid "from sourcing file %s\n"
+msgstr "from sourcing file %s\n"
 
 msgid "in command substitution\n"
 msgstr "in command substitution\n"
 
 #, c-format
-msgid "in event handler: %ls\n"
-msgstr "in event handler: %ls\n"
+msgid "in event handler: %s\n"
+msgstr "in event handler: %s\n"
 
 #, c-format
-msgid "in function '%ls'"
+msgid "in function '%s'"
 msgstr ""
 
 #, c-format
-msgid "invalid field width: %ls"
-msgstr "invalid field width: %ls"
+msgid "invalid field width: %s"
+msgstr "invalid field width: %s"
 
 #, c-format
-msgid "invalid precision: %ls"
-msgstr "invalid precision: %ls"
+msgid "invalid precision: %s"
+msgstr "invalid precision: %s"
 
 msgid "missing hexadecimal number in escape"
 msgstr "missing hexadecimal number in escape"
@@ -1855,8 +1843,8 @@ msgid "or press ctrl-%c or ctrl-%c twice in a row."
 msgstr ""
 
 #, c-format
-msgid "rows %lu to %lu of %lu"
-msgstr "rows %lu to %lu of %lu"
+msgid "rows %u to %u of %u"
+msgstr "rows %u to %u of %u"
 
 msgid "running"
 msgstr "running"
@@ -1868,14 +1856,14 @@ msgid "stopped"
 msgstr "stopped"
 
 #, c-format
-msgid "switch: Expected at most one argument, got %lu\n"
+msgid "switch: Expected at most one argument, got %u\n"
 msgstr ""
 
 msgid "symlink"
 msgstr ""
 
 #, c-format
-msgid "ulimit: Permission denied when changing resource of type '%ls'\n"
+msgid "ulimit: Permission denied when changing resource of type '%s'\n"
 msgstr ""
 
 msgid "unexported"
@@ -1894,17 +1882,14 @@ msgstr ""
 msgid "fish-section-tier1-from-script-explicitly-added"
 msgstr ""
 
-msgid "%ls: %ls: expected %d arguments; got %d\\n"
-msgstr ""
-
-msgid "%ls: %ls: subcommand takes no options\\n"
-msgstr ""
-
-msgid "%ls: Expected at least %d args, got only %d\\n"
-msgstr ""
-
 msgid "%s: %s is an array variable. Use %svared%s %s[n]%s to edit the n:th element of %s\\n"
 msgstr "%s: %s is an array variable. Use %svared%s %s[n]%s to edit the n:th element of %s\\n"
+
+msgid "%s: %s: expected %d arguments; got %d\\n"
+msgstr ""
+
+msgid "%s: %s: subcommand takes no options\\n"
+msgstr ""
 
 msgid "%s: Could not create configuration directory '%s'\\n"
 msgstr ""
@@ -1913,6 +1898,9 @@ msgid "%s: Could not find a web browser.\\n"
 msgstr "%s: Could not find a web browser.\\n"
 
 msgid "%s: Directory stack is empty…\\n"
+msgstr ""
+
+msgid "%s: Expected at least %d args, got only %d\\n"
 msgstr ""
 
 msgid "%s: Expected exactly one argument, got %s.\\n\\nSynopsis:\\n\\t%svared%s VARIABLE\\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -131,7 +131,7 @@ msgstr ""
 "   PID Commande\n"
 
 #, c-format
-msgid " (%ls)\n"
+msgid " (%s)\n"
 msgstr ""
 
 msgid " (read-only)\n"
@@ -141,7 +141,7 @@ msgid " a path variable"
 msgstr ""
 
 #, c-format
-msgid " with arguments '%ls'"
+msgid " with arguments '%s'"
 msgstr ""
 
 msgid " with definition"
@@ -154,15 +154,15 @@ msgid "$$ is not the pid. In fish, please use $fish_pid."
 msgstr "$$ n’est pas le PID. Dans fish, veuillez utiliser $fish_pid."
 
 #, c-format
-msgid "$%lc is not a valid variable in fish."
-msgstr "$%lc est un nom de variable invalide dans fish."
+msgid "$%c is not a valid variable in fish."
+msgstr "$%c est un nom de variable invalide dans fish."
 
 #, c-format
-msgid "$%ls: originally inherited as |%ls|\n"
+msgid "$%s: originally inherited as |%s|\n"
 msgstr ""
 
 #, c-format
-msgid "$%ls: set in %ls scope, %ls,%ls with %d elements"
+msgid "$%s: set in %s scope, %s,%s with %d elements"
 msgstr ""
 
 msgid "$* is not supported. In fish, please use $argv."
@@ -178,728 +178,52 @@ msgid "$status is not valid as a command. See `help conditions`"
 msgstr ""
 
 #, c-format
-msgid "%.*ls: invalid conversion specification"
-msgstr "%.*ls : spécification de conversion invalide"
-
-#, c-format
-msgid "%ls"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: Abbreviation %ls already exists, cannot rename %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: Abbreviation '%ls' cannot have spaces in the word\n"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: Name cannot be empty\n"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: No abbreviation named %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: Requires at least two arguments\n"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: Requires exactly two arguments\n"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: Unexpected argument -- '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls (line %d): "
-msgstr "%ls (ligne %d) : "
-
-#, c-format
-msgid "%ls (line %lu): "
-msgstr "%ls (ligne %lu) : "
-
-#, c-format
-msgid "%ls is %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls is a builtin\n"
-msgstr ""
-
-#, c-format
-msgid "%ls is a function"
-msgstr ""
-
-#, c-format
-msgid "%ls, version %s"
-msgstr ""
-
-#, c-format
-msgid "%ls: %*ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls %ls: options cannot be used together\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: cannot overwrite read-only variable"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: cannot use reserved keyword as function name"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: contains a syntax error\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: expected %d arguments; got %d\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid base value\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid function name"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid integer\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid mode\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid mode name. See `help identifiers`\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid process id"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid scale\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid subcommand\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid variable name. See `help identifiers`\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: option does not take an argument\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: option requires an argument\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: subcommand takes no options\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: unexpected positional argument"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: unknown option\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: '%ls' is a broken symbolic link to '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: '%ls' is not a directory\n"
-msgstr "%ls : '%ls' n’est pas un dossier\n"
-
-#, c-format
-msgid "%ls: '%ls' is not a job\n"
-msgstr "%ls : '%ls' n’est pas une tâche\n"
-
-#, c-format
-msgid "%ls: '%ls' is not a valid job id\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: '%ls' is not a valid job specifier\n"
-msgstr "%ls : '%ls' est un nom de variable invalide\n"
-
-#, c-format
-msgid "%ls: '%ls' is not a valid process id\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: --command cannot be combined with --position command"
-msgstr ""
-
-#, c-format
-msgid "%ls: --function option requires --add\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: --position option requires --add\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: --regex option requires --add\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: --set-cursor argument cannot be empty\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: --set-cursor option requires --add\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: -l requires a non-empty string\n"
-msgstr "%ls : -l requiert une chaîne non-vide\n"
-
-#, c-format
-msgid "%ls: -o requires a non-empty string\n"
-msgstr "%ls : -o requiert une chaîne non-vide\n"
-
-#, c-format
-msgid "%ls: -s requires a non-empty string\n"
-msgstr "%ls : -s requiert une chaîne non-vide\n"
-
-#, c-format
-msgid "%ls: Ambiguous job\n"
-msgstr "%ls : Tâche ambiguë\n"
-
-#, c-format
-msgid "%ls: An option spec must have at least a short or a long flag\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Argument '%ls' is out of range\n"
-msgstr "%ls : L’argument '%ls' est hors limites\n"
-
-#, c-format
-msgid "%ls: Can not specify scope when removing block\n"
-msgstr "%ls : Ne peut pas indiquer la portée en enlevant le bloc\n"
-
-#, c-format
-msgid "%ls: Can't put job %d, '%ls' to foreground because it is not under job control\n"
-msgstr "%ls : Impossible de mettre la tâche %d, '%ls', au premier plan parce qu’elle n’est pas gérée par le contrôleur de tâches\n"
-
-#, c-format
-msgid "%ls: Can't put job %s, '%ls' to background because it is not under job control\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Cannot combine options %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Cannot specify multiple positions\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Cannot specify multiple regex patterns\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Cannot specify multiple set-cursor options\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Cannot use --append or --prepend when assigning to a slice"
-msgstr ""
-
-#, c-format
-msgid "%ls: Command not valid at an interactive prompt\n"
-msgstr "%ls : Commande invalide dans une invite interactive\n"
-
-#, c-format
-msgid "%ls: Could not find '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Could not find a job with process id '%d'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Could not find child processes with the name '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Could not find home directory\n"
-msgstr "%ls : Dossier personnel introuvable\n"
-
-#, c-format
-msgid "%ls: Could not find job '%d'\n"
-msgstr "%ls : Impossible de trouver la tâche '%d'\n"
-
-#, c-format
-msgid "%ls: Did you mean `set %ls %ls`?"
-msgstr ""
-
-#, c-format
-msgid "%ls: Empty directory '%ls' does not exist\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Error encountered while sourcing file '%ls':\n"
-msgstr "%ls : Erreur de lecture sur le fichier '%ls'\n"
-
-#, c-format
-msgid "%ls: Error while reading file '%ls'\n"
-msgstr "%ls : Erreur de lecture sur le fichier '%ls'\n"
-
-#, c-format
-msgid "%ls: Expected at least one argument"
-msgstr ""
-
-#, c-format
-msgid "%ls: Expected exactly one function name\n"
-msgstr "%ls : Exactement un nom de fonction est attendu\n"
-
-#, c-format
-msgid "%ls: Expected exactly two names (current function name, and new function name)\n"
-msgstr "%ls : Exactement deux noms attendus (noms de fonctions actuel et projeté)\n"
-
-#, c-format
-msgid "%ls: Expected generic | variable | signal | exit | job-id for --handlers-type\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Function '%ls' already exists. Cannot create copy of '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Function '%ls' does not exist\n"
-msgstr "%ls : La fonction '%ls' n’existe pas\n"
-
-#, c-format
-msgid "%ls: Illegal function name '%ls'\n"
-msgstr "%ls : Nom de fonction incorrect '%ls'\n"
-
-#, c-format
-msgid "%ls: Implicit int flag '%lc' already defined\n"
-msgstr "%ls : Le sémaphore entier court '%lc' est déjà défini\n"
-
-#, c-format
-msgid "%ls: Implicit int short flag '%lc' does not allow modifiers like '%lc'\n"
-msgstr "%ls : Le sémaphore entier court implicite '%lc' n’autorise pas de modificateurs comme '%lc'\n"
-
-#, c-format
-msgid "%ls: Invalid --max-args value '%ls'\n"
-msgstr "%ls : Valeur --max-args '%ls' invalide\n"
-
-#, c-format
-msgid "%ls: Invalid --min-args value '%ls'\n"
-msgstr "%ls : Valeur --min-args '%ls' invalide\n"
-
-#, c-format
-msgid "%ls: Invalid --unknown-arguments value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid count value '%ls'\n"
-msgstr "%ls : compte '%ls' invalide\n"
-
-#, c-format
-msgid "%ls: Invalid end value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid escape style '%ls'\n"
-msgstr "%ls : Style d’échappement '%ls' invalide\n"
-
-#, c-format
-msgid "%ls: Invalid fields value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid function name: %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid index starting at '%ls'\n"
-msgstr "%ls : Indice invalide commençant à '%ls'\n"
-
-#, c-format
-msgid "%ls: Invalid job control mode '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid length value '%ls'\n"
-msgstr "%ls : Taille '%ls' invalide\n"
-
-#, c-format
-msgid "%ls: Invalid level value '%ls'\n"
-msgstr "%ls : Niveau '%ls' invalide\n"
-
-#, c-format
-msgid "%ls: Invalid limit '%ls'\n"
-msgstr "%ls : Limite '%ls' invalide\n"
-
-#, c-format
-msgid "%ls: Invalid max matches value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid max value '%ls'\n"
-msgstr "%ls : Valeur maximale '%ls' invalide\n"
-
-#, c-format
-msgid "%ls: Invalid option spec '%ls' at char '%lc'\n"
-msgstr "%ls : Option invalide '%ls' au caractère '%lc'\n"
-
-#, c-format
-msgid "%ls: Invalid padding character of width zero '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid permission '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid position '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid range value for field '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid sort key '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid start value '%ls'\n"
-msgstr "%ls : Indice de départ '%ls' invalide\n"
-
-#, c-format
-msgid "%ls: Invalid state\n"
-msgstr "%ls : État invalide\n"
-
-#, c-format
-msgid "%ls: Invalid style value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid token '%ls'\n"
-msgstr "%ls : Lexème invalide '%ls'\n"
-
-#, c-format
-msgid "%ls: Invalid type '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid width value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Key not specified\n"
-msgstr "%ls : Clé non spécifiée\n"
-
-#, c-format
-msgid "%ls: Long flag '%ls' already defined\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Missing -- separator\n"
-msgstr "%ls : Séparateur -- manquant\n"
-
-#, c-format
-msgid "%ls: New limit cannot be an empty string\n"
-msgstr "%ls : La nouvelle limite ne peut être une chaîne vide\n"
-
-#, c-format
-msgid "%ls: No binding found for key '%ls'\n"
-msgstr "%ls : Aucun lien trouvé pour la combinaison %ls\n"
-
-#, c-format
-msgid "%ls: No binding found for key sequence '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: No blocks defined\n"
-msgstr "%ls : Aucun bloc défini\n"
-
-#, c-format
-msgid "%ls: No suitable job: %d\n"
-msgstr "%ls : Aucune tâche appropriée : %d\n"
-
-#, c-format
-msgid "%ls: No suitable job: %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Not inside of loop\n"
-msgstr "%ls : À l’extérieur de toute boucle\n"
-
-#, c-format
-msgid "%ls: Options %ls and %ls cannot be used together\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Padding should be a character '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Permission denied: '%ls'\n"
-msgstr "%ls : Permission refusée '%ls'\n"
-
-#, c-format
-msgid "%ls: Regular expression compile error: %ls\n"
-msgstr "%ls : Erreur de compilation de l’expression régulière: %ls\n"
-
-#, c-format
-msgid "%ls: Regular expression substitute error: %ls\n"
-msgstr "%ls : Erreur de substitution de l’expression régulière : %ls\n"
-
-#, c-format
-msgid "%ls: Resource limit not available on this operating system\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: STEP must be a positive integer\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Short flag '%lc' already defined\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Short flag '%lc' invalid, must be alphanum or '#'\n"
-msgstr "%ls : Le sémaphore '%lc' est invalide : il doit être alphanumérique ou valoir '#'\n"
-
-#, c-format
-msgid "%ls: The directory '%ls' does not exist\n"
-msgstr "%ls : Le dossier '%ls' n’existe pas\n"
-
-#, c-format
-msgid "%ls: The variable '%ls' does not exist\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: There are no jobs\n"
-msgstr "%ls : Aucune tâche\n"
-
-#, c-format
-msgid "%ls: There are no suitable jobs\n"
-msgstr "%ls : Aucune tâche appropriée\n"
-
-#, c-format
-msgid "%ls: Too many levels of symbolic links: '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Too many long-only options\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Tried to change the read-only variable '%ls'\n"
-msgstr "%ls : Impossible de modifier la variable en lecture seule '%ls'\n"
-
-#, c-format
-msgid "%ls: Tried to modify the special variable '%ls' to an invalid value\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Tried to modify the special variable '%ls' with the wrong scope\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Unknown color '%ls'\n"
-msgstr "%ls : Couleur  '%ls' inconnue\n"
-
-#, c-format
-msgid "%ls: Unknown error trying to locate directory '%ls'\n"
-msgstr "%ls : Erreur inconnue en tentant de localiser le dossier '%ls'\n"
-
-#, c-format
-msgid "%ls: Unknown input function '%ls'"
-msgstr "%ls : Fonction d’entrée '%ls' inconnue"
-
-#, c-format
-msgid "%ls: Unknown signal '%ls'"
-msgstr "%ls : Signal '%ls' inconnu"
-
-#, c-format
-msgid "%ls: Warning: Option '%ls' was removed and is now ignored"
-msgstr ""
-
-#, c-format
-msgid "%ls: `set --show` does not allow slices with the var names\n"
-msgstr "%ls : `set --show` n’autorise pas de tranches avec les noms des variables\n"
-
-#, c-format
-msgid "%ls: array index out of bounds\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: called with no arguments. This will be an error in future."
-msgstr ""
-
-#, c-format
-msgid "%ls: called with one argument. This will return false in future."
-msgstr ""
-
-#, c-format
-msgid "%ls: calling job for event handler not found"
-msgstr ""
-
-#, c-format
-msgid "%ls: can't merge history in private mode\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: cannot both export and unexport\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: cannot both path and unpath\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: column %ls exceeds line length\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: exclusive flag '%ls' is not valid\n"
-msgstr "%ls : le sémaphore exclusif '%ls' est invalide\n"
-
-#, c-format
-msgid "%ls: exclusive flag string '%ls' is not valid\n"
-msgstr "%ls : le sémaphore texte exclusif '%ls' est invalide\n"
-
-#, c-format
-msgid "%ls: expected %d arguments; got %d\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: expected <= %d arguments; got %d\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: expected >= %d arguments; got %d\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: expected a numeric value"
-msgstr "%ls : valeur numérique attendue"
-
-#, c-format
-msgid "%ls: fish was not built with embedded files"
-msgstr ""
-
-#, c-format
-msgid "%ls: given %d indexes but %d values\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: invalid option combination\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: invalid option combination, %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: invalid underline style: %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: job %d ('%ls') was stopped and has been signalled to continue.\n"
-msgstr "%ls : la tâche %d ('%ls') a été arrêtée et a reçu un signal pour continuer.\n"
-
-#, c-format
-msgid "%ls: line/column index starts at 1"
-msgstr ""
-
-#, c-format
-msgid "%ls: missing argument\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: missing filename argument or input redirection\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: missing subcommand\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: nothing to choose from\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: realpath failed: %s\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: scope can be only one of: universal function global local\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: stdin is closed\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: successfully set universal '%ls'; but a global by that name shadows it\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: the -k/--key syntax is no longer supported. See `bind --help` and `bind --key-names`\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: there is no line %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: too many arguments\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: usage of -i for --silent is deprecated. Please use -s or --silent instead.\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: value not completely converted (can't convert '%ls')"
-msgstr ""
-
-#, c-format
-msgid "%ls: variable '%ls' is read-only\n"
-msgstr ""
-
-#, c-format
-msgid "%lsand %lu more rows"
-msgstr "%lset %lu lignes de plus"
-
-#, c-format
-msgid "%lu\n"
-msgstr ""
+msgid "%.*s: invalid conversion specification"
+msgstr "%.*s : spécification de conversion invalide"
 
 #, c-format
 msgid "%s"
 msgstr ""
 
 #, c-format
-msgid "%s %s: unrecognized feature '%ls'"
+msgid "%s %s: Abbreviation %s already exists, cannot rename %s\n"
 msgstr ""
+
+#, c-format
+msgid "%s %s: Abbreviation '%s' cannot have spaces in the word\n"
+msgstr ""
+
+#, c-format
+msgid "%s %s: Name cannot be empty\n"
+msgstr ""
+
+#, c-format
+msgid "%s %s: No abbreviation named %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s %s: Requires at least two arguments\n"
+msgstr ""
+
+#, c-format
+msgid "%s %s: Requires exactly two arguments\n"
+msgstr ""
+
+#, c-format
+msgid "%s %s: Unexpected argument -- '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s %s: unrecognized feature '%s'"
+msgstr ""
+
+#, c-format
+msgid "%s (line %d): "
+msgstr "%s (ligne %d) : "
+
+#, c-format
+msgid "%s (line %u): "
+msgstr "%s (ligne %u) : "
 
 #, c-format
 msgid "%s and %s are mutually exclusive"
@@ -910,12 +234,680 @@ msgid "%s could not read response to Primary Device Attribute query after waitin
 msgstr ""
 
 #, c-format
+msgid "%s is %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s is a builtin\n"
+msgstr ""
+
+#, c-format
+msgid "%s is a function"
+msgstr ""
+
+#, c-format
 msgid "%s, version %s"
 msgstr ""
 
 #, c-format
 msgid "%s, version %s\n"
 msgstr "%s, version %s\n"
+
+#, c-format
+msgid "%s: %*s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s %s: options cannot be used together\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: cannot overwrite read-only variable"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: cannot use reserved keyword as function name"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: contains a syntax error\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: expected %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid base value\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid function name"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid integer\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid mode\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid mode name. See `help identifiers`\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid process id"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid scale\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid subcommand\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid variable name. See `help identifiers`\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: option does not take an argument\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: option requires an argument\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: subcommand takes no options\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: unexpected positional argument"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: unknown option\n"
+msgstr ""
+
+#, c-format
+msgid "%s: '%s' is a broken symbolic link to '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: '%s' is not a directory\n"
+msgstr "%s : '%s' n’est pas un dossier\n"
+
+#, c-format
+msgid "%s: '%s' is not a job\n"
+msgstr "%s : '%s' n’est pas une tâche\n"
+
+#, c-format
+msgid "%s: '%s' is not a valid job id\n"
+msgstr ""
+
+#, c-format
+msgid "%s: '%s' is not a valid job specifier\n"
+msgstr "%s : '%s' est un nom de variable invalide\n"
+
+#, c-format
+msgid "%s: '%s' is not a valid process id\n"
+msgstr ""
+
+#, c-format
+msgid "%s: --command cannot be combined with --position command"
+msgstr ""
+
+#, c-format
+msgid "%s: --function option requires --add\n"
+msgstr ""
+
+#, c-format
+msgid "%s: --position option requires --add\n"
+msgstr ""
+
+#, c-format
+msgid "%s: --regex option requires --add\n"
+msgstr ""
+
+#, c-format
+msgid "%s: --set-cursor argument cannot be empty\n"
+msgstr ""
+
+#, c-format
+msgid "%s: --set-cursor option requires --add\n"
+msgstr ""
+
+#, c-format
+msgid "%s: -l requires a non-empty string\n"
+msgstr "%s : -l requiert une chaîne non-vide\n"
+
+#, c-format
+msgid "%s: -o requires a non-empty string\n"
+msgstr "%s : -o requiert une chaîne non-vide\n"
+
+#, c-format
+msgid "%s: -s requires a non-empty string\n"
+msgstr "%s : -s requiert une chaîne non-vide\n"
+
+#, c-format
+msgid "%s: Ambiguous job\n"
+msgstr "%s : Tâche ambiguë\n"
+
+#, c-format
+msgid "%s: An option spec must have at least a short or a long flag\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Argument '%s' is out of range\n"
+msgstr "%s : L’argument '%s' est hors limites\n"
+
+#, c-format
+msgid "%s: Can not specify scope when removing block\n"
+msgstr "%s : Ne peut pas indiquer la portée en enlevant le bloc\n"
+
+#, c-format
+msgid "%s: Can't put job %d, '%s' to foreground because it is not under job control\n"
+msgstr "%s : Impossible de mettre la tâche %d, '%s', au premier plan parce qu’elle n’est pas gérée par le contrôleur de tâches\n"
+
+#, c-format
+msgid "%s: Can't put job %s, '%s' to background because it is not under job control\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Cannot combine options %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Cannot specify multiple positions\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Cannot specify multiple regex patterns\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Cannot specify multiple set-cursor options\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Cannot use --append or --prepend when assigning to a slice"
+msgstr ""
+
+#, c-format
+msgid "%s: Command not valid at an interactive prompt\n"
+msgstr "%s : Commande invalide dans une invite interactive\n"
+
+#, c-format
+msgid "%s: Could not find '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Could not find a job with process id '%d'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Could not find child processes with the name '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Could not find home directory\n"
+msgstr "%s : Dossier personnel introuvable\n"
+
+#, c-format
+msgid "%s: Could not find job '%d'\n"
+msgstr "%s : Impossible de trouver la tâche '%d'\n"
+
+#, c-format
+msgid "%s: Did you mean `set %s %s`?"
+msgstr ""
+
+#, c-format
+msgid "%s: Empty directory '%s' does not exist\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Error encountered while sourcing file '%s':\n"
+msgstr "%s : Erreur de lecture sur le fichier '%s'\n"
+
+#, c-format
+msgid "%s: Error while reading file '%s'\n"
+msgstr "%s : Erreur de lecture sur le fichier '%s'\n"
+
+#, c-format
+msgid "%s: Expected at least one argument"
+msgstr ""
+
+#, c-format
+msgid "%s: Expected exactly one function name\n"
+msgstr "%s : Exactement un nom de fonction est attendu\n"
+
+#, c-format
+msgid "%s: Expected exactly two names (current function name, and new function name)\n"
+msgstr "%s : Exactement deux noms attendus (noms de fonctions actuel et projeté)\n"
+
+#, c-format
+msgid "%s: Expected generic | variable | signal | exit | job-id for --handlers-type\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Function '%s' already exists. Cannot create copy of '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Function '%s' does not exist\n"
+msgstr "%s : La fonction '%s' n’existe pas\n"
+
+#, c-format
+msgid "%s: Illegal function name '%s'\n"
+msgstr "%s : Nom de fonction incorrect '%s'\n"
+
+#, c-format
+msgid "%s: Implicit int flag '%c' already defined\n"
+msgstr "%s : Le sémaphore entier court '%c' est déjà défini\n"
+
+#, c-format
+msgid "%s: Implicit int short flag '%c' does not allow modifiers like '%c'\n"
+msgstr "%s : Le sémaphore entier court implicite '%c' n’autorise pas de modificateurs comme '%c'\n"
+
+#, c-format
+msgid "%s: Invalid --max-args value '%s'\n"
+msgstr "%s : Valeur --max-args '%s' invalide\n"
+
+#, c-format
+msgid "%s: Invalid --min-args value '%s'\n"
+msgstr "%s : Valeur --min-args '%s' invalide\n"
+
+#, c-format
+msgid "%s: Invalid --unknown-arguments value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid count value '%s'\n"
+msgstr "%s : compte '%s' invalide\n"
+
+#, c-format
+msgid "%s: Invalid end value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid escape style '%s'\n"
+msgstr "%s : Style d’échappement '%s' invalide\n"
+
+#, c-format
+msgid "%s: Invalid fields value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid function name: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid index starting at '%s'\n"
+msgstr "%s : Indice invalide commençant à '%s'\n"
+
+#, c-format
+msgid "%s: Invalid job control mode '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid length value '%s'\n"
+msgstr "%s : Taille '%s' invalide\n"
+
+#, c-format
+msgid "%s: Invalid level value '%s'\n"
+msgstr "%s : Niveau '%s' invalide\n"
+
+#, c-format
+msgid "%s: Invalid limit '%s'\n"
+msgstr "%s : Limite '%s' invalide\n"
+
+#, c-format
+msgid "%s: Invalid max matches value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid max value '%s'\n"
+msgstr "%s : Valeur maximale '%s' invalide\n"
+
+#, c-format
+msgid "%s: Invalid option spec '%s' at char '%c'\n"
+msgstr "%s : Option invalide '%s' au caractère '%c'\n"
+
+#, c-format
+msgid "%s: Invalid padding character of width zero '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid permission '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid position '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid range value for field '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid sort key '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid start value '%s'\n"
+msgstr "%s : Indice de départ '%s' invalide\n"
+
+#, c-format
+msgid "%s: Invalid state\n"
+msgstr "%s : État invalide\n"
+
+#, c-format
+msgid "%s: Invalid style value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid token '%s'\n"
+msgstr "%s : Lexème invalide '%s'\n"
+
+#, c-format
+msgid "%s: Invalid type '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid width value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Key not specified\n"
+msgstr "%s : Clé non spécifiée\n"
+
+#, c-format
+msgid "%s: Long flag '%s' already defined\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Missing -- separator\n"
+msgstr "%s : Séparateur -- manquant\n"
+
+#, c-format
+msgid "%s: New limit cannot be an empty string\n"
+msgstr "%s : La nouvelle limite ne peut être une chaîne vide\n"
+
+#, c-format
+msgid "%s: No binding found for key '%s'\n"
+msgstr "%s : Aucun lien trouvé pour la combinaison %s\n"
+
+#, c-format
+msgid "%s: No binding found for key sequence '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: No blocks defined\n"
+msgstr "%s : Aucun bloc défini\n"
+
+#, c-format
+msgid "%s: No suitable job: %d\n"
+msgstr "%s : Aucune tâche appropriée : %d\n"
+
+#, c-format
+msgid "%s: No suitable job: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Not inside of loop\n"
+msgstr "%s : À l’extérieur de toute boucle\n"
+
+#, c-format
+msgid "%s: Options %s and %s cannot be used together\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Padding should be a character '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Permission denied: '%s'\n"
+msgstr "%s : Permission refusée '%s'\n"
+
+#, c-format
+msgid "%s: Regular expression compile error: %s\n"
+msgstr "%s : Erreur de compilation de l’expression régulière: %s\n"
+
+#, c-format
+msgid "%s: Regular expression substitute error: %s\n"
+msgstr "%s : Erreur de substitution de l’expression régulière : %s\n"
+
+#, c-format
+msgid "%s: Resource limit not available on this operating system\n"
+msgstr ""
+
+#, c-format
+msgid "%s: STEP must be a positive integer\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Short flag '%c' already defined\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Short flag '%c' invalid, must be alphanum or '#'\n"
+msgstr "%s : Le sémaphore '%c' est invalide : il doit être alphanumérique ou valoir '#'\n"
+
+#, c-format
+msgid "%s: The directory '%s' does not exist\n"
+msgstr "%s : Le dossier '%s' n’existe pas\n"
+
+#, c-format
+msgid "%s: The variable '%s' does not exist\n"
+msgstr ""
+
+#, c-format
+msgid "%s: There are no jobs\n"
+msgstr "%s : Aucune tâche\n"
+
+#, c-format
+msgid "%s: There are no suitable jobs\n"
+msgstr "%s : Aucune tâche appropriée\n"
+
+#, c-format
+msgid "%s: Too many levels of symbolic links: '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Too many long-only options\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Tried to change the read-only variable '%s'\n"
+msgstr "%s : Impossible de modifier la variable en lecture seule '%s'\n"
+
+#, c-format
+msgid "%s: Tried to modify the special variable '%s' to an invalid value\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Tried to modify the special variable '%s' with the wrong scope\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Unknown color '%s'\n"
+msgstr "%s : Couleur  '%s' inconnue\n"
+
+#, c-format
+msgid "%s: Unknown error trying to locate directory '%s'\n"
+msgstr "%s : Erreur inconnue en tentant de localiser le dossier '%s'\n"
+
+#, c-format
+msgid "%s: Unknown input function '%s'"
+msgstr "%s : Fonction d’entrée '%s' inconnue"
+
+#, c-format
+msgid "%s: Unknown signal '%s'"
+msgstr "%s : Signal '%s' inconnu"
+
+#, c-format
+msgid "%s: Warning: Option '%s' was removed and is now ignored"
+msgstr ""
+
+#, c-format
+msgid "%s: `set --show` does not allow slices with the var names\n"
+msgstr "%s : `set --show` n’autorise pas de tranches avec les noms des variables\n"
+
+#, c-format
+msgid "%s: array index out of bounds\n"
+msgstr ""
+
+#, c-format
+msgid "%s: called with no arguments. This will be an error in future."
+msgstr ""
+
+#, c-format
+msgid "%s: called with one argument. This will return false in future."
+msgstr ""
+
+#, c-format
+msgid "%s: calling job for event handler not found"
+msgstr ""
+
+#, c-format
+msgid "%s: can't merge history in private mode\n"
+msgstr ""
+
+#, c-format
+msgid "%s: cannot both export and unexport\n"
+msgstr ""
+
+#, c-format
+msgid "%s: cannot both path and unpath\n"
+msgstr ""
+
+#, c-format
+msgid "%s: column %s exceeds line length\n"
+msgstr ""
+
+#, c-format
+msgid "%s: exclusive flag '%s' is not valid\n"
+msgstr "%s : le sémaphore exclusif '%s' est invalide\n"
+
+#, c-format
+msgid "%s: exclusive flag string '%s' is not valid\n"
+msgstr "%s : le sémaphore texte exclusif '%s' est invalide\n"
+
+#, c-format
+msgid "%s: expected %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%s: expected <= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%s: expected >= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%s: expected a numeric value"
+msgstr "%s : valeur numérique attendue"
+
+#, c-format
+msgid "%s: fish was not built with embedded files"
+msgstr ""
+
+#, c-format
+msgid "%s: given %d indexes but %d values\n"
+msgstr ""
+
+#, c-format
+msgid "%s: invalid option combination\n"
+msgstr ""
+
+#, c-format
+msgid "%s: invalid option combination, %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: invalid underline style: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: job %d ('%s') was stopped and has been signalled to continue.\n"
+msgstr "%s : la tâche %d ('%s') a été arrêtée et a reçu un signal pour continuer.\n"
+
+#, c-format
+msgid "%s: line/column index starts at 1"
+msgstr ""
+
+#, c-format
+msgid "%s: missing argument\n"
+msgstr ""
+
+#, c-format
+msgid "%s: missing filename argument or input redirection\n"
+msgstr ""
+
+#, c-format
+msgid "%s: missing subcommand\n"
+msgstr ""
+
+#, c-format
+msgid "%s: nothing to choose from\n"
+msgstr ""
+
+#, c-format
+msgid "%s: realpath failed: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: scope can be only one of: universal function global local\n"
+msgstr ""
+
+#, c-format
+msgid "%s: stdin is closed\n"
+msgstr ""
+
+#, c-format
+msgid "%s: successfully set universal '%s'; but a global by that name shadows it\n"
+msgstr ""
+
+#, c-format
+msgid "%s: the -k/--key syntax is no longer supported. See `bind --help` and `bind --key-names`\n"
+msgstr ""
+
+#, c-format
+msgid "%s: there is no line %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: too many arguments\n"
+msgstr ""
+
+#, c-format
+msgid "%s: usage of -i for --silent is deprecated. Please use -s or --silent instead.\n"
+msgstr ""
+
+#, c-format
+msgid "%s: value not completely converted (can't convert '%s')"
+msgstr ""
+
+#, c-format
+msgid "%s: variable '%s' is read-only\n"
+msgstr ""
+
+#, c-format
+msgid "%sand %u more rows"
+msgstr "%set %u lignes de plus"
+
+#, c-format
+msgid "%u\n"
+msgstr ""
 
 msgid "'break' while not inside of loop"
 msgstr "'break' hors d’une boucle"
@@ -942,14 +934,14 @@ msgid "'}' does not take arguments. Did you forget a ';'?"
 msgstr ""
 
 #, c-format
-msgid "(Type 'help %ls' for related documentation)\n"
+msgid "(Type 'help %s' for related documentation)\n"
 msgstr ""
 
 msgid "(no matches)"
 msgstr "(pas d’occurrence)"
 
 #, c-format
-msgid ", copied in %ls @ line %d"
+msgid ", copied in %s @ line %d"
 msgstr ""
 
 msgid ", copied interactively"
@@ -986,7 +978,7 @@ msgid "Abbreviation expansion"
 msgstr ""
 
 #, c-format
-msgid "Abbreviation: %ls"
+msgid "Abbreviation: %s"
 msgstr ""
 
 msgid "Abort"
@@ -1005,7 +997,7 @@ msgid "An error occurred while setting up pipe"
 msgstr "Une erreur est survenue lors du paramétrage du tube"
 
 #, c-format
-msgid "Argument is not a number: '%ls'"
+msgid "Argument is not a number: '%s'"
 msgstr ""
 
 msgid "Await background process completion"
@@ -1107,7 +1099,7 @@ msgid "Define a new function"
 msgstr "Définir une nouvelle fonction"
 
 #, c-format
-msgid "Defined in %ls @ line %d"
+msgid "Defined in %s @ line %d"
 msgstr ""
 
 msgid "Defined interactively"
@@ -1137,8 +1129,8 @@ msgid "Error when renaming file: %s"
 msgstr ""
 
 #, c-format
-msgid "Error while reading file %ls\n"
-msgstr "Erreur lors de la lecture du fichier %ls\n"
+msgid "Error while reading file %s\n"
+msgstr "Erreur lors de la lecture du fichier %s\n"
 
 msgid "Errors reported by exec (on by default)"
 msgstr ""
@@ -1171,19 +1163,15 @@ msgid "Expansion produced too many results"
 msgstr ""
 
 #, c-format
-msgid "Expected %ls, but found %ls"
+msgid "Expected %s, but found %s"
 msgstr ""
 
 #, c-format
-msgid "Expected %s, but found %ls"
+msgid "Expected a command, but found %s"
 msgstr ""
 
 #, c-format
-msgid "Expected a command, but found %ls"
-msgstr ""
-
-#, c-format
-msgid "Expected a string, but found %ls"
+msgid "Expected a string, but found %s"
 msgstr ""
 
 msgid "Expected a string, but found a redirection"
@@ -1196,7 +1184,7 @@ msgstr "Un nom de variable est attendu après un $."
 msgid ""
 "Expected file path to read/write for -w:\n"
 "\n"
-" $ %ls -w foo.fish"
+" $ %s -w foo.fish"
 msgstr ""
 
 #, c-format
@@ -1268,32 +1256,32 @@ msgid "History performance measurements"
 msgstr ""
 
 #, c-format
-msgid "History session ID '%ls' is not a valid variable name. Falling back to `%ls`."
-msgstr "L’ID de session d’historique '%ls' n’est pas un nom de variable valide ; retour à la valeur par défaut `%ls`."
+msgid "History session ID '%s' is not a valid variable name. Falling back to `%s`."
+msgstr "L’ID de session d’historique '%s' n’est pas un nom de variable valide ; retour à la valeur par défaut `%s`."
 
 #, c-format
-msgid "Home for %ls"
+msgid "Home for %s"
 msgstr ""
 
 msgid "I/O on asynchronous file descriptor is possible"
 msgstr "E/S sur un descripteur de fichier asynchrone possible"
 
 #, c-format
-msgid "Illegal file descriptor in redirection '%ls'"
-msgstr "Descripteur de fichier erroné dans la redirection '%ls'"
+msgid "Illegal file descriptor in redirection '%s'"
+msgstr "Descripteur de fichier erroné dans la redirection '%s'"
 
 msgid "Illegal instruction"
 msgstr "Instruction illégale"
 
 #, c-format
-msgid "Incomplete escape sequence '%ls'"
+msgid "Incomplete escape sequence '%s'"
 msgstr ""
 
 msgid "Information request"
 msgstr "Demande d'information"
 
 #, c-format
-msgid "Integer %lld in '%ls' followed by non-digit"
+msgid "Integer %d in '%s' followed by non-digit"
 msgstr ""
 
 msgid "Internal (non-forked) process events"
@@ -1315,31 +1303,31 @@ msgid "Invalid input/output redirection"
 msgstr "Redirection d’entrée/sortie invalide"
 
 #, c-format
-msgid "Invalid number: %ls"
+msgid "Invalid number: %s"
 msgstr ""
 
 #, c-format
-msgid "Invalid redirection target: %ls"
-msgstr "Cible de redirection invalide: %ls"
+msgid "Invalid redirection target: %s"
+msgstr "Cible de redirection invalide: %s"
 
 #, c-format
-msgid "Invalid redirection: %ls"
+msgid "Invalid redirection: %s"
 msgstr ""
 
 #, c-format
-msgid "Invalid token '%ls'"
+msgid "Invalid token '%s'"
 msgstr ""
 
 #, c-format
-msgid "Items %lu to %lu of %lu"
+msgid "Items %u to %u of %u"
 msgstr ""
 
 msgid "Job\tGroup\t"
 msgstr "Tâche\tGroupe\t"
 
 #, c-format
-msgid "Job control: %ls\n"
-msgstr "Contrôle des tâches : %ls\n"
+msgid "Job control: %s\n"
+msgstr "Contrôle des tâches : %s\n"
 
 msgid "Jobs being executed"
 msgstr ""
@@ -1378,7 +1366,7 @@ msgid "Missing closing parenthesis"
 msgstr ""
 
 #, c-format
-msgid "Missing end to balance this %ls"
+msgid "Missing end to balance this %s"
 msgstr ""
 
 msgid "Missing hexadecimal number in Unicode escape"
@@ -1388,7 +1376,7 @@ msgid "Missing operator"
 msgstr ""
 
 #, c-format
-msgid "Modification of read-only variable \"%ls\" is not allowed\n"
+msgid "Modification of read-only variable \"%s\" is not allowed\n"
 msgstr ""
 
 msgid "Negate exit status of job"
@@ -1401,7 +1389,7 @@ msgid "No TTY for interactive shell (tcgetpgrp failed)"
 msgstr "Pas de TTY pour shell interactif (tcgetpgrp a échoué)"
 
 #, c-format
-msgid "No matches for wildcard '%ls'. See `help wildcards-globbing`."
+msgid "No matches for wildcard '%s'. See `help wildcards-globbing`."
 msgstr ""
 
 msgid "Not a function"
@@ -1445,12 +1433,12 @@ msgid "Perform a set of commands multiple times"
 msgstr "Exécuter un jeu de commandes plusieurs fois"
 
 #, c-format
-msgid "Please set $%ls to a directory where you have write access."
-msgstr "Veuillez paramétrer $%ls à un dossier dans lequel vous avez un accès en écriture."
+msgid "Please set $%s to a directory where you have write access."
+msgstr "Veuillez paramétrer $%s à un dossier dans lequel vous avez un accès en écriture."
 
 #, c-format
-msgid "Please set the %ls or HOME environment variable before starting fish."
-msgstr "Veuillez paramétrer la variable d’environnement %ls ou HOME avant de lancer fish."
+msgid "Please set the %s or HOME environment variable before starting fish."
+msgstr "Veuillez paramétrer la variable d’environnement %s ou HOME avant de lancer fish."
 
 msgid "Polite quit request"
 msgstr "Demande polie de quitter"
@@ -1514,11 +1502,11 @@ msgid "Rendering the command line"
 msgstr ""
 
 #, c-format
-msgid "Requested redirection to '%ls', which is not a valid file descriptor"
-msgstr "Redirection demandée à '%ls', qui n’est pas un descripteur de fichier valide"
+msgid "Requested redirection to '%s', which is not a valid file descriptor"
+msgstr "Redirection demandée à '%s', qui n’est pas un descripteur de fichier valide"
 
 #, c-format
-msgid "Result too large: %ls"
+msgid "Result too large: %s"
 msgstr ""
 
 msgid "Return a successful result"
@@ -1552,11 +1540,11 @@ msgid "Searching/using paths"
 msgstr ""
 
 #, c-format
-msgid "Send job %d (%ls) to foreground\n"
+msgid "Send job %d (%s) to foreground\n"
 msgstr ""
 
 #, c-format
-msgid "Send job %s '%ls' to background\n"
+msgid "Send job %s '%s' to background\n"
 msgstr ""
 
 msgid "Send job to background"
@@ -1634,12 +1622,12 @@ msgid "Test a condition"
 msgstr "Vérifier une condition"
 
 #, c-format
-msgid "The '%ls' command can not be used immediately after a backgrounded job"
-msgstr "La commande '%ls' ne peut pas être utilisée immédiatement après une tâche en arrière-plan"
+msgid "The '%s' command can not be used immediately after a backgrounded job"
+msgstr "La commande '%s' ne peut pas être utilisée immédiatement après une tâche en arrière-plan"
 
 #, c-format
-msgid "The '%ls' command can not be used in a pipeline"
-msgstr "La commande '%ls' ne peut pas être utilisée dans un tube"
+msgid "The '%s' command can not be used in a pipeline"
+msgstr "La commande '%s' ne peut pas être utilisée dans un tube"
 
 msgid "The 'time' command may only be at the beginning of a pipeline"
 msgstr ""
@@ -1661,8 +1649,8 @@ msgid "The expanded command was empty."
 msgstr ""
 
 #, c-format
-msgid "The function '%ls' calls itself immediately, which would result in an infinite loop."
-msgstr "La fonction '%ls' s’appelle immédiatement, ce qui provoquerait une boucle infinie."
+msgid "The function '%s' calls itself immediately, which would result in an infinite loop."
+msgstr "La fonction '%s' s’appelle immédiatement, ce qui provoquerait une boucle infinie."
 
 msgid "The interactive reader/input system"
 msgstr ""
@@ -1701,23 +1689,23 @@ msgid "Trying to print invalid output"
 msgstr ""
 
 #, c-format
-msgid "Unable to create temporary file '%ls': %s"
+msgid "Unable to create temporary file '%s': %s"
 msgstr ""
 
 msgid "Unable to evaluate string substitution"
 msgstr ""
 
 #, c-format
-msgid "Unable to expand variable name '%ls'"
-msgstr "Impossible d’étendre le nom de variable '%ls'"
+msgid "Unable to expand variable name '%s'"
+msgstr "Impossible d’étendre le nom de variable '%s'"
 
 #, c-format
-msgid "Unable to locate %ls directory derived from $%ls: '%ls'."
-msgstr "Impossible de localiser le dossier %ls obtenu de $%ls: '%ls'."
+msgid "Unable to locate %s directory derived from $%s: '%s'."
+msgstr "Impossible de localiser le dossier %s obtenu de $%s: '%s'."
 
 #, c-format
-msgid "Unable to locate the %ls directory."
-msgstr "Impossible de localiser le dossier %ls."
+msgid "Unable to locate the %s directory."
+msgstr "Impossible de localiser le dossier %s."
 
 #, c-format
 msgid "Unable to read input file: %s"
@@ -1764,22 +1752,22 @@ msgid "Unknown"
 msgstr "Inconnu"
 
 #, c-format
-msgid "Unknown builtin '%ls'"
-msgstr "Commande interne inconnue '%ls'"
+msgid "Unknown builtin '%s'"
+msgstr "Commande interne inconnue '%s'"
 
 msgid "Unknown command"
 msgstr ""
 
 #, c-format
-msgid "Unknown command. '%ls' exists but is not an executable file."
+msgid "Unknown command. '%s' exists but is not an executable file."
 msgstr ""
 
 #, c-format
-msgid "Unknown command. A component of '%ls' is not a directory."
+msgid "Unknown command. A component of '%s' is not a directory."
 msgstr ""
 
 #, c-format
-msgid "Unknown command. A component of '%ls' is not a directory. Check your $PATH."
+msgid "Unknown command. A component of '%s' is not a directory. Check your $PATH."
 msgstr ""
 
 msgid "Unknown command:"
@@ -1792,15 +1780,15 @@ msgid "Unknown function"
 msgstr ""
 
 #, c-format
-msgid "Unknown function '%ls'"
-msgstr "Fonction inconnue '%ls'"
+msgid "Unknown function '%s'"
+msgstr "Fonction inconnue '%s'"
 
 msgid "Unmatched wildcard"
 msgstr ""
 
 #, c-format
-msgid "Unsupported use of '='. In fish, please use 'set %ls %ls'."
-msgstr "Usage de '=' non supporté. Dans fish, veuillez utiliser 'set %ls %ls'."
+msgid "Unsupported use of '='. In fish, please use 'set %s %s'."
+msgstr "Usage de '=' non supporté. Dans fish, veuillez utiliser 'set %s %s'."
 
 msgid "Unused signal"
 msgstr "Signal inutilisé"
@@ -1818,16 +1806,16 @@ msgid "User defined signal 2"
 msgstr "Signal défini par l'utilisateur 2"
 
 #, c-format
-msgid "Variable: %ls"
-msgstr "Variable : %ls"
+msgid "Variable: %s"
+msgstr "Variable : %s"
 
 #, c-format
-msgid "Variables cannot be bracketed. In fish, please use \"$%ls\"."
-msgstr "Les variables ne peuvent être placées entre crochets. Dans fish, veuillez utiliser \"$%ls\"."
+msgid "Variables cannot be bracketed. In fish, please use \"$%s\"."
+msgstr "Les variables ne peuvent être placées entre crochets. Dans fish, veuillez utiliser \"$%s\"."
 
 #, c-format
-msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
-msgstr "Les variables ne peuvent être placées entre crochets. Dans fish, veuillez utiliser {$%ls}."
+msgid "Variables cannot be bracketed. In fish, please use {$%s}."
+msgstr "Les variables ne peuvent être placées entre crochets. Dans fish, veuillez utiliser {$%s}."
 
 msgid "Virtual timer expired"
 msgstr ""
@@ -1857,15 +1845,15 @@ msgid "autoloading"
 msgstr ""
 
 #, c-format
-msgid "builtin %ls: %ls: %s\n"
+msgid "builtin %s: %s: %s\n"
 msgstr ""
 
 #, c-format
-msgid "builtin %ls: Invalid arg: %ls\n"
+msgid "builtin %s: Invalid arg: %s\n"
 msgstr ""
 
 #, c-format
-msgid "builtin %ls: realpath failed: %s\n"
+msgid "builtin %s: realpath failed: %s\n"
 msgstr ""
 
 msgid "builtin history delete --exact requires --case-sensitive\n"
@@ -1916,33 +1904,33 @@ msgstr "fichier"
 
 #, c-format
 msgid ""
-"fish: %ls: missing man page\n"
+"fish: %s: missing man page\n"
 "Documentation may not be installed.\n"
-"`help %ls` will show an online version\n"
+"`help %s` will show an online version\n"
 msgstr ""
 
 #, c-format
-msgid "from sourcing file %ls\n"
-msgstr "du fichier source %ls\n"
+msgid "from sourcing file %s\n"
+msgstr "du fichier source %s\n"
 
 msgid "in command substitution\n"
 msgstr "dans la substitution de commande\n"
 
 #, c-format
-msgid "in event handler: %ls\n"
-msgstr "dans le gestionnaire d'événement: %ls\n"
+msgid "in event handler: %s\n"
+msgstr "dans le gestionnaire d'événement: %s\n"
 
 #, c-format
-msgid "in function '%ls'"
+msgid "in function '%s'"
 msgstr ""
 
 #, c-format
-msgid "invalid field width: %ls"
-msgstr "largeur de champ invalide : %ls"
+msgid "invalid field width: %s"
+msgstr "largeur de champ invalide : %s"
 
 #, c-format
-msgid "invalid precision: %ls"
-msgstr "précision invalide : %ls"
+msgid "invalid precision: %s"
+msgstr "précision invalide : %s"
 
 msgid "missing hexadecimal number in escape"
 msgstr "nombre hexadécimal manquant dans l’échappement"
@@ -1956,8 +1944,8 @@ msgid "or press ctrl-%c or ctrl-%c twice in a row."
 msgstr ""
 
 #, c-format
-msgid "rows %lu to %lu of %lu"
-msgstr "lignes %lu à %lu de %lu"
+msgid "rows %u to %u of %u"
+msgstr "lignes %u à %u de %u"
 
 msgid "running"
 msgstr "en cours d’exécution"
@@ -1969,14 +1957,14 @@ msgid "stopped"
 msgstr "arrêtée"
 
 #, c-format
-msgid "switch: Expected at most one argument, got %lu\n"
+msgid "switch: Expected at most one argument, got %u\n"
 msgstr ""
 
 msgid "symlink"
 msgstr ""
 
 #, c-format
-msgid "ulimit: Permission denied when changing resource of type '%ls'\n"
+msgid "ulimit: Permission denied when changing resource of type '%s'\n"
 msgstr ""
 
 msgid "unexported"
@@ -1995,17 +1983,14 @@ msgstr ""
 msgid "fish-section-tier1-from-script-explicitly-added"
 msgstr ""
 
-msgid "%ls: %ls: expected %d arguments; got %d\\n"
-msgstr ""
-
-msgid "%ls: %ls: subcommand takes no options\\n"
-msgstr ""
-
-msgid "%ls: Expected at least %d args, got only %d\\n"
-msgstr ""
-
 msgid "%s: %s is an array variable. Use %svared%s %s[n]%s to edit the n:th element of %s\\n"
 msgstr "%s : %s est un tableau. Utilisez %svared%s %s[n]%s pour éditer le n-ième élément de %s\\n"
+
+msgid "%s: %s: expected %d arguments; got %d\\n"
+msgstr ""
+
+msgid "%s: %s: subcommand takes no options\\n"
+msgstr ""
 
 msgid "%s: Could not create configuration directory '%s'\\n"
 msgstr ""
@@ -2015,6 +2000,9 @@ msgstr "%s : Impossible de trouver un navigateur Web.\\n"
 
 msgid "%s: Directory stack is empty…\\n"
 msgstr "%s : Pile de dossiers vide…\\n"
+
+msgid "%s: Expected at least %d args, got only %d\\n"
+msgstr ""
 
 msgid "%s: Expected exactly one argument, got %s.\\n\\nSynopsis:\\n\\t%svared%s VARIABLE\\n"
 msgstr "%s : Un argument attendu, %s reçu(s).\\n\\nRésumé :\\n\\t%svared%s VARIABLE\\n"

--- a/po/pl.po
+++ b/po/pl.po
@@ -26,7 +26,7 @@ msgid ""
 msgstr ""
 
 #, c-format
-msgid " (%ls)\n"
+msgid " (%s)\n"
 msgstr ""
 
 msgid " (read-only)\n"
@@ -36,7 +36,7 @@ msgid " a path variable"
 msgstr ""
 
 #, c-format
-msgid " with arguments '%ls'"
+msgid " with arguments '%s'"
 msgstr ""
 
 msgid " with definition"
@@ -49,15 +49,15 @@ msgid "$$ is not the pid. In fish, please use $fish_pid."
 msgstr "$$ nie jest numerem identyfikacyjnym procesu. W fish używane jest $fish_pid."
 
 #, c-format
-msgid "$%lc is not a valid variable in fish."
-msgstr "$%lc nie jest prawidłową zmienną w fish."
+msgid "$%c is not a valid variable in fish."
+msgstr "$%c nie jest prawidłową zmienną w fish."
 
 #, c-format
-msgid "$%ls: originally inherited as |%ls|\n"
+msgid "$%s: originally inherited as |%s|\n"
 msgstr ""
 
 #, c-format
-msgid "$%ls: set in %ls scope, %ls,%ls with %d elements"
+msgid "$%s: set in %s scope, %s,%s with %d elements"
 msgstr ""
 
 msgid "$* is not supported. In fish, please use $argv."
@@ -73,719 +73,7 @@ msgid "$status is not valid as a command. See `help conditions`"
 msgstr ""
 
 #, c-format
-msgid "%.*ls: invalid conversion specification"
-msgstr ""
-
-#, c-format
-msgid "%ls"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: Abbreviation %ls already exists, cannot rename %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: Abbreviation '%ls' cannot have spaces in the word\n"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: Name cannot be empty\n"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: No abbreviation named %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: Requires at least two arguments\n"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: Requires exactly two arguments\n"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: Unexpected argument -- '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls (line %d): "
-msgstr "%ls (linia %d): "
-
-#, c-format
-msgid "%ls (line %lu): "
-msgstr "%ls (linia %lu): "
-
-#, c-format
-msgid "%ls is %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls is a builtin\n"
-msgstr ""
-
-#, c-format
-msgid "%ls is a function"
-msgstr ""
-
-#, c-format
-msgid "%ls, version %s"
-msgstr ""
-
-#, c-format
-msgid "%ls: %*ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls %ls: options cannot be used together\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: cannot overwrite read-only variable"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: cannot use reserved keyword as function name"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: contains a syntax error\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: expected %d arguments; got %d\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid base value\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid function name"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid integer\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid mode\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid mode name. See `help identifiers`\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid process id"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid scale\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid subcommand\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid variable name. See `help identifiers`\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: option does not take an argument\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: option requires an argument\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: subcommand takes no options\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: unexpected positional argument"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: unknown option\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: '%ls' is a broken symbolic link to '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: '%ls' is not a directory\n"
-msgstr "%ls: '%ls' nie jest ścieżką\n"
-
-#, c-format
-msgid "%ls: '%ls' is not a job\n"
-msgstr "%ls: '%ls' nie jest zadaniem\n"
-
-#, c-format
-msgid "%ls: '%ls' is not a valid job id\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: '%ls' is not a valid job specifier\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: '%ls' is not a valid process id\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: --command cannot be combined with --position command"
-msgstr ""
-
-#, c-format
-msgid "%ls: --function option requires --add\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: --position option requires --add\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: --regex option requires --add\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: --set-cursor argument cannot be empty\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: --set-cursor option requires --add\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: -l requires a non-empty string\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: -o requires a non-empty string\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: -s requires a non-empty string\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Ambiguous job\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: An option spec must have at least a short or a long flag\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Argument '%ls' is out of range\n"
-msgstr "%ls: Argument '%ls' jest poza zasięgiem\n"
-
-#, c-format
-msgid "%ls: Can not specify scope when removing block\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Can't put job %d, '%ls' to foreground because it is not under job control\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Can't put job %s, '%ls' to background because it is not under job control\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Cannot combine options %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Cannot specify multiple positions\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Cannot specify multiple regex patterns\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Cannot specify multiple set-cursor options\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Cannot use --append or --prepend when assigning to a slice"
-msgstr ""
-
-#, c-format
-msgid "%ls: Command not valid at an interactive prompt\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Could not find '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Could not find a job with process id '%d'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Could not find child processes with the name '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Could not find home directory\n"
-msgstr "%ls: Nie można odnaleźć katalogu domowego\n"
-
-#, c-format
-msgid "%ls: Could not find job '%d'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Did you mean `set %ls %ls`?"
-msgstr ""
-
-#, c-format
-msgid "%ls: Empty directory '%ls' does not exist\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Error encountered while sourcing file '%ls':\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Error while reading file '%ls'\n"
-msgstr "%ls: Nie udało się odczytać '%ls'\n"
-
-#, c-format
-msgid "%ls: Expected at least one argument"
-msgstr ""
-
-#, c-format
-msgid "%ls: Expected exactly one function name\n"
-msgstr "%ls: Oczekiwano dokładnie jednej nazwy funkcji\n"
-
-#, c-format
-msgid "%ls: Expected exactly two names (current function name, and new function name)\n"
-msgstr "%ls: Oczekiwano dokładnie dwóch nazw (nazwa obecnej funkcji i nazwa nowej)\n"
-
-#, c-format
-msgid "%ls: Expected generic | variable | signal | exit | job-id for --handlers-type\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Function '%ls' already exists. Cannot create copy of '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Function '%ls' does not exist\n"
-msgstr "%ls: Funkcja '%ls' nie istnieje\n"
-
-#, c-format
-msgid "%ls: Illegal function name '%ls'\n"
-msgstr "%ls: Niedozwolona nazwa funkcji '%ls'\n"
-
-#, c-format
-msgid "%ls: Implicit int flag '%lc' already defined\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Implicit int short flag '%lc' does not allow modifiers like '%lc'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid --max-args value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid --min-args value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid --unknown-arguments value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid count value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid end value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid escape style '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid fields value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid function name: %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid index starting at '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid job control mode '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid length value '%ls'\n"
-msgstr "%ls: Nieprawidłowa wartość długości  '%ls'\n"
-
-#, c-format
-msgid "%ls: Invalid level value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid limit '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid max matches value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid max value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid option spec '%ls' at char '%lc'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid padding character of width zero '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid permission '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid position '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid range value for field '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid sort key '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid start value '%ls'\n"
-msgstr "%ls: Nieprawidłową wartość początkowa '%ls'\n"
-
-#, c-format
-msgid "%ls: Invalid state\n"
-msgstr "%ls: Nieprawidłowy stan\n"
-
-#, c-format
-msgid "%ls: Invalid style value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid token '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid type '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid width value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Key not specified\n"
-msgstr "%ls: Nie określono klawisza\n"
-
-#, c-format
-msgid "%ls: Long flag '%ls' already defined\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Missing -- separator\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: New limit cannot be an empty string\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: No binding found for key '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: No binding found for key sequence '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: No blocks defined\n"
-msgstr "%ls: Nie określono bloków\n"
-
-#, c-format
-msgid "%ls: No suitable job: %d\n"
-msgstr "%ls: Brak pasujących zadań: %d\n"
-
-#, c-format
-msgid "%ls: No suitable job: %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Not inside of loop\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Options %ls and %ls cannot be used together\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Padding should be a character '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Permission denied: '%ls'\n"
-msgstr "%ls: Brak uprawnień: '%ls'\n"
-
-#, c-format
-msgid "%ls: Regular expression compile error: %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Regular expression substitute error: %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Resource limit not available on this operating system\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: STEP must be a positive integer\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Short flag '%lc' already defined\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Short flag '%lc' invalid, must be alphanum or '#'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: The directory '%ls' does not exist\n"
-msgstr "%ls: Ścieżka '%ls' nie istnieje\n"
-
-#, c-format
-msgid "%ls: The variable '%ls' does not exist\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: There are no jobs\n"
-msgstr "%ls: Nie ma żadnych zadań\n"
-
-#, c-format
-msgid "%ls: There are no suitable jobs\n"
-msgstr "%ls: Brak pasujących zadań\n"
-
-#, c-format
-msgid "%ls: Too many levels of symbolic links: '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Too many long-only options\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Tried to change the read-only variable '%ls'\n"
-msgstr "%ls: Próbowano zmienić wartość zmiennej tylko do odczytu '%ls'\n"
-
-#, c-format
-msgid "%ls: Tried to modify the special variable '%ls' to an invalid value\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Tried to modify the special variable '%ls' with the wrong scope\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Unknown color '%ls'\n"
-msgstr "%ls: Nieznany kolor '%ls'\n"
-
-#, c-format
-msgid "%ls: Unknown error trying to locate directory '%ls'\n"
-msgstr "%ls: Nieokreślony błąd podczas wyszukiwania lokalizacji '%ls'\n"
-
-#, c-format
-msgid "%ls: Unknown input function '%ls'"
-msgstr ""
-
-#, c-format
-msgid "%ls: Unknown signal '%ls'"
-msgstr "%ls: Nieznany sygnał '%ls'"
-
-#, c-format
-msgid "%ls: Warning: Option '%ls' was removed and is now ignored"
-msgstr ""
-
-#, c-format
-msgid "%ls: `set --show` does not allow slices with the var names\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: array index out of bounds\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: called with no arguments. This will be an error in future."
-msgstr ""
-
-#, c-format
-msgid "%ls: called with one argument. This will return false in future."
-msgstr ""
-
-#, c-format
-msgid "%ls: calling job for event handler not found"
-msgstr ""
-
-#, c-format
-msgid "%ls: can't merge history in private mode\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: cannot both export and unexport\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: cannot both path and unpath\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: column %ls exceeds line length\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: exclusive flag '%ls' is not valid\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: exclusive flag string '%ls' is not valid\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: expected %d arguments; got %d\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: expected <= %d arguments; got %d\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: expected >= %d arguments; got %d\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: expected a numeric value"
-msgstr "%ls: oczekiwano wartości liczbowej"
-
-#, c-format
-msgid "%ls: fish was not built with embedded files"
-msgstr ""
-
-#, c-format
-msgid "%ls: given %d indexes but %d values\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: invalid option combination\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: invalid option combination, %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: invalid underline style: %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: job %d ('%ls') was stopped and has been signalled to continue.\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: line/column index starts at 1"
-msgstr ""
-
-#, c-format
-msgid "%ls: missing argument\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: missing filename argument or input redirection\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: missing subcommand\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: nothing to choose from\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: realpath failed: %s\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: scope can be only one of: universal function global local\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: stdin is closed\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: successfully set universal '%ls'; but a global by that name shadows it\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: the -k/--key syntax is no longer supported. See `bind --help` and `bind --key-names`\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: there is no line %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: too many arguments\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: usage of -i for --silent is deprecated. Please use -s or --silent instead.\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: value not completely converted (can't convert '%ls')"
-msgstr ""
-
-#, c-format
-msgid "%ls: variable '%ls' is read-only\n"
-msgstr ""
-
-#, c-format
-msgid "%lsand %lu more rows"
-msgstr "%lsand %lu więcej rzędów"
-
-#, c-format
-msgid "%lu\n"
+msgid "%.*s: invalid conversion specification"
 msgstr ""
 
 #, c-format
@@ -793,8 +81,44 @@ msgid "%s"
 msgstr ""
 
 #, c-format
-msgid "%s %s: unrecognized feature '%ls'"
+msgid "%s %s: Abbreviation %s already exists, cannot rename %s\n"
 msgstr ""
+
+#, c-format
+msgid "%s %s: Abbreviation '%s' cannot have spaces in the word\n"
+msgstr ""
+
+#, c-format
+msgid "%s %s: Name cannot be empty\n"
+msgstr ""
+
+#, c-format
+msgid "%s %s: No abbreviation named %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s %s: Requires at least two arguments\n"
+msgstr ""
+
+#, c-format
+msgid "%s %s: Requires exactly two arguments\n"
+msgstr ""
+
+#, c-format
+msgid "%s %s: Unexpected argument -- '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s %s: unrecognized feature '%s'"
+msgstr ""
+
+#, c-format
+msgid "%s (line %d): "
+msgstr "%s (linia %d): "
+
+#, c-format
+msgid "%s (line %u): "
+msgstr "%s (linia %u): "
 
 #, c-format
 msgid "%s and %s are mutually exclusive"
@@ -805,12 +129,680 @@ msgid "%s could not read response to Primary Device Attribute query after waitin
 msgstr ""
 
 #, c-format
+msgid "%s is %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s is a builtin\n"
+msgstr ""
+
+#, c-format
+msgid "%s is a function"
+msgstr ""
+
+#, c-format
 msgid "%s, version %s"
 msgstr ""
 
 #, c-format
 msgid "%s, version %s\n"
 msgstr "%s, wersja %s\n"
+
+#, c-format
+msgid "%s: %*s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s %s: options cannot be used together\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: cannot overwrite read-only variable"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: cannot use reserved keyword as function name"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: contains a syntax error\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: expected %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid base value\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid function name"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid integer\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid mode\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid mode name. See `help identifiers`\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid process id"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid scale\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid subcommand\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid variable name. See `help identifiers`\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: option does not take an argument\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: option requires an argument\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: subcommand takes no options\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: unexpected positional argument"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: unknown option\n"
+msgstr ""
+
+#, c-format
+msgid "%s: '%s' is a broken symbolic link to '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: '%s' is not a directory\n"
+msgstr "%s: '%s' nie jest ścieżką\n"
+
+#, c-format
+msgid "%s: '%s' is not a job\n"
+msgstr "%s: '%s' nie jest zadaniem\n"
+
+#, c-format
+msgid "%s: '%s' is not a valid job id\n"
+msgstr ""
+
+#, c-format
+msgid "%s: '%s' is not a valid job specifier\n"
+msgstr ""
+
+#, c-format
+msgid "%s: '%s' is not a valid process id\n"
+msgstr ""
+
+#, c-format
+msgid "%s: --command cannot be combined with --position command"
+msgstr ""
+
+#, c-format
+msgid "%s: --function option requires --add\n"
+msgstr ""
+
+#, c-format
+msgid "%s: --position option requires --add\n"
+msgstr ""
+
+#, c-format
+msgid "%s: --regex option requires --add\n"
+msgstr ""
+
+#, c-format
+msgid "%s: --set-cursor argument cannot be empty\n"
+msgstr ""
+
+#, c-format
+msgid "%s: --set-cursor option requires --add\n"
+msgstr ""
+
+#, c-format
+msgid "%s: -l requires a non-empty string\n"
+msgstr ""
+
+#, c-format
+msgid "%s: -o requires a non-empty string\n"
+msgstr ""
+
+#, c-format
+msgid "%s: -s requires a non-empty string\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Ambiguous job\n"
+msgstr ""
+
+#, c-format
+msgid "%s: An option spec must have at least a short or a long flag\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Argument '%s' is out of range\n"
+msgstr "%s: Argument '%s' jest poza zasięgiem\n"
+
+#, c-format
+msgid "%s: Can not specify scope when removing block\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Can't put job %d, '%s' to foreground because it is not under job control\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Can't put job %s, '%s' to background because it is not under job control\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Cannot combine options %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Cannot specify multiple positions\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Cannot specify multiple regex patterns\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Cannot specify multiple set-cursor options\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Cannot use --append or --prepend when assigning to a slice"
+msgstr ""
+
+#, c-format
+msgid "%s: Command not valid at an interactive prompt\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Could not find '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Could not find a job with process id '%d'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Could not find child processes with the name '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Could not find home directory\n"
+msgstr "%s: Nie można odnaleźć katalogu domowego\n"
+
+#, c-format
+msgid "%s: Could not find job '%d'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Did you mean `set %s %s`?"
+msgstr ""
+
+#, c-format
+msgid "%s: Empty directory '%s' does not exist\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Error encountered while sourcing file '%s':\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Error while reading file '%s'\n"
+msgstr "%s: Nie udało się odczytać '%s'\n"
+
+#, c-format
+msgid "%s: Expected at least one argument"
+msgstr ""
+
+#, c-format
+msgid "%s: Expected exactly one function name\n"
+msgstr "%s: Oczekiwano dokładnie jednej nazwy funkcji\n"
+
+#, c-format
+msgid "%s: Expected exactly two names (current function name, and new function name)\n"
+msgstr "%s: Oczekiwano dokładnie dwóch nazw (nazwa obecnej funkcji i nazwa nowej)\n"
+
+#, c-format
+msgid "%s: Expected generic | variable | signal | exit | job-id for --handlers-type\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Function '%s' already exists. Cannot create copy of '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Function '%s' does not exist\n"
+msgstr "%s: Funkcja '%s' nie istnieje\n"
+
+#, c-format
+msgid "%s: Illegal function name '%s'\n"
+msgstr "%s: Niedozwolona nazwa funkcji '%s'\n"
+
+#, c-format
+msgid "%s: Implicit int flag '%c' already defined\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Implicit int short flag '%c' does not allow modifiers like '%c'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid --max-args value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid --min-args value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid --unknown-arguments value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid count value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid end value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid escape style '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid fields value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid function name: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid index starting at '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid job control mode '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid length value '%s'\n"
+msgstr "%s: Nieprawidłowa wartość długości  '%s'\n"
+
+#, c-format
+msgid "%s: Invalid level value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid limit '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid max matches value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid max value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid option spec '%s' at char '%c'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid padding character of width zero '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid permission '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid position '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid range value for field '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid sort key '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid start value '%s'\n"
+msgstr "%s: Nieprawidłową wartość początkowa '%s'\n"
+
+#, c-format
+msgid "%s: Invalid state\n"
+msgstr "%s: Nieprawidłowy stan\n"
+
+#, c-format
+msgid "%s: Invalid style value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid token '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid type '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid width value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Key not specified\n"
+msgstr "%s: Nie określono klawisza\n"
+
+#, c-format
+msgid "%s: Long flag '%s' already defined\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Missing -- separator\n"
+msgstr ""
+
+#, c-format
+msgid "%s: New limit cannot be an empty string\n"
+msgstr ""
+
+#, c-format
+msgid "%s: No binding found for key '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: No binding found for key sequence '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: No blocks defined\n"
+msgstr "%s: Nie określono bloków\n"
+
+#, c-format
+msgid "%s: No suitable job: %d\n"
+msgstr "%s: Brak pasujących zadań: %d\n"
+
+#, c-format
+msgid "%s: No suitable job: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Not inside of loop\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Options %s and %s cannot be used together\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Padding should be a character '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Permission denied: '%s'\n"
+msgstr "%s: Brak uprawnień: '%s'\n"
+
+#, c-format
+msgid "%s: Regular expression compile error: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Regular expression substitute error: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Resource limit not available on this operating system\n"
+msgstr ""
+
+#, c-format
+msgid "%s: STEP must be a positive integer\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Short flag '%c' already defined\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Short flag '%c' invalid, must be alphanum or '#'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: The directory '%s' does not exist\n"
+msgstr "%s: Ścieżka '%s' nie istnieje\n"
+
+#, c-format
+msgid "%s: The variable '%s' does not exist\n"
+msgstr ""
+
+#, c-format
+msgid "%s: There are no jobs\n"
+msgstr "%s: Nie ma żadnych zadań\n"
+
+#, c-format
+msgid "%s: There are no suitable jobs\n"
+msgstr "%s: Brak pasujących zadań\n"
+
+#, c-format
+msgid "%s: Too many levels of symbolic links: '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Too many long-only options\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Tried to change the read-only variable '%s'\n"
+msgstr "%s: Próbowano zmienić wartość zmiennej tylko do odczytu '%s'\n"
+
+#, c-format
+msgid "%s: Tried to modify the special variable '%s' to an invalid value\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Tried to modify the special variable '%s' with the wrong scope\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Unknown color '%s'\n"
+msgstr "%s: Nieznany kolor '%s'\n"
+
+#, c-format
+msgid "%s: Unknown error trying to locate directory '%s'\n"
+msgstr "%s: Nieokreślony błąd podczas wyszukiwania lokalizacji '%s'\n"
+
+#, c-format
+msgid "%s: Unknown input function '%s'"
+msgstr ""
+
+#, c-format
+msgid "%s: Unknown signal '%s'"
+msgstr "%s: Nieznany sygnał '%s'"
+
+#, c-format
+msgid "%s: Warning: Option '%s' was removed and is now ignored"
+msgstr ""
+
+#, c-format
+msgid "%s: `set --show` does not allow slices with the var names\n"
+msgstr ""
+
+#, c-format
+msgid "%s: array index out of bounds\n"
+msgstr ""
+
+#, c-format
+msgid "%s: called with no arguments. This will be an error in future."
+msgstr ""
+
+#, c-format
+msgid "%s: called with one argument. This will return false in future."
+msgstr ""
+
+#, c-format
+msgid "%s: calling job for event handler not found"
+msgstr ""
+
+#, c-format
+msgid "%s: can't merge history in private mode\n"
+msgstr ""
+
+#, c-format
+msgid "%s: cannot both export and unexport\n"
+msgstr ""
+
+#, c-format
+msgid "%s: cannot both path and unpath\n"
+msgstr ""
+
+#, c-format
+msgid "%s: column %s exceeds line length\n"
+msgstr ""
+
+#, c-format
+msgid "%s: exclusive flag '%s' is not valid\n"
+msgstr ""
+
+#, c-format
+msgid "%s: exclusive flag string '%s' is not valid\n"
+msgstr ""
+
+#, c-format
+msgid "%s: expected %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%s: expected <= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%s: expected >= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%s: expected a numeric value"
+msgstr "%s: oczekiwano wartości liczbowej"
+
+#, c-format
+msgid "%s: fish was not built with embedded files"
+msgstr ""
+
+#, c-format
+msgid "%s: given %d indexes but %d values\n"
+msgstr ""
+
+#, c-format
+msgid "%s: invalid option combination\n"
+msgstr ""
+
+#, c-format
+msgid "%s: invalid option combination, %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: invalid underline style: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: job %d ('%s') was stopped and has been signalled to continue.\n"
+msgstr ""
+
+#, c-format
+msgid "%s: line/column index starts at 1"
+msgstr ""
+
+#, c-format
+msgid "%s: missing argument\n"
+msgstr ""
+
+#, c-format
+msgid "%s: missing filename argument or input redirection\n"
+msgstr ""
+
+#, c-format
+msgid "%s: missing subcommand\n"
+msgstr ""
+
+#, c-format
+msgid "%s: nothing to choose from\n"
+msgstr ""
+
+#, c-format
+msgid "%s: realpath failed: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: scope can be only one of: universal function global local\n"
+msgstr ""
+
+#, c-format
+msgid "%s: stdin is closed\n"
+msgstr ""
+
+#, c-format
+msgid "%s: successfully set universal '%s'; but a global by that name shadows it\n"
+msgstr ""
+
+#, c-format
+msgid "%s: the -k/--key syntax is no longer supported. See `bind --help` and `bind --key-names`\n"
+msgstr ""
+
+#, c-format
+msgid "%s: there is no line %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: too many arguments\n"
+msgstr ""
+
+#, c-format
+msgid "%s: usage of -i for --silent is deprecated. Please use -s or --silent instead.\n"
+msgstr ""
+
+#, c-format
+msgid "%s: value not completely converted (can't convert '%s')"
+msgstr ""
+
+#, c-format
+msgid "%s: variable '%s' is read-only\n"
+msgstr ""
+
+#, c-format
+msgid "%sand %u more rows"
+msgstr "%sand %u więcej rzędów"
+
+#, c-format
+msgid "%u\n"
+msgstr ""
 
 msgid "'break' while not inside of loop"
 msgstr "'break' użyte poza pętlą"
@@ -837,14 +829,14 @@ msgid "'}' does not take arguments. Did you forget a ';'?"
 msgstr ""
 
 #, c-format
-msgid "(Type 'help %ls' for related documentation)\n"
+msgid "(Type 'help %s' for related documentation)\n"
 msgstr ""
 
 msgid "(no matches)"
 msgstr "(brak pasujących wyników)"
 
 #, c-format
-msgid ", copied in %ls @ line %d"
+msgid ", copied in %s @ line %d"
 msgstr ""
 
 msgid ", copied interactively"
@@ -881,7 +873,7 @@ msgid "Abbreviation expansion"
 msgstr ""
 
 #, c-format
-msgid "Abbreviation: %ls"
+msgid "Abbreviation: %s"
 msgstr ""
 
 msgid "Abort"
@@ -900,7 +892,7 @@ msgid "An error occurred while setting up pipe"
 msgstr ""
 
 #, c-format
-msgid "Argument is not a number: '%ls'"
+msgid "Argument is not a number: '%s'"
 msgstr ""
 
 msgid "Await background process completion"
@@ -1002,7 +994,7 @@ msgid "Define a new function"
 msgstr "Zdefiniuj nową funkcję"
 
 #, c-format
-msgid "Defined in %ls @ line %d"
+msgid "Defined in %s @ line %d"
 msgstr ""
 
 msgid "Defined interactively"
@@ -1032,8 +1024,8 @@ msgid "Error when renaming file: %s"
 msgstr ""
 
 #, c-format
-msgid "Error while reading file %ls\n"
-msgstr "Wystąpił błąd podczas odczytywania pliku %ls\n"
+msgid "Error while reading file %s\n"
+msgstr "Wystąpił błąd podczas odczytywania pliku %s\n"
 
 msgid "Errors reported by exec (on by default)"
 msgstr ""
@@ -1066,19 +1058,15 @@ msgid "Expansion produced too many results"
 msgstr ""
 
 #, c-format
-msgid "Expected %ls, but found %ls"
+msgid "Expected %s, but found %s"
 msgstr ""
 
 #, c-format
-msgid "Expected %s, but found %ls"
+msgid "Expected a command, but found %s"
 msgstr ""
 
 #, c-format
-msgid "Expected a command, but found %ls"
-msgstr ""
-
-#, c-format
-msgid "Expected a string, but found %ls"
+msgid "Expected a string, but found %s"
 msgstr ""
 
 msgid "Expected a string, but found a redirection"
@@ -1091,7 +1079,7 @@ msgstr "Oczekiwano nazwy zmiennej po znaku $."
 msgid ""
 "Expected file path to read/write for -w:\n"
 "\n"
-" $ %ls -w foo.fish"
+" $ %s -w foo.fish"
 msgstr ""
 
 #, c-format
@@ -1163,32 +1151,32 @@ msgid "History performance measurements"
 msgstr ""
 
 #, c-format
-msgid "History session ID '%ls' is not a valid variable name. Falling back to `%ls`."
+msgid "History session ID '%s' is not a valid variable name. Falling back to `%s`."
 msgstr ""
 
 #, c-format
-msgid "Home for %ls"
-msgstr "Katalog domowy dla %ls"
+msgid "Home for %s"
+msgstr "Katalog domowy dla %s"
 
 msgid "I/O on asynchronous file descriptor is possible"
 msgstr ""
 
 #, c-format
-msgid "Illegal file descriptor in redirection '%ls'"
+msgid "Illegal file descriptor in redirection '%s'"
 msgstr ""
 
 msgid "Illegal instruction"
 msgstr "Niedozwolona instrukcja"
 
 #, c-format
-msgid "Incomplete escape sequence '%ls'"
+msgid "Incomplete escape sequence '%s'"
 msgstr ""
 
 msgid "Information request"
 msgstr "Żądanie informacji"
 
 #, c-format
-msgid "Integer %lld in '%ls' followed by non-digit"
+msgid "Integer %d in '%s' followed by non-digit"
 msgstr ""
 
 msgid "Internal (non-forked) process events"
@@ -1210,31 +1198,31 @@ msgid "Invalid input/output redirection"
 msgstr ""
 
 #, c-format
-msgid "Invalid number: %ls"
+msgid "Invalid number: %s"
 msgstr ""
 
 #, c-format
-msgid "Invalid redirection target: %ls"
-msgstr "Nieprawidłowy cel przekierowania: %ls"
+msgid "Invalid redirection target: %s"
+msgstr "Nieprawidłowy cel przekierowania: %s"
 
 #, c-format
-msgid "Invalid redirection: %ls"
+msgid "Invalid redirection: %s"
 msgstr ""
 
 #, c-format
-msgid "Invalid token '%ls'"
+msgid "Invalid token '%s'"
 msgstr ""
 
 #, c-format
-msgid "Items %lu to %lu of %lu"
+msgid "Items %u to %u of %u"
 msgstr ""
 
 msgid "Job\tGroup\t"
 msgstr "Zadanie\tGrupa\t"
 
 #, c-format
-msgid "Job control: %ls\n"
-msgstr "Kontrola zadania: %ls\n"
+msgid "Job control: %s\n"
+msgstr "Kontrola zadania: %s\n"
 
 msgid "Jobs being executed"
 msgstr ""
@@ -1273,7 +1261,7 @@ msgid "Missing closing parenthesis"
 msgstr ""
 
 #, c-format
-msgid "Missing end to balance this %ls"
+msgid "Missing end to balance this %s"
 msgstr ""
 
 msgid "Missing hexadecimal number in Unicode escape"
@@ -1283,7 +1271,7 @@ msgid "Missing operator"
 msgstr ""
 
 #, c-format
-msgid "Modification of read-only variable \"%ls\" is not allowed\n"
+msgid "Modification of read-only variable \"%s\" is not allowed\n"
 msgstr ""
 
 msgid "Negate exit status of job"
@@ -1296,7 +1284,7 @@ msgid "No TTY for interactive shell (tcgetpgrp failed)"
 msgstr ""
 
 #, c-format
-msgid "No matches for wildcard '%ls'. See `help wildcards-globbing`."
+msgid "No matches for wildcard '%s'. See `help wildcards-globbing`."
 msgstr ""
 
 msgid "Not a function"
@@ -1340,11 +1328,11 @@ msgid "Perform a set of commands multiple times"
 msgstr "Wykonaj zestaw komend wielokrotnie"
 
 #, c-format
-msgid "Please set $%ls to a directory where you have write access."
+msgid "Please set $%s to a directory where you have write access."
 msgstr ""
 
 #, c-format
-msgid "Please set the %ls or HOME environment variable before starting fish."
+msgid "Please set the %s or HOME environment variable before starting fish."
 msgstr ""
 
 msgid "Polite quit request"
@@ -1409,11 +1397,11 @@ msgid "Rendering the command line"
 msgstr ""
 
 #, c-format
-msgid "Requested redirection to '%ls', which is not a valid file descriptor"
+msgid "Requested redirection to '%s', which is not a valid file descriptor"
 msgstr ""
 
 #, c-format
-msgid "Result too large: %ls"
+msgid "Result too large: %s"
 msgstr ""
 
 msgid "Return a successful result"
@@ -1447,11 +1435,11 @@ msgid "Searching/using paths"
 msgstr ""
 
 #, c-format
-msgid "Send job %d (%ls) to foreground\n"
+msgid "Send job %d (%s) to foreground\n"
 msgstr ""
 
 #, c-format
-msgid "Send job %s '%ls' to background\n"
+msgid "Send job %s '%s' to background\n"
 msgstr ""
 
 msgid "Send job to background"
@@ -1529,11 +1517,11 @@ msgid "Test a condition"
 msgstr ""
 
 #, c-format
-msgid "The '%ls' command can not be used immediately after a backgrounded job"
-msgstr "Komenda '%ls' nie może zostać użyta bezpośrednio po zadaniu w tle"
+msgid "The '%s' command can not be used immediately after a backgrounded job"
+msgstr "Komenda '%s' nie może zostać użyta bezpośrednio po zadaniu w tle"
 
 #, c-format
-msgid "The '%ls' command can not be used in a pipeline"
+msgid "The '%s' command can not be used in a pipeline"
 msgstr ""
 
 msgid "The 'time' command may only be at the beginning of a pipeline"
@@ -1556,8 +1544,8 @@ msgid "The expanded command was empty."
 msgstr ""
 
 #, c-format
-msgid "The function '%ls' calls itself immediately, which would result in an infinite loop."
-msgstr "Funkcja '%ls' wywołuje natychmiastowo siebie. Może to skutkować nieskończoną pętlą."
+msgid "The function '%s' calls itself immediately, which would result in an infinite loop."
+msgstr "Funkcja '%s' wywołuje natychmiastowo siebie. Może to skutkować nieskończoną pętlą."
 
 msgid "The interactive reader/input system"
 msgstr ""
@@ -1596,22 +1584,22 @@ msgid "Trying to print invalid output"
 msgstr ""
 
 #, c-format
-msgid "Unable to create temporary file '%ls': %s"
+msgid "Unable to create temporary file '%s': %s"
 msgstr ""
 
 msgid "Unable to evaluate string substitution"
 msgstr ""
 
 #, c-format
-msgid "Unable to expand variable name '%ls'"
-msgstr "Nie udało się rozszerzyć nazwy zmiennej '%ls'"
+msgid "Unable to expand variable name '%s'"
+msgstr "Nie udało się rozszerzyć nazwy zmiennej '%s'"
 
 #, c-format
-msgid "Unable to locate %ls directory derived from $%ls: '%ls'."
+msgid "Unable to locate %s directory derived from $%s: '%s'."
 msgstr ""
 
 #, c-format
-msgid "Unable to locate the %ls directory."
+msgid "Unable to locate the %s directory."
 msgstr ""
 
 #, c-format
@@ -1659,22 +1647,22 @@ msgid "Unknown"
 msgstr "Nieznany"
 
 #, c-format
-msgid "Unknown builtin '%ls'"
+msgid "Unknown builtin '%s'"
 msgstr ""
 
 msgid "Unknown command"
 msgstr ""
 
 #, c-format
-msgid "Unknown command. '%ls' exists but is not an executable file."
+msgid "Unknown command. '%s' exists but is not an executable file."
 msgstr ""
 
 #, c-format
-msgid "Unknown command. A component of '%ls' is not a directory."
+msgid "Unknown command. A component of '%s' is not a directory."
 msgstr ""
 
 #, c-format
-msgid "Unknown command. A component of '%ls' is not a directory. Check your $PATH."
+msgid "Unknown command. A component of '%s' is not a directory. Check your $PATH."
 msgstr ""
 
 msgid "Unknown command:"
@@ -1687,15 +1675,15 @@ msgid "Unknown function"
 msgstr ""
 
 #, c-format
-msgid "Unknown function '%ls'"
-msgstr "Nieznana funkcja '%ls'"
+msgid "Unknown function '%s'"
+msgstr "Nieznana funkcja '%s'"
 
 msgid "Unmatched wildcard"
 msgstr ""
 
 #, c-format
-msgid "Unsupported use of '='. In fish, please use 'set %ls %ls'."
-msgstr "Nieobsługiwane użycie '='. W fish używane jest 'set %ls %ls'."
+msgid "Unsupported use of '='. In fish, please use 'set %s %s'."
+msgstr "Nieobsługiwane użycie '='. W fish używane jest 'set %s %s'."
 
 msgid "Unused signal"
 msgstr "Niewykorzystywany sygnał"
@@ -1713,16 +1701,16 @@ msgid "User defined signal 2"
 msgstr "Sygnał zdefiniowany przez użytkownika 2"
 
 #, c-format
-msgid "Variable: %ls"
-msgstr "Zmienna: %ls"
+msgid "Variable: %s"
+msgstr "Zmienna: %s"
 
 #, c-format
-msgid "Variables cannot be bracketed. In fish, please use \"$%ls\"."
-msgstr "Zmienne nie mogą znajdować się w nawiasach. W fish używane jest \"$%ls\"."
+msgid "Variables cannot be bracketed. In fish, please use \"$%s\"."
+msgstr "Zmienne nie mogą znajdować się w nawiasach. W fish używane jest \"$%s\"."
 
 #, c-format
-msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
-msgstr "Zmienne nie mogą znajdować się w nawiasach. W fish używane jest {$%ls}."
+msgid "Variables cannot be bracketed. In fish, please use {$%s}."
+msgstr "Zmienne nie mogą znajdować się w nawiasach. W fish używane jest {$%s}."
 
 msgid "Virtual timer expired"
 msgstr ""
@@ -1752,15 +1740,15 @@ msgid "autoloading"
 msgstr ""
 
 #, c-format
-msgid "builtin %ls: %ls: %s\n"
+msgid "builtin %s: %s: %s\n"
 msgstr ""
 
 #, c-format
-msgid "builtin %ls: Invalid arg: %ls\n"
+msgid "builtin %s: Invalid arg: %s\n"
 msgstr ""
 
 #, c-format
-msgid "builtin %ls: realpath failed: %s\n"
+msgid "builtin %s: realpath failed: %s\n"
 msgstr ""
 
 msgid "builtin history delete --exact requires --case-sensitive\n"
@@ -1811,32 +1799,32 @@ msgstr ""
 
 #, c-format
 msgid ""
-"fish: %ls: missing man page\n"
+"fish: %s: missing man page\n"
 "Documentation may not be installed.\n"
-"`help %ls` will show an online version\n"
+"`help %s` will show an online version\n"
 msgstr ""
 
 #, c-format
-msgid "from sourcing file %ls\n"
+msgid "from sourcing file %s\n"
 msgstr ""
 
 msgid "in command substitution\n"
 msgstr "w zastępstwie polecenia \n"
 
 #, c-format
-msgid "in event handler: %ls\n"
-msgstr "w procedurze obsługi zdarzeń: %ls\n"
+msgid "in event handler: %s\n"
+msgstr "w procedurze obsługi zdarzeń: %s\n"
 
 #, c-format
-msgid "in function '%ls'"
+msgid "in function '%s'"
 msgstr ""
 
 #, c-format
-msgid "invalid field width: %ls"
+msgid "invalid field width: %s"
 msgstr ""
 
 #, c-format
-msgid "invalid precision: %ls"
+msgid "invalid precision: %s"
 msgstr ""
 
 msgid "missing hexadecimal number in escape"
@@ -1851,8 +1839,8 @@ msgid "or press ctrl-%c or ctrl-%c twice in a row."
 msgstr ""
 
 #, c-format
-msgid "rows %lu to %lu of %lu"
-msgstr "rzędy od %lu do %lu z %lu"
+msgid "rows %u to %u of %u"
+msgstr "rzędy od %u do %u z %u"
 
 msgid "running"
 msgstr "uruchomiona"
@@ -1864,14 +1852,14 @@ msgid "stopped"
 msgstr "zatrzymana"
 
 #, c-format
-msgid "switch: Expected at most one argument, got %lu\n"
+msgid "switch: Expected at most one argument, got %u\n"
 msgstr ""
 
 msgid "symlink"
 msgstr ""
 
 #, c-format
-msgid "ulimit: Permission denied when changing resource of type '%ls'\n"
+msgid "ulimit: Permission denied when changing resource of type '%s'\n"
 msgstr ""
 
 msgid "unexported"
@@ -1890,16 +1878,13 @@ msgstr ""
 msgid "fish-section-tier1-from-script-explicitly-added"
 msgstr ""
 
-msgid "%ls: %ls: expected %d arguments; got %d\\n"
-msgstr ""
-
-msgid "%ls: %ls: subcommand takes no options\\n"
-msgstr ""
-
-msgid "%ls: Expected at least %d args, got only %d\\n"
-msgstr ""
-
 msgid "%s: %s is an array variable. Use %svared%s %s[n]%s to edit the n:th element of %s\\n"
+msgstr ""
+
+msgid "%s: %s: expected %d arguments; got %d\\n"
+msgstr ""
+
+msgid "%s: %s: subcommand takes no options\\n"
 msgstr ""
 
 msgid "%s: Could not create configuration directory '%s'\\n"
@@ -1909,6 +1894,9 @@ msgid "%s: Could not find a web browser.\\n"
 msgstr ""
 
 msgid "%s: Directory stack is empty…\\n"
+msgstr ""
+
+msgid "%s: Expected at least %d args, got only %d\\n"
 msgstr ""
 
 msgid "%s: Expected exactly one argument, got %s.\\n\\nSynopsis:\\n\\t%svared%s VARIABLE\\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -31,7 +31,7 @@ msgid ""
 msgstr ""
 
 #, c-format
-msgid " (%ls)\n"
+msgid " (%s)\n"
 msgstr ""
 
 msgid " (read-only)\n"
@@ -41,7 +41,7 @@ msgid " a path variable"
 msgstr ""
 
 #, c-format
-msgid " with arguments '%ls'"
+msgid " with arguments '%s'"
 msgstr ""
 
 msgid " with definition"
@@ -54,15 +54,15 @@ msgid "$$ is not the pid. In fish, please use $fish_pid."
 msgstr ""
 
 #, c-format
-msgid "$%lc is not a valid variable in fish."
+msgid "$%c is not a valid variable in fish."
 msgstr ""
 
 #, c-format
-msgid "$%ls: originally inherited as |%ls|\n"
+msgid "$%s: originally inherited as |%s|\n"
 msgstr ""
 
 #, c-format
-msgid "$%ls: set in %ls scope, %ls,%ls with %d elements"
+msgid "$%s: set in %s scope, %s,%s with %d elements"
 msgstr ""
 
 msgid "$* is not supported. In fish, please use $argv."
@@ -78,728 +78,52 @@ msgid "$status is not valid as a command. See `help conditions`"
 msgstr ""
 
 #, c-format
-msgid "%.*ls: invalid conversion specification"
-msgstr "%.*ls: especificação de conversão inválida"
-
-#, c-format
-msgid "%ls"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: Abbreviation %ls already exists, cannot rename %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: Abbreviation '%ls' cannot have spaces in the word\n"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: Name cannot be empty\n"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: No abbreviation named %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: Requires at least two arguments\n"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: Requires exactly two arguments\n"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: Unexpected argument -- '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls (line %d): "
-msgstr "%ls (linha %d): "
-
-#, c-format
-msgid "%ls (line %lu): "
-msgstr "%ls (linha %lu): "
-
-#, c-format
-msgid "%ls is %ls\n"
-msgstr "%ls é %ls\n"
-
-#, c-format
-msgid "%ls is a builtin\n"
-msgstr "%ls é um builtin\n"
-
-#, c-format
-msgid "%ls is a function"
-msgstr "%ls é uma função"
-
-#, c-format
-msgid "%ls, version %s"
-msgstr ""
-
-#, c-format
-msgid "%ls: %*ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls %ls: options cannot be used together\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: cannot overwrite read-only variable"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: cannot use reserved keyword as function name"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: contains a syntax error\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: expected %d arguments; got %d\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid base value\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid function name"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid integer\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid mode\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid mode name. See `help identifiers`\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid process id"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid scale\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid subcommand\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid variable name. See `help identifiers`\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: option does not take an argument\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: option requires an argument\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: subcommand takes no options\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: unexpected positional argument"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: unknown option\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: '%ls' is a broken symbolic link to '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: '%ls' is not a directory\n"
-msgstr "%ls: “%ls” não é um diretório\n"
-
-#, c-format
-msgid "%ls: '%ls' is not a job\n"
-msgstr "%ls: “%ls” não é uma tarefa\n"
-
-#, c-format
-msgid "%ls: '%ls' is not a valid job id\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: '%ls' is not a valid job specifier\n"
-msgstr "%ls: '%ls' não é um identificador de tarefa válido\n"
-
-#, c-format
-msgid "%ls: '%ls' is not a valid process id\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: --command cannot be combined with --position command"
-msgstr ""
-
-#, c-format
-msgid "%ls: --function option requires --add\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: --position option requires --add\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: --regex option requires --add\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: --set-cursor argument cannot be empty\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: --set-cursor option requires --add\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: -l requires a non-empty string\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: -o requires a non-empty string\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: -s requires a non-empty string\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Ambiguous job\n"
-msgstr "%ls: Tarefa ambígua\n"
-
-#, c-format
-msgid "%ls: An option spec must have at least a short or a long flag\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Argument '%ls' is out of range\n"
-msgstr "%ls: Argumento “%ls” está fora do alcance\n"
-
-#, c-format
-msgid "%ls: Can not specify scope when removing block\n"
-msgstr "%ls: Não é possível especificar escopo ao remover bloco\n"
-
-#, c-format
-msgid "%ls: Can't put job %d, '%ls' to foreground because it is not under job control\n"
-msgstr "%ls: Não é possível colocar tarefa %d, “%ls” em primeiro plano porque não está sob controle de tarefas\n"
-
-#, c-format
-msgid "%ls: Can't put job %s, '%ls' to background because it is not under job control\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Cannot combine options %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Cannot specify multiple positions\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Cannot specify multiple regex patterns\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Cannot specify multiple set-cursor options\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Cannot use --append or --prepend when assigning to a slice"
-msgstr ""
-
-#, c-format
-msgid "%ls: Command not valid at an interactive prompt\n"
-msgstr "%ls: Comando inválido em um prompt interativo\n"
-
-#, c-format
-msgid "%ls: Could not find '%ls'\n"
-msgstr "%ls: Não foi possível encontrar '%ls'\n"
-
-#, c-format
-msgid "%ls: Could not find a job with process id '%d'\n"
-msgstr "%ls: Não foi possível encontrar uma tarefa com id de processo '%d'\n"
-
-#, c-format
-msgid "%ls: Could not find child processes with the name '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Could not find home directory\n"
-msgstr "%ls: Não foi possível encontrar o diretório home\n"
-
-#, c-format
-msgid "%ls: Could not find job '%d'\n"
-msgstr "%ls: Não foi possível encontrar a tarefa '%d'\n"
-
-#, c-format
-msgid "%ls: Did you mean `set %ls %ls`?"
-msgstr ""
-
-#, c-format
-msgid "%ls: Empty directory '%ls' does not exist\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Error encountered while sourcing file '%ls':\n"
-msgstr "%ls: Erro encontrado ao interpretar arquivo “%ls”:\n"
-
-#, c-format
-msgid "%ls: Error while reading file '%ls'\n"
-msgstr "%ls: Erro ao ler o arquivo “%ls”\n"
-
-#, c-format
-msgid "%ls: Expected at least one argument"
-msgstr ""
-
-#, c-format
-msgid "%ls: Expected exactly one function name\n"
-msgstr "%ls: Esperava exatamente um nome de função\n"
-
-#, c-format
-msgid "%ls: Expected exactly two names (current function name, and new function name)\n"
-msgstr "%ls: Esperava exatamente dois nomes (nome atual da função, e novo nome da função)\n"
-
-#, c-format
-msgid "%ls: Expected generic | variable | signal | exit | job-id for --handlers-type\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Function '%ls' already exists. Cannot create copy of '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Function '%ls' does not exist\n"
-msgstr "%ls: Função “%ls” não existe\n"
-
-#, c-format
-msgid "%ls: Illegal function name '%ls'\n"
-msgstr "%ls: Nome de função ilegal “%ls”\n"
-
-#, c-format
-msgid "%ls: Implicit int flag '%lc' already defined\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Implicit int short flag '%lc' does not allow modifiers like '%lc'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid --max-args value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid --min-args value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid --unknown-arguments value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid count value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid end value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid escape style '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid fields value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid function name: %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid index starting at '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid job control mode '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid length value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid level value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid limit '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid max matches value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid max value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid option spec '%ls' at char '%lc'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid padding character of width zero '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid permission '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid position '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid range value for field '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid sort key '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid start value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid state\n"
-msgstr "%ls: Estado inválido\n"
-
-#, c-format
-msgid "%ls: Invalid style value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid token '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid type '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid width value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Key not specified\n"
-msgstr "%ls: Chave não especificada\n"
-
-#, c-format
-msgid "%ls: Long flag '%ls' already defined\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Missing -- separator\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: New limit cannot be an empty string\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: No binding found for key '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: No binding found for key sequence '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: No blocks defined\n"
-msgstr "%ls: Não há blocos definidos\n"
-
-#, c-format
-msgid "%ls: No suitable job: %d\n"
-msgstr "%ls: Não é trabalho adequado: %d\n"
-
-#, c-format
-msgid "%ls: No suitable job: %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Not inside of loop\n"
-msgstr "%ls: Não está dentro de laço\n"
-
-#, c-format
-msgid "%ls: Options %ls and %ls cannot be used together\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Padding should be a character '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Permission denied: '%ls'\n"
-msgstr "%ls: Permissão negada: “%ls”\n"
-
-#, c-format
-msgid "%ls: Regular expression compile error: %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Regular expression substitute error: %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Resource limit not available on this operating system\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: STEP must be a positive integer\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Short flag '%lc' already defined\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Short flag '%lc' invalid, must be alphanum or '#'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: The directory '%ls' does not exist\n"
-msgstr "%ls: O diretório “%ls” não existe\n"
-
-#, c-format
-msgid "%ls: The variable '%ls' does not exist\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: There are no jobs\n"
-msgstr "%ls: Não há tarefas\n"
-
-#, c-format
-msgid "%ls: There are no suitable jobs\n"
-msgstr "%ls: Não há tarefas adequadas\n"
-
-#, c-format
-msgid "%ls: Too many levels of symbolic links: '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Too many long-only options\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Tried to change the read-only variable '%ls'\n"
-msgstr "%ls: Tentou mudar a variável somente leitura “%ls”\n"
-
-#, c-format
-msgid "%ls: Tried to modify the special variable '%ls' to an invalid value\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Tried to modify the special variable '%ls' with the wrong scope\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Unknown color '%ls'\n"
-msgstr "%ls: Cor desconhecida “%ls”\n"
-
-#, c-format
-msgid "%ls: Unknown error trying to locate directory '%ls'\n"
-msgstr "%ls: Erro desconhecido ao tentar localizar diretório “%ls”\n"
-
-#, c-format
-msgid "%ls: Unknown input function '%ls'"
-msgstr ""
-
-#, c-format
-msgid "%ls: Unknown signal '%ls'"
-msgstr ""
-
-#, c-format
-msgid "%ls: Warning: Option '%ls' was removed and is now ignored"
-msgstr ""
-
-#, c-format
-msgid "%ls: `set --show` does not allow slices with the var names\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: array index out of bounds\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: called with no arguments. This will be an error in future."
-msgstr ""
-
-#, c-format
-msgid "%ls: called with one argument. This will return false in future."
-msgstr ""
-
-#, c-format
-msgid "%ls: calling job for event handler not found"
-msgstr ""
-
-#, c-format
-msgid "%ls: can't merge history in private mode\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: cannot both export and unexport\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: cannot both path and unpath\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: column %ls exceeds line length\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: exclusive flag '%ls' is not valid\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: exclusive flag string '%ls' is not valid\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: expected %d arguments; got %d\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: expected <= %d arguments; got %d\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: expected >= %d arguments; got %d\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: expected a numeric value"
-msgstr "%ls: esperava valor numérico"
-
-#, c-format
-msgid "%ls: fish was not built with embedded files"
-msgstr ""
-
-#, c-format
-msgid "%ls: given %d indexes but %d values\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: invalid option combination\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: invalid option combination, %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: invalid underline style: %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: job %d ('%ls') was stopped and has been signalled to continue.\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: line/column index starts at 1"
-msgstr ""
-
-#, c-format
-msgid "%ls: missing argument\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: missing filename argument or input redirection\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: missing subcommand\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: nothing to choose from\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: realpath failed: %s\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: scope can be only one of: universal function global local\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: stdin is closed\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: successfully set universal '%ls'; but a global by that name shadows it\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: the -k/--key syntax is no longer supported. See `bind --help` and `bind --key-names`\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: there is no line %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: too many arguments\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: usage of -i for --silent is deprecated. Please use -s or --silent instead.\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: value not completely converted (can't convert '%ls')"
-msgstr ""
-
-#, c-format
-msgid "%ls: variable '%ls' is read-only\n"
-msgstr ""
-
-#, c-format
-msgid "%lsand %lu more rows"
-msgstr "%lse mais %lu linhas"
-
-#, c-format
-msgid "%lu\n"
-msgstr ""
+msgid "%.*s: invalid conversion specification"
+msgstr "%.*s: especificação de conversão inválida"
 
 #, c-format
 msgid "%s"
 msgstr ""
 
 #, c-format
-msgid "%s %s: unrecognized feature '%ls'"
+msgid "%s %s: Abbreviation %s already exists, cannot rename %s\n"
 msgstr ""
+
+#, c-format
+msgid "%s %s: Abbreviation '%s' cannot have spaces in the word\n"
+msgstr ""
+
+#, c-format
+msgid "%s %s: Name cannot be empty\n"
+msgstr ""
+
+#, c-format
+msgid "%s %s: No abbreviation named %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s %s: Requires at least two arguments\n"
+msgstr ""
+
+#, c-format
+msgid "%s %s: Requires exactly two arguments\n"
+msgstr ""
+
+#, c-format
+msgid "%s %s: Unexpected argument -- '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s %s: unrecognized feature '%s'"
+msgstr ""
+
+#, c-format
+msgid "%s (line %d): "
+msgstr "%s (linha %d): "
+
+#, c-format
+msgid "%s (line %u): "
+msgstr "%s (linha %u): "
 
 #, c-format
 msgid "%s and %s are mutually exclusive"
@@ -810,12 +134,680 @@ msgid "%s could not read response to Primary Device Attribute query after waitin
 msgstr ""
 
 #, c-format
+msgid "%s is %s\n"
+msgstr "%s é %s\n"
+
+#, c-format
+msgid "%s is a builtin\n"
+msgstr "%s é um builtin\n"
+
+#, c-format
+msgid "%s is a function"
+msgstr "%s é uma função"
+
+#, c-format
 msgid "%s, version %s"
 msgstr ""
 
 #, c-format
 msgid "%s, version %s\n"
 msgstr "%s, versão %s\n"
+
+#, c-format
+msgid "%s: %*s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s %s: options cannot be used together\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: cannot overwrite read-only variable"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: cannot use reserved keyword as function name"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: contains a syntax error\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: expected %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid base value\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid function name"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid integer\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid mode\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid mode name. See `help identifiers`\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid process id"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid scale\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid subcommand\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid variable name. See `help identifiers`\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: option does not take an argument\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: option requires an argument\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: subcommand takes no options\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: unexpected positional argument"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: unknown option\n"
+msgstr ""
+
+#, c-format
+msgid "%s: '%s' is a broken symbolic link to '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: '%s' is not a directory\n"
+msgstr "%s: “%s” não é um diretório\n"
+
+#, c-format
+msgid "%s: '%s' is not a job\n"
+msgstr "%s: “%s” não é uma tarefa\n"
+
+#, c-format
+msgid "%s: '%s' is not a valid job id\n"
+msgstr ""
+
+#, c-format
+msgid "%s: '%s' is not a valid job specifier\n"
+msgstr "%s: '%s' não é um identificador de tarefa válido\n"
+
+#, c-format
+msgid "%s: '%s' is not a valid process id\n"
+msgstr ""
+
+#, c-format
+msgid "%s: --command cannot be combined with --position command"
+msgstr ""
+
+#, c-format
+msgid "%s: --function option requires --add\n"
+msgstr ""
+
+#, c-format
+msgid "%s: --position option requires --add\n"
+msgstr ""
+
+#, c-format
+msgid "%s: --regex option requires --add\n"
+msgstr ""
+
+#, c-format
+msgid "%s: --set-cursor argument cannot be empty\n"
+msgstr ""
+
+#, c-format
+msgid "%s: --set-cursor option requires --add\n"
+msgstr ""
+
+#, c-format
+msgid "%s: -l requires a non-empty string\n"
+msgstr ""
+
+#, c-format
+msgid "%s: -o requires a non-empty string\n"
+msgstr ""
+
+#, c-format
+msgid "%s: -s requires a non-empty string\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Ambiguous job\n"
+msgstr "%s: Tarefa ambígua\n"
+
+#, c-format
+msgid "%s: An option spec must have at least a short or a long flag\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Argument '%s' is out of range\n"
+msgstr "%s: Argumento “%s” está fora do alcance\n"
+
+#, c-format
+msgid "%s: Can not specify scope when removing block\n"
+msgstr "%s: Não é possível especificar escopo ao remover bloco\n"
+
+#, c-format
+msgid "%s: Can't put job %d, '%s' to foreground because it is not under job control\n"
+msgstr "%s: Não é possível colocar tarefa %d, “%s” em primeiro plano porque não está sob controle de tarefas\n"
+
+#, c-format
+msgid "%s: Can't put job %s, '%s' to background because it is not under job control\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Cannot combine options %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Cannot specify multiple positions\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Cannot specify multiple regex patterns\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Cannot specify multiple set-cursor options\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Cannot use --append or --prepend when assigning to a slice"
+msgstr ""
+
+#, c-format
+msgid "%s: Command not valid at an interactive prompt\n"
+msgstr "%s: Comando inválido em um prompt interativo\n"
+
+#, c-format
+msgid "%s: Could not find '%s'\n"
+msgstr "%s: Não foi possível encontrar '%s'\n"
+
+#, c-format
+msgid "%s: Could not find a job with process id '%d'\n"
+msgstr "%s: Não foi possível encontrar uma tarefa com id de processo '%d'\n"
+
+#, c-format
+msgid "%s: Could not find child processes with the name '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Could not find home directory\n"
+msgstr "%s: Não foi possível encontrar o diretório home\n"
+
+#, c-format
+msgid "%s: Could not find job '%d'\n"
+msgstr "%s: Não foi possível encontrar a tarefa '%d'\n"
+
+#, c-format
+msgid "%s: Did you mean `set %s %s`?"
+msgstr ""
+
+#, c-format
+msgid "%s: Empty directory '%s' does not exist\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Error encountered while sourcing file '%s':\n"
+msgstr "%s: Erro encontrado ao interpretar arquivo “%s”:\n"
+
+#, c-format
+msgid "%s: Error while reading file '%s'\n"
+msgstr "%s: Erro ao ler o arquivo “%s”\n"
+
+#, c-format
+msgid "%s: Expected at least one argument"
+msgstr ""
+
+#, c-format
+msgid "%s: Expected exactly one function name\n"
+msgstr "%s: Esperava exatamente um nome de função\n"
+
+#, c-format
+msgid "%s: Expected exactly two names (current function name, and new function name)\n"
+msgstr "%s: Esperava exatamente dois nomes (nome atual da função, e novo nome da função)\n"
+
+#, c-format
+msgid "%s: Expected generic | variable | signal | exit | job-id for --handlers-type\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Function '%s' already exists. Cannot create copy of '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Function '%s' does not exist\n"
+msgstr "%s: Função “%s” não existe\n"
+
+#, c-format
+msgid "%s: Illegal function name '%s'\n"
+msgstr "%s: Nome de função ilegal “%s”\n"
+
+#, c-format
+msgid "%s: Implicit int flag '%c' already defined\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Implicit int short flag '%c' does not allow modifiers like '%c'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid --max-args value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid --min-args value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid --unknown-arguments value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid count value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid end value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid escape style '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid fields value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid function name: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid index starting at '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid job control mode '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid length value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid level value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid limit '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid max matches value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid max value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid option spec '%s' at char '%c'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid padding character of width zero '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid permission '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid position '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid range value for field '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid sort key '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid start value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid state\n"
+msgstr "%s: Estado inválido\n"
+
+#, c-format
+msgid "%s: Invalid style value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid token '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid type '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid width value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Key not specified\n"
+msgstr "%s: Chave não especificada\n"
+
+#, c-format
+msgid "%s: Long flag '%s' already defined\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Missing -- separator\n"
+msgstr ""
+
+#, c-format
+msgid "%s: New limit cannot be an empty string\n"
+msgstr ""
+
+#, c-format
+msgid "%s: No binding found for key '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: No binding found for key sequence '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: No blocks defined\n"
+msgstr "%s: Não há blocos definidos\n"
+
+#, c-format
+msgid "%s: No suitable job: %d\n"
+msgstr "%s: Não é trabalho adequado: %d\n"
+
+#, c-format
+msgid "%s: No suitable job: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Not inside of loop\n"
+msgstr "%s: Não está dentro de laço\n"
+
+#, c-format
+msgid "%s: Options %s and %s cannot be used together\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Padding should be a character '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Permission denied: '%s'\n"
+msgstr "%s: Permissão negada: “%s”\n"
+
+#, c-format
+msgid "%s: Regular expression compile error: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Regular expression substitute error: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Resource limit not available on this operating system\n"
+msgstr ""
+
+#, c-format
+msgid "%s: STEP must be a positive integer\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Short flag '%c' already defined\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Short flag '%c' invalid, must be alphanum or '#'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: The directory '%s' does not exist\n"
+msgstr "%s: O diretório “%s” não existe\n"
+
+#, c-format
+msgid "%s: The variable '%s' does not exist\n"
+msgstr ""
+
+#, c-format
+msgid "%s: There are no jobs\n"
+msgstr "%s: Não há tarefas\n"
+
+#, c-format
+msgid "%s: There are no suitable jobs\n"
+msgstr "%s: Não há tarefas adequadas\n"
+
+#, c-format
+msgid "%s: Too many levels of symbolic links: '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Too many long-only options\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Tried to change the read-only variable '%s'\n"
+msgstr "%s: Tentou mudar a variável somente leitura “%s”\n"
+
+#, c-format
+msgid "%s: Tried to modify the special variable '%s' to an invalid value\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Tried to modify the special variable '%s' with the wrong scope\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Unknown color '%s'\n"
+msgstr "%s: Cor desconhecida “%s”\n"
+
+#, c-format
+msgid "%s: Unknown error trying to locate directory '%s'\n"
+msgstr "%s: Erro desconhecido ao tentar localizar diretório “%s”\n"
+
+#, c-format
+msgid "%s: Unknown input function '%s'"
+msgstr ""
+
+#, c-format
+msgid "%s: Unknown signal '%s'"
+msgstr ""
+
+#, c-format
+msgid "%s: Warning: Option '%s' was removed and is now ignored"
+msgstr ""
+
+#, c-format
+msgid "%s: `set --show` does not allow slices with the var names\n"
+msgstr ""
+
+#, c-format
+msgid "%s: array index out of bounds\n"
+msgstr ""
+
+#, c-format
+msgid "%s: called with no arguments. This will be an error in future."
+msgstr ""
+
+#, c-format
+msgid "%s: called with one argument. This will return false in future."
+msgstr ""
+
+#, c-format
+msgid "%s: calling job for event handler not found"
+msgstr ""
+
+#, c-format
+msgid "%s: can't merge history in private mode\n"
+msgstr ""
+
+#, c-format
+msgid "%s: cannot both export and unexport\n"
+msgstr ""
+
+#, c-format
+msgid "%s: cannot both path and unpath\n"
+msgstr ""
+
+#, c-format
+msgid "%s: column %s exceeds line length\n"
+msgstr ""
+
+#, c-format
+msgid "%s: exclusive flag '%s' is not valid\n"
+msgstr ""
+
+#, c-format
+msgid "%s: exclusive flag string '%s' is not valid\n"
+msgstr ""
+
+#, c-format
+msgid "%s: expected %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%s: expected <= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%s: expected >= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%s: expected a numeric value"
+msgstr "%s: esperava valor numérico"
+
+#, c-format
+msgid "%s: fish was not built with embedded files"
+msgstr ""
+
+#, c-format
+msgid "%s: given %d indexes but %d values\n"
+msgstr ""
+
+#, c-format
+msgid "%s: invalid option combination\n"
+msgstr ""
+
+#, c-format
+msgid "%s: invalid option combination, %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: invalid underline style: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: job %d ('%s') was stopped and has been signalled to continue.\n"
+msgstr ""
+
+#, c-format
+msgid "%s: line/column index starts at 1"
+msgstr ""
+
+#, c-format
+msgid "%s: missing argument\n"
+msgstr ""
+
+#, c-format
+msgid "%s: missing filename argument or input redirection\n"
+msgstr ""
+
+#, c-format
+msgid "%s: missing subcommand\n"
+msgstr ""
+
+#, c-format
+msgid "%s: nothing to choose from\n"
+msgstr ""
+
+#, c-format
+msgid "%s: realpath failed: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: scope can be only one of: universal function global local\n"
+msgstr ""
+
+#, c-format
+msgid "%s: stdin is closed\n"
+msgstr ""
+
+#, c-format
+msgid "%s: successfully set universal '%s'; but a global by that name shadows it\n"
+msgstr ""
+
+#, c-format
+msgid "%s: the -k/--key syntax is no longer supported. See `bind --help` and `bind --key-names`\n"
+msgstr ""
+
+#, c-format
+msgid "%s: there is no line %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: too many arguments\n"
+msgstr ""
+
+#, c-format
+msgid "%s: usage of -i for --silent is deprecated. Please use -s or --silent instead.\n"
+msgstr ""
+
+#, c-format
+msgid "%s: value not completely converted (can't convert '%s')"
+msgstr ""
+
+#, c-format
+msgid "%s: variable '%s' is read-only\n"
+msgstr ""
+
+#, c-format
+msgid "%sand %u more rows"
+msgstr "%se mais %u linhas"
+
+#, c-format
+msgid "%u\n"
+msgstr ""
 
 msgid "'break' while not inside of loop"
 msgstr "'break' enquanto fora de um laço"
@@ -842,14 +834,14 @@ msgid "'}' does not take arguments. Did you forget a ';'?"
 msgstr ""
 
 #, c-format
-msgid "(Type 'help %ls' for related documentation)\n"
-msgstr "(Digite 'help %ls' para documentação relacionada)\n"
+msgid "(Type 'help %s' for related documentation)\n"
+msgstr "(Digite 'help %s' para documentação relacionada)\n"
 
 msgid "(no matches)"
 msgstr "(nenhum resultado)"
 
 #, c-format
-msgid ", copied in %ls @ line %d"
+msgid ", copied in %s @ line %d"
 msgstr ""
 
 msgid ", copied interactively"
@@ -886,7 +878,7 @@ msgid "Abbreviation expansion"
 msgstr ""
 
 #, c-format
-msgid "Abbreviation: %ls"
+msgid "Abbreviation: %s"
 msgstr ""
 
 msgid "Abort"
@@ -905,7 +897,7 @@ msgid "An error occurred while setting up pipe"
 msgstr "Ocorreu um erro ao preparar pipe"
 
 #, c-format
-msgid "Argument is not a number: '%ls'"
+msgid "Argument is not a number: '%s'"
 msgstr ""
 
 msgid "Await background process completion"
@@ -1007,7 +999,7 @@ msgid "Define a new function"
 msgstr "Define uma nova função"
 
 #, c-format
-msgid "Defined in %ls @ line %d"
+msgid "Defined in %s @ line %d"
 msgstr ""
 
 msgid "Defined interactively"
@@ -1037,8 +1029,8 @@ msgid "Error when renaming file: %s"
 msgstr ""
 
 #, c-format
-msgid "Error while reading file %ls\n"
-msgstr "Erro ao ler arquivo %ls\n"
+msgid "Error while reading file %s\n"
+msgstr "Erro ao ler arquivo %s\n"
 
 msgid "Errors reported by exec (on by default)"
 msgstr ""
@@ -1071,20 +1063,16 @@ msgid "Expansion produced too many results"
 msgstr ""
 
 #, c-format
-msgid "Expected %ls, but found %ls"
-msgstr "Esperava %ls, mas achou %ls"
+msgid "Expected %s, but found %s"
+msgstr "Esperava %s, mas achou %s"
 
 #, c-format
-msgid "Expected %s, but found %ls"
-msgstr ""
+msgid "Expected a command, but found %s"
+msgstr "Esperava um comando, mas achou %s"
 
 #, c-format
-msgid "Expected a command, but found %ls"
-msgstr "Esperava um comando, mas achou %ls"
-
-#, c-format
-msgid "Expected a string, but found %ls"
-msgstr "Esperava uma string, mas achou %ls"
+msgid "Expected a string, but found %s"
+msgstr "Esperava uma string, mas achou %s"
 
 msgid "Expected a string, but found a redirection"
 msgstr ""
@@ -1096,7 +1084,7 @@ msgstr ""
 msgid ""
 "Expected file path to read/write for -w:\n"
 "\n"
-" $ %ls -w foo.fish"
+" $ %s -w foo.fish"
 msgstr ""
 
 #, c-format
@@ -1168,32 +1156,32 @@ msgid "History performance measurements"
 msgstr ""
 
 #, c-format
-msgid "History session ID '%ls' is not a valid variable name. Falling back to `%ls`."
+msgid "History session ID '%s' is not a valid variable name. Falling back to `%s`."
 msgstr ""
 
 #, c-format
-msgid "Home for %ls"
-msgstr "Diretório de usuário para %ls"
+msgid "Home for %s"
+msgstr "Diretório de usuário para %s"
 
 msgid "I/O on asynchronous file descriptor is possible"
 msgstr "E/S em descritor de arquivo assíncrono possível"
 
 #, c-format
-msgid "Illegal file descriptor in redirection '%ls'"
-msgstr "Descritor de arquivo ilegal na redireção “%ls”"
+msgid "Illegal file descriptor in redirection '%s'"
+msgstr "Descritor de arquivo ilegal na redireção “%s”"
 
 msgid "Illegal instruction"
 msgstr "Instrução ilegal"
 
 #, c-format
-msgid "Incomplete escape sequence '%ls'"
+msgid "Incomplete escape sequence '%s'"
 msgstr ""
 
 msgid "Information request"
 msgstr "Requisição de informação"
 
 #, c-format
-msgid "Integer %lld in '%ls' followed by non-digit"
+msgid "Integer %d in '%s' followed by non-digit"
 msgstr ""
 
 msgid "Internal (non-forked) process events"
@@ -1215,31 +1203,31 @@ msgid "Invalid input/output redirection"
 msgstr "Redireção inválida de entrada/saída"
 
 #, c-format
-msgid "Invalid number: %ls"
+msgid "Invalid number: %s"
 msgstr ""
 
 #, c-format
-msgid "Invalid redirection target: %ls"
-msgstr "Alvo de redireção inválido: %ls"
+msgid "Invalid redirection target: %s"
+msgstr "Alvo de redireção inválido: %s"
 
 #, c-format
-msgid "Invalid redirection: %ls"
-msgstr "Redireção inválida: %ls"
+msgid "Invalid redirection: %s"
+msgstr "Redireção inválida: %s"
 
 #, c-format
-msgid "Invalid token '%ls'"
+msgid "Invalid token '%s'"
 msgstr ""
 
 #, c-format
-msgid "Items %lu to %lu of %lu"
+msgid "Items %u to %u of %u"
 msgstr ""
 
 msgid "Job\tGroup\t"
 msgstr "Tarefa\tGrupo\t"
 
 #, c-format
-msgid "Job control: %ls\n"
-msgstr "Controle de tarefa: %ls\n"
+msgid "Job control: %s\n"
+msgstr "Controle de tarefa: %s\n"
 
 msgid "Jobs being executed"
 msgstr ""
@@ -1278,7 +1266,7 @@ msgid "Missing closing parenthesis"
 msgstr ""
 
 #, c-format
-msgid "Missing end to balance this %ls"
+msgid "Missing end to balance this %s"
 msgstr ""
 
 msgid "Missing hexadecimal number in Unicode escape"
@@ -1288,7 +1276,7 @@ msgid "Missing operator"
 msgstr ""
 
 #, c-format
-msgid "Modification of read-only variable \"%ls\" is not allowed\n"
+msgid "Modification of read-only variable \"%s\" is not allowed\n"
 msgstr ""
 
 msgid "Negate exit status of job"
@@ -1301,7 +1289,7 @@ msgid "No TTY for interactive shell (tcgetpgrp failed)"
 msgstr "Não há TTY para shell interativo (falha em tcgetpgrp)"
 
 #, c-format
-msgid "No matches for wildcard '%ls'. See `help wildcards-globbing`."
+msgid "No matches for wildcard '%s'. See `help wildcards-globbing`."
 msgstr ""
 
 msgid "Not a function"
@@ -1345,11 +1333,11 @@ msgid "Perform a set of commands multiple times"
 msgstr "Executa um conjunto de comandos várias vezes"
 
 #, c-format
-msgid "Please set $%ls to a directory where you have write access."
+msgid "Please set $%s to a directory where you have write access."
 msgstr ""
 
 #, c-format
-msgid "Please set the %ls or HOME environment variable before starting fish."
+msgid "Please set the %s or HOME environment variable before starting fish."
 msgstr ""
 
 msgid "Polite quit request"
@@ -1414,11 +1402,11 @@ msgid "Rendering the command line"
 msgstr ""
 
 #, c-format
-msgid "Requested redirection to '%ls', which is not a valid file descriptor"
-msgstr "Requeriu redireção para “%ls”, que não é um descritor de arquivo válido"
+msgid "Requested redirection to '%s', which is not a valid file descriptor"
+msgstr "Requeriu redireção para “%s”, que não é um descritor de arquivo válido"
 
 #, c-format
-msgid "Result too large: %ls"
+msgid "Result too large: %s"
 msgstr ""
 
 msgid "Return a successful result"
@@ -1452,11 +1440,11 @@ msgid "Searching/using paths"
 msgstr ""
 
 #, c-format
-msgid "Send job %d (%ls) to foreground\n"
+msgid "Send job %d (%s) to foreground\n"
 msgstr ""
 
 #, c-format
-msgid "Send job %s '%ls' to background\n"
+msgid "Send job %s '%s' to background\n"
 msgstr ""
 
 msgid "Send job to background"
@@ -1534,12 +1522,12 @@ msgid "Test a condition"
 msgstr "Testa uma condição"
 
 #, c-format
-msgid "The '%ls' command can not be used immediately after a backgrounded job"
+msgid "The '%s' command can not be used immediately after a backgrounded job"
 msgstr ""
 
 #, c-format
-msgid "The '%ls' command can not be used in a pipeline"
-msgstr "O comand “%ls” não pode ser usado em pipe"
+msgid "The '%s' command can not be used in a pipeline"
+msgstr "O comand “%s” não pode ser usado em pipe"
 
 msgid "The 'time' command may only be at the beginning of a pipeline"
 msgstr ""
@@ -1561,8 +1549,8 @@ msgid "The expanded command was empty."
 msgstr "O comand expandido estava vazio."
 
 #, c-format
-msgid "The function '%ls' calls itself immediately, which would result in an infinite loop."
-msgstr "A função “%ls” se chama imediatamente, o que causaria um loop infinito."
+msgid "The function '%s' calls itself immediately, which would result in an infinite loop."
+msgstr "A função “%s” se chama imediatamente, o que causaria um loop infinito."
 
 msgid "The interactive reader/input system"
 msgstr ""
@@ -1601,22 +1589,22 @@ msgid "Trying to print invalid output"
 msgstr ""
 
 #, c-format
-msgid "Unable to create temporary file '%ls': %s"
+msgid "Unable to create temporary file '%s': %s"
 msgstr ""
 
 msgid "Unable to evaluate string substitution"
 msgstr ""
 
 #, c-format
-msgid "Unable to expand variable name '%ls'"
-msgstr "Incapaz de expandir o nome da variável “%ls”"
+msgid "Unable to expand variable name '%s'"
+msgstr "Incapaz de expandir o nome da variável “%s”"
 
 #, c-format
-msgid "Unable to locate %ls directory derived from $%ls: '%ls'."
+msgid "Unable to locate %s directory derived from $%s: '%s'."
 msgstr ""
 
 #, c-format
-msgid "Unable to locate the %ls directory."
+msgid "Unable to locate the %s directory."
 msgstr ""
 
 #, c-format
@@ -1664,22 +1652,22 @@ msgid "Unknown"
 msgstr "Desconhecido"
 
 #, c-format
-msgid "Unknown builtin '%ls'"
-msgstr "Builtin desconhecida “%ls”"
+msgid "Unknown builtin '%s'"
+msgstr "Builtin desconhecida “%s”"
 
 msgid "Unknown command"
 msgstr ""
 
 #, c-format
-msgid "Unknown command. '%ls' exists but is not an executable file."
+msgid "Unknown command. '%s' exists but is not an executable file."
 msgstr ""
 
 #, c-format
-msgid "Unknown command. A component of '%ls' is not a directory."
+msgid "Unknown command. A component of '%s' is not a directory."
 msgstr ""
 
 #, c-format
-msgid "Unknown command. A component of '%ls' is not a directory. Check your $PATH."
+msgid "Unknown command. A component of '%s' is not a directory. Check your $PATH."
 msgstr ""
 
 msgid "Unknown command:"
@@ -1692,14 +1680,14 @@ msgid "Unknown function"
 msgstr ""
 
 #, c-format
-msgid "Unknown function '%ls'"
-msgstr "Função desconhecida “%ls”"
+msgid "Unknown function '%s'"
+msgstr "Função desconhecida “%s”"
 
 msgid "Unmatched wildcard"
 msgstr ""
 
 #, c-format
-msgid "Unsupported use of '='. In fish, please use 'set %ls %ls'."
+msgid "Unsupported use of '='. In fish, please use 'set %s %s'."
 msgstr ""
 
 msgid "Unused signal"
@@ -1718,15 +1706,15 @@ msgid "User defined signal 2"
 msgstr "Sinal definido pelo usuário 2"
 
 #, c-format
-msgid "Variable: %ls"
-msgstr "Variável: %ls"
+msgid "Variable: %s"
+msgstr "Variável: %s"
 
 #, c-format
-msgid "Variables cannot be bracketed. In fish, please use \"$%ls\"."
+msgid "Variables cannot be bracketed. In fish, please use \"$%s\"."
 msgstr ""
 
 #, c-format
-msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
+msgid "Variables cannot be bracketed. In fish, please use {$%s}."
 msgstr ""
 
 msgid "Virtual timer expired"
@@ -1757,15 +1745,15 @@ msgid "autoloading"
 msgstr ""
 
 #, c-format
-msgid "builtin %ls: %ls: %s\n"
+msgid "builtin %s: %s: %s\n"
 msgstr ""
 
 #, c-format
-msgid "builtin %ls: Invalid arg: %ls\n"
+msgid "builtin %s: Invalid arg: %s\n"
 msgstr ""
 
 #, c-format
-msgid "builtin %ls: realpath failed: %s\n"
+msgid "builtin %s: realpath failed: %s\n"
 msgstr ""
 
 msgid "builtin history delete --exact requires --case-sensitive\n"
@@ -1816,33 +1804,33 @@ msgstr "arquivo"
 
 #, c-format
 msgid ""
-"fish: %ls: missing man page\n"
+"fish: %s: missing man page\n"
 "Documentation may not be installed.\n"
-"`help %ls` will show an online version\n"
+"`help %s` will show an online version\n"
 msgstr ""
 
 #, c-format
-msgid "from sourcing file %ls\n"
-msgstr "do arquivo %ls\n"
+msgid "from sourcing file %s\n"
+msgstr "do arquivo %s\n"
 
 msgid "in command substitution\n"
 msgstr "na substituição de comando\n"
 
 #, c-format
-msgid "in event handler: %ls\n"
+msgid "in event handler: %s\n"
 msgstr ""
 
 #, c-format
-msgid "in function '%ls'"
+msgid "in function '%s'"
 msgstr ""
 
 #, c-format
-msgid "invalid field width: %ls"
-msgstr "tamanho de campo inválido: %ls"
+msgid "invalid field width: %s"
+msgstr "tamanho de campo inválido: %s"
 
 #, c-format
-msgid "invalid precision: %ls"
-msgstr "precisão inválida: %ls"
+msgid "invalid precision: %s"
+msgstr "precisão inválida: %s"
 
 msgid "missing hexadecimal number in escape"
 msgstr "falta número hexadecimal no escape"
@@ -1856,8 +1844,8 @@ msgid "or press ctrl-%c or ctrl-%c twice in a row."
 msgstr ""
 
 #, c-format
-msgid "rows %lu to %lu of %lu"
-msgstr "linhas %lu a %lu de %lu"
+msgid "rows %u to %u of %u"
+msgstr "linhas %u a %u de %u"
 
 msgid "running"
 msgstr ""
@@ -1869,14 +1857,14 @@ msgid "stopped"
 msgstr "parado"
 
 #, c-format
-msgid "switch: Expected at most one argument, got %lu\n"
-msgstr "switch: Esperava no máximo um argumento, recebeu %lu\n"
+msgid "switch: Expected at most one argument, got %u\n"
+msgstr "switch: Esperava no máximo um argumento, recebeu %u\n"
 
 msgid "symlink"
 msgstr ""
 
 #, c-format
-msgid "ulimit: Permission denied when changing resource of type '%ls'\n"
+msgid "ulimit: Permission denied when changing resource of type '%s'\n"
 msgstr ""
 
 msgid "unexported"
@@ -1895,16 +1883,13 @@ msgstr ""
 msgid "fish-section-tier1-from-script-explicitly-added"
 msgstr ""
 
-msgid "%ls: %ls: expected %d arguments; got %d\\n"
-msgstr ""
-
-msgid "%ls: %ls: subcommand takes no options\\n"
-msgstr ""
-
-msgid "%ls: Expected at least %d args, got only %d\\n"
-msgstr ""
-
 msgid "%s: %s is an array variable. Use %svared%s %s[n]%s to edit the n:th element of %s\\n"
+msgstr ""
+
+msgid "%s: %s: expected %d arguments; got %d\\n"
+msgstr ""
+
+msgid "%s: %s: subcommand takes no options\\n"
 msgstr ""
 
 msgid "%s: Could not create configuration directory '%s'\\n"
@@ -1914,6 +1899,9 @@ msgid "%s: Could not find a web browser.\\n"
 msgstr ""
 
 msgid "%s: Directory stack is empty…\\n"
+msgstr ""
+
+msgid "%s: Expected at least %d args, got only %d\\n"
 msgstr ""
 
 msgid "%s: Expected exactly one argument, got %s.\\n\\nSynopsis:\\n\\t%svared%s VARIABLE\\n"

--- a/po/sv.po
+++ b/po/sv.po
@@ -27,7 +27,7 @@ msgid ""
 msgstr ""
 
 #, c-format
-msgid " (%ls)\n"
+msgid " (%s)\n"
 msgstr ""
 
 msgid " (read-only)\n"
@@ -37,7 +37,7 @@ msgid " a path variable"
 msgstr ""
 
 #, c-format
-msgid " with arguments '%ls'"
+msgid " with arguments '%s'"
 msgstr ""
 
 msgid " with definition"
@@ -50,15 +50,15 @@ msgid "$$ is not the pid. In fish, please use $fish_pid."
 msgstr ""
 
 #, c-format
-msgid "$%lc is not a valid variable in fish."
+msgid "$%c is not a valid variable in fish."
 msgstr ""
 
 #, c-format
-msgid "$%ls: originally inherited as |%ls|\n"
+msgid "$%s: originally inherited as |%s|\n"
 msgstr ""
 
 #, c-format
-msgid "$%ls: set in %ls scope, %ls,%ls with %d elements"
+msgid "$%s: set in %s scope, %s,%s with %d elements"
 msgstr ""
 
 msgid "$* is not supported. In fish, please use $argv."
@@ -74,719 +74,7 @@ msgid "$status is not valid as a command. See `help conditions`"
 msgstr ""
 
 #, c-format
-msgid "%.*ls: invalid conversion specification"
-msgstr ""
-
-#, c-format
-msgid "%ls"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: Abbreviation %ls already exists, cannot rename %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: Abbreviation '%ls' cannot have spaces in the word\n"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: Name cannot be empty\n"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: No abbreviation named %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: Requires at least two arguments\n"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: Requires exactly two arguments\n"
-msgstr ""
-
-#, c-format
-msgid "%ls %ls: Unexpected argument -- '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls (line %d): "
-msgstr "%ls (rad %d): "
-
-#, c-format
-msgid "%ls (line %lu): "
-msgstr ""
-
-#, c-format
-msgid "%ls is %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls is a builtin\n"
-msgstr ""
-
-#, c-format
-msgid "%ls is a function"
-msgstr ""
-
-#, c-format
-msgid "%ls, version %s"
-msgstr ""
-
-#, c-format
-msgid "%ls: %*ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls %ls: options cannot be used together\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: cannot overwrite read-only variable"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: cannot use reserved keyword as function name"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: contains a syntax error\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: expected %d arguments; got %d\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid base value\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid function name"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid integer\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid mode\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid mode name. See `help identifiers`\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid process id"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid scale\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid subcommand\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: invalid variable name. See `help identifiers`\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: option does not take an argument\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: option requires an argument\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: subcommand takes no options\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: unexpected positional argument"
-msgstr ""
-
-#, c-format
-msgid "%ls: %ls: unknown option\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: '%ls' is a broken symbolic link to '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: '%ls' is not a directory\n"
-msgstr "%ls: '%ls' är inte en katalog\n"
-
-#, c-format
-msgid "%ls: '%ls' is not a job\n"
-msgstr "%ls: '%ls' är inte ett jobb\n"
-
-#, c-format
-msgid "%ls: '%ls' is not a valid job id\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: '%ls' is not a valid job specifier\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: '%ls' is not a valid process id\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: --command cannot be combined with --position command"
-msgstr ""
-
-#, c-format
-msgid "%ls: --function option requires --add\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: --position option requires --add\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: --regex option requires --add\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: --set-cursor argument cannot be empty\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: --set-cursor option requires --add\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: -l requires a non-empty string\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: -o requires a non-empty string\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: -s requires a non-empty string\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Ambiguous job\n"
-msgstr "%ls: Mer än ett jobb matchar\n"
-
-#, c-format
-msgid "%ls: An option spec must have at least a short or a long flag\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Argument '%ls' is out of range\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Can not specify scope when removing block\n"
-msgstr "%ls: Kan inte ange definitionsområde vid blockradering\n"
-
-#, c-format
-msgid "%ls: Can't put job %d, '%ls' to foreground because it is not under job control\n"
-msgstr "%ls: Kan inte skicka jobb %d, '%ls' till förgrunden eftersom det inte använder jobbkontroll\n"
-
-#, c-format
-msgid "%ls: Can't put job %s, '%ls' to background because it is not under job control\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Cannot combine options %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Cannot specify multiple positions\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Cannot specify multiple regex patterns\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Cannot specify multiple set-cursor options\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Cannot use --append or --prepend when assigning to a slice"
-msgstr ""
-
-#, c-format
-msgid "%ls: Command not valid at an interactive prompt\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Could not find '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Could not find a job with process id '%d'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Could not find child processes with the name '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Could not find home directory\n"
-msgstr "%ls: Kunde inte hitta hemkatalogen\n"
-
-#, c-format
-msgid "%ls: Could not find job '%d'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Did you mean `set %ls %ls`?"
-msgstr ""
-
-#, c-format
-msgid "%ls: Empty directory '%ls' does not exist\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Error encountered while sourcing file '%ls':\n"
-msgstr "%ls: Ett fel uppstod medan filen '%ls' lästes in\n"
-
-#, c-format
-msgid "%ls: Error while reading file '%ls'\n"
-msgstr "%ls: Ett fel uppstod medan filen '%ls' lästes\n"
-
-#, c-format
-msgid "%ls: Expected at least one argument"
-msgstr ""
-
-#, c-format
-msgid "%ls: Expected exactly one function name\n"
-msgstr "%ls: Förväntade exakt ett funktionsnamn\n"
-
-#, c-format
-msgid "%ls: Expected exactly two names (current function name, and new function name)\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Expected generic | variable | signal | exit | job-id for --handlers-type\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Function '%ls' already exists. Cannot create copy of '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Function '%ls' does not exist\n"
-msgstr "%ls: Funktionen '%ls' existerar inte\n"
-
-#, c-format
-msgid "%ls: Illegal function name '%ls'\n"
-msgstr "%ls: Ogiltigt funktionsnamn '%ls'\n"
-
-#, c-format
-msgid "%ls: Implicit int flag '%lc' already defined\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Implicit int short flag '%lc' does not allow modifiers like '%lc'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid --max-args value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid --min-args value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid --unknown-arguments value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid count value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid end value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid escape style '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid fields value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid function name: %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid index starting at '%ls'\n"
-msgstr "%ls: Ogiltigt index vid '%ls'\n"
-
-#, c-format
-msgid "%ls: Invalid job control mode '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid length value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid level value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid limit '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid max matches value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid max value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid option spec '%ls' at char '%lc'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid padding character of width zero '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid permission '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid position '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid range value for field '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid sort key '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid start value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid state\n"
-msgstr "%ls: Ogiltigt tillstånd\n"
-
-#, c-format
-msgid "%ls: Invalid style value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid token '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid type '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Invalid width value '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Key not specified\n"
-msgstr "%ls: Ingen nyckel angiven\n"
-
-#, c-format
-msgid "%ls: Long flag '%ls' already defined\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Missing -- separator\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: New limit cannot be an empty string\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: No binding found for key '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: No binding found for key sequence '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: No blocks defined\n"
-msgstr "%ls: Inga block definerade\n"
-
-#, c-format
-msgid "%ls: No suitable job: %d\n"
-msgstr "%ls: Inget passande jobb: %d\n"
-
-#, c-format
-msgid "%ls: No suitable job: %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Not inside of loop\n"
-msgstr "%ls: Inte i en loop\n"
-
-#, c-format
-msgid "%ls: Options %ls and %ls cannot be used together\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Padding should be a character '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Permission denied: '%ls'\n"
-msgstr "%ls: Åtkomst nekad till katalogen '%ls'\n"
-
-#, c-format
-msgid "%ls: Regular expression compile error: %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Regular expression substitute error: %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Resource limit not available on this operating system\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: STEP must be a positive integer\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Short flag '%lc' already defined\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Short flag '%lc' invalid, must be alphanum or '#'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: The directory '%ls' does not exist\n"
-msgstr "%ls: Katalogen '%ls' existerar inte\n"
-
-#, c-format
-msgid "%ls: The variable '%ls' does not exist\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: There are no jobs\n"
-msgstr "%ls: Det finns inga jobb\n"
-
-#, c-format
-msgid "%ls: There are no suitable jobs\n"
-msgstr "%ls: Det finns inga lämpliga jobb\n"
-
-#, c-format
-msgid "%ls: Too many levels of symbolic links: '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Too many long-only options\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Tried to change the read-only variable '%ls'\n"
-msgstr "%ls: Försökte ändra den skrivskyddade variablen '%ls'\n"
-
-#, c-format
-msgid "%ls: Tried to modify the special variable '%ls' to an invalid value\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Tried to modify the special variable '%ls' with the wrong scope\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Unknown color '%ls'\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: Unknown error trying to locate directory '%ls'\n"
-msgstr "%ls: Okänd fel inträffade under lokalisering av katalogen '%ls'\n"
-
-#, c-format
-msgid "%ls: Unknown input function '%ls'"
-msgstr ""
-
-#, c-format
-msgid "%ls: Unknown signal '%ls'"
-msgstr ""
-
-#, c-format
-msgid "%ls: Warning: Option '%ls' was removed and is now ignored"
-msgstr ""
-
-#, c-format
-msgid "%ls: `set --show` does not allow slices with the var names\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: array index out of bounds\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: called with no arguments. This will be an error in future."
-msgstr ""
-
-#, c-format
-msgid "%ls: called with one argument. This will return false in future."
-msgstr ""
-
-#, c-format
-msgid "%ls: calling job for event handler not found"
-msgstr ""
-
-#, c-format
-msgid "%ls: can't merge history in private mode\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: cannot both export and unexport\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: cannot both path and unpath\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: column %ls exceeds line length\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: exclusive flag '%ls' is not valid\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: exclusive flag string '%ls' is not valid\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: expected %d arguments; got %d\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: expected <= %d arguments; got %d\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: expected >= %d arguments; got %d\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: expected a numeric value"
-msgstr ""
-
-#, c-format
-msgid "%ls: fish was not built with embedded files"
-msgstr ""
-
-#, c-format
-msgid "%ls: given %d indexes but %d values\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: invalid option combination\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: invalid option combination, %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: invalid underline style: %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: job %d ('%ls') was stopped and has been signalled to continue.\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: line/column index starts at 1"
-msgstr ""
-
-#, c-format
-msgid "%ls: missing argument\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: missing filename argument or input redirection\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: missing subcommand\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: nothing to choose from\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: realpath failed: %s\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: scope can be only one of: universal function global local\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: stdin is closed\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: successfully set universal '%ls'; but a global by that name shadows it\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: the -k/--key syntax is no longer supported. See `bind --help` and `bind --key-names`\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: there is no line %ls\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: too many arguments\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: usage of -i for --silent is deprecated. Please use -s or --silent instead.\n"
-msgstr ""
-
-#, c-format
-msgid "%ls: value not completely converted (can't convert '%ls')"
-msgstr ""
-
-#, c-format
-msgid "%ls: variable '%ls' is read-only\n"
-msgstr ""
-
-#, c-format
-msgid "%lsand %lu more rows"
-msgstr "%lsoch %lu rader till"
-
-#, c-format
-msgid "%lu\n"
+msgid "%.*s: invalid conversion specification"
 msgstr ""
 
 #, c-format
@@ -794,7 +82,43 @@ msgid "%s"
 msgstr ""
 
 #, c-format
-msgid "%s %s: unrecognized feature '%ls'"
+msgid "%s %s: Abbreviation %s already exists, cannot rename %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s %s: Abbreviation '%s' cannot have spaces in the word\n"
+msgstr ""
+
+#, c-format
+msgid "%s %s: Name cannot be empty\n"
+msgstr ""
+
+#, c-format
+msgid "%s %s: No abbreviation named %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s %s: Requires at least two arguments\n"
+msgstr ""
+
+#, c-format
+msgid "%s %s: Requires exactly two arguments\n"
+msgstr ""
+
+#, c-format
+msgid "%s %s: Unexpected argument -- '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s %s: unrecognized feature '%s'"
+msgstr ""
+
+#, c-format
+msgid "%s (line %d): "
+msgstr "%s (rad %d): "
+
+#, c-format
+msgid "%s (line %u): "
 msgstr ""
 
 #, c-format
@@ -806,12 +130,680 @@ msgid "%s could not read response to Primary Device Attribute query after waitin
 msgstr ""
 
 #, c-format
+msgid "%s is %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s is a builtin\n"
+msgstr ""
+
+#, c-format
+msgid "%s is a function"
+msgstr ""
+
+#, c-format
 msgid "%s, version %s"
 msgstr ""
 
 #, c-format
 msgid "%s, version %s\n"
 msgstr "%s, version %s\n"
+
+#, c-format
+msgid "%s: %*s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s %s: options cannot be used together\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: cannot overwrite read-only variable"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: cannot use reserved keyword as function name"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: contains a syntax error\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: expected %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid base value\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid function name"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid integer\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid mode\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid mode name. See `help identifiers`\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid process id"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid scale\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid subcommand\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: invalid variable name. See `help identifiers`\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: option does not take an argument\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: option requires an argument\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: subcommand takes no options\n"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: unexpected positional argument"
+msgstr ""
+
+#, c-format
+msgid "%s: %s: unknown option\n"
+msgstr ""
+
+#, c-format
+msgid "%s: '%s' is a broken symbolic link to '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: '%s' is not a directory\n"
+msgstr "%s: '%s' är inte en katalog\n"
+
+#, c-format
+msgid "%s: '%s' is not a job\n"
+msgstr "%s: '%s' är inte ett jobb\n"
+
+#, c-format
+msgid "%s: '%s' is not a valid job id\n"
+msgstr ""
+
+#, c-format
+msgid "%s: '%s' is not a valid job specifier\n"
+msgstr ""
+
+#, c-format
+msgid "%s: '%s' is not a valid process id\n"
+msgstr ""
+
+#, c-format
+msgid "%s: --command cannot be combined with --position command"
+msgstr ""
+
+#, c-format
+msgid "%s: --function option requires --add\n"
+msgstr ""
+
+#, c-format
+msgid "%s: --position option requires --add\n"
+msgstr ""
+
+#, c-format
+msgid "%s: --regex option requires --add\n"
+msgstr ""
+
+#, c-format
+msgid "%s: --set-cursor argument cannot be empty\n"
+msgstr ""
+
+#, c-format
+msgid "%s: --set-cursor option requires --add\n"
+msgstr ""
+
+#, c-format
+msgid "%s: -l requires a non-empty string\n"
+msgstr ""
+
+#, c-format
+msgid "%s: -o requires a non-empty string\n"
+msgstr ""
+
+#, c-format
+msgid "%s: -s requires a non-empty string\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Ambiguous job\n"
+msgstr "%s: Mer än ett jobb matchar\n"
+
+#, c-format
+msgid "%s: An option spec must have at least a short or a long flag\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Argument '%s' is out of range\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Can not specify scope when removing block\n"
+msgstr "%s: Kan inte ange definitionsområde vid blockradering\n"
+
+#, c-format
+msgid "%s: Can't put job %d, '%s' to foreground because it is not under job control\n"
+msgstr "%s: Kan inte skicka jobb %d, '%s' till förgrunden eftersom det inte använder jobbkontroll\n"
+
+#, c-format
+msgid "%s: Can't put job %s, '%s' to background because it is not under job control\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Cannot combine options %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Cannot specify multiple positions\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Cannot specify multiple regex patterns\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Cannot specify multiple set-cursor options\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Cannot use --append or --prepend when assigning to a slice"
+msgstr ""
+
+#, c-format
+msgid "%s: Command not valid at an interactive prompt\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Could not find '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Could not find a job with process id '%d'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Could not find child processes with the name '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Could not find home directory\n"
+msgstr "%s: Kunde inte hitta hemkatalogen\n"
+
+#, c-format
+msgid "%s: Could not find job '%d'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Did you mean `set %s %s`?"
+msgstr ""
+
+#, c-format
+msgid "%s: Empty directory '%s' does not exist\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Error encountered while sourcing file '%s':\n"
+msgstr "%s: Ett fel uppstod medan filen '%s' lästes in\n"
+
+#, c-format
+msgid "%s: Error while reading file '%s'\n"
+msgstr "%s: Ett fel uppstod medan filen '%s' lästes\n"
+
+#, c-format
+msgid "%s: Expected at least one argument"
+msgstr ""
+
+#, c-format
+msgid "%s: Expected exactly one function name\n"
+msgstr "%s: Förväntade exakt ett funktionsnamn\n"
+
+#, c-format
+msgid "%s: Expected exactly two names (current function name, and new function name)\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Expected generic | variable | signal | exit | job-id for --handlers-type\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Function '%s' already exists. Cannot create copy of '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Function '%s' does not exist\n"
+msgstr "%s: Funktionen '%s' existerar inte\n"
+
+#, c-format
+msgid "%s: Illegal function name '%s'\n"
+msgstr "%s: Ogiltigt funktionsnamn '%s'\n"
+
+#, c-format
+msgid "%s: Implicit int flag '%c' already defined\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Implicit int short flag '%c' does not allow modifiers like '%c'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid --max-args value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid --min-args value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid --unknown-arguments value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid count value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid end value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid escape style '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid fields value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid function name: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid index starting at '%s'\n"
+msgstr "%s: Ogiltigt index vid '%s'\n"
+
+#, c-format
+msgid "%s: Invalid job control mode '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid length value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid level value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid limit '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid max matches value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid max value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid option spec '%s' at char '%c'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid padding character of width zero '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid permission '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid position '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid range value for field '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid sort key '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid start value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid state\n"
+msgstr "%s: Ogiltigt tillstånd\n"
+
+#, c-format
+msgid "%s: Invalid style value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid token '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid type '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Invalid width value '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Key not specified\n"
+msgstr "%s: Ingen nyckel angiven\n"
+
+#, c-format
+msgid "%s: Long flag '%s' already defined\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Missing -- separator\n"
+msgstr ""
+
+#, c-format
+msgid "%s: New limit cannot be an empty string\n"
+msgstr ""
+
+#, c-format
+msgid "%s: No binding found for key '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: No binding found for key sequence '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: No blocks defined\n"
+msgstr "%s: Inga block definerade\n"
+
+#, c-format
+msgid "%s: No suitable job: %d\n"
+msgstr "%s: Inget passande jobb: %d\n"
+
+#, c-format
+msgid "%s: No suitable job: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Not inside of loop\n"
+msgstr "%s: Inte i en loop\n"
+
+#, c-format
+msgid "%s: Options %s and %s cannot be used together\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Padding should be a character '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Permission denied: '%s'\n"
+msgstr "%s: Åtkomst nekad till katalogen '%s'\n"
+
+#, c-format
+msgid "%s: Regular expression compile error: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Regular expression substitute error: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Resource limit not available on this operating system\n"
+msgstr ""
+
+#, c-format
+msgid "%s: STEP must be a positive integer\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Short flag '%c' already defined\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Short flag '%c' invalid, must be alphanum or '#'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: The directory '%s' does not exist\n"
+msgstr "%s: Katalogen '%s' existerar inte\n"
+
+#, c-format
+msgid "%s: The variable '%s' does not exist\n"
+msgstr ""
+
+#, c-format
+msgid "%s: There are no jobs\n"
+msgstr "%s: Det finns inga jobb\n"
+
+#, c-format
+msgid "%s: There are no suitable jobs\n"
+msgstr "%s: Det finns inga lämpliga jobb\n"
+
+#, c-format
+msgid "%s: Too many levels of symbolic links: '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Too many long-only options\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Tried to change the read-only variable '%s'\n"
+msgstr "%s: Försökte ändra den skrivskyddade variablen '%s'\n"
+
+#, c-format
+msgid "%s: Tried to modify the special variable '%s' to an invalid value\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Tried to modify the special variable '%s' with the wrong scope\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Unknown color '%s'\n"
+msgstr ""
+
+#, c-format
+msgid "%s: Unknown error trying to locate directory '%s'\n"
+msgstr "%s: Okänd fel inträffade under lokalisering av katalogen '%s'\n"
+
+#, c-format
+msgid "%s: Unknown input function '%s'"
+msgstr ""
+
+#, c-format
+msgid "%s: Unknown signal '%s'"
+msgstr ""
+
+#, c-format
+msgid "%s: Warning: Option '%s' was removed and is now ignored"
+msgstr ""
+
+#, c-format
+msgid "%s: `set --show` does not allow slices with the var names\n"
+msgstr ""
+
+#, c-format
+msgid "%s: array index out of bounds\n"
+msgstr ""
+
+#, c-format
+msgid "%s: called with no arguments. This will be an error in future."
+msgstr ""
+
+#, c-format
+msgid "%s: called with one argument. This will return false in future."
+msgstr ""
+
+#, c-format
+msgid "%s: calling job for event handler not found"
+msgstr ""
+
+#, c-format
+msgid "%s: can't merge history in private mode\n"
+msgstr ""
+
+#, c-format
+msgid "%s: cannot both export and unexport\n"
+msgstr ""
+
+#, c-format
+msgid "%s: cannot both path and unpath\n"
+msgstr ""
+
+#, c-format
+msgid "%s: column %s exceeds line length\n"
+msgstr ""
+
+#, c-format
+msgid "%s: exclusive flag '%s' is not valid\n"
+msgstr ""
+
+#, c-format
+msgid "%s: exclusive flag string '%s' is not valid\n"
+msgstr ""
+
+#, c-format
+msgid "%s: expected %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%s: expected <= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%s: expected >= %d arguments; got %d\n"
+msgstr ""
+
+#, c-format
+msgid "%s: expected a numeric value"
+msgstr ""
+
+#, c-format
+msgid "%s: fish was not built with embedded files"
+msgstr ""
+
+#, c-format
+msgid "%s: given %d indexes but %d values\n"
+msgstr ""
+
+#, c-format
+msgid "%s: invalid option combination\n"
+msgstr ""
+
+#, c-format
+msgid "%s: invalid option combination, %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: invalid underline style: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: job %d ('%s') was stopped and has been signalled to continue.\n"
+msgstr ""
+
+#, c-format
+msgid "%s: line/column index starts at 1"
+msgstr ""
+
+#, c-format
+msgid "%s: missing argument\n"
+msgstr ""
+
+#, c-format
+msgid "%s: missing filename argument or input redirection\n"
+msgstr ""
+
+#, c-format
+msgid "%s: missing subcommand\n"
+msgstr ""
+
+#, c-format
+msgid "%s: nothing to choose from\n"
+msgstr ""
+
+#, c-format
+msgid "%s: realpath failed: %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: scope can be only one of: universal function global local\n"
+msgstr ""
+
+#, c-format
+msgid "%s: stdin is closed\n"
+msgstr ""
+
+#, c-format
+msgid "%s: successfully set universal '%s'; but a global by that name shadows it\n"
+msgstr ""
+
+#, c-format
+msgid "%s: the -k/--key syntax is no longer supported. See `bind --help` and `bind --key-names`\n"
+msgstr ""
+
+#, c-format
+msgid "%s: there is no line %s\n"
+msgstr ""
+
+#, c-format
+msgid "%s: too many arguments\n"
+msgstr ""
+
+#, c-format
+msgid "%s: usage of -i for --silent is deprecated. Please use -s or --silent instead.\n"
+msgstr ""
+
+#, c-format
+msgid "%s: value not completely converted (can't convert '%s')"
+msgstr ""
+
+#, c-format
+msgid "%s: variable '%s' is read-only\n"
+msgstr ""
+
+#, c-format
+msgid "%sand %u more rows"
+msgstr "%soch %u rader till"
+
+#, c-format
+msgid "%u\n"
+msgstr ""
 
 msgid "'break' while not inside of loop"
 msgstr ""
@@ -838,14 +830,14 @@ msgid "'}' does not take arguments. Did you forget a ';'?"
 msgstr ""
 
 #, c-format
-msgid "(Type 'help %ls' for related documentation)\n"
+msgid "(Type 'help %s' for related documentation)\n"
 msgstr ""
 
 msgid "(no matches)"
 msgstr ""
 
 #, c-format
-msgid ", copied in %ls @ line %d"
+msgid ", copied in %s @ line %d"
 msgstr ""
 
 msgid ", copied interactively"
@@ -882,7 +874,7 @@ msgid "Abbreviation expansion"
 msgstr ""
 
 #, c-format
-msgid "Abbreviation: %ls"
+msgid "Abbreviation: %s"
 msgstr ""
 
 msgid "Abort"
@@ -901,7 +893,7 @@ msgid "An error occurred while setting up pipe"
 msgstr "Ett fel inträffade under skapandet av ett rör"
 
 #, c-format
-msgid "Argument is not a number: '%ls'"
+msgid "Argument is not a number: '%s'"
 msgstr ""
 
 msgid "Await background process completion"
@@ -1003,7 +995,7 @@ msgid "Define a new function"
 msgstr "Definera en ny funktion"
 
 #, c-format
-msgid "Defined in %ls @ line %d"
+msgid "Defined in %s @ line %d"
 msgstr ""
 
 msgid "Defined interactively"
@@ -1033,8 +1025,8 @@ msgid "Error when renaming file: %s"
 msgstr ""
 
 #, c-format
-msgid "Error while reading file %ls\n"
-msgstr "Ett fel uppstod medan filen '%ls' lästes\n"
+msgid "Error while reading file %s\n"
+msgstr "Ett fel uppstod medan filen '%s' lästes\n"
 
 msgid "Errors reported by exec (on by default)"
 msgstr ""
@@ -1067,19 +1059,15 @@ msgid "Expansion produced too many results"
 msgstr ""
 
 #, c-format
-msgid "Expected %ls, but found %ls"
+msgid "Expected %s, but found %s"
 msgstr ""
 
 #, c-format
-msgid "Expected %s, but found %ls"
+msgid "Expected a command, but found %s"
 msgstr ""
 
 #, c-format
-msgid "Expected a command, but found %ls"
-msgstr ""
-
-#, c-format
-msgid "Expected a string, but found %ls"
+msgid "Expected a string, but found %s"
 msgstr ""
 
 msgid "Expected a string, but found a redirection"
@@ -1092,7 +1080,7 @@ msgstr ""
 msgid ""
 "Expected file path to read/write for -w:\n"
 "\n"
-" $ %ls -w foo.fish"
+" $ %s -w foo.fish"
 msgstr ""
 
 #, c-format
@@ -1164,32 +1152,32 @@ msgid "History performance measurements"
 msgstr ""
 
 #, c-format
-msgid "History session ID '%ls' is not a valid variable name. Falling back to `%ls`."
+msgid "History session ID '%s' is not a valid variable name. Falling back to `%s`."
 msgstr ""
 
 #, c-format
-msgid "Home for %ls"
+msgid "Home for %s"
 msgstr ""
 
 msgid "I/O on asynchronous file descriptor is possible"
 msgstr "Läsning/skrivning på asynkron filidentifierare möjligt"
 
 #, c-format
-msgid "Illegal file descriptor in redirection '%ls'"
+msgid "Illegal file descriptor in redirection '%s'"
 msgstr ""
 
 msgid "Illegal instruction"
 msgstr "Ogiltig instruktion"
 
 #, c-format
-msgid "Incomplete escape sequence '%ls'"
+msgid "Incomplete escape sequence '%s'"
 msgstr ""
 
 msgid "Information request"
 msgstr "Informationsbegäran"
 
 #, c-format
-msgid "Integer %lld in '%ls' followed by non-digit"
+msgid "Integer %d in '%s' followed by non-digit"
 msgstr ""
 
 msgid "Internal (non-forked) process events"
@@ -1211,31 +1199,31 @@ msgid "Invalid input/output redirection"
 msgstr "Ogiltig IO dirigering"
 
 #, c-format
-msgid "Invalid number: %ls"
+msgid "Invalid number: %s"
 msgstr ""
 
 #, c-format
-msgid "Invalid redirection target: %ls"
+msgid "Invalid redirection target: %s"
 msgstr ""
 
 #, c-format
-msgid "Invalid redirection: %ls"
+msgid "Invalid redirection: %s"
 msgstr ""
 
 #, c-format
-msgid "Invalid token '%ls'"
+msgid "Invalid token '%s'"
 msgstr ""
 
 #, c-format
-msgid "Items %lu to %lu of %lu"
+msgid "Items %u to %u of %u"
 msgstr ""
 
 msgid "Job\tGroup\t"
 msgstr "Jobb\tGrupp\t"
 
 #, c-format
-msgid "Job control: %ls\n"
-msgstr "Jobkontroll: %ls\n"
+msgid "Job control: %s\n"
+msgstr "Jobkontroll: %s\n"
 
 msgid "Jobs being executed"
 msgstr ""
@@ -1274,7 +1262,7 @@ msgid "Missing closing parenthesis"
 msgstr ""
 
 #, c-format
-msgid "Missing end to balance this %ls"
+msgid "Missing end to balance this %s"
 msgstr ""
 
 msgid "Missing hexadecimal number in Unicode escape"
@@ -1284,7 +1272,7 @@ msgid "Missing operator"
 msgstr ""
 
 #, c-format
-msgid "Modification of read-only variable \"%ls\" is not allowed\n"
+msgid "Modification of read-only variable \"%s\" is not allowed\n"
 msgstr ""
 
 msgid "Negate exit status of job"
@@ -1297,7 +1285,7 @@ msgid "No TTY for interactive shell (tcgetpgrp failed)"
 msgstr ""
 
 #, c-format
-msgid "No matches for wildcard '%ls'. See `help wildcards-globbing`."
+msgid "No matches for wildcard '%s'. See `help wildcards-globbing`."
 msgstr ""
 
 msgid "Not a function"
@@ -1341,11 +1329,11 @@ msgid "Perform a set of commands multiple times"
 msgstr "Kör ett block flera gånger"
 
 #, c-format
-msgid "Please set $%ls to a directory where you have write access."
+msgid "Please set $%s to a directory where you have write access."
 msgstr ""
 
 #, c-format
-msgid "Please set the %ls or HOME environment variable before starting fish."
+msgid "Please set the %s or HOME environment variable before starting fish."
 msgstr ""
 
 msgid "Polite quit request"
@@ -1410,11 +1398,11 @@ msgid "Rendering the command line"
 msgstr ""
 
 #, c-format
-msgid "Requested redirection to '%ls', which is not a valid file descriptor"
+msgid "Requested redirection to '%s', which is not a valid file descriptor"
 msgstr ""
 
 #, c-format
-msgid "Result too large: %ls"
+msgid "Result too large: %s"
 msgstr ""
 
 msgid "Return a successful result"
@@ -1448,11 +1436,11 @@ msgid "Searching/using paths"
 msgstr ""
 
 #, c-format
-msgid "Send job %d (%ls) to foreground\n"
+msgid "Send job %d (%s) to foreground\n"
 msgstr ""
 
 #, c-format
-msgid "Send job %s '%ls' to background\n"
+msgid "Send job %s '%s' to background\n"
 msgstr ""
 
 msgid "Send job to background"
@@ -1530,11 +1518,11 @@ msgid "Test a condition"
 msgstr ""
 
 #, c-format
-msgid "The '%ls' command can not be used immediately after a backgrounded job"
+msgid "The '%s' command can not be used immediately after a backgrounded job"
 msgstr ""
 
 #, c-format
-msgid "The '%ls' command can not be used in a pipeline"
+msgid "The '%s' command can not be used in a pipeline"
 msgstr ""
 
 msgid "The 'time' command may only be at the beginning of a pipeline"
@@ -1557,7 +1545,7 @@ msgid "The expanded command was empty."
 msgstr ""
 
 #, c-format
-msgid "The function '%ls' calls itself immediately, which would result in an infinite loop."
+msgid "The function '%s' calls itself immediately, which would result in an infinite loop."
 msgstr ""
 
 msgid "The interactive reader/input system"
@@ -1597,22 +1585,22 @@ msgid "Trying to print invalid output"
 msgstr ""
 
 #, c-format
-msgid "Unable to create temporary file '%ls': %s"
+msgid "Unable to create temporary file '%s': %s"
 msgstr ""
 
 msgid "Unable to evaluate string substitution"
 msgstr ""
 
 #, c-format
-msgid "Unable to expand variable name '%ls'"
+msgid "Unable to expand variable name '%s'"
 msgstr ""
 
 #, c-format
-msgid "Unable to locate %ls directory derived from $%ls: '%ls'."
+msgid "Unable to locate %s directory derived from $%s: '%s'."
 msgstr ""
 
 #, c-format
-msgid "Unable to locate the %ls directory."
+msgid "Unable to locate the %s directory."
 msgstr ""
 
 #, c-format
@@ -1660,22 +1648,22 @@ msgid "Unknown"
 msgstr "Okänd"
 
 #, c-format
-msgid "Unknown builtin '%ls'"
-msgstr "Okänt inbyggt kommando '%ls'"
+msgid "Unknown builtin '%s'"
+msgstr "Okänt inbyggt kommando '%s'"
 
 msgid "Unknown command"
 msgstr ""
 
 #, c-format
-msgid "Unknown command. '%ls' exists but is not an executable file."
+msgid "Unknown command. '%s' exists but is not an executable file."
 msgstr ""
 
 #, c-format
-msgid "Unknown command. A component of '%ls' is not a directory."
+msgid "Unknown command. A component of '%s' is not a directory."
 msgstr ""
 
 #, c-format
-msgid "Unknown command. A component of '%ls' is not a directory. Check your $PATH."
+msgid "Unknown command. A component of '%s' is not a directory. Check your $PATH."
 msgstr ""
 
 msgid "Unknown command:"
@@ -1688,14 +1676,14 @@ msgid "Unknown function"
 msgstr ""
 
 #, c-format
-msgid "Unknown function '%ls'"
-msgstr "Okänd funktion '%ls'"
+msgid "Unknown function '%s'"
+msgstr "Okänd funktion '%s'"
 
 msgid "Unmatched wildcard"
 msgstr ""
 
 #, c-format
-msgid "Unsupported use of '='. In fish, please use 'set %ls %ls'."
+msgid "Unsupported use of '='. In fish, please use 'set %s %s'."
 msgstr ""
 
 msgid "Unused signal"
@@ -1714,15 +1702,15 @@ msgid "User defined signal 2"
 msgstr "Användardefinerad signal 2"
 
 #, c-format
-msgid "Variable: %ls"
-msgstr "Variabel: %ls"
+msgid "Variable: %s"
+msgstr "Variabel: %s"
 
 #, c-format
-msgid "Variables cannot be bracketed. In fish, please use \"$%ls\"."
+msgid "Variables cannot be bracketed. In fish, please use \"$%s\"."
 msgstr ""
 
 #, c-format
-msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
+msgid "Variables cannot be bracketed. In fish, please use {$%s}."
 msgstr ""
 
 msgid "Virtual timer expired"
@@ -1753,15 +1741,15 @@ msgid "autoloading"
 msgstr ""
 
 #, c-format
-msgid "builtin %ls: %ls: %s\n"
+msgid "builtin %s: %s: %s\n"
 msgstr ""
 
 #, c-format
-msgid "builtin %ls: Invalid arg: %ls\n"
+msgid "builtin %s: Invalid arg: %s\n"
 msgstr ""
 
 #, c-format
-msgid "builtin %ls: realpath failed: %s\n"
+msgid "builtin %s: realpath failed: %s\n"
 msgstr ""
 
 msgid "builtin history delete --exact requires --case-sensitive\n"
@@ -1812,32 +1800,32 @@ msgstr ""
 
 #, c-format
 msgid ""
-"fish: %ls: missing man page\n"
+"fish: %s: missing man page\n"
 "Documentation may not be installed.\n"
-"`help %ls` will show an online version\n"
+"`help %s` will show an online version\n"
 msgstr ""
 
 #, c-format
-msgid "from sourcing file %ls\n"
+msgid "from sourcing file %s\n"
 msgstr ""
 
 msgid "in command substitution\n"
 msgstr "i kommandosubstitution\n"
 
 #, c-format
-msgid "in event handler: %ls\n"
-msgstr "i händelsehanterare: %ls\n"
+msgid "in event handler: %s\n"
+msgstr "i händelsehanterare: %s\n"
 
 #, c-format
-msgid "in function '%ls'"
+msgid "in function '%s'"
 msgstr ""
 
 #, c-format
-msgid "invalid field width: %ls"
-msgstr "oglitig fältvidd: %ls"
+msgid "invalid field width: %s"
+msgstr "oglitig fältvidd: %s"
 
 #, c-format
-msgid "invalid precision: %ls"
+msgid "invalid precision: %s"
 msgstr ""
 
 msgid "missing hexadecimal number in escape"
@@ -1852,7 +1840,7 @@ msgid "or press ctrl-%c or ctrl-%c twice in a row."
 msgstr ""
 
 #, c-format
-msgid "rows %lu to %lu of %lu"
+msgid "rows %u to %u of %u"
 msgstr ""
 
 msgid "running"
@@ -1865,14 +1853,14 @@ msgid "stopped"
 msgstr "stannat"
 
 #, c-format
-msgid "switch: Expected at most one argument, got %lu\n"
+msgid "switch: Expected at most one argument, got %u\n"
 msgstr ""
 
 msgid "symlink"
 msgstr ""
 
 #, c-format
-msgid "ulimit: Permission denied when changing resource of type '%ls'\n"
+msgid "ulimit: Permission denied when changing resource of type '%s'\n"
 msgstr ""
 
 msgid "unexported"
@@ -1891,16 +1879,13 @@ msgstr ""
 msgid "fish-section-tier1-from-script-explicitly-added"
 msgstr ""
 
-msgid "%ls: %ls: expected %d arguments; got %d\\n"
-msgstr ""
-
-msgid "%ls: %ls: subcommand takes no options\\n"
-msgstr ""
-
-msgid "%ls: Expected at least %d args, got only %d\\n"
-msgstr ""
-
 msgid "%s: %s is an array variable. Use %svared%s %s[n]%s to edit the n:th element of %s\\n"
+msgstr ""
+
+msgid "%s: %s: expected %d arguments; got %d\\n"
+msgstr ""
+
+msgid "%s: %s: subcommand takes no options\\n"
 msgstr ""
 
 msgid "%s: Could not create configuration directory '%s'\\n"
@@ -1910,6 +1895,9 @@ msgid "%s: Could not find a web browser.\\n"
 msgstr "%s: Kunde inte hitta en webbrowser\\n"
 
 msgid "%s: Directory stack is empty…\\n"
+msgstr ""
+
+msgid "%s: Expected at least %d args, got only %d\\n"
 msgstr ""
 
 msgid "%s: Expected exactly one argument, got %s.\\n\\nSynopsis:\\n\\t%svared%s VARIABLE\\n"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -53,8 +53,8 @@ msgstr ""
 "   PID  命令\n"
 
 #, c-format
-msgid " (%ls)\n"
-msgstr " (%ls)\n"
+msgid " (%s)\n"
+msgstr " (%s)\n"
 
 msgid " (read-only)\n"
 msgstr " (只读)\n"
@@ -63,8 +63,8 @@ msgid " a path variable"
 msgstr "路径变量"
 
 #, c-format
-msgid " with arguments '%ls'"
-msgstr "，参数为 '%ls'"
+msgid " with arguments '%s'"
+msgstr "，参数为 '%s'"
 
 msgid " with definition"
 msgstr "，定义为"
@@ -76,16 +76,16 @@ msgid "$$ is not the pid. In fish, please use $fish_pid."
 msgstr "$$ 不是 PID。在 fish 中，请使用 $fish_pid。"
 
 #, c-format
-msgid "$%lc is not a valid variable in fish."
-msgstr "$%lc 在 fish 中不是有效变量。"
+msgid "$%c is not a valid variable in fish."
+msgstr "$%c 在 fish 中不是有效变量。"
 
 #, c-format
-msgid "$%ls: originally inherited as |%ls|\n"
-msgstr "$%ls: 原继承值为 |%ls|\n"
+msgid "$%s: originally inherited as |%s|\n"
+msgstr "$%s: 原继承值为 |%s|\n"
 
 #, c-format
-msgid "$%ls: set in %ls scope, %ls,%ls with %d elements"
-msgstr "%ls: 设定在 %ls 作用域，%ls，%ls，包含 %d 个元素"
+msgid "$%s: set in %s scope, %s,%s with %d elements"
+msgstr "%s: 设定在 %s 作用域，%s，%s，包含 %d 个元素"
 
 msgid "$* is not supported. In fish, please use $argv."
 msgstr "不支持 $*。在 fish 中，请使用 $argv。"
@@ -100,728 +100,52 @@ msgid "$status is not valid as a command. See `help conditions`"
 msgstr "$status 不是有效的命令。参见 `help conditions`"
 
 #, c-format
-msgid "%.*ls: invalid conversion specification"
-msgstr "%.*ls: 无效的转换规范"
-
-#, c-format
-msgid "%ls"
-msgstr "%ls"
-
-#, c-format
-msgid "%ls %ls: Abbreviation %ls already exists, cannot rename %ls\n"
-msgstr "%ls %ls: 缩写 %ls 已经存在，无法重命名 %ls\n"
-
-#, c-format
-msgid "%ls %ls: Abbreviation '%ls' cannot have spaces in the word\n"
-msgstr "%ls %ls: 缩写词 '%ls' 不能包含空格\n"
-
-#, c-format
-msgid "%ls %ls: Name cannot be empty\n"
-msgstr "%ls %ls: 名称不能为空\n"
-
-#, c-format
-msgid "%ls %ls: No abbreviation named %ls\n"
-msgstr "%ls %ls: 没有命名为 %ls 的缩写\n"
-
-#, c-format
-msgid "%ls %ls: Requires at least two arguments\n"
-msgstr "%ls %ls: 需要至少两个参数\n"
-
-#, c-format
-msgid "%ls %ls: Requires exactly two arguments\n"
-msgstr "%ls %ls: 需要两个参数\n"
-
-#, c-format
-msgid "%ls %ls: Unexpected argument -- '%ls'\n"
-msgstr "%ls %ls: 意外参数 -- '%ls'\n"
-
-#, c-format
-msgid "%ls (line %d): "
-msgstr "%ls (行 %d): "
-
-#, c-format
-msgid "%ls (line %lu): "
-msgstr "%ls (行 %lu): "
-
-#, c-format
-msgid "%ls is %ls\n"
-msgstr "%ls 是 %ls\n"
-
-#, c-format
-msgid "%ls is a builtin\n"
-msgstr "%ls 是一个内建命令\n"
-
-#, c-format
-msgid "%ls is a function"
-msgstr "%ls 是一个函数"
-
-#, c-format
-msgid "%ls, version %s"
-msgstr "%ls，版本 %s"
-
-#, c-format
-msgid "%ls: %*ls\n"
-msgstr "%ls: %*ls\n"
-
-#, c-format
-msgid "%ls: %ls\n"
-msgstr "%ls: %ls\n"
-
-#, c-format
-msgid "%ls: %ls %ls: options cannot be used together\n"
-msgstr "%ls: %ls %ls: 选项无法一起使用\n"
-
-#, c-format
-msgid "%ls: %ls: cannot overwrite read-only variable"
-msgstr "%ls: %ls: 无法覆写只读变量"
-
-#, c-format
-msgid "%ls: %ls: cannot use reserved keyword as function name"
-msgstr "%ls: %ls: 无法将保留关键字作为函数名"
-
-#, c-format
-msgid "%ls: %ls: contains a syntax error\n"
-msgstr "%ls: %ls: 包含语法错误\n"
-
-#, c-format
-msgid "%ls: %ls: expected %d arguments; got %d\n"
-msgstr "%ls: %ls: 预期收到 %d 个参数；实际收到 %d 个\n"
-
-#, c-format
-msgid "%ls: %ls: invalid base value\n"
-msgstr "%ls: %ls: 无效的进制值\n"
-
-#, c-format
-msgid "%ls: %ls: invalid function name"
-msgstr "%ls: %ls: 无效的函数名"
-
-#, c-format
-msgid "%ls: %ls: invalid integer\n"
-msgstr "%ls: %ls: 无效整数\n"
-
-#, c-format
-msgid "%ls: %ls: invalid mode\n"
-msgstr "%ls: %ls: 无效舍入模式\n"
-
-#, c-format
-msgid "%ls: %ls: invalid mode name. See `help identifiers`\n"
-msgstr "%ls: %ls: 无效模式名。参见 `help identifiers`\n"
-
-#, c-format
-msgid "%ls: %ls: invalid process id"
-msgstr "%ls: %ls: 无效进程 ID"
-
-#, c-format
-msgid "%ls: %ls: invalid scale\n"
-msgstr "%ls: %ls: 无效位数\n"
-
-#, c-format
-msgid "%ls: %ls: invalid subcommand\n"
-msgstr "%ls: %ls: 无效的子命令\n"
-
-#, c-format
-msgid "%ls: %ls: invalid variable name. See `help identifiers`\n"
-msgstr "%ls: %ls: 无效的变量名。参见 `help identifiers`\n"
-
-#, c-format
-msgid "%ls: %ls: option does not take an argument\n"
-msgstr "%ls: %ls: 选项不接受参数\n"
-
-#, c-format
-msgid "%ls: %ls: option requires an argument\n"
-msgstr "%ls: %ls: 选项需要参数\n"
-
-#, c-format
-msgid "%ls: %ls: subcommand takes no options\n"
-msgstr "%ls: %ls: 子命令不接受选项\n"
-
-#, c-format
-msgid "%ls: %ls: unexpected positional argument"
-msgstr "%ls: %ls: 意外的位置参数"
-
-#, c-format
-msgid "%ls: %ls: unknown option\n"
-msgstr "%ls: %ls: 未知选项\n"
-
-#, c-format
-msgid "%ls: '%ls' is a broken symbolic link to '%ls'\n"
-msgstr "%ls: '%ls' 是损坏的到 '%ls' 的符号链接\n"
-
-#, c-format
-msgid "%ls: '%ls' is not a directory\n"
-msgstr "%ls: '%ls' 不是一个目录\n"
-
-#, c-format
-msgid "%ls: '%ls' is not a job\n"
-msgstr "%ls: '%ls' 不是一个作业\n"
-
-#, c-format
-msgid "%ls: '%ls' is not a valid job id\n"
-msgstr "%ls: '%ls' 不是一个有效的作业 ID\n"
-
-#, c-format
-msgid "%ls: '%ls' is not a valid job specifier\n"
-msgstr "%ls: '%ls' 不是有效的作业说明符\n"
-
-#, c-format
-msgid "%ls: '%ls' is not a valid process id\n"
-msgstr "%ls: '%ls' 不是一个有效的进程 ID\n"
-
-#, c-format
-msgid "%ls: --command cannot be combined with --position command"
-msgstr "%ls: --command 选项不能与 --position 命令组合使用"
-
-#, c-format
-msgid "%ls: --function option requires --add\n"
-msgstr "%ls: --function 选项需要 --add\n"
-
-#, c-format
-msgid "%ls: --position option requires --add\n"
-msgstr "%ls: --position 选项需要 --add\n"
-
-#, c-format
-msgid "%ls: --regex option requires --add\n"
-msgstr "%ls: --regex 选项需要 --add\n"
-
-#, c-format
-msgid "%ls: --set-cursor argument cannot be empty\n"
-msgstr "%ls: --set-cursor 参数不能为空\n"
-
-#, c-format
-msgid "%ls: --set-cursor option requires --add\n"
-msgstr "%ls: --set-cursor 选项需要 --add\n"
-
-#, c-format
-msgid "%ls: -l requires a non-empty string\n"
-msgstr "%ls: -l 需要一个非空字符串\n"
-
-#, c-format
-msgid "%ls: -o requires a non-empty string\n"
-msgstr "%ls: -o 需要一个非空字符串\n"
-
-#, c-format
-msgid "%ls: -s requires a non-empty string\n"
-msgstr "%ls: -s 需要一个非空字符串\n"
-
-#, c-format
-msgid "%ls: Ambiguous job\n"
-msgstr "%ls: 有歧义的作业\n"
-
-#, c-format
-msgid "%ls: An option spec must have at least a short or a long flag\n"
-msgstr "%ls: 选项规范必须至少包含一个短标识或长标识\n"
-
-#, c-format
-msgid "%ls: Argument '%ls' is out of range\n"
-msgstr "%ls: 参数 '%ls' 超出取值范围\n"
-
-#, c-format
-msgid "%ls: Can not specify scope when removing block\n"
-msgstr "%ls: 移除范围时不能指定作用域\n"
-
-#, c-format
-msgid "%ls: Can't put job %d, '%ls' to foreground because it is not under job control\n"
-msgstr "%ls: 不能将作业 %d，'%ls' 带到前台，因为它不受作业控制管理\n"
-
-#, c-format
-msgid "%ls: Can't put job %s, '%ls' to background because it is not under job control\n"
-msgstr "%ls: 无法将作业 %s，'%ls' 放到后台，因为它不受作业控制管理\n"
-
-#, c-format
-msgid "%ls: Cannot combine options %ls\n"
-msgstr "%ls: 无法合并选项 %ls\n"
-
-#, fuzzy, c-format
-msgid "%ls: Cannot specify multiple positions\n"
-msgstr "%ls: 无法指定多个位置\n"
-
-#, fuzzy, c-format
-msgid "%ls: Cannot specify multiple regex patterns\n"
-msgstr "%ls: 无法指定多种正则匹配规则\n"
-
-#, c-format
-msgid "%ls: Cannot specify multiple set-cursor options\n"
-msgstr "%ls: 无法指定多个 set-cursor 选项\n"
-
-#, c-format
-msgid "%ls: Cannot use --append or --prepend when assigning to a slice"
-msgstr "%ls: 分配切片时无法使用 --append 或 --prepend"
-
-#, c-format
-msgid "%ls: Command not valid at an interactive prompt\n"
-msgstr "%ls: 命令在交互提示符下无效\n"
-
-#, c-format
-msgid "%ls: Could not find '%ls'\n"
-msgstr "%ls: 找不到 '%ls'\n"
-
-#, fuzzy, c-format
-msgid "%ls: Could not find a job with process id '%d'\n"
-msgstr "%ls: 无法找到进程 ID 为 '%d' 的作业\n"
-
-#, fuzzy, c-format
-msgid "%ls: Could not find child processes with the name '%ls'\n"
-msgstr "%ls: 无法找到名为 '%ls' 的子进程\n"
-
-#, c-format
-msgid "%ls: Could not find home directory\n"
-msgstr "%ls: 找不到主目录\n"
-
-#, c-format
-msgid "%ls: Could not find job '%d'\n"
-msgstr "%ls: 找不到作业 '%d'\n"
-
-#, c-format
-msgid "%ls: Did you mean `set %ls %ls`?"
-msgstr "%ls: 您是否想输入 `set %ls %ls`？"
-
-#, c-format
-msgid "%ls: Empty directory '%ls' does not exist\n"
-msgstr "%ls: 空目录 '%ls' 不存在\n"
-
-#, c-format
-msgid "%ls: Error encountered while sourcing file '%ls':\n"
-msgstr "%ls: 加载源文件 '%ls' 时遇到错误：\n"
-
-#, c-format
-msgid "%ls: Error while reading file '%ls'\n"
-msgstr "%ls: 读取文件 '%ls' 时发生错误\n"
-
-#, c-format
-msgid "%ls: Expected at least one argument"
-msgstr "%ls: 至少需要一个参数"
-
-#, c-format
-msgid "%ls: Expected exactly one function name\n"
-msgstr "%ls: 需要一个函数名\n"
-
-#, c-format
-msgid "%ls: Expected exactly two names (current function name, and new function name)\n"
-msgstr "%ls: 预期有两个名称 (当前函数名，和新函数名)\n"
-
-#, c-format
-msgid "%ls: Expected generic | variable | signal | exit | job-id for --handlers-type\n"
-msgstr "%ls: 对于 --handlers-type 选项，预期 generic | variable | signal | exit | job-id\n"
-
-#, c-format
-msgid "%ls: Function '%ls' already exists. Cannot create copy of '%ls'\n"
-msgstr "%ls: 函数 '%ls' 已经存在。无法创建副本 '%ls'\n"
-
-#, c-format
-msgid "%ls: Function '%ls' does not exist\n"
-msgstr "%ls: 函数 '%ls' 不存在\n"
-
-#, c-format
-msgid "%ls: Illegal function name '%ls'\n"
-msgstr "%ls: 非法函数名 '%ls'\n"
-
-#, c-format
-msgid "%ls: Implicit int flag '%lc' already defined\n"
-msgstr "%ls: 隐式整形标识 '%lc' 已被定义\n"
-
-#, fuzzy, c-format
-msgid "%ls: Implicit int short flag '%lc' does not allow modifiers like '%lc'\n"
-msgstr "%ls: 隐式整形短标识 '%lc' 不能带有形如 '%lc' 的修饰符\n"
-
-#, c-format
-msgid "%ls: Invalid --max-args value '%ls'\n"
-msgstr "%ls: 无效的 --max-args 值 '%ls'\n"
-
-#, c-format
-msgid "%ls: Invalid --min-args value '%ls'\n"
-msgstr "%ls: 无效的 --min-args 值 '%ls'\n"
-
-#, c-format
-msgid "%ls: Invalid --unknown-arguments value '%ls'\n"
-msgstr "%ls: 无效的 --unknown-arguments 值 '%ls'\n"
-
-#, fuzzy, c-format
-msgid "%ls: Invalid count value '%ls'\n"
-msgstr "%ls: 无效的计数值 '%ls'\n"
-
-#, c-format
-msgid "%ls: Invalid end value '%ls'\n"
-msgstr "%ls: 无效的终止值 '%ls'\n"
-
-#, c-format
-msgid "%ls: Invalid escape style '%ls'\n"
-msgstr "%ls: 无效的转义格式 '%ls'\n"
-
-#, fuzzy, c-format
-msgid "%ls: Invalid fields value '%ls'\n"
-msgstr "%ls: 无效的字段值 '%ls'\n"
-
-#, fuzzy, c-format
-msgid "%ls: Invalid function name: %ls\n"
-msgstr "%ls: 无效的函数名：%ls\n"
-
-#, c-format
-msgid "%ls: Invalid index starting at '%ls'\n"
-msgstr "%ls: 无效的起始索引值 '%ls'\n"
-
-#, c-format
-msgid "%ls: Invalid job control mode '%ls'\n"
-msgstr "%ls: 无效的作业控制模式 '%ls'\n"
-
-#, fuzzy, c-format
-msgid "%ls: Invalid length value '%ls'\n"
-msgstr "%ls: 无效的长度值 '%ls'\n"
-
-#, fuzzy, c-format
-msgid "%ls: Invalid level value '%ls'\n"
-msgstr "%ls: 无效的级别值 '%ls'\n"
-
-#, c-format
-msgid "%ls: Invalid limit '%ls'\n"
-msgstr "%ls: 无效的限制 '%ls'\n"
-
-#, c-format
-msgid "%ls: Invalid max matches value '%ls'\n"
-msgstr "%ls: 无效的最大匹配值 '%ls'\n"
-
-#, fuzzy, c-format
-msgid "%ls: Invalid max value '%ls'\n"
-msgstr "%ls: 无效的最大值 '%ls'\n"
-
-#, fuzzy, c-format
-msgid "%ls: Invalid option spec '%ls' at char '%lc'\n"
-msgstr "%ls: 无效的选项规范 '%ls' 于字符 '%lc'\n"
-
-#, c-format
-msgid "%ls: Invalid padding character of width zero '%ls'\n"
-msgstr "%ls: 宽度为零的无效的填充字符 '%ls'\n"
-
-#, c-format
-msgid "%ls: Invalid permission '%ls'\n"
-msgstr "%ls: 无效的权限 '%ls'\n"
-
-#, c-format
-msgid "%ls: Invalid position '%ls'\n"
-msgstr "%ls: 无效的位置 '%ls'\n"
-
-#, c-format
-msgid "%ls: Invalid range value for field '%ls'\n"
-msgstr "%ls: 字段 '%ls' 的范围值无效\n"
-
-#, c-format
-msgid "%ls: Invalid sort key '%ls'\n"
-msgstr "%ls: 无效的排序键 '%ls'\n"
-
-#, fuzzy, c-format
-msgid "%ls: Invalid start value '%ls'\n"
-msgstr "%ls: 无效的起始值 '%ls'\n"
-
-#, c-format
-msgid "%ls: Invalid state\n"
-msgstr "%ls: 无效状态\n"
-
-#, c-format
-msgid "%ls: Invalid style value '%ls'\n"
-msgstr "%ls: 无效的样式值 '%ls'\n"
-
-#, c-format
-msgid "%ls: Invalid token '%ls'\n"
-msgstr "%ls: 无效记号 '%ls'\n"
-
-#, c-format
-msgid "%ls: Invalid type '%ls'\n"
-msgstr "%ls: 无效类型 '%ls'\n"
-
-#, c-format
-msgid "%ls: Invalid width value '%ls'\n"
-msgstr "%ls: 无效的宽度值 '%ls'\n"
-
-#, c-format
-msgid "%ls: Key not specified\n"
-msgstr "%ls: 没有指定键\n"
-
-#, c-format
-msgid "%ls: Long flag '%ls' already defined\n"
-msgstr "%ls: 长标识 '%ls' 已定义\n"
-
-#, c-format
-msgid "%ls: Missing -- separator\n"
-msgstr "%ls: 缺少 -- 分隔符\n"
-
-#, c-format
-msgid "%ls: New limit cannot be an empty string\n"
-msgstr "%ls: 新限制不能为空字符串\n"
-
-#, c-format
-msgid "%ls: No binding found for key '%ls'\n"
-msgstr "%ls: 未找到键 '%ls' 的绑定\n"
-
-#, c-format
-msgid "%ls: No binding found for key sequence '%ls'\n"
-msgstr "%ls: 未找到键序列 '%ls' 的绑定\n"
-
-#, c-format
-msgid "%ls: No blocks defined\n"
-msgstr "%ls: 没有定义作用域\n"
-
-#, c-format
-msgid "%ls: No suitable job: %d\n"
-msgstr "%ls: 没有合适的作业：%d\n"
-
-#, c-format
-msgid "%ls: No suitable job: %ls\n"
-msgstr "%ls: 没有合适的作业：%ls\n"
-
-#, c-format
-msgid "%ls: Not inside of loop\n"
-msgstr "%ls: 不在循环体内部\n"
-
-#, c-format
-msgid "%ls: Options %ls and %ls cannot be used together\n"
-msgstr "%ls: 选项 %ls 和 %ls 无法一起使用\n"
-
-#, c-format
-msgid "%ls: Padding should be a character '%ls'\n"
-msgstr "%ls: 填充应为字符 '%ls'\n"
-
-#, c-format
-msgid "%ls: Permission denied: '%ls'\n"
-msgstr "%ls: 拒绝访问: '%ls'\n"
-
-#, c-format
-msgid "%ls: Regular expression compile error: %ls\n"
-msgstr "%ls: 正则表达式编译错误：%ls\n"
-
-#, c-format
-msgid "%ls: Regular expression substitute error: %ls\n"
-msgstr "%ls: 正则表达式替换错误：%ls\n"
-
-#, c-format
-msgid "%ls: Resource limit not available on this operating system\n"
-msgstr "%ls: 该操作系统不支持资源限制\n"
-
-#, c-format
-msgid "%ls: STEP must be a positive integer\n"
-msgstr "%ls: STEP 必须是正整数\n"
-
-#, fuzzy, c-format
-msgid "%ls: Short flag '%lc' already defined\n"
-msgstr "%ls: 已经定义了短标识 '%lc'\n"
-
-#, c-format
-msgid "%ls: Short flag '%lc' invalid, must be alphanum or '#'\n"
-msgstr "%ls: 短标识 '%lc' 无效，必须是字母、数字或 '#'\n"
-
-#, c-format
-msgid "%ls: The directory '%ls' does not exist\n"
-msgstr "%ls: 目录 '%ls' 不存在\n"
-
-#, c-format
-msgid "%ls: The variable '%ls' does not exist\n"
-msgstr "%ls: 变量 '%ls' 不存在\n"
-
-#, c-format
-msgid "%ls: There are no jobs\n"
-msgstr "%ls: 没有作业\n"
-
-#, c-format
-msgid "%ls: There are no suitable jobs\n"
-msgstr "%ls: 没有匹配的作业\n"
-
-#, c-format
-msgid "%ls: Too many levels of symbolic links: '%ls'\n"
-msgstr "%ls: 符号链接的级别过多：'%ls'\n"
-
-#, c-format
-msgid "%ls: Too many long-only options\n"
-msgstr "%ls: 过多的仅长选项\n"
-
-#, c-format
-msgid "%ls: Tried to change the read-only variable '%ls'\n"
-msgstr "%ls: 试图改变只读变量 '%ls' 的值\n"
-
-#, c-format
-msgid "%ls: Tried to modify the special variable '%ls' to an invalid value\n"
-msgstr "%ls: 尝试将特殊变量 '%ls' 修改为无效值\n"
-
-#, c-format
-msgid "%ls: Tried to modify the special variable '%ls' with the wrong scope\n"
-msgstr "%ls: 尝试用错误的范围修改特殊变量 '%ls'\n"
-
-#, c-format
-msgid "%ls: Unknown color '%ls'\n"
-msgstr "%ls: 未知颜色 '%ls'\n"
-
-#, c-format
-msgid "%ls: Unknown error trying to locate directory '%ls'\n"
-msgstr "%ls: 定位目录 '%ls' 时发生未知错误\n"
-
-#, c-format
-msgid "%ls: Unknown input function '%ls'"
-msgstr "%ls: 未知的输入函数 '%ls'"
-
-#, c-format
-msgid "%ls: Unknown signal '%ls'"
-msgstr "%ls: 未知信号 '%ls'"
-
-#, c-format
-msgid "%ls: Warning: Option '%ls' was removed and is now ignored"
-msgstr "%ls: 警告：忽略已被删除的选项 '%ls'"
-
-#, c-format
-msgid "%ls: `set --show` does not allow slices with the var names\n"
-msgstr "%ls: `set --show` 不支持使用带有变量名称的切片\n"
-
-#, c-format
-msgid "%ls: array index out of bounds\n"
-msgstr "%ls: 数组索引越界\n"
-
-#, c-format
-msgid "%ls: called with no arguments. This will be an error in future."
-msgstr "%ls: 未带参数调用。此操作在未来版本中将视为错误。"
-
-#, c-format
-msgid "%ls: called with one argument. This will return false in future."
-msgstr "%ls：带一个参数调用。此操作在未来版本中将返回 false。"
-
-#, c-format
-msgid "%ls: calling job for event handler not found"
-msgstr "%ls: 未找到事件处理程序的调用作业"
-
-#, c-format
-msgid "%ls: can't merge history in private mode\n"
-msgstr "%ls: 无法在私密模式中合并历史\n"
-
-#, c-format
-msgid "%ls: cannot both export and unexport\n"
-msgstr "%ls: 无法同时导出和取消导出\n"
-
-#, c-format
-msgid "%ls: cannot both path and unpath\n"
-msgstr "%ls: 无法同时是路径变量和非路径变量\n"
-
-#, c-format
-msgid "%ls: column %ls exceeds line length\n"
-msgstr "%ls: 列 %ls 超出行长度\n"
-
-#, c-format
-msgid "%ls: exclusive flag '%ls' is not valid\n"
-msgstr "%ls: 排他标识 '%ls' 无效\n"
-
-#, c-format
-msgid "%ls: exclusive flag string '%ls' is not valid\n"
-msgstr "%ls: 排他标识字符串 '%ls' 无效\n"
-
-#, c-format
-msgid "%ls: expected %d arguments; got %d\n"
-msgstr "%ls: 预期收到 %d 个参数；实际收到 %d 个\n"
-
-#, c-format
-msgid "%ls: expected <= %d arguments; got %d\n"
-msgstr "%ls: 预期收到 <= %d 个参数；实际收到 %d 个\n"
-
-#, c-format
-msgid "%ls: expected >= %d arguments; got %d\n"
-msgstr "%ls: 预期收到 >= %d 个参数；实际收到 %d 个\n"
-
-#, c-format
-msgid "%ls: expected a numeric value"
-msgstr "%ls: 预期收到数值"
-
-#, c-format
-msgid "%ls: fish was not built with embedded files"
-msgstr "%ls: fish 构建时未包含嵌入文件"
-
-#, c-format
-msgid "%ls: given %d indexes but %d values\n"
-msgstr "%ls: 给定索引 %d 但只有 %d 个值\n"
-
-#, c-format
-msgid "%ls: invalid option combination\n"
-msgstr "%ls: 无效的选项组合\n"
-
-#, c-format
-msgid "%ls: invalid option combination, %ls\n"
-msgstr "%ls: 无效的选项组合，%ls\n"
-
-#, c-format
-msgid "%ls: invalid underline style: %ls\n"
-msgstr "%ls: 无效的下划线样式：%ls\n"
-
-#, c-format
-msgid "%ls: job %d ('%ls') was stopped and has been signalled to continue.\n"
-msgstr "%ls: 作业 %d ('%ls') 已停止并收到继续信号。\n"
-
-#, c-format
-msgid "%ls: line/column index starts at 1"
-msgstr "%ls: 行/列索引从1开始"
-
-#, c-format
-msgid "%ls: missing argument\n"
-msgstr "%ls: 缺少参数\n"
-
-#, c-format
-msgid "%ls: missing filename argument or input redirection\n"
-msgstr "%ls: 缺少文件名参数或输入重定向\n"
-
-#, c-format
-msgid "%ls: missing subcommand\n"
-msgstr "%ls: 缺少子命令\n"
-
-#, c-format
-msgid "%ls: nothing to choose from\n"
-msgstr "%ls: 没有可选项\n"
-
-#, c-format
-msgid "%ls: realpath failed: %s\n"
-msgstr "%ls: realpath 失败：%s\n"
-
-#, c-format
-msgid "%ls: scope can be only one of: universal function global local\n"
-msgstr "%ls: 范围只能是：universal（通用）function（函数）global（全局）local（局域）\n"
-
-#, c-format
-msgid "%ls: stdin is closed\n"
-msgstr "%ls: stdin 已关闭\n"
-
-#, c-format
-msgid "%ls: successfully set universal '%ls'; but a global by that name shadows it\n"
-msgstr "%ls: 成功设置通用变量 '%ls' ；但是同名全局变量遮蔽它\n"
-
-#, c-format
-msgid "%ls: the -k/--key syntax is no longer supported. See `bind --help` and `bind --key-names`\n"
-msgstr "%ls：-k/--key 语法不再受支持。参见 `bind --help` 和 `bind --key-names`\n"
-
-#, c-format
-msgid "%ls: there is no line %ls\n"
-msgstr "%ls: 不存在行 %ls\n"
-
-#, c-format
-msgid "%ls: too many arguments\n"
-msgstr "%ls: 参数太多\n"
-
-#, c-format
-msgid "%ls: usage of -i for --silent is deprecated. Please use -s or --silent instead.\n"
-msgstr "%ls: 参数 -i 用于表示 --silent 已弃用。请改用 -s 或 --silent 代替。\n"
-
-#, c-format
-msgid "%ls: value not completely converted (can't convert '%ls')"
-msgstr "%ls: 数值未完全转换 (无法转换 '%ls')"
-
-#, c-format
-msgid "%ls: variable '%ls' is read-only\n"
-msgstr "%ls: 变量 '%ls' 只读\n"
-
-#, c-format
-msgid "%lsand %lu more rows"
-msgstr "%ls还有 %lu 行"
-
-#, c-format
-msgid "%lu\n"
-msgstr "%lu\n"
+msgid "%.*s: invalid conversion specification"
+msgstr "%.*s: 无效的转换规范"
 
 #, c-format
 msgid "%s"
 msgstr "%s"
 
 #, c-format
-msgid "%s %s: unrecognized feature '%ls'"
-msgstr "%s %s: 未识别的特性 '%ls'"
+msgid "%s %s: Abbreviation %s already exists, cannot rename %s\n"
+msgstr "%s %s: 缩写 %s 已经存在，无法重命名 %s\n"
+
+#, c-format
+msgid "%s %s: Abbreviation '%s' cannot have spaces in the word\n"
+msgstr "%s %s: 缩写词 '%s' 不能包含空格\n"
+
+#, c-format
+msgid "%s %s: Name cannot be empty\n"
+msgstr "%s %s: 名称不能为空\n"
+
+#, c-format
+msgid "%s %s: No abbreviation named %s\n"
+msgstr "%s %s: 没有命名为 %s 的缩写\n"
+
+#, c-format
+msgid "%s %s: Requires at least two arguments\n"
+msgstr "%s %s: 需要至少两个参数\n"
+
+#, c-format
+msgid "%s %s: Requires exactly two arguments\n"
+msgstr "%s %s: 需要两个参数\n"
+
+#, c-format
+msgid "%s %s: Unexpected argument -- '%s'\n"
+msgstr "%s %s: 意外参数 -- '%s'\n"
+
+#, c-format
+msgid "%s %s: unrecognized feature '%s'"
+msgstr "%s %s: 未识别的特性 '%s'"
+
+#, c-format
+msgid "%s (line %d): "
+msgstr "%s (行 %d): "
+
+#, c-format
+msgid "%s (line %u): "
+msgstr "%s (行 %u): "
 
 #, c-format
 msgid "%s and %s are mutually exclusive"
@@ -832,12 +156,680 @@ msgid "%s could not read response to Primary Device Attribute query after waitin
 msgstr "%s 等待 %d 秒后仍无法读取 Primary Device Attribute 查询的响应。这通常是由于终端缺少相应功能所致。参见 'help terminal-compatibility' 或 'man fish-terminal-compatibility'。此 %s 进程将不再等待未处理的查询，这将禁用某些可选功能。"
 
 #, c-format
+msgid "%s is %s\n"
+msgstr "%s 是 %s\n"
+
+#, c-format
+msgid "%s is a builtin\n"
+msgstr "%s 是一个内建命令\n"
+
+#, c-format
+msgid "%s is a function"
+msgstr "%s 是一个函数"
+
+#, c-format
 msgid "%s, version %s"
 msgstr "%s，版本 %s"
 
 #, c-format
 msgid "%s, version %s\n"
 msgstr "%s，版本 %s\n"
+
+#, c-format
+msgid "%s: %*s\n"
+msgstr "%s: %*s\n"
+
+#, c-format
+msgid "%s: %s\n"
+msgstr "%s: %s\n"
+
+#, c-format
+msgid "%s: %s %s: options cannot be used together\n"
+msgstr "%s: %s %s: 选项无法一起使用\n"
+
+#, c-format
+msgid "%s: %s: cannot overwrite read-only variable"
+msgstr "%s: %s: 无法覆写只读变量"
+
+#, c-format
+msgid "%s: %s: cannot use reserved keyword as function name"
+msgstr "%s: %s: 无法将保留关键字作为函数名"
+
+#, c-format
+msgid "%s: %s: contains a syntax error\n"
+msgstr "%s: %s: 包含语法错误\n"
+
+#, c-format
+msgid "%s: %s: expected %d arguments; got %d\n"
+msgstr "%s: %s: 预期收到 %d 个参数；实际收到 %d 个\n"
+
+#, c-format
+msgid "%s: %s: invalid base value\n"
+msgstr "%s: %s: 无效的进制值\n"
+
+#, c-format
+msgid "%s: %s: invalid function name"
+msgstr "%s: %s: 无效的函数名"
+
+#, c-format
+msgid "%s: %s: invalid integer\n"
+msgstr "%s: %s: 无效整数\n"
+
+#, c-format
+msgid "%s: %s: invalid mode\n"
+msgstr "%s: %s: 无效舍入模式\n"
+
+#, c-format
+msgid "%s: %s: invalid mode name. See `help identifiers`\n"
+msgstr "%s: %s: 无效模式名。参见 `help identifiers`\n"
+
+#, c-format
+msgid "%s: %s: invalid process id"
+msgstr "%s: %s: 无效进程 ID"
+
+#, c-format
+msgid "%s: %s: invalid scale\n"
+msgstr "%s: %s: 无效位数\n"
+
+#, c-format
+msgid "%s: %s: invalid subcommand\n"
+msgstr "%s: %s: 无效的子命令\n"
+
+#, c-format
+msgid "%s: %s: invalid variable name. See `help identifiers`\n"
+msgstr "%s: %s: 无效的变量名。参见 `help identifiers`\n"
+
+#, c-format
+msgid "%s: %s: option does not take an argument\n"
+msgstr "%s: %s: 选项不接受参数\n"
+
+#, c-format
+msgid "%s: %s: option requires an argument\n"
+msgstr "%s: %s: 选项需要参数\n"
+
+#, c-format
+msgid "%s: %s: subcommand takes no options\n"
+msgstr "%s: %s: 子命令不接受选项\n"
+
+#, c-format
+msgid "%s: %s: unexpected positional argument"
+msgstr "%s: %s: 意外的位置参数"
+
+#, c-format
+msgid "%s: %s: unknown option\n"
+msgstr "%s: %s: 未知选项\n"
+
+#, c-format
+msgid "%s: '%s' is a broken symbolic link to '%s'\n"
+msgstr "%s: '%s' 是损坏的到 '%s' 的符号链接\n"
+
+#, c-format
+msgid "%s: '%s' is not a directory\n"
+msgstr "%s: '%s' 不是一个目录\n"
+
+#, c-format
+msgid "%s: '%s' is not a job\n"
+msgstr "%s: '%s' 不是一个作业\n"
+
+#, c-format
+msgid "%s: '%s' is not a valid job id\n"
+msgstr "%s: '%s' 不是一个有效的作业 ID\n"
+
+#, c-format
+msgid "%s: '%s' is not a valid job specifier\n"
+msgstr "%s: '%s' 不是有效的作业说明符\n"
+
+#, c-format
+msgid "%s: '%s' is not a valid process id\n"
+msgstr "%s: '%s' 不是一个有效的进程 ID\n"
+
+#, c-format
+msgid "%s: --command cannot be combined with --position command"
+msgstr "%s: --command 选项不能与 --position 命令组合使用"
+
+#, c-format
+msgid "%s: --function option requires --add\n"
+msgstr "%s: --function 选项需要 --add\n"
+
+#, c-format
+msgid "%s: --position option requires --add\n"
+msgstr "%s: --position 选项需要 --add\n"
+
+#, c-format
+msgid "%s: --regex option requires --add\n"
+msgstr "%s: --regex 选项需要 --add\n"
+
+#, c-format
+msgid "%s: --set-cursor argument cannot be empty\n"
+msgstr "%s: --set-cursor 参数不能为空\n"
+
+#, c-format
+msgid "%s: --set-cursor option requires --add\n"
+msgstr "%s: --set-cursor 选项需要 --add\n"
+
+#, c-format
+msgid "%s: -l requires a non-empty string\n"
+msgstr "%s: -l 需要一个非空字符串\n"
+
+#, c-format
+msgid "%s: -o requires a non-empty string\n"
+msgstr "%s: -o 需要一个非空字符串\n"
+
+#, c-format
+msgid "%s: -s requires a non-empty string\n"
+msgstr "%s: -s 需要一个非空字符串\n"
+
+#, c-format
+msgid "%s: Ambiguous job\n"
+msgstr "%s: 有歧义的作业\n"
+
+#, c-format
+msgid "%s: An option spec must have at least a short or a long flag\n"
+msgstr "%s: 选项规范必须至少包含一个短标识或长标识\n"
+
+#, c-format
+msgid "%s: Argument '%s' is out of range\n"
+msgstr "%s: 参数 '%s' 超出取值范围\n"
+
+#, c-format
+msgid "%s: Can not specify scope when removing block\n"
+msgstr "%s: 移除范围时不能指定作用域\n"
+
+#, c-format
+msgid "%s: Can't put job %d, '%s' to foreground because it is not under job control\n"
+msgstr "%s: 不能将作业 %d，'%s' 带到前台，因为它不受作业控制管理\n"
+
+#, c-format
+msgid "%s: Can't put job %s, '%s' to background because it is not under job control\n"
+msgstr "%s: 无法将作业 %s，'%s' 放到后台，因为它不受作业控制管理\n"
+
+#, c-format
+msgid "%s: Cannot combine options %s\n"
+msgstr "%s: 无法合并选项 %s\n"
+
+#, fuzzy, c-format
+msgid "%s: Cannot specify multiple positions\n"
+msgstr "%s: 无法指定多个位置\n"
+
+#, fuzzy, c-format
+msgid "%s: Cannot specify multiple regex patterns\n"
+msgstr "%s: 无法指定多种正则匹配规则\n"
+
+#, c-format
+msgid "%s: Cannot specify multiple set-cursor options\n"
+msgstr "%s: 无法指定多个 set-cursor 选项\n"
+
+#, c-format
+msgid "%s: Cannot use --append or --prepend when assigning to a slice"
+msgstr "%s: 分配切片时无法使用 --append 或 --prepend"
+
+#, c-format
+msgid "%s: Command not valid at an interactive prompt\n"
+msgstr "%s: 命令在交互提示符下无效\n"
+
+#, c-format
+msgid "%s: Could not find '%s'\n"
+msgstr "%s: 找不到 '%s'\n"
+
+#, fuzzy, c-format
+msgid "%s: Could not find a job with process id '%d'\n"
+msgstr "%s: 无法找到进程 ID 为 '%d' 的作业\n"
+
+#, fuzzy, c-format
+msgid "%s: Could not find child processes with the name '%s'\n"
+msgstr "%s: 无法找到名为 '%s' 的子进程\n"
+
+#, c-format
+msgid "%s: Could not find home directory\n"
+msgstr "%s: 找不到主目录\n"
+
+#, c-format
+msgid "%s: Could not find job '%d'\n"
+msgstr "%s: 找不到作业 '%d'\n"
+
+#, c-format
+msgid "%s: Did you mean `set %s %s`?"
+msgstr "%s: 您是否想输入 `set %s %s`？"
+
+#, c-format
+msgid "%s: Empty directory '%s' does not exist\n"
+msgstr "%s: 空目录 '%s' 不存在\n"
+
+#, c-format
+msgid "%s: Error encountered while sourcing file '%s':\n"
+msgstr "%s: 加载源文件 '%s' 时遇到错误：\n"
+
+#, c-format
+msgid "%s: Error while reading file '%s'\n"
+msgstr "%s: 读取文件 '%s' 时发生错误\n"
+
+#, c-format
+msgid "%s: Expected at least one argument"
+msgstr "%s: 至少需要一个参数"
+
+#, c-format
+msgid "%s: Expected exactly one function name\n"
+msgstr "%s: 需要一个函数名\n"
+
+#, c-format
+msgid "%s: Expected exactly two names (current function name, and new function name)\n"
+msgstr "%s: 预期有两个名称 (当前函数名，和新函数名)\n"
+
+#, c-format
+msgid "%s: Expected generic | variable | signal | exit | job-id for --handlers-type\n"
+msgstr "%s: 对于 --handlers-type 选项，预期 generic | variable | signal | exit | job-id\n"
+
+#, c-format
+msgid "%s: Function '%s' already exists. Cannot create copy of '%s'\n"
+msgstr "%s: 函数 '%s' 已经存在。无法创建副本 '%s'\n"
+
+#, c-format
+msgid "%s: Function '%s' does not exist\n"
+msgstr "%s: 函数 '%s' 不存在\n"
+
+#, c-format
+msgid "%s: Illegal function name '%s'\n"
+msgstr "%s: 非法函数名 '%s'\n"
+
+#, c-format
+msgid "%s: Implicit int flag '%c' already defined\n"
+msgstr "%s: 隐式整形标识 '%c' 已被定义\n"
+
+#, fuzzy, c-format
+msgid "%s: Implicit int short flag '%c' does not allow modifiers like '%c'\n"
+msgstr "%s: 隐式整形短标识 '%c' 不能带有形如 '%c' 的修饰符\n"
+
+#, c-format
+msgid "%s: Invalid --max-args value '%s'\n"
+msgstr "%s: 无效的 --max-args 值 '%s'\n"
+
+#, c-format
+msgid "%s: Invalid --min-args value '%s'\n"
+msgstr "%s: 无效的 --min-args 值 '%s'\n"
+
+#, c-format
+msgid "%s: Invalid --unknown-arguments value '%s'\n"
+msgstr "%s: 无效的 --unknown-arguments 值 '%s'\n"
+
+#, fuzzy, c-format
+msgid "%s: Invalid count value '%s'\n"
+msgstr "%s: 无效的计数值 '%s'\n"
+
+#, c-format
+msgid "%s: Invalid end value '%s'\n"
+msgstr "%s: 无效的终止值 '%s'\n"
+
+#, c-format
+msgid "%s: Invalid escape style '%s'\n"
+msgstr "%s: 无效的转义格式 '%s'\n"
+
+#, fuzzy, c-format
+msgid "%s: Invalid fields value '%s'\n"
+msgstr "%s: 无效的字段值 '%s'\n"
+
+#, fuzzy, c-format
+msgid "%s: Invalid function name: %s\n"
+msgstr "%s: 无效的函数名：%s\n"
+
+#, c-format
+msgid "%s: Invalid index starting at '%s'\n"
+msgstr "%s: 无效的起始索引值 '%s'\n"
+
+#, c-format
+msgid "%s: Invalid job control mode '%s'\n"
+msgstr "%s: 无效的作业控制模式 '%s'\n"
+
+#, fuzzy, c-format
+msgid "%s: Invalid length value '%s'\n"
+msgstr "%s: 无效的长度值 '%s'\n"
+
+#, fuzzy, c-format
+msgid "%s: Invalid level value '%s'\n"
+msgstr "%s: 无效的级别值 '%s'\n"
+
+#, c-format
+msgid "%s: Invalid limit '%s'\n"
+msgstr "%s: 无效的限制 '%s'\n"
+
+#, c-format
+msgid "%s: Invalid max matches value '%s'\n"
+msgstr "%s: 无效的最大匹配值 '%s'\n"
+
+#, fuzzy, c-format
+msgid "%s: Invalid max value '%s'\n"
+msgstr "%s: 无效的最大值 '%s'\n"
+
+#, fuzzy, c-format
+msgid "%s: Invalid option spec '%s' at char '%c'\n"
+msgstr "%s: 无效的选项规范 '%s' 于字符 '%c'\n"
+
+#, c-format
+msgid "%s: Invalid padding character of width zero '%s'\n"
+msgstr "%s: 宽度为零的无效的填充字符 '%s'\n"
+
+#, c-format
+msgid "%s: Invalid permission '%s'\n"
+msgstr "%s: 无效的权限 '%s'\n"
+
+#, c-format
+msgid "%s: Invalid position '%s'\n"
+msgstr "%s: 无效的位置 '%s'\n"
+
+#, c-format
+msgid "%s: Invalid range value for field '%s'\n"
+msgstr "%s: 字段 '%s' 的范围值无效\n"
+
+#, c-format
+msgid "%s: Invalid sort key '%s'\n"
+msgstr "%s: 无效的排序键 '%s'\n"
+
+#, fuzzy, c-format
+msgid "%s: Invalid start value '%s'\n"
+msgstr "%s: 无效的起始值 '%s'\n"
+
+#, c-format
+msgid "%s: Invalid state\n"
+msgstr "%s: 无效状态\n"
+
+#, c-format
+msgid "%s: Invalid style value '%s'\n"
+msgstr "%s: 无效的样式值 '%s'\n"
+
+#, c-format
+msgid "%s: Invalid token '%s'\n"
+msgstr "%s: 无效记号 '%s'\n"
+
+#, c-format
+msgid "%s: Invalid type '%s'\n"
+msgstr "%s: 无效类型 '%s'\n"
+
+#, c-format
+msgid "%s: Invalid width value '%s'\n"
+msgstr "%s: 无效的宽度值 '%s'\n"
+
+#, c-format
+msgid "%s: Key not specified\n"
+msgstr "%s: 没有指定键\n"
+
+#, c-format
+msgid "%s: Long flag '%s' already defined\n"
+msgstr "%s: 长标识 '%s' 已定义\n"
+
+#, c-format
+msgid "%s: Missing -- separator\n"
+msgstr "%s: 缺少 -- 分隔符\n"
+
+#, c-format
+msgid "%s: New limit cannot be an empty string\n"
+msgstr "%s: 新限制不能为空字符串\n"
+
+#, c-format
+msgid "%s: No binding found for key '%s'\n"
+msgstr "%s: 未找到键 '%s' 的绑定\n"
+
+#, c-format
+msgid "%s: No binding found for key sequence '%s'\n"
+msgstr "%s: 未找到键序列 '%s' 的绑定\n"
+
+#, c-format
+msgid "%s: No blocks defined\n"
+msgstr "%s: 没有定义作用域\n"
+
+#, c-format
+msgid "%s: No suitable job: %d\n"
+msgstr "%s: 没有合适的作业：%d\n"
+
+#, c-format
+msgid "%s: No suitable job: %s\n"
+msgstr "%s: 没有合适的作业：%s\n"
+
+#, c-format
+msgid "%s: Not inside of loop\n"
+msgstr "%s: 不在循环体内部\n"
+
+#, c-format
+msgid "%s: Options %s and %s cannot be used together\n"
+msgstr "%s: 选项 %s 和 %s 无法一起使用\n"
+
+#, c-format
+msgid "%s: Padding should be a character '%s'\n"
+msgstr "%s: 填充应为字符 '%s'\n"
+
+#, c-format
+msgid "%s: Permission denied: '%s'\n"
+msgstr "%s: 拒绝访问: '%s'\n"
+
+#, c-format
+msgid "%s: Regular expression compile error: %s\n"
+msgstr "%s: 正则表达式编译错误：%s\n"
+
+#, c-format
+msgid "%s: Regular expression substitute error: %s\n"
+msgstr "%s: 正则表达式替换错误：%s\n"
+
+#, c-format
+msgid "%s: Resource limit not available on this operating system\n"
+msgstr "%s: 该操作系统不支持资源限制\n"
+
+#, c-format
+msgid "%s: STEP must be a positive integer\n"
+msgstr "%s: STEP 必须是正整数\n"
+
+#, fuzzy, c-format
+msgid "%s: Short flag '%c' already defined\n"
+msgstr "%s: 已经定义了短标识 '%c'\n"
+
+#, c-format
+msgid "%s: Short flag '%c' invalid, must be alphanum or '#'\n"
+msgstr "%s: 短标识 '%c' 无效，必须是字母、数字或 '#'\n"
+
+#, c-format
+msgid "%s: The directory '%s' does not exist\n"
+msgstr "%s: 目录 '%s' 不存在\n"
+
+#, c-format
+msgid "%s: The variable '%s' does not exist\n"
+msgstr "%s: 变量 '%s' 不存在\n"
+
+#, c-format
+msgid "%s: There are no jobs\n"
+msgstr "%s: 没有作业\n"
+
+#, c-format
+msgid "%s: There are no suitable jobs\n"
+msgstr "%s: 没有匹配的作业\n"
+
+#, c-format
+msgid "%s: Too many levels of symbolic links: '%s'\n"
+msgstr "%s: 符号链接的级别过多：'%s'\n"
+
+#, c-format
+msgid "%s: Too many long-only options\n"
+msgstr "%s: 过多的仅长选项\n"
+
+#, c-format
+msgid "%s: Tried to change the read-only variable '%s'\n"
+msgstr "%s: 试图改变只读变量 '%s' 的值\n"
+
+#, c-format
+msgid "%s: Tried to modify the special variable '%s' to an invalid value\n"
+msgstr "%s: 尝试将特殊变量 '%s' 修改为无效值\n"
+
+#, c-format
+msgid "%s: Tried to modify the special variable '%s' with the wrong scope\n"
+msgstr "%s: 尝试用错误的范围修改特殊变量 '%s'\n"
+
+#, c-format
+msgid "%s: Unknown color '%s'\n"
+msgstr "%s: 未知颜色 '%s'\n"
+
+#, c-format
+msgid "%s: Unknown error trying to locate directory '%s'\n"
+msgstr "%s: 定位目录 '%s' 时发生未知错误\n"
+
+#, c-format
+msgid "%s: Unknown input function '%s'"
+msgstr "%s: 未知的输入函数 '%s'"
+
+#, c-format
+msgid "%s: Unknown signal '%s'"
+msgstr "%s: 未知信号 '%s'"
+
+#, c-format
+msgid "%s: Warning: Option '%s' was removed and is now ignored"
+msgstr "%s: 警告：忽略已被删除的选项 '%s'"
+
+#, c-format
+msgid "%s: `set --show` does not allow slices with the var names\n"
+msgstr "%s: `set --show` 不支持使用带有变量名称的切片\n"
+
+#, c-format
+msgid "%s: array index out of bounds\n"
+msgstr "%s: 数组索引越界\n"
+
+#, c-format
+msgid "%s: called with no arguments. This will be an error in future."
+msgstr "%s: 未带参数调用。此操作在未来版本中将视为错误。"
+
+#, c-format
+msgid "%s: called with one argument. This will return false in future."
+msgstr "%s：带一个参数调用。此操作在未来版本中将返回 false。"
+
+#, c-format
+msgid "%s: calling job for event handler not found"
+msgstr "%s: 未找到事件处理程序的调用作业"
+
+#, c-format
+msgid "%s: can't merge history in private mode\n"
+msgstr "%s: 无法在私密模式中合并历史\n"
+
+#, c-format
+msgid "%s: cannot both export and unexport\n"
+msgstr "%s: 无法同时导出和取消导出\n"
+
+#, c-format
+msgid "%s: cannot both path and unpath\n"
+msgstr "%s: 无法同时是路径变量和非路径变量\n"
+
+#, c-format
+msgid "%s: column %s exceeds line length\n"
+msgstr "%s: 列 %s 超出行长度\n"
+
+#, c-format
+msgid "%s: exclusive flag '%s' is not valid\n"
+msgstr "%s: 排他标识 '%s' 无效\n"
+
+#, c-format
+msgid "%s: exclusive flag string '%s' is not valid\n"
+msgstr "%s: 排他标识字符串 '%s' 无效\n"
+
+#, c-format
+msgid "%s: expected %d arguments; got %d\n"
+msgstr "%s: 预期收到 %d 个参数；实际收到 %d 个\n"
+
+#, c-format
+msgid "%s: expected <= %d arguments; got %d\n"
+msgstr "%s: 预期收到 <= %d 个参数；实际收到 %d 个\n"
+
+#, c-format
+msgid "%s: expected >= %d arguments; got %d\n"
+msgstr "%s: 预期收到 >= %d 个参数；实际收到 %d 个\n"
+
+#, c-format
+msgid "%s: expected a numeric value"
+msgstr "%s: 预期收到数值"
+
+#, c-format
+msgid "%s: fish was not built with embedded files"
+msgstr "%s: fish 构建时未包含嵌入文件"
+
+#, c-format
+msgid "%s: given %d indexes but %d values\n"
+msgstr "%s: 给定索引 %d 但只有 %d 个值\n"
+
+#, c-format
+msgid "%s: invalid option combination\n"
+msgstr "%s: 无效的选项组合\n"
+
+#, c-format
+msgid "%s: invalid option combination, %s\n"
+msgstr "%s: 无效的选项组合，%s\n"
+
+#, c-format
+msgid "%s: invalid underline style: %s\n"
+msgstr "%s: 无效的下划线样式：%s\n"
+
+#, c-format
+msgid "%s: job %d ('%s') was stopped and has been signalled to continue.\n"
+msgstr "%s: 作业 %d ('%s') 已停止并收到继续信号。\n"
+
+#, c-format
+msgid "%s: line/column index starts at 1"
+msgstr "%s: 行/列索引从1开始"
+
+#, c-format
+msgid "%s: missing argument\n"
+msgstr "%s: 缺少参数\n"
+
+#, c-format
+msgid "%s: missing filename argument or input redirection\n"
+msgstr "%s: 缺少文件名参数或输入重定向\n"
+
+#, c-format
+msgid "%s: missing subcommand\n"
+msgstr "%s: 缺少子命令\n"
+
+#, c-format
+msgid "%s: nothing to choose from\n"
+msgstr "%s: 没有可选项\n"
+
+#, c-format
+msgid "%s: realpath failed: %s\n"
+msgstr "%s: realpath 失败：%s\n"
+
+#, c-format
+msgid "%s: scope can be only one of: universal function global local\n"
+msgstr "%s: 范围只能是：universal（通用）function（函数）global（全局）local（局域）\n"
+
+#, c-format
+msgid "%s: stdin is closed\n"
+msgstr "%s: stdin 已关闭\n"
+
+#, c-format
+msgid "%s: successfully set universal '%s'; but a global by that name shadows it\n"
+msgstr "%s: 成功设置通用变量 '%s' ；但是同名全局变量遮蔽它\n"
+
+#, c-format
+msgid "%s: the -k/--key syntax is no longer supported. See `bind --help` and `bind --key-names`\n"
+msgstr "%s：-k/--key 语法不再受支持。参见 `bind --help` 和 `bind --key-names`\n"
+
+#, c-format
+msgid "%s: there is no line %s\n"
+msgstr "%s: 不存在行 %s\n"
+
+#, c-format
+msgid "%s: too many arguments\n"
+msgstr "%s: 参数太多\n"
+
+#, c-format
+msgid "%s: usage of -i for --silent is deprecated. Please use -s or --silent instead.\n"
+msgstr "%s: 参数 -i 用于表示 --silent 已弃用。请改用 -s 或 --silent 代替。\n"
+
+#, c-format
+msgid "%s: value not completely converted (can't convert '%s')"
+msgstr "%s: 数值未完全转换 (无法转换 '%s')"
+
+#, c-format
+msgid "%s: variable '%s' is read-only\n"
+msgstr "%s: 变量 '%s' 只读\n"
+
+#, c-format
+msgid "%sand %u more rows"
+msgstr "%s还有 %u 行"
+
+#, c-format
+msgid "%u\n"
+msgstr "%u\n"
 
 msgid "'break' while not inside of loop"
 msgstr "'break' 不在循环内"
@@ -864,15 +856,15 @@ msgid "'}' does not take arguments. Did you forget a ';'?"
 msgstr "'}' 不接受参数。是否漏掉了分号';'？"
 
 #, c-format
-msgid "(Type 'help %ls' for related documentation)\n"
-msgstr "(输入 'help %ls' 查看相关文档)\n"
+msgid "(Type 'help %s' for related documentation)\n"
+msgstr "(输入 'help %s' 查看相关文档)\n"
 
 msgid "(no matches)"
 msgstr "(无匹配)"
 
 #, c-format
-msgid ", copied in %ls @ line %d"
-msgstr "，复制到 %ls @ line %d"
+msgid ", copied in %s @ line %d"
+msgstr "，复制到 %s @ line %d"
 
 msgid ", copied interactively"
 msgstr "，交互时复制"
@@ -908,8 +900,8 @@ msgid "Abbreviation expansion"
 msgstr "缩写展开"
 
 #, c-format
-msgid "Abbreviation: %ls"
-msgstr "缩写：%ls"
+msgid "Abbreviation: %s"
+msgstr "缩写：%s"
 
 msgid "Abort"
 msgstr "中止"
@@ -927,8 +919,8 @@ msgid "An error occurred while setting up pipe"
 msgstr "设置管道时出错"
 
 #, c-format
-msgid "Argument is not a number: '%ls'"
-msgstr "参数不是数字：'%ls'"
+msgid "Argument is not a number: '%s'"
+msgstr "参数不是数字：'%s'"
 
 msgid "Await background process completion"
 msgstr "等待后台进程完成"
@@ -1029,8 +1021,8 @@ msgid "Define a new function"
 msgstr "定义一个新函数"
 
 #, c-format
-msgid "Defined in %ls @ line %d"
-msgstr "定义于 %ls @ line %d"
+msgid "Defined in %s @ line %d"
+msgstr "定义于 %s @ line %d"
 
 msgid "Defined interactively"
 msgstr "交互时定义"
@@ -1059,8 +1051,8 @@ msgid "Error when renaming file: %s"
 msgstr "重命名文件时出错：%s"
 
 #, c-format
-msgid "Error while reading file %ls\n"
-msgstr "读取文件 %ls 时出错\n"
+msgid "Error while reading file %s\n"
+msgstr "读取文件 %s 时出错\n"
 
 msgid "Errors reported by exec (on by default)"
 msgstr "exec 报告的错误 (默认开启)"
@@ -1093,20 +1085,16 @@ msgid "Expansion produced too many results"
 msgstr "展开产生了太多的结果"
 
 #, c-format
-msgid "Expected %ls, but found %ls"
-msgstr "预期 %ls，但找到 %ls"
+msgid "Expected %s, but found %s"
+msgstr "预期 %s，但找到 %s"
 
 #, c-format
-msgid "Expected %s, but found %ls"
-msgstr "预期 %s，但找到 %ls"
+msgid "Expected a command, but found %s"
+msgstr "预期是一个命令，但找到 %s"
 
 #, c-format
-msgid "Expected a command, but found %ls"
-msgstr "预期是一个命令，但找到 %ls"
-
-#, c-format
-msgid "Expected a string, but found %ls"
-msgstr "预期是字符串，但找到 %ls"
+msgid "Expected a string, but found %s"
+msgstr "预期是字符串，但找到 %s"
 
 msgid "Expected a string, but found a redirection"
 msgstr "预期是字符串，但找到重定向"
@@ -1118,11 +1106,11 @@ msgstr "在此 $ 之后应有变量名称。"
 msgid ""
 "Expected file path to read/write for -w:\n"
 "\n"
-" $ %ls -w foo.fish"
+" $ %s -w foo.fish"
 msgstr ""
 "预期 -w 后有用于读或写的文件路径：\n"
 "\n"
-" $ %ls -w foo.fish"
+" $ %s -w foo.fish"
 
 #, c-format
 msgid "Expected no arguments, got %d"
@@ -1193,33 +1181,33 @@ msgid "History performance measurements"
 msgstr "历史性能测量"
 
 #, c-format
-msgid "History session ID '%ls' is not a valid variable name. Falling back to `%ls`."
-msgstr "历史会话 ID '%ls' 不是有效的变量名称。回退到 `%ls`。"
+msgid "History session ID '%s' is not a valid variable name. Falling back to `%s`."
+msgstr "历史会话 ID '%s' 不是有效的变量名称。回退到 `%s`。"
 
 #, c-format
-msgid "Home for %ls"
-msgstr "%ls 的主目录"
+msgid "Home for %s"
+msgstr "%s 的主目录"
 
 msgid "I/O on asynchronous file descriptor is possible"
 msgstr "在异步文件描述符上的 I/O 是可行的"
 
 #, c-format
-msgid "Illegal file descriptor in redirection '%ls'"
-msgstr "重定向 '%ls' 中有非法文件描述符"
+msgid "Illegal file descriptor in redirection '%s'"
+msgstr "重定向 '%s' 中有非法文件描述符"
 
 msgid "Illegal instruction"
 msgstr "非法指令"
 
 #, c-format
-msgid "Incomplete escape sequence '%ls'"
-msgstr "不完整的转义序列 '%ls'"
+msgid "Incomplete escape sequence '%s'"
+msgstr "不完整的转义序列 '%s'"
 
 msgid "Information request"
 msgstr "信息请求"
 
 #, c-format
-msgid "Integer %lld in '%ls' followed by non-digit"
-msgstr "整数 %lld 于 '%ls' 中，后面跟随着非数字"
+msgid "Integer %d in '%s' followed by non-digit"
+msgstr "整数 %d 于 '%s' 中，后面跟随着非数字"
 
 msgid "Internal (non-forked) process events"
 msgstr "内部 (非 fork) 进程事件"
@@ -1240,31 +1228,31 @@ msgid "Invalid input/output redirection"
 msgstr "无效的输入/输出重定向"
 
 #, c-format
-msgid "Invalid number: %ls"
-msgstr "无效的数字：%ls"
+msgid "Invalid number: %s"
+msgstr "无效的数字：%s"
 
 #, c-format
-msgid "Invalid redirection target: %ls"
-msgstr "无效的重定向目标：%ls"
+msgid "Invalid redirection target: %s"
+msgstr "无效的重定向目标：%s"
 
 #, c-format
-msgid "Invalid redirection: %ls"
-msgstr "无效的重定向：%ls"
+msgid "Invalid redirection: %s"
+msgstr "无效的重定向：%s"
 
 #, c-format
-msgid "Invalid token '%ls'"
-msgstr "无效记号 '%ls'"
+msgid "Invalid token '%s'"
+msgstr "无效记号 '%s'"
 
 #, c-format
-msgid "Items %lu to %lu of %lu"
-msgstr "第 %lu 个至第 %lu 个项目，共 %lu 个"
+msgid "Items %u to %u of %u"
+msgstr "第 %u 个至第 %u 个项目，共 %u 个"
 
 msgid "Job\tGroup\t"
 msgstr "作业\t组\t"
 
 #, c-format
-msgid "Job control: %ls\n"
-msgstr "作业控制:%ls\n"
+msgid "Job control: %s\n"
+msgstr "作业控制:%s\n"
 
 msgid "Jobs being executed"
 msgstr "正在执行的作业"
@@ -1303,8 +1291,8 @@ msgid "Missing closing parenthesis"
 msgstr "缺少收尾括号"
 
 #, c-format
-msgid "Missing end to balance this %ls"
-msgstr "缺少结尾以平衡 %ls"
+msgid "Missing end to balance this %s"
+msgstr "缺少结尾以平衡 %s"
 
 msgid "Missing hexadecimal number in Unicode escape"
 msgstr "Unicode 转义序列中缺少十六进制数字"
@@ -1313,8 +1301,8 @@ msgid "Missing operator"
 msgstr "缺少运算符"
 
 #, c-format
-msgid "Modification of read-only variable \"%ls\" is not allowed\n"
-msgstr "不允许修改只读变量 \"%ls\"\n"
+msgid "Modification of read-only variable \"%s\" is not allowed\n"
+msgstr "不允许修改只读变量 \"%s\"\n"
 
 msgid "Negate exit status of job"
 msgstr "对作业退出代码取反"
@@ -1326,8 +1314,8 @@ msgid "No TTY for interactive shell (tcgetpgrp failed)"
 msgstr "交互 shell 没有 TTY (tcgetpgrp 失败)"
 
 #, c-format
-msgid "No matches for wildcard '%ls'. See `help wildcards-globbing`."
-msgstr "未找到通配符 '%ls' 的匹配项。参见 `help wildcards-globbing`。"
+msgid "No matches for wildcard '%s'. See `help wildcards-globbing`."
+msgstr "未找到通配符 '%s' 的匹配项。参见 `help wildcards-globbing`。"
 
 msgid "Not a function"
 msgstr "不是一个函数"
@@ -1370,12 +1358,12 @@ msgid "Perform a set of commands multiple times"
 msgstr "多次执行一组指令"
 
 #, fuzzy, c-format
-msgid "Please set $%ls to a directory where you have write access."
-msgstr "请将 $%ls 设置为您有写入权限的目录。"
+msgid "Please set $%s to a directory where you have write access."
+msgstr "请将 $%s 设置为您有写入权限的目录。"
 
 #, c-format
-msgid "Please set the %ls or HOME environment variable before starting fish."
-msgstr "请在启动 fish 前设置 %ls 或 HOME 环境变量。"
+msgid "Please set the %s or HOME environment variable before starting fish."
+msgstr "请在启动 fish 前设置 %s 或 HOME 环境变量。"
 
 msgid "Polite quit request"
 msgstr "请求温和退出"
@@ -1439,12 +1427,12 @@ msgid "Rendering the command line"
 msgstr "渲染命令行"
 
 #, c-format
-msgid "Requested redirection to '%ls', which is not a valid file descriptor"
-msgstr "请求重定向到 '%ls'，这不是一个有效的文件描述符"
+msgid "Requested redirection to '%s', which is not a valid file descriptor"
+msgstr "请求重定向到 '%s'，这不是一个有效的文件描述符"
 
 #, c-format
-msgid "Result too large: %ls"
-msgstr "结果太大：%ls"
+msgid "Result too large: %s"
+msgstr "结果太大：%s"
 
 msgid "Return a successful result"
 msgstr "返回一个成功的结果"
@@ -1477,12 +1465,12 @@ msgid "Searching/using paths"
 msgstr "搜索/使用路径"
 
 #, c-format
-msgid "Send job %d (%ls) to foreground\n"
-msgstr "将作业 %d (%ls) 发送到前台\n"
+msgid "Send job %d (%s) to foreground\n"
+msgstr "将作业 %d (%s) 发送到前台\n"
 
 #, fuzzy, c-format
-msgid "Send job %s '%ls' to background\n"
-msgstr "将作业 %s '%ls' 发送到后台\n"
+msgid "Send job %s '%s' to background\n"
+msgstr "将作业 %s '%s' 发送到后台\n"
 
 msgid "Send job to background"
 msgstr "将作业发送到后台"
@@ -1559,12 +1547,12 @@ msgid "Test a condition"
 msgstr "测试一个条件"
 
 #, c-format
-msgid "The '%ls' command can not be used immediately after a backgrounded job"
-msgstr "在后台作业之后无法立即使用 '%ls' 命令"
+msgid "The '%s' command can not be used immediately after a backgrounded job"
+msgstr "在后台作业之后无法立即使用 '%s' 命令"
 
 #, c-format
-msgid "The '%ls' command can not be used in a pipeline"
-msgstr "无法在管道中使用 '%ls' 命令"
+msgid "The '%s' command can not be used in a pipeline"
+msgstr "无法在管道中使用 '%s' 命令"
 
 msgid "The 'time' command may only be at the beginning of a pipeline"
 msgstr "'time' 命令只可以在管道开始的时候"
@@ -1586,8 +1574,8 @@ msgid "The expanded command was empty."
 msgstr "展开后的命令为空。"
 
 #, c-format
-msgid "The function '%ls' calls itself immediately, which would result in an infinite loop."
-msgstr "函数 '%ls' 立即调用自身，会导致无限循环。"
+msgid "The function '%s' calls itself immediately, which would result in an infinite loop."
+msgstr "函数 '%s' 立即调用自身，会导致无限循环。"
 
 msgid "The interactive reader/input system"
 msgstr "交互式阅读器/输入系统"
@@ -1626,23 +1614,23 @@ msgid "Trying to print invalid output"
 msgstr "尝试打印无效输出"
 
 #, c-format
-msgid "Unable to create temporary file '%ls': %s"
-msgstr "无法创建临时文件 '%ls': %s"
+msgid "Unable to create temporary file '%s': %s"
+msgstr "无法创建临时文件 '%s': %s"
 
 msgid "Unable to evaluate string substitution"
 msgstr "无法求值字符串替换"
 
 #, c-format
-msgid "Unable to expand variable name '%ls'"
-msgstr "无法展开变量名称 '%ls'"
+msgid "Unable to expand variable name '%s'"
+msgstr "无法展开变量名称 '%s'"
 
 #, fuzzy, c-format
-msgid "Unable to locate %ls directory derived from $%ls: '%ls'."
-msgstr "无法定位目录 %ls 导出自 $%ls：'%ls'。"
+msgid "Unable to locate %s directory derived from $%s: '%s'."
+msgstr "无法定位目录 %s 导出自 $%s：'%s'。"
 
 #, c-format
-msgid "Unable to locate the %ls directory."
-msgstr "无法找到目录 %ls。"
+msgid "Unable to locate the %s directory."
+msgstr "无法找到目录 %s。"
 
 #, c-format
 msgid "Unable to read input file: %s"
@@ -1689,23 +1677,23 @@ msgid "Unknown"
 msgstr "未知"
 
 #, c-format
-msgid "Unknown builtin '%ls'"
-msgstr "未知的内建命令 '%ls'"
+msgid "Unknown builtin '%s'"
+msgstr "未知的内建命令 '%s'"
 
 msgid "Unknown command"
 msgstr "未知的命令"
 
 #, c-format
-msgid "Unknown command. '%ls' exists but is not an executable file."
-msgstr "未知的命令。'%ls' 存在，但不是一个可执行文件。"
+msgid "Unknown command. '%s' exists but is not an executable file."
+msgstr "未知的命令。'%s' 存在，但不是一个可执行文件。"
 
 #, c-format
-msgid "Unknown command. A component of '%ls' is not a directory."
-msgstr "未知的命令。%ls 的一个组件不是目录。"
+msgid "Unknown command. A component of '%s' is not a directory."
+msgstr "未知的命令。%s 的一个组件不是目录。"
 
 #, c-format
-msgid "Unknown command. A component of '%ls' is not a directory. Check your $PATH."
-msgstr "未知的命令。%ls 的一个组件不是目录。检查你的 $PATH."
+msgid "Unknown command. A component of '%s' is not a directory. Check your $PATH."
+msgstr "未知的命令。%s 的一个组件不是目录。检查你的 $PATH."
 
 msgid "Unknown command:"
 msgstr "未知的命令："
@@ -1717,15 +1705,15 @@ msgid "Unknown function"
 msgstr "未知函数"
 
 #, c-format
-msgid "Unknown function '%ls'"
-msgstr "未知函数 '%ls'"
+msgid "Unknown function '%s'"
+msgstr "未知函数 '%s'"
 
 msgid "Unmatched wildcard"
 msgstr "未匹配的通配符"
 
 #, c-format
-msgid "Unsupported use of '='. In fish, please use 'set %ls %ls'."
-msgstr "不支持使用 '='。在 fish 中，请使用 'set %ls %ls'。"
+msgid "Unsupported use of '='. In fish, please use 'set %s %s'."
+msgstr "不支持使用 '='。在 fish 中，请使用 'set %s %s'。"
 
 msgid "Unused signal"
 msgstr "未使用的信号"
@@ -1743,16 +1731,16 @@ msgid "User defined signal 2"
 msgstr "用户定义的信号2"
 
 #, c-format
-msgid "Variable: %ls"
-msgstr "变量：%ls"
+msgid "Variable: %s"
+msgstr "变量：%s"
 
 #, c-format
-msgid "Variables cannot be bracketed. In fish, please use \"$%ls\"."
-msgstr "变量不能用方括号包围。在 fish 中，请使用 \"$%ls\"。"
+msgid "Variables cannot be bracketed. In fish, please use \"$%s\"."
+msgstr "变量不能用方括号包围。在 fish 中，请使用 \"$%s\"。"
 
 #, c-format
-msgid "Variables cannot be bracketed. In fish, please use {$%ls}."
-msgstr "变量不能用方括号包围。在 fish 中，请使用 {$%ls}。"
+msgid "Variables cannot be bracketed. In fish, please use {$%s}."
+msgstr "变量不能用方括号包围。在 fish 中，请使用 {$%s}。"
 
 msgid "Virtual timer expired"
 msgstr "虚拟计时器到期"
@@ -1782,16 +1770,16 @@ msgid "autoloading"
 msgstr "自动加载"
 
 #, c-format
-msgid "builtin %ls: %ls: %s\n"
-msgstr "内建 %ls: %ls: %s\n"
+msgid "builtin %s: %s: %s\n"
+msgstr "内建 %s: %s: %s\n"
 
 #, c-format
-msgid "builtin %ls: Invalid arg: %ls\n"
-msgstr "内建 %ls: 无效的参数：%ls\n"
+msgid "builtin %s: Invalid arg: %s\n"
+msgstr "内建 %s: 无效的参数：%s\n"
 
 #, c-format
-msgid "builtin %ls: realpath failed: %s\n"
-msgstr "内建 %ls: realpath 失败：%s\n"
+msgid "builtin %s: realpath failed: %s\n"
+msgstr "内建 %s: realpath 失败：%s\n"
 
 msgid "builtin history delete --exact requires --case-sensitive\n"
 msgstr "内建历史删除 --exact 需要 --case-sensitive\n"
@@ -1841,36 +1829,36 @@ msgstr "文件"
 
 #, c-format
 msgid ""
-"fish: %ls: missing man page\n"
+"fish: %s: missing man page\n"
 "Documentation may not be installed.\n"
-"`help %ls` will show an online version\n"
+"`help %s` will show an online version\n"
 msgstr ""
-"fish: %ls: 缺少 man page\n"
+"fish: %s: 缺少 man page\n"
 "文档可能未安装。\n"
-"`help %ls` 将显示在线版本\n"
+"`help %s` 将显示在线版本\n"
 
 #, c-format
-msgid "from sourcing file %ls\n"
-msgstr "从源文件 %ls\n"
+msgid "from sourcing file %s\n"
+msgstr "从源文件 %s\n"
 
 msgid "in command substitution\n"
 msgstr "在命令替换中\n"
 
 #, c-format
-msgid "in event handler: %ls\n"
-msgstr "在事件处理程序：%ls\n"
+msgid "in event handler: %s\n"
+msgstr "在事件处理程序：%s\n"
 
 #, c-format
-msgid "in function '%ls'"
-msgstr "在函数 '%ls' 中"
+msgid "in function '%s'"
+msgstr "在函数 '%s' 中"
 
 #, c-format
-msgid "invalid field width: %ls"
-msgstr "无效的字段宽度：%ls"
+msgid "invalid field width: %s"
+msgstr "无效的字段宽度：%s"
 
 #, c-format
-msgid "invalid precision: %ls"
-msgstr "无效的精度：%ls"
+msgid "invalid precision: %s"
+msgstr "无效的精度：%s"
 
 msgid "missing hexadecimal number in escape"
 msgstr "在转义中缺少十六进制数字"
@@ -1884,8 +1872,8 @@ msgid "or press ctrl-%c or ctrl-%c twice in a row."
 msgstr "或按下 ctrl-%c 键，或连续按两次 ctrl-%c 键。"
 
 #, fuzzy, c-format
-msgid "rows %lu to %lu of %lu"
-msgstr "第 %lu 行至第 %lu 行，共 %lu 行"
+msgid "rows %u to %u of %u"
+msgstr "第 %u 行至第 %u 行，共 %u 行"
 
 msgid "running"
 msgstr "运行中"
@@ -1897,15 +1885,15 @@ msgid "stopped"
 msgstr "已终止"
 
 #, c-format
-msgid "switch: Expected at most one argument, got %lu\n"
-msgstr "switch: 最多需要一个参数，但收到 %lu 个\n"
+msgid "switch: Expected at most one argument, got %u\n"
+msgstr "switch: 最多需要一个参数，但收到 %u 个\n"
 
 msgid "symlink"
 msgstr "符号链接"
 
 #, c-format
-msgid "ulimit: Permission denied when changing resource of type '%ls'\n"
-msgstr "ulimit: 更改类型 '%ls' 的资源时权限被拒绝\n"
+msgid "ulimit: Permission denied when changing resource of type '%s'\n"
+msgstr "ulimit: 更改类型 '%s' 的资源时权限被拒绝\n"
 
 msgid "unexported"
 msgstr "未导出"
@@ -1923,17 +1911,14 @@ msgstr "|& 无效。在 fish 中，用 &| 来同时管道链接 stdout 和 stder
 msgid "fish-section-tier1-from-script-explicitly-added"
 msgstr ""
 
-msgid "%ls: %ls: expected %d arguments; got %d\\n"
-msgstr "%ls: %ls: 期望 %d 个参数；收到 %d 个\\n"
-
-msgid "%ls: %ls: subcommand takes no options\\n"
-msgstr "%ls: %ls: 子命令不需要选项\\n"
-
-msgid "%ls: Expected at least %d args, got only %d\\n"
-msgstr "%ls: 需要至少 %d 个参数，只收到 %d 个\\n"
-
 msgid "%s: %s is an array variable. Use %svared%s %s[n]%s to edit the n:th element of %s\\n"
 msgstr "%s: %s 是一个数组变量。使用 %svared%s %s[n]%s 编辑第 n 个元素于 %s\\n"
+
+msgid "%s: %s: expected %d arguments; got %d\\n"
+msgstr "%s: %s: 期望 %d 个参数；收到 %d 个\\n"
+
+msgid "%s: %s: subcommand takes no options\\n"
+msgstr "%s: %s: 子命令不需要选项\\n"
 
 msgid "%s: Could not create configuration directory '%s'\\n"
 msgstr "%s: 无法创建配置目录 '%s'\\n"
@@ -1943,6 +1928,9 @@ msgstr "%s: 找不到网络浏览器。\\n"
 
 msgid "%s: Directory stack is empty…\\n"
 msgstr "%s: 目录栈为空...\\n"
+
+msgid "%s: Expected at least %d args, got only %d\\n"
+msgstr "%s: 需要至少 %d 个参数，只收到 %d 个\\n"
 
 msgid "%s: Expected exactly one argument, got %s.\\n\\nSynopsis:\\n\\t%svared%s VARIABLE\\n"
 msgstr "%s: 需要一个参数，收到 %s 个。\\n\\nSynopsis:\\n\\t%svared%s VARIABLE\\n"

--- a/share/functions/funced.fish
+++ b/share/functions/funced.fish
@@ -10,7 +10,7 @@ function funced --description 'Edit function definition'
     end
 
     if not set -q argv[1]
-        printf (_ "%ls: Expected at least %d args, got only %d\n") funced 1 0
+        printf (_ "%s: Expected at least %d args, got only %d\n") funced 1 0
         return 1
     end
 

--- a/share/functions/funcsave.fish
+++ b/share/functions/funcsave.fish
@@ -17,7 +17,7 @@ function funcsave --description "Save the current definition of all specified fu
     end
 
     if not set -q argv[1]
-        printf (_ "%ls: Expected at least %d args, got only %d\n") funcsave 1 0 >&2
+        printf (_ "%s: Expected at least %d args, got only %d\n") funcsave 1 0 >&2
         return 1
     end
 

--- a/share/functions/history.fish
+++ b/share/functions/history.fish
@@ -185,11 +185,11 @@ function history --description "display or manipulate interactive command histor
         case clear # clear the interactive command history
             if test -n "$search_mode"
                 or set -q show_time[1]
-                printf (_ "%ls: %ls: subcommand takes no options\n") history $hist_cmd >&2
+                printf (_ "%s: %s: subcommand takes no options\n") history $hist_cmd >&2
                 return 1
             end
             if set -q argv[1]
-                printf (_ "%ls: %ls: expected %d arguments; got %d\n") history $hist_cmd 0 (count $argv) >&2
+                printf (_ "%s: %s: expected %d arguments; got %d\n") history $hist_cmd 0 (count $argv) >&2
                 return 1
             end
 
@@ -214,7 +214,7 @@ function history --description "display or manipulate interactive command histor
 
             builtin history append $search_mode $show_time $max_count $_flag_case_sensitive $_flag_reverse $_flag_null -- $newitem
         case '*'
-            printf "%ls: unexpected subcommand '%ls'\n" $cmd $hist_cmd
+            printf "%s: unexpected subcommand '%s'\n" $cmd $hist_cmd
             return 2
     end
 end

--- a/share/functions/open.fish
+++ b/share/functions/open.fish
@@ -15,7 +15,7 @@ if not command -sq open
         end
 
         if not set -q argv[1]
-            printf (_ "%ls: Expected at least %d args, got only %d\n") open 1 0 >&2
+            printf (_ "%s: Expected at least %d args, got only %d\n") open 1 0 >&2
             return 1
         end
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -163,10 +163,10 @@ pub trait Node: Acceptor + AsNode + std::fmt::Debug {
         let mut res = ast_kind_to_string(self.kind()).to_owned();
         if let Some(n) = self.as_token() {
             let token_type = n.token_type().to_wstr();
-            sprintf!(=> &mut res, " '%ls'", token_type);
+            sprintf!(=> &mut res, " '%s'", token_type);
         } else if let Some(n) = self.as_keyword() {
             let keyword = n.keyword().to_wstr();
-            sprintf!(=> &mut res, " '%ls'", keyword);
+            sprintf!(=> &mut res, " '%s'", keyword);
         }
         res
     }
@@ -1447,23 +1447,23 @@ impl<N: Node> Ast<N> {
             if let Kind::Argument(n) = node.kind() {
                 result += "argument";
                 if let Some(argsrc) = n.try_source(orig) {
-                    sprintf!(=> &mut result, ": '%ls'", argsrc);
+                    sprintf!(=> &mut result, ": '%s'", argsrc);
                 }
             } else if let Some(n) = node.as_keyword() {
-                sprintf!(=> &mut result, "keyword: %ls", n.keyword().to_wstr());
+                sprintf!(=> &mut result, "keyword: %s", n.keyword().to_wstr());
             } else if let Some(n) = node.as_token() {
                 let desc = match n.token_type() {
                     ParseTokenType::string => {
                         let mut desc = WString::from_str("string");
                         if let Some(strsource) = n.try_source(orig) {
-                            sprintf!(=> &mut desc, ": '%ls'", strsource);
+                            sprintf!(=> &mut desc, ": '%s'", strsource);
                         }
                         desc
                     }
                     ParseTokenType::redirection => {
                         let mut desc = WString::from_str("redirection");
                         if let Some(strsource) = n.try_source(orig) {
-                            sprintf!(=> &mut desc, ": '%ls'", strsource);
+                            sprintf!(=> &mut desc, ": '%s'", strsource);
                         }
                         desc
                     }
@@ -1804,7 +1804,7 @@ impl<'s> NodeVisitorMut for Populator<'s> {
     fn will_visit_fields_of<N: NodeMut>(&mut self, node: &mut N) {
         FLOGF!(
             ast_construction,
-            "%*swill_visit %ls",
+            "%*swill_visit %s",
             self.spaces(),
             "",
             node.describe()
@@ -1881,7 +1881,7 @@ impl<'s> NodeVisitorMut for Populator<'s> {
                 self,
                 header_kw_range,
                 ParseErrorCode::generic,
-                "Missing end to balance this %ls",
+                "Missing end to balance this %s",
                 enclosing_stmt
             );
         } else {
@@ -1889,7 +1889,7 @@ impl<'s> NodeVisitorMut for Populator<'s> {
                 self,
                 token,
                 ParseErrorCode::generic,
-                "Expected %ls, but found %ls",
+                "Expected %s, but found %s",
                 keywords_user_presentable_description(error.allowed_keywords),
                 error.token.user_presentable_description(),
             );
@@ -1907,14 +1907,14 @@ impl<'s> NodeVisitorMut for Populator<'s> {
 fn keywords_user_presentable_description(kws: &'static [ParseKeyword]) -> WString {
     assert!(!kws.is_empty(), "Should not be empty list");
     if kws.len() == 1 {
-        return sprintf!("keyword '%ls'", kws[0]);
+        return sprintf!("keyword '%s'", kws[0]);
     }
     let mut res = L!("keywords ").to_owned();
     for (i, kw) in kws.iter().enumerate() {
         if i != 0 {
             res += L!(" or ");
         }
-        res += &sprintf!("'%ls'", *kw)[..];
+        res += &sprintf!("'%s'", *kw)[..];
     }
     res
 }
@@ -2032,7 +2032,7 @@ impl<'s> Populator<'s> {
                 internal_error!(
                     self,
                     list_kind_chomps_newlines,
-                    "Type %ls not handled",
+                    "Type %s not handled",
                     ast_kind_to_string(kind)
                 );
             }
@@ -2082,7 +2082,7 @@ impl<'s> Populator<'s> {
                 internal_error!(
                     self,
                     list_kind_chomps_semis,
-                    "Type %ls not handled",
+                    "Type %s not handled",
                     ast_kind_to_string(kind)
                 );
             }
@@ -2155,7 +2155,7 @@ impl<'s> Populator<'s> {
                 self,
                 tok,
                 ParseErrorCode::generic,
-                "Expected %ls, but found %ls",
+                "Expected %s, but found %s",
                 token_type_user_presentable_description(typ, ParseKeyword::None),
                 tok.user_presentable_description()
             );
@@ -2180,7 +2180,7 @@ impl<'s> Populator<'s> {
                 self,
                 tok,
                 ParseErrorCode::generic,
-                "Expected %ls, but found %ls",
+                "Expected %s, but found %s",
                 token_type_user_presentable_description(ParseTokenType::string, ParseKeyword::None),
                 tok.user_presentable_description()
             );
@@ -2219,7 +2219,7 @@ impl<'s> Populator<'s> {
                         internal_error!(
                             self,
                             consume_excess_token_generating_error,
-                            "Token %ls should not have prevented parsing a job list",
+                            "Token %s should not have prevented parsing a job list",
                             tok.user_presentable_description()
                         );
                     }
@@ -2244,7 +2244,7 @@ impl<'s> Populator<'s> {
                     self,
                     tok,
                     ParseErrorCode::generic,
-                    "Expected a string, but found %ls",
+                    "Expected a string, but found %s",
                     tok.user_presentable_description()
                 );
             }
@@ -2253,7 +2253,7 @@ impl<'s> Populator<'s> {
                     self,
                     tok,
                     ParseErrorCode::from(tok.tok_error),
-                    "%ls",
+                    "%s",
                     tok.tok_error
                 );
             }
@@ -2275,7 +2275,7 @@ impl<'s> Populator<'s> {
                 internal_error!(
                     self,
                     consume_excess_token_generating_error,
-                    "Unexpected excess token type: %ls",
+                    "Unexpected excess token type: %s",
                     tok.user_presentable_description()
                 );
             }
@@ -2301,7 +2301,7 @@ impl<'s> Populator<'s> {
             // Mark in the list that it was unwound.
             FLOGF!(
                 ast_construction,
-                "%*sunwinding %ls",
+                "%*sunwinding %s",
                 self.spaces(),
                 "",
                 ast_kind_to_string(list.kind())
@@ -2379,7 +2379,7 @@ impl<'s> Populator<'s> {
 
         FLOGF!(
             ast_construction,
-            "%*s%ls size: %lu",
+            "%*s%s size: %u",
             self.spaces(),
             "",
             ast_kind_to_string(list.kind()),
@@ -2403,7 +2403,7 @@ impl<'s> Populator<'s> {
                     slf,
                     slf.peek_token(0),
                     ParseErrorCode::generic,
-                    "Expected %s, but found %ls",
+                    "Expected %s, but found %s",
                     token_type_user_presentable_description(
                         ParseTokenType::end,
                         ParseKeyword::None
@@ -2428,7 +2428,7 @@ impl<'s> Populator<'s> {
                 self,
                 self.peek_token(0),
                 ParseErrorCode::generic,
-                "Expected a command, but found %ls",
+                "Expected a command, but found %s",
                 self.peek_token(0).user_presentable_description()
             );
             return got_error(self);
@@ -2517,7 +2517,7 @@ impl<'s> Populator<'s> {
                     self,
                     self.peek_token(0),
                     ParseErrorCode::generic,
-                    "Expected a command, but found %ls",
+                    "Expected a command, but found %s",
                     self.peek_token(0).user_presentable_description()
                 );
                 return got_error(self);
@@ -2659,7 +2659,7 @@ impl<'s> Populator<'s> {
                 self,
                 self.peek_token(0),
                 ParseErrorCode::generic,
-                "Expected %ls, but found %ls",
+                "Expected %s, but found %s",
                 token_types_user_presentable_description(token.allowed_tokens()),
                 self.peek_token(0).user_presentable_description()
             );
@@ -2703,7 +2703,7 @@ impl<'s> Populator<'s> {
                     self,
                     self.peek_token(0),
                     ParseErrorCode::generic,
-                    "Expected %ls, but found %ls",
+                    "Expected %s, but found %s",
                     keywords_user_presentable_description(allowed_keywords),
                     self.peek_token(0).user_presentable_description(),
                 );

--- a/src/autoload.rs
+++ b/src/autoload.rs
@@ -116,12 +116,12 @@ impl Autoload {
                 match &path {
                     #[cfg(feature = "embed-data")]
                     AutoloadPath::Embedded(_) => {
-                        FLOGF!(autoload, "Embedded: %ls", cmd);
+                        FLOGF!(autoload, "Embedded: %s", cmd);
                     }
                     AutoloadPath::Path(path) => {
                         FLOGF!(
                             autoload,
-                            "Loading %ls from var %ls from path %ls",
+                            "Loading %s from var %s from path %s",
                             cmd,
                             self.env_var_name,
                             path
@@ -152,14 +152,14 @@ impl Autoload {
             AutoloadPath::Embedded(name) => {
                 use crate::common::str2wcstring;
                 use std::sync::Arc;
-                FLOGF!(autoload, "Loading embedded: %ls", name);
+                FLOGF!(autoload, "Loading embedded: %s", name);
                 let emfile = Asset::get(name).expect("Embedded file not found");
                 let src = str2wcstring(&emfile.data);
                 let mut widename = L!("embedded:").to_owned();
                 widename.push_str(name);
                 let ret = parser.eval_file_wstr(src, Arc::new(widename), &IoChain::new(), None);
                 if let Err(msg) = ret {
-                    eprintf!("%ls", msg);
+                    eprintf!("%s", msg);
                 }
             }
         }
@@ -527,8 +527,8 @@ fn test_autoload() {
         .is_none());
     assert!(autoload.get_autoloaded_commands().is_empty());
 
-    run!("touch %ls/file1.fish", p1);
-    run!("touch %ls/file2.fish", p2);
+    run!("touch %s/file1.fish", p1);
+    run!("touch %s/file2.fish", p2);
     autoload.invalidate_cache();
 
     assert!(!autoload.autoload_in_progress(L!("file1")));
@@ -586,11 +586,11 @@ fn test_autoload() {
         autoload.resolve_command_impl(L!("file1"), paths),
         AutoloadResult::Loaded
     ));
-    touch_file(&sprintf!("%ls/file1.fish", p1));
+    touch_file(&sprintf!("%s/file1.fish", p1));
     autoload.invalidate_cache();
     assert!(autoload.resolve_command_impl(L!("file1"), paths).is_some());
     autoload.mark_autoload_finished(L!("file1"));
 
-    run!(L!("rm -Rf %ls"), p1);
-    run!(L!("rm -Rf %ls"), p2);
+    run!(L!("rm -Rf %s"), p1);
+    run!(L!("rm -Rf %s"), p2);
 }

--- a/src/bin/fish.rs
+++ b/src/bin/fish.rs
@@ -156,7 +156,7 @@ fn source_config_in_directory(parser: &Parser, dir: &wstr) -> bool {
     if waccess(&config_pathname, libc::R_OK) != 0 {
         FLOGF!(
             config,
-            "not sourcing %ls (not readable or does not exist)",
+            "not sourcing %s (not readable or does not exist)",
             escaped_pathname
         );
         return false;
@@ -182,7 +182,7 @@ fn read_init(parser: &Parser, paths: &ConfigPaths) {
         let ret = parser.eval_file_wstr(src, fname, &IoChain::new(), None);
         parser.libdata_mut().within_fish_init = false;
         if let Err(msg) = ret {
-            eprintf!("%ls", msg);
+            eprintf!("%s", msg);
         }
     }
     #[cfg(not(feature = "embed-data"))]
@@ -196,7 +196,7 @@ fn read_init(parser: &Parser, paths: &ConfigPaths) {
             let escaped_pathname = escape(&datapath);
             FLOGF!(
                 error,
-                "Fish cannot find its asset files in '%ls'.\n\
+                "Fish cannot find its asset files in '%s'.\n\
                  Refusing to read configuration because of this.",
                 escaped_pathname,
             );
@@ -287,7 +287,7 @@ fn fish_parse_opt(args: &mut [WString], opts: &mut FishCmdOpts) -> ControlFlow<i
                 activate_flog_categories_by_pattern(w.woptarg.unwrap());
                 for cat in flog::categories::all_categories() {
                     if cat.enabled.load(Ordering::Relaxed) {
-                        printf!("Debug enabled for category: %ls\n", cat.name);
+                        printf!("Debug enabled for category: %s\n", cat.name);
                     }
                 }
             }
@@ -315,7 +315,7 @@ fn fish_parse_opt(args: &mut [WString], opts: &mut FishCmdOpts) -> ControlFlow<i
                 for cat in cats.iter() {
                     let desc = cat.description.localize();
                     // this is left-justified
-                    printf!("%-*ls %ls\n", name_width, cat.name, desc);
+                    printf!("%-*s %s\n", name_width, cat.name, desc);
                 }
                 return ControlFlow::Break(0);
             }
@@ -342,21 +342,21 @@ fn fish_parse_opt(args: &mut [WString], opts: &mut FishCmdOpts) -> ControlFlow<i
             }
             '?' => {
                 eprintf!(
-                    "%ls\n",
+                    "%s\n",
                     wgettext_fmt!(BUILTIN_ERR_UNKNOWN, "fish", args[w.wopt_index - 1])
                 );
                 return ControlFlow::Break(1);
             }
             ':' => {
                 eprintf!(
-                    "%ls\n",
+                    "%s\n",
                     wgettext_fmt!(BUILTIN_ERR_MISSING, "fish", args[w.wopt_index - 1])
                 );
                 return ControlFlow::Break(1);
             }
             ';' => {
                 eprintf!(
-                    "%ls\n",
+                    "%s\n",
                     wgettext_fmt!(BUILTIN_ERR_UNEXP_ARG, "fish", args[w.wopt_index - 1])
                 );
                 return ControlFlow::Break(1);
@@ -623,7 +623,7 @@ fn throwing_main() -> i32 {
                 if res.is_err() {
                     FLOGF!(
                         warning,
-                        wgettext!("Error while reading file %ls\n"),
+                        wgettext!("Error while reading file %s\n"),
                         path.to_string_lossy()
                     );
                 }

--- a/src/builtins/abbr.rs
+++ b/src/builtins/abbr.rs
@@ -48,7 +48,7 @@ impl Options {
 
         if cmds.len() > 1 {
             streams.err.append(wgettext_fmt!(
-                "%ls: Cannot combine options %ls\n",
+                "%s: Cannot combine options %s\n",
                 CMD,
                 join(&cmds, L!(", "))
             ));
@@ -63,28 +63,26 @@ impl Options {
         }
 
         if !self.add && self.position.is_some() {
-            streams.err.append(wgettext_fmt!(
-                "%ls: --position option requires --add\n",
-                CMD
-            ));
+            streams
+                .err
+                .append(wgettext_fmt!("%s: --position option requires --add\n", CMD));
             return false;
         }
         if !self.add && self.regex_pattern.is_some() {
             streams
                 .err
-                .append(wgettext_fmt!("%ls: --regex option requires --add\n", CMD));
+                .append(wgettext_fmt!("%s: --regex option requires --add\n", CMD));
             return false;
         }
         if !self.add && self.function.is_some() {
-            streams.err.append(wgettext_fmt!(
-                "%ls: --function option requires --add\n",
-                CMD
-            ));
+            streams
+                .err
+                .append(wgettext_fmt!("%s: --function option requires --add\n", CMD));
             return false;
         }
         if !self.add && self.set_cursor_marker.is_some() {
             streams.err.append(wgettext_fmt!(
-                "%ls: --set-cursor option requires --add\n",
+                "%s: --set-cursor option requires --add\n",
                 CMD
             ));
             return false;
@@ -96,7 +94,7 @@ impl Options {
             .unwrap_or(false)
         {
             streams.err.append(wgettext_fmt!(
-                "%ls: --set-cursor argument cannot be empty\n",
+                "%s: --set-cursor argument cannot be empty\n",
                 CMD
             ));
             return false;
@@ -182,7 +180,7 @@ fn abbr_list(opts: &Options, streams: &mut IoStreams) -> BuiltinResult {
     const subcmd: &wstr = L!("--list");
     if !opts.args.is_empty() {
         streams.err.append(wgettext_fmt!(
-            "%ls %ls: Unexpected argument -- '%ls'\n",
+            "%s %s: Unexpected argument -- '%s'\n",
             CMD,
             subcmd,
             &opts.args[0]
@@ -206,7 +204,7 @@ fn abbr_rename(opts: &Options, streams: &mut IoStreams) -> BuiltinResult {
 
     if opts.args.len() != 2 {
         streams.err.append(wgettext_fmt!(
-            "%ls %ls: Requires exactly two arguments\n",
+            "%s %s: Requires exactly two arguments\n",
             CMD,
             subcmd
         ));
@@ -215,17 +213,15 @@ fn abbr_rename(opts: &Options, streams: &mut IoStreams) -> BuiltinResult {
     let old_name = &opts.args[0];
     let new_name = &opts.args[1];
     if old_name.is_empty() || new_name.is_empty() {
-        streams.err.append(wgettext_fmt!(
-            "%ls %ls: Name cannot be empty\n",
-            CMD,
-            subcmd
-        ));
+        streams
+            .err
+            .append(wgettext_fmt!("%s %s: Name cannot be empty\n", CMD, subcmd));
         return Err(STATUS_INVALID_ARGS);
     }
 
     if contains_whitespace(new_name) {
         streams.err.append(wgettext_fmt!(
-            "%ls %ls: Abbreviation '%ls' cannot have spaces in the word\n",
+            "%s %s: Abbreviation '%s' cannot have spaces in the word\n",
             CMD,
             subcmd,
             new_name.as_utfstr()
@@ -235,7 +231,7 @@ fn abbr_rename(opts: &Options, streams: &mut IoStreams) -> BuiltinResult {
     abbrs::with_abbrs_mut(|abbrs| -> BuiltinResult {
         if !abbrs.has_name(old_name) {
             streams.err.append(wgettext_fmt!(
-                "%ls %ls: No abbreviation named %ls\n",
+                "%s %s: No abbreviation named %s\n",
                 CMD,
                 subcmd,
                 old_name.as_utfstr()
@@ -244,7 +240,7 @@ fn abbr_rename(opts: &Options, streams: &mut IoStreams) -> BuiltinResult {
         }
         if abbrs.has_name(new_name) {
             streams.err.append(wgettext_fmt!(
-                "%ls %ls: Abbreviation %ls already exists, cannot rename %ls\n",
+                "%s %s: Abbreviation %s already exists, cannot rename %s\n",
                 CMD,
                 subcmd,
                 new_name.as_utfstr(),
@@ -280,7 +276,7 @@ fn abbr_add(opts: &Options, streams: &mut IoStreams) -> BuiltinResult {
 
     if opts.args.len() < 2 && opts.function.is_none() {
         streams.err.append(wgettext_fmt!(
-            "%ls %ls: Requires at least two arguments\n",
+            "%s %s: Requires at least two arguments\n",
             CMD,
             subcmd
         ));
@@ -288,17 +284,15 @@ fn abbr_add(opts: &Options, streams: &mut IoStreams) -> BuiltinResult {
     }
 
     if opts.args.is_empty() || opts.args[0].is_empty() {
-        streams.err.append(wgettext_fmt!(
-            "%ls %ls: Name cannot be empty\n",
-            CMD,
-            subcmd
-        ));
+        streams
+            .err
+            .append(wgettext_fmt!("%s %s: Name cannot be empty\n", CMD, subcmd));
         return Err(STATUS_INVALID_ARGS);
     }
     let name = &opts.args[0];
     if name.chars().any(|c| c.is_whitespace()) {
         streams.err.append(wgettext_fmt!(
-            "%ls %ls: Abbreviation '%ls' cannot have spaces in the word\n",
+            "%s %s: Abbreviation '%s' cannot have spaces in the word\n",
             CMD,
             subcmd,
             name.as_utfstr()
@@ -319,17 +313,15 @@ fn abbr_add(opts: &Options, streams: &mut IoStreams) -> BuiltinResult {
 
         if let Err(error) = result {
             streams.err.append(wgettext_fmt!(
-                "%ls: Regular expression compile error: %ls\n",
+                "%s: Regular expression compile error: %s\n",
                 CMD,
                 error.error_message(),
             ));
             if let Some(offset) = error.offset() {
                 streams
                     .err
-                    .append(wgettext_fmt!("%ls: %ls\n", CMD, regex_pattern.as_utfstr()));
-                streams
-                    .err
-                    .append(sprintf!("%ls: %*ls\n", CMD, offset, "^"));
+                    .append(wgettext_fmt!("%s: %s\n", CMD, regex_pattern.as_utfstr()));
+                streams.err.append(sprintf!("%s: %*s\n", CMD, offset, "^"));
             }
             return Err(STATUS_INVALID_ARGS);
         }
@@ -359,7 +351,7 @@ fn abbr_add(opts: &Options, streams: &mut IoStreams) -> BuiltinResult {
         // This is to prevent accidental usage of e.g. `--function 'string replace'`
         if !valid_func_name(function) || contains_whitespace(function) {
             streams.err.append(wgettext_fmt!(
-                "%ls: Invalid function name: %ls\n",
+                "%s: Invalid function name: %s\n",
                 CMD,
                 function.as_utfstr()
             ));
@@ -387,7 +379,7 @@ fn abbr_add(opts: &Options, streams: &mut IoStreams) -> BuiltinResult {
     });
     if !opts.commands.is_empty() && position == Position::Command {
         streams.err.appendln(wgettext_fmt!(
-            "%ls: --command cannot be combined with --position command",
+            "%s: --command cannot be combined with --position command",
             CMD,
         ));
         return Err(STATUS_INVALID_ARGS);
@@ -501,7 +493,7 @@ pub fn abbr(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
             'p' => {
                 if opts.position.is_some() {
                     streams.err.append(wgettext_fmt!(
-                        "%ls: Cannot specify multiple positions\n",
+                        "%s: Cannot specify multiple positions\n",
                         CMD
                     ));
                     return Err(STATUS_INVALID_ARGS);
@@ -512,7 +504,7 @@ pub fn abbr(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
                     opts.position = Some(Position::Anywhere);
                 } else {
                     streams.err.append(wgettext_fmt!(
-                        "%ls: Invalid position '%ls'\n",
+                        "%s: Invalid position '%s'\n",
                         CMD,
                         w.woptarg.unwrap_or_default()
                     ));
@@ -525,7 +517,7 @@ pub fn abbr(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
             'r' => {
                 if opts.regex_pattern.is_some() {
                     streams.err.append(wgettext_fmt!(
-                        "%ls: Cannot specify multiple regex patterns\n",
+                        "%s: Cannot specify multiple regex patterns\n",
                         CMD
                     ));
                     return Err(STATUS_INVALID_ARGS);
@@ -535,7 +527,7 @@ pub fn abbr(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
             SET_CURSOR_SHORT => {
                 if opts.set_cursor_marker.is_some() {
                     streams.err.append(wgettext_fmt!(
-                        "%ls: Cannot specify multiple set-cursor options\n",
+                        "%s: Cannot specify multiple set-cursor options\n",
                         CMD
                     ));
                     return Err(STATUS_INVALID_ARGS);
@@ -558,7 +550,7 @@ pub fn abbr(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
             'U' => {
                 // Kept and made ineffective, so we warn.
                 streams.err.append(wgettext_fmt!(
-                    "%ls: Warning: Option '%ls' was removed and is now ignored",
+                    "%s: Warning: Option '%s' was removed and is now ignored",
                     cmd,
                     argv_read[w.wopt_index - 1]
                 ));

--- a/src/builtins/argparse.rs
+++ b/src/builtins/argparse.rs
@@ -10,7 +10,7 @@ const VAR_NAME_PREFIX: &wstr = L!("_flag_");
 
 localizable_consts!(
     BUILTIN_ERR_INVALID_OPT_SPEC
-    "%ls: Invalid option spec '%ls' at char '%lc'\n"
+    "%s: Invalid option spec '%s' at char '%c'\n"
 );
 
 #[derive(Default)]
@@ -146,7 +146,7 @@ fn check_for_mutually_exclusive_flags(
                             std::mem::swap(&mut flag1, &mut flag2);
                         }
                         streams.err.append(wgettext_fmt!(
-                            "%ls: %ls %ls: options cannot be used together\n",
+                            "%s: %s %s: options cannot be used together\n",
                             opts.name,
                             flag1,
                             flag2
@@ -168,7 +168,7 @@ fn parse_exclusive_args(opts: &mut ArgParseCmdOpts, streams: &mut IoStreams) -> 
         let xflags: Vec<_> = raw_xflags.split(',').collect();
         if xflags.len() < 2 {
             streams.err.append(wgettext_fmt!(
-                "%ls: exclusive flag string '%ls' is not valid\n",
+                "%s: exclusive flag string '%s' is not valid\n",
                 opts.name,
                 raw_xflags
             ));
@@ -186,7 +186,7 @@ fn parse_exclusive_args(opts: &mut ArgParseCmdOpts, streams: &mut IoStreams) -> 
                 exclusive_set.push(*short_equiv);
             } else {
                 streams.err.append(wgettext_fmt!(
-                    "%ls: exclusive flag '%ls' is not valid\n",
+                    "%s: exclusive flag '%s' is not valid\n",
                     opts.name,
                     flag
                 ));
@@ -215,7 +215,7 @@ fn parse_flag_modifiers<'args>(
         && s.char_at(0) != '&'
     {
         streams.err.append(wgettext_fmt!(
-            "%ls: Implicit int short flag '%lc' does not allow modifiers like '%lc'\n",
+            "%s: Implicit int short flag '%c' does not allow modifiers like '%c'\n",
             opts.name,
             opt_spec.short_flag,
             s.char_at(0)
@@ -277,7 +277,7 @@ fn parse_flag_modifiers<'args>(
 
     if opts.options.contains_key(&opt_spec.short_flag) {
         streams.err.append(wgettext_fmt!(
-            "%ls: Short flag '%lc' already defined\n",
+            "%s: Short flag '%c' already defined\n",
             opts.name,
             opt_spec.short_flag
         ));
@@ -309,7 +309,7 @@ fn parse_option_spec_sep<'args>(
         }
         if opts.implicit_int_flag != '\0' {
             streams.err.append(wgettext_fmt!(
-                "%ls: Implicit int flag '%lc' already defined\n",
+                "%s: Implicit int flag '%c' already defined\n",
                 opts.name,
                 opts.implicit_int_flag
             ));
@@ -351,7 +351,7 @@ fn parse_option_spec_sep<'args>(
         '#' => {
             if opts.implicit_int_flag != '\0' {
                 streams.err.append(wgettext_fmt!(
-                    "%ls: Implicit int flag '%lc' already defined\n",
+                    "%s: Implicit int flag '%c' already defined\n",
                     opts.name,
                     opts.implicit_int_flag
                 ));
@@ -395,7 +395,7 @@ fn parse_option_spec<'args>(
 ) -> bool {
     if option_spec.is_empty() {
         streams.err.append(wgettext_fmt!(
-            "%ls: An option spec must have at least a short or a long flag\n",
+            "%s: An option spec must have at least a short or a long flag\n",
             opts.name
         ));
         return false;
@@ -405,7 +405,7 @@ fn parse_option_spec<'args>(
     if !fish_iswalnum(s.char_at(0)) && s.char_at(0) != '#' && !(s.char_at(0) == '/' && s.len() > 1)
     {
         streams.err.append(wgettext_fmt!(
-            "%ls: Short flag '%lc' invalid, must be alphanum or '#'\n",
+            "%s: Short flag '%c' invalid, must be alphanum or '#'\n",
             opts.name,
             s.char_at(0)
         ));
@@ -432,7 +432,7 @@ fn parse_option_spec<'args>(
             opt_spec.long_flag = s.slice_to(long_flag_char_count);
             if opts.long_to_short_flag.contains_key(opt_spec.long_flag) {
                 streams.err.append(wgettext_fmt!(
-                    "%ls: Long flag '%ls' already defined\n",
+                    "%s: Long flag '%s' already defined\n",
                     opts.name,
                     opt_spec.long_flag
                 ));
@@ -480,7 +480,7 @@ fn collect_option_specs<'args>(
         if *optind == argc {
             streams
                 .err
-                .append(wgettext_fmt!("%ls: Missing -- separator\n", cmd));
+                .append(wgettext_fmt!("%s: Missing -- separator\n", cmd));
             return Err(STATUS_INVALID_ARGS);
         }
 
@@ -502,7 +502,7 @@ fn collect_option_specs<'args>(
     if counter > counter_max {
         streams
             .err
-            .append(wgettext_fmt!("%ls: Too many long-only options\n", cmd));
+            .append(wgettext_fmt!("%s: Too many long-only options\n", cmd));
         return Err(STATUS_INVALID_ARGS);
     }
 
@@ -557,7 +557,7 @@ fn parse_cmd_opts<'args>(
                     ArgType::NoArgument
                 } else {
                     streams.err.append(wgettext_fmt!(
-                        "%ls: Invalid --unknown-arguments value '%ls'\n",
+                        "%s: Invalid --unknown-arguments value '%s'\n",
                         cmd,
                         kind
                     ));
@@ -574,7 +574,7 @@ fn parse_cmd_opts<'args>(
                     let x = fish_wcstol(w.woptarg.unwrap()).unwrap_or(-1);
                     if x < 0 {
                         streams.err.append(wgettext_fmt!(
-                            "%ls: Invalid --min-args value '%ls'\n",
+                            "%s: Invalid --min-args value '%s'\n",
                             cmd,
                             w.woptarg.unwrap()
                         ));
@@ -588,7 +588,7 @@ fn parse_cmd_opts<'args>(
                     let x = fish_wcstol(w.woptarg.unwrap()).unwrap_or(-1);
                     if x < 0 {
                         streams.err.append(wgettext_fmt!(
-                            "%ls: Invalid --max-args value '%ls'\n",
+                            "%s: Invalid --max-args value '%s'\n",
                             cmd,
                             w.woptarg.unwrap()
                         ));
@@ -642,7 +642,7 @@ fn parse_cmd_opts<'args>(
         // The user didn't specify any option specs.
         streams
             .err
-            .append(wgettext_fmt!("%ls: Missing -- separator\n", cmd));
+            .append(wgettext_fmt!("%s: Missing -- separator\n", cmd));
         return Err(STATUS_INVALID_ARGS);
     }
 

--- a/src/builtins/bg.rs
+++ b/src/builtins/bg.rs
@@ -16,7 +16,7 @@ fn send_to_bg(
         if !jobs[job_pos].wants_job_control() {
             let job = &jobs[job_pos];
             streams.err.append(wgettext_fmt!(
-                "%ls: Can't put job %s, '%ls' to background because it is not under job control\n",
+                "%s: Can't put job %s, '%s' to background because it is not under job control\n",
                 cmd,
                 job.job_id().to_wstring(),
                 job.command()
@@ -26,7 +26,7 @@ fn send_to_bg(
 
         let job = &jobs[job_pos];
         streams.err.append(wgettext_fmt!(
-            "Send job %s '%ls' to background\n",
+            "Send job %s '%s' to background\n",
             job.job_id().to_wstring(),
             job.command()
         ));
@@ -66,7 +66,7 @@ pub fn bg(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Built
         let Some(job_pos) = job_pos else {
             streams
                 .err
-                .append(wgettext_fmt!("%ls: There are no suitable jobs\n", cmd));
+                .append(wgettext_fmt!("%s: There are no suitable jobs\n", cmd));
             return Err(STATUS_CMD_ERROR);
         };
 
@@ -83,7 +83,7 @@ pub fn bg(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Built
             Ok(Some(pid)) => Some(pid),
             _ => {
                 streams.err.append(wgettext_fmt!(
-                    "%ls: '%ls' is not a valid job specifier\n",
+                    "%s: '%s' is not a valid job specifier\n",
                     cmd,
                     arg
                 ));
@@ -103,7 +103,7 @@ pub fn bg(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Built
         } else {
             streams
                 .err
-                .append(wgettext_fmt!("%ls: Could not find job '%d'\n", cmd, pid));
+                .append(wgettext_fmt!("%s: Could not find job '%d'\n", cmd, pid));
         }
     }
 

--- a/src/builtins/bind.rs
+++ b/src/builtins/bind.rs
@@ -350,13 +350,13 @@ impl BuiltinBind {
                 if !self.opts.silent {
                     if seq.len() == 1 {
                         streams.err.append(wgettext_fmt!(
-                            "%ls: No binding found for key '%ls'\n",
+                            "%s: No binding found for key '%s'\n",
                             cmd,
                             seq[0]
                         ));
                     } else {
                         streams.err.append(wgettext_fmt!(
-                            "%ls: No binding found for key sequence '%ls'\n",
+                            "%s: No binding found for key sequence '%s'\n",
                             cmd,
                             eseq
                         ));
@@ -432,7 +432,7 @@ fn parse_cmd_opts(
             'h' => opts.print_help = true,
             'k' => {
                 streams.err.append(wgettext_fmt!(
-                    "%ls: the -k/--key syntax is no longer supported. See `bind --help` and `bind --key-names`\n",
+                    "%s: the -k/--key syntax is no longer supported. See `bind --help` and `bind --key-names`\n",
                     cmd,
                 ));
                 return Err(STATUS_INVALID_ARGS);
@@ -555,7 +555,7 @@ impl BuiltinBind {
             _ => {
                 streams
                     .err
-                    .append(wgettext_fmt!("%ls: Invalid state\n", cmd));
+                    .append(wgettext_fmt!("%s: Invalid state\n", cmd));
                 return Err(STATUS_CMD_ERROR);
             }
         }

--- a/src/builtins/block.rs
+++ b/src/builtins/block.rs
@@ -90,7 +90,7 @@ pub fn block(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Bu
     if opts.erase {
         if opts.scope != Scope::Unset {
             streams.err.append(wgettext_fmt!(
-                "%ls: Can not specify scope when removing block\n",
+                "%s: Can not specify scope when removing block\n",
                 cmd
             ));
             return Err(STATUS_INVALID_ARGS);
@@ -99,7 +99,7 @@ pub fn block(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Bu
         if parser.global_event_blocks.load(Ordering::Relaxed) == 0 {
             streams
                 .err
-                .append(wgettext_fmt!("%ls: No blocks defined\n", cmd));
+                .append(wgettext_fmt!("%s: No blocks defined\n", cmd));
             return Err(STATUS_CMD_ERROR);
         }
         parser.global_event_blocks.fetch_sub(1, Ordering::Relaxed);

--- a/src/builtins/cd.rs
+++ b/src/builtins/cd.rs
@@ -39,7 +39,7 @@ pub fn cd(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Built
             None => {
                 streams
                     .err
-                    .append(wgettext_fmt!("%ls: Could not find home directory\n", cmd));
+                    .append(wgettext_fmt!("%s: Could not find home directory\n", cmd));
                 return Err(STATUS_CMD_ERROR);
             }
         }
@@ -48,7 +48,7 @@ pub fn cd(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Built
     // Stop `cd ""` from crashing
     if dir_in.is_empty() {
         streams.err.append(wgettext_fmt!(
-            "%ls: Empty directory '%ls' does not exist\n",
+            "%s: Empty directory '%s' does not exist\n",
             cmd,
             dir_in
         ));
@@ -63,7 +63,7 @@ pub fn cd(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Built
     let dirs = path_apply_cdpath(dir_in, &pwd, vars);
     if dirs.is_empty() {
         streams.err.append(wgettext_fmt!(
-            "%ls: The directory '%ls' does not exist\n",
+            "%s: The directory '%s' does not exist\n",
             cmd,
             dir_in
         ));
@@ -132,41 +132,37 @@ pub fn cd(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Built
     }
 
     if best_errno == ENOTDIR {
-        streams.err.append(wgettext_fmt!(
-            "%ls: '%ls' is not a directory\n",
-            cmd,
-            dir_in
-        ));
+        streams
+            .err
+            .append(wgettext_fmt!("%s: '%s' is not a directory\n", cmd, dir_in));
     } else if !broken_symlink.is_empty() {
         streams.err.append(wgettext_fmt!(
-            "%ls: '%ls' is a broken symbolic link to '%ls'\n",
+            "%s: '%s' is a broken symbolic link to '%s'\n",
             cmd,
             broken_symlink,
             broken_symlink_target
         ));
     } else if best_errno == ELOOP {
         streams.err.append(wgettext_fmt!(
-            "%ls: Too many levels of symbolic links: '%ls'\n",
+            "%s: Too many levels of symbolic links: '%s'\n",
             cmd,
             dir_in
         ));
     } else if best_errno == ENOENT {
         streams.err.append(wgettext_fmt!(
-            "%ls: The directory '%ls' does not exist\n",
+            "%s: The directory '%s' does not exist\n",
             cmd,
             dir_in
         ));
     } else if best_errno == EACCES || best_errno == EPERM {
-        streams.err.append(wgettext_fmt!(
-            "%ls: Permission denied: '%ls'\n",
-            cmd,
-            dir_in
-        ));
+        streams
+            .err
+            .append(wgettext_fmt!("%s: Permission denied: '%s'\n", cmd, dir_in));
     } else {
         errno::set_errno(Errno(best_errno));
         wperror(L!("cd"));
         streams.err.append(wgettext_fmt!(
-            "%ls: Unknown error trying to locate directory '%ls'\n",
+            "%s: Unknown error trying to locate directory '%s'\n",
             cmd,
             dir_in
         ));

--- a/src/builtins/commandline.rs
+++ b/src/builtins/commandline.rs
@@ -393,7 +393,7 @@ pub fn commandline(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr])
             let Some(cmd) = input_function_get_code(arg) else {
                 streams
                     .err
-                    .append(wgettext_fmt!("%ls: Unknown input function '%ls'", cmd, arg));
+                    .append(wgettext_fmt!("%s: Unknown input function '%s'", cmd, arg));
                 builtin_print_error_trailer(parser, streams.err, cmd);
                 return Err(STATUS_INVALID_ARGS);
             };
@@ -517,7 +517,7 @@ pub fn commandline(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr])
             let Ok(new_coord) = usize::try_from(new_coord) else {
                 streams
                     .err
-                    .append(wgettext_fmt!("%ls: line/column index starts at 1", cmd));
+                    .append(wgettext_fmt!("%s: line/column index starts at 1", cmd));
                 builtin_print_error_trailer(parser, streams.err, cmd);
                 return Err(STATUS_INVALID_ARGS);
             };
@@ -529,7 +529,7 @@ pub fn commandline(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr])
                 ) else {
                     streams
                         .err
-                        .append(wgettext_fmt!("%ls: there is no line %ls\n", cmd, arg));
+                        .append(wgettext_fmt!("%s: there is no line %s\n", cmd, arg));
                     builtin_print_error_trailer(parser, streams.err, cmd);
                     return Err(STATUS_INVALID_ARGS);
                 };
@@ -544,7 +544,7 @@ pub fn commandline(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr])
                         .unwrap_or(rstate.text.len());
                 if line_offset + new_coord > next_line_offset {
                     streams.err.append(wgettext_fmt!(
-                        "%ls: column %ls exceeds line length\n",
+                        "%s: column %s exceeds line length\n",
                         cmd,
                         arg
                     ));
@@ -601,7 +601,7 @@ pub fn commandline(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr])
         let Some(selection) = rstate.selection else {
             return Err(STATUS_CMD_ERROR);
         };
-        streams.out.append(sprintf!("%lu\n", selection.start));
+        streams.out.append(sprintf!("%u\n", selection.start));
         return Ok(SUCCESS);
     }
 
@@ -609,7 +609,7 @@ pub fn commandline(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr])
         let Some(selection) = rstate.selection else {
             return Err(STATUS_CMD_ERROR);
         };
-        streams.out.append(sprintf!("%lu\n", selection.end));
+        streams.out.append(sprintf!("%u\n", selection.end));
         return Ok(SUCCESS);
     }
 
@@ -716,7 +716,7 @@ pub fn commandline(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr])
         } else {
             streams
                 .out
-                .append(sprintf!("%lu\n", current_cursor_pos - range.start));
+                .append(sprintf!("%u\n", current_cursor_pos - range.start));
         }
         return Ok(SUCCESS);
     }

--- a/src/builtins/complete.rs
+++ b/src/builtins/complete.rs
@@ -296,7 +296,7 @@ pub fn complete(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) ->
                     }
                 } else {
                     streams.err.append(wgettext_fmt!(
-                        "%ls: Invalid token '%ls'\n",
+                        "%s: Invalid token '%s'\n",
                         cmd,
                         w.woptarg.unwrap()
                     ));
@@ -318,7 +318,7 @@ pub fn complete(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) ->
                 if arg.is_empty() {
                     streams
                         .err
-                        .append(wgettext_fmt!("%ls: -s requires a non-empty string\n", cmd,));
+                        .append(wgettext_fmt!("%s: -s requires a non-empty string\n", cmd,));
                     return Err(STATUS_INVALID_ARGS);
                 }
             }
@@ -328,7 +328,7 @@ pub fn complete(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) ->
                 if arg.is_empty() {
                     streams
                         .err
-                        .append(wgettext_fmt!("%ls: -l requires a non-empty string\n", cmd,));
+                        .append(wgettext_fmt!("%s: -l requires a non-empty string\n", cmd,));
                     return Err(STATUS_INVALID_ARGS);
                 }
             }
@@ -338,7 +338,7 @@ pub fn complete(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) ->
                 if arg.is_empty() {
                     streams
                         .err
-                        .append(wgettext_fmt!("%ls: -o requires a non-empty string\n", cmd,));
+                        .append(wgettext_fmt!("%s: -o requires a non-empty string\n", cmd,));
                     return Err(STATUS_INVALID_ARGS);
                 }
             }
@@ -442,7 +442,7 @@ pub fn complete(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) ->
 
         if let Err(err_text) = parse_util_detect_errors_in_argument_list(&comp, &prefix) {
             streams.err.append(wgettext_fmt!(
-                "%ls: %ls: contains a syntax error\n",
+                "%s: %s: contains a syntax error\n",
                 cmd,
                 comp
             ));

--- a/src/builtins/contains.rs
+++ b/src/builtins/contains.rs
@@ -73,7 +73,7 @@ pub fn contains(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) ->
     } else {
         streams
             .err
-            .append(wgettext_fmt!("%ls: Key not specified\n", cmd));
+            .append(wgettext_fmt!("%s: Key not specified\n", cmd));
     }
 
     return Err(STATUS_CMD_ERROR);

--- a/src/builtins/disown.rs
+++ b/src/builtins/disown.rs
@@ -27,7 +27,7 @@ fn disown_job(cmd: &wstr, streams: &mut IoStreams, j: &Job) {
             }
         }
         streams.err.append(wgettext_fmt!(
-            "%ls: job %d ('%ls') was stopped and has been signalled to continue.\n",
+            "%s: job %d ('%s') was stopped and has been signalled to continue.\n",
             cmd,
             j.job_id(),
             j.command()
@@ -71,7 +71,7 @@ pub fn disown(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
         } else {
             streams
                 .err
-                .append(wgettext_fmt!("%ls: There are no suitable jobs\n", cmd));
+                .append(wgettext_fmt!("%s: There are no suitable jobs\n", cmd));
             retval = Err(STATUS_CMD_ERROR);
         }
     } else {
@@ -88,7 +88,7 @@ pub fn disown(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
                     None => {
                         // Invalid identifier
                         streams.err.append(wgettext_fmt!(
-                            "%ls: '%ls' is not a valid job specifier\n",
+                            "%s: '%s' is not a valid job specifier\n",
                             cmd,
                             arg
                         ));
@@ -98,7 +98,7 @@ pub fn disown(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
                     Some(pid) => parser.job_get_from_pid(pid).or_else(|| {
                         // Valid identifier but no such job
                         streams.err.append(wgettext_fmt!(
-                            "%ls: Could not find job '%d'\n",
+                            "%s: Could not find job '%d'\n",
                             cmd,
                             pid
                         ));

--- a/src/builtins/emit.rs
+++ b/src/builtins/emit.rs
@@ -16,7 +16,7 @@ pub fn emit(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
     let Some(event_name) = argv.get(opts.optind) else {
         streams
             .err
-            .append(sprintf!(L!("%ls: expected event name\n"), cmd));
+            .append(sprintf!(L!("%s: expected event name\n"), cmd));
         return Err(STATUS_INVALID_ARGS);
     };
 

--- a/src/builtins/fg.rs
+++ b/src/builtins/fg.rs
@@ -38,7 +38,7 @@ pub fn fg(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Built
             None => {
                 streams
                     .err
-                    .append(wgettext_fmt!("%ls: There are no suitable jobs\n", cmd));
+                    .append(wgettext_fmt!("%s: There are no suitable jobs\n", cmd));
                 return Err(STATUS_INVALID_ARGS);
             }
             Some((pos, j)) => {
@@ -58,13 +58,11 @@ pub fn fg(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Built
         if found_job {
             streams
                 .err
-                .append(wgettext_fmt!("%ls: Ambiguous job\n", cmd));
+                .append(wgettext_fmt!("%s: Ambiguous job\n", cmd));
         } else {
-            streams.err.append(wgettext_fmt!(
-                "%ls: '%ls' is not a job\n",
-                cmd,
-                argv[optind]
-            ));
+            streams
+                .err
+                .append(wgettext_fmt!("%s: '%s' is not a job\n", cmd, argv[optind]));
         }
 
         builtin_print_error_trailer(parser, streams.err, cmd);
@@ -89,7 +87,7 @@ pub fn fg(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Built
                 {
                     streams
                         .err
-                        .append(wgettext_fmt!("%ls: No suitable job: %d\n", cmd, raw_pid));
+                        .append(wgettext_fmt!("%s: No suitable job: %d\n", cmd, raw_pid));
                     job_pos = None;
                     job = None
                 } else {
@@ -97,7 +95,7 @@ pub fn fg(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Built
                     job_pos = Some(pos);
                     job = if !j.wants_job_control() {
                         streams.err.append(wgettext_fmt!(
-                            "%ls: Can't put job %d, '%ls' to foreground because it is not under job control\n",
+                            "%s: Can't put job %d, '%s' to foreground because it is not under job control\n",
                             cmd,
                             raw_pid,
                             j.command()

--- a/src/builtins/fish_indent.rs
+++ b/src/builtins/fish_indent.rs
@@ -997,7 +997,7 @@ fn do_indent(streams: &mut IoStreams, args: Vec<WString>) -> BuiltinResult {
         if args.is_empty() && i == 0 {
             if output_type == OutputType::File {
                 streams.err.appendln(wgettext_fmt!(
-                    "Expected file path to read/write for -w:\n\n $ %ls -w foo.fish",
+                    "Expected file path to read/write for -w:\n\n $ %s -w foo.fish",
                     PROGRAM_NAME.get().unwrap()
                 ));
                 return Err(STATUS_CMD_ERROR);
@@ -1299,7 +1299,7 @@ fn html_colorize(text: &wstr, colors: &[HighlightSpec]) -> Vec<u8> {
             html.push_str("</span>");
         }
         if i == 0 || color != last_color {
-            sprintf!(=> &mut html, "<span class=\"%ls\">", html_class_name_for_color(color));
+            sprintf!(=> &mut html, "<span class=\"%s\">", html_class_name_for_color(color));
         }
         last_color = color;
 

--- a/src/builtins/fish_key_reader.rs
+++ b/src/builtins/fish_key_reader.rs
@@ -200,7 +200,7 @@ fn parse_flags(
             }
             'v' => {
                 streams.out.appendln(wgettext_fmt!(
-                    "%ls, version %s",
+                    "%s, version %s",
                     PROGRAM_NAME.get().unwrap(),
                     crate::BUILD_VERSION
                 ));

--- a/src/builtins/function.rs
+++ b/src/builtins/function.rs
@@ -94,7 +94,7 @@ fn parse_cmd_opts(
                 if handling_named_arguments {
                     if is_read_only(&woptarg) {
                         streams.err.append(wgettext_fmt!(
-                            "%ls: variable '%ls' is read-only\n",
+                            "%s: variable '%s' is read-only\n",
                             cmd,
                             woptarg
                         ));
@@ -103,7 +103,7 @@ fn parse_cmd_opts(
                     opts.named_arguments.push(woptarg);
                 } else {
                     streams.err.append(wgettext_fmt!(
-                        "%ls: %ls: unexpected positional argument",
+                        "%s: %s: unexpected positional argument",
                         cmd,
                         woptarg
                     ));
@@ -116,7 +116,7 @@ fn parse_cmd_opts(
             's' => {
                 let Some(signal) = Signal::parse(w.woptarg.unwrap()) else {
                     streams.err.append(wgettext_fmt!(
-                        "%ls: Unknown signal '%ls'",
+                        "%s: Unknown signal '%s'",
                         cmd,
                         w.woptarg.unwrap()
                     ));
@@ -149,7 +149,7 @@ fn parse_cmd_opts(
                     };
                     if caller_id == 0 {
                         streams.err.append(wgettext_fmt!(
-                            "%ls: calling job for event handler not found",
+                            "%s: calling job for event handler not found",
                             cmd
                         ));
                         return STATUS_INVALID_ARGS;
@@ -161,7 +161,7 @@ fn parse_cmd_opts(
                 } else {
                     let Ok(pid @ 0..) = fish_wcstoi(woptarg) else {
                         streams.err.append(wgettext_fmt!(
-                            "%ls: %ls: invalid process id",
+                            "%s: %s: invalid process id",
                             cmd,
                             woptarg
                         ));
@@ -187,7 +187,7 @@ fn parse_cmd_opts(
                 let name = w.woptarg.unwrap().to_owned();
                 if is_read_only(&name) {
                     streams.err.append(wgettext_fmt!(
-                        "%ls: variable '%ls' is read-only\n",
+                        "%s: variable '%s' is read-only\n",
                         cmd,
                         name
                     ));
@@ -246,7 +246,7 @@ fn parse_cmd_opts(
 fn validate_function_name(function_name: &wstr, cmd: &wstr, streams: &mut IoStreams) -> c_int {
     if !valid_func_name(function_name) {
         streams.err.append(wgettext_fmt!(
-            "%ls: %ls: invalid function name",
+            "%s: %s: invalid function name",
             cmd,
             function_name,
         ));
@@ -254,7 +254,7 @@ fn validate_function_name(function_name: &wstr, cmd: &wstr, streams: &mut IoStre
     }
     if parser_keywords_is_reserved(function_name) {
         streams.err.append(wgettext_fmt!(
-            "%ls: %ls: cannot use reserved keyword as function name",
+            "%s: %s: cannot use reserved keyword as function name",
             cmd,
             function_name
         ));
@@ -314,7 +314,7 @@ pub fn function(
             }
         } else {
             streams.err.append(wgettext_fmt!(
-                "%ls: %ls: unexpected positional argument",
+                "%s: %s: unexpected positional argument",
                 cmd,
                 argv[optind],
             ));

--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -172,7 +172,7 @@ pub fn functions(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -
     if let Some(desc) = opts.description {
         if args.len() != 1 {
             streams.err.append(wgettext_fmt!(
-                "%ls: Expected exactly one function name\n",
+                "%s: Expected exactly one function name\n",
                 cmd
             ));
             builtin_print_error_trailer(parser, streams.err, cmd);
@@ -182,7 +182,7 @@ pub fn functions(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -
 
         if !function::exists(current_func, parser) {
             streams.err.append(wgettext_fmt!(
-                "%ls: Function '%ls' does not exist\n",
+                "%s: Function '%s' does not exist\n",
                 cmd,
                 current_func
             ));
@@ -280,7 +280,7 @@ pub fn functions(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -
             && !event::EVENT_FILTER_NAMES.contains(&opts.handlers_type.unwrap())
         {
             streams.err.append(wgettext_fmt!(
-                "%ls: Expected generic | variable | signal | exit | job-id for --handlers-type\n",
+                "%s: Expected generic | variable | signal | exit | job-id for --handlers-type\n",
                 cmd
             ));
             return Err(STATUS_INVALID_ARGS);
@@ -320,7 +320,7 @@ pub fn functions(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -
     if opts.copy {
         if args.len() != 2 {
             streams.err.append(wgettext_fmt!(
-                "%ls: Expected exactly two names (current function name, and new function name)\n",
+                "%s: Expected exactly two names (current function name, and new function name)\n",
                 cmd
             ));
             builtin_print_error_trailer(parser, streams.err, cmd);
@@ -331,7 +331,7 @@ pub fn functions(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -
 
         if !function::exists(current_func, parser) {
             streams.err.append(wgettext_fmt!(
-                "%ls: Function '%ls' does not exist\n",
+                "%s: Function '%s' does not exist\n",
                 cmd,
                 current_func
             ));
@@ -341,7 +341,7 @@ pub fn functions(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -
 
         if !valid_func_name(new_func) || parser_keywords_is_reserved(new_func) {
             streams.err.append(wgettext_fmt!(
-                "%ls: Illegal function name '%ls'\n",
+                "%s: Illegal function name '%s'\n",
                 cmd,
                 new_func
             ));
@@ -351,7 +351,7 @@ pub fn functions(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -
 
         if function::exists(new_func, parser) {
             streams.err.append(wgettext_fmt!(
-                "%ls: Function '%ls' already exists. Cannot create copy of '%ls'\n",
+                "%s: Function '%s' already exists. Cannot create copy of '%s'\n",
                 cmd,
                 new_func,
                 current_func
@@ -391,7 +391,7 @@ pub fn functions(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -
                 }
                 Some(path) => {
                     comment.push_utfstr(&wgettext_fmt!(
-                        "Defined in %ls @ line %d",
+                        "Defined in %s @ line %d",
                         path,
                         props.definition_lineno()
                     ));
@@ -406,7 +406,7 @@ pub fn functions(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -
                     }
                     Some(path) => {
                         comment.push_utfstr(&wgettext_fmt!(
-                            ", copied in %ls @ line %d",
+                            ", copied in %s @ line %d",
                             path,
                             props.copy_definition_lineno()
                         ));
@@ -420,7 +420,7 @@ pub fn functions(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -
 
         if !comment.is_empty() {
             def.push_utfstr(&sprintf!(
-                "# %ls\n%ls",
+                "# %s\n%s",
                 comment,
                 props.annotated_definition(arg)
             ));

--- a/src/builtins/history.rs
+++ b/src/builtins/history.rs
@@ -113,7 +113,7 @@ fn check_for_unexpected_hist_args(
     if opts.search_type.is_some() || opts.show_time_format.is_some() || opts.null_terminate {
         let subcmd_str = opts.hist_cmd.to_wstr();
         streams.err.append(wgettext_fmt!(
-            "%ls: %ls: subcommand takes no options\n",
+            "%s: %s: subcommand takes no options\n",
             cmd,
             subcmd_str
         ));
@@ -335,7 +335,7 @@ pub fn history(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> 
 
             if in_private_mode(parser.vars()) {
                 streams.err.append(wgettext_fmt!(
-                    "%ls: can't merge history in private mode\n",
+                    "%s: can't merge history in private mode\n",
                     cmd
                 ));
                 return Err(STATUS_INVALID_ARGS);

--- a/src/builtins/jobs.rs
+++ b/src/builtins/jobs.rs
@@ -110,7 +110,7 @@ fn builtin_jobs_print(j: &Job, mode: JobsPrintMode, header: bool, streams: &mut 
             }
 
             for p in j.processes() {
-                out += &sprintf!("%ls\n", p.argv0().unwrap())[..];
+                out += &sprintf!("%s\n", p.argv0().unwrap())[..];
             }
             streams.out.append(out);
         }
@@ -196,7 +196,7 @@ pub fn jobs(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
                 match fish_wcstoi(&arg[1..]).ok().filter(|&job_id| job_id >= 0) {
                     None => {
                         streams.err.append(wgettext_fmt!(
-                            "%ls: '%ls' is not a valid job id\n",
+                            "%s: '%s' is not a valid job id\n",
                             cmd,
                             arg
                         ));
@@ -217,7 +217,7 @@ pub fn jobs(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
                 match fish_wcstoi(arg).ok().and_then(Pid::new) {
                     None => {
                         streams.err.append(wgettext_fmt!(
-                            "%ls: '%ls' is not a valid process id\n",
+                            "%s: '%s' is not a valid process id\n",
                             cmd,
                             arg
                         ));
@@ -236,7 +236,7 @@ pub fn jobs(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
                 if mode != JobsPrintMode::PrintNothing {
                     streams
                         .err
-                        .append(wgettext_fmt!("%ls: No suitable job: %ls\n", cmd, arg));
+                        .append(wgettext_fmt!("%s: No suitable job: %s\n", cmd, arg));
                 }
                 return Err(STATUS_CMD_ERROR);
             }
@@ -256,7 +256,7 @@ pub fn jobs(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
         if !streams.out_is_redirected && mode != JobsPrintMode::PrintNothing {
             streams
                 .out
-                .append(wgettext_fmt!("%ls: There are no jobs\n", argv[0]));
+                .append(wgettext_fmt!("%s: There are no jobs\n", argv[0]));
         }
         return Err(STATUS_CMD_ERROR);
     }

--- a/src/builtins/math.rs
+++ b/src/builtins/math.rs
@@ -69,7 +69,7 @@ fn parse_cmd_opts(
                     if scale < 0 || scale > 15 {
                         streams
                             .err
-                            .append(wgettext_fmt!("%ls: %ls: invalid scale\n", cmd, optarg));
+                            .append(wgettext_fmt!("%s: %s: invalid scale\n", cmd, optarg));
                         return Err(STATUS_INVALID_ARGS);
                     }
                     // We know the value is in the range [0, 15]
@@ -89,7 +89,7 @@ fn parse_cmd_opts(
                 } else {
                     streams
                         .err
-                        .append(wgettext_fmt!("%ls: %ls: invalid mode\n", cmd, optarg));
+                        .append(wgettext_fmt!("%s: %s: invalid mode\n", cmd, optarg));
                     return Err(STATUS_INVALID_ARGS);
                 }
             }
@@ -103,7 +103,7 @@ fn parse_cmd_opts(
                     let base = fish_wcstoi(optarg).unwrap_or(-1);
                     if base != 8 && base != 16 {
                         streams.err.append(wgettext_fmt!(
-                            "%ls: %ls: invalid base value\n",
+                            "%s: %s: invalid base value\n",
                             cmd,
                             optarg
                         ));
@@ -159,7 +159,7 @@ fn format_double(mut v: f64, opts: &Options) -> WString {
     if opts.base == 16 {
         v = v.trunc();
         let mneg = if v.is_sign_negative() { "-" } else { "" };
-        return sprintf!("%s0x%lx", mneg, v.abs() as u64);
+        return sprintf!("%s0x%x", mneg, v.abs() as u64);
     } else if opts.base == 8 {
         v = v.trunc();
         if v == 0.0 {
@@ -167,7 +167,7 @@ fn format_double(mut v: f64, opts: &Options) -> WString {
             return WString::from_str("0");
         }
         let mneg = if v.is_sign_negative() { "-" } else { "" };
-        return sprintf!("%s0%lo", mneg, v.abs() as u64);
+        return sprintf!("%s0%o", mneg, v.abs() as u64);
     }
 
     v *= pow(10f64, opts.scale);
@@ -245,24 +245,24 @@ fn evaluate_expression(
 
             streams
                 .err
-                .append(sprintf!("%ls: Error: %ls\n", cmd, error_message));
-            streams.err.append(sprintf!("'%ls'\n", expression));
+                .append(sprintf!("%s: Error: %s\n", cmd, error_message));
+            streams.err.append(sprintf!("'%s'\n", expression));
 
             Err(STATUS_CMD_ERROR)
         }
         Err(err) => {
             streams.err.append(sprintf!(
-                L!("%ls: Error: %ls\n"),
+                L!("%s: Error: %s\n"),
                 cmd,
                 err.kind.describe_wstr()
             ));
-            streams.err.append(sprintf!("'%ls'\n", expression));
+            streams.err.append(sprintf!("'%s'\n", expression));
             let padding = WString::from_chars(vec![' '; err.position + 1]);
             if err.len >= 2 {
                 let tildes = WString::from_chars(vec!['~'; err.len - 2]);
-                streams.err.append(sprintf!("%ls^%ls^\n", padding, tildes));
+                streams.err.append(sprintf!("%s^%s^\n", padding, tildes));
             } else {
-                streams.err.append(sprintf!("%ls^\n", padding));
+                streams.err.append(sprintf!("%s^\n", padding));
             }
 
             Err(STATUS_CMD_ERROR)

--- a/src/builtins/path.rs
+++ b/src/builtins/path.rs
@@ -283,7 +283,7 @@ fn parse_opts<'args>(
                 let types_args = split_string_tok(w.woptarg.unwrap(), L!(","), None);
                 for t in types_args {
                     let Ok(r#type) = t.try_into() else {
-                        path_error!(streams, "%ls: Invalid type '%ls'\n", "path", t);
+                        path_error!(streams, "%s: Invalid type '%s'\n", "path", t);
                         return Err(STATUS_INVALID_ARGS);
                     };
                     *types |= r#type;
@@ -295,7 +295,7 @@ fn parse_opts<'args>(
                 let perms_args = split_string_tok(w.woptarg.unwrap(), L!(","), None);
                 for p in perms_args {
                     let Ok(perm) = p.try_into() else {
-                        path_error!(streams, "%ls: Invalid permission '%ls'\n", "path", p);
+                        path_error!(streams, "%s: Invalid permission '%s'\n", "path", p);
                         return Err(STATUS_INVALID_ARGS);
                     };
                     *perms |= perm;
@@ -709,7 +709,7 @@ fn path_sort(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Bu
         }
         None => wbasename,
         Some(k) => {
-            path_error!(streams, "%ls: Invalid sort key '%ls'\n", args[0], k);
+            path_error!(streams, "%s: Invalid sort key '%s'\n", args[0], k);
             return Err(STATUS_INVALID_ARGS);
         }
     };

--- a/src/builtins/printf.rs
+++ b/src/builtins/printf.rs
@@ -208,10 +208,10 @@ impl<'a, 'b> builtin_printf_state_t<'a, 'b> {
         if errcode != None && errcode != Some(Error::InvalidChar) && errcode != Some(Error::Empty) {
             match errcode.unwrap() {
                 Error::Overflow => {
-                    self.fatal_error(sprintf!("%ls: %ls", s, wgettext!("Number out of range")));
+                    self.fatal_error(sprintf!("%s: %s", s, wgettext!("Number out of range")));
                 }
                 Error::Empty => {
-                    self.fatal_error(sprintf!("%ls: %ls", s, wgettext!("Number was empty")));
+                    self.fatal_error(sprintf!("%s: %s", s, wgettext!("Number was empty")));
                 }
                 Error::InvalidChar => {
                     panic!("Unreachable");
@@ -219,11 +219,11 @@ impl<'a, 'b> builtin_printf_state_t<'a, 'b> {
             }
         } else if !end.is_empty() {
             if s.as_ptr() == end.as_ptr() {
-                self.fatal_error(wgettext_fmt!("%ls: expected a numeric value", s));
+                self.fatal_error(wgettext_fmt!("%s: expected a numeric value", s));
             } else {
                 // This isn't entirely fatal - the value should still be printed.
                 self.nonfatal_error(wgettext_fmt!(
-                    "%ls: value not completely converted (can't convert '%ls')",
+                    "%s: value not completely converted (can't convert '%s')",
                     s,
                     end
                 ));
@@ -472,10 +472,7 @@ impl<'a, 'b> builtin_printf_state_t<'a, 'b> {
                             if (c_int::MIN as i64) <= width && width <= (c_int::MAX as i64) {
                                 field_width = Some(width);
                             } else {
-                                self.fatal_error(wgettext_fmt!(
-                                    "invalid field width: %ls",
-                                    argv[0]
-                                ));
+                                self.fatal_error(wgettext_fmt!("invalid field width: %s", argv[0]));
                             }
                             argv = &argv[1..];
                             argc -= 1;
@@ -504,7 +501,7 @@ impl<'a, 'b> builtin_printf_state_t<'a, 'b> {
                                     precision = Some(-1);
                                 } else if (c_int::MAX as i64) < prec {
                                     self.fatal_error(wgettext_fmt!(
-                                        "invalid precision: %ls",
+                                        "invalid precision: %s",
                                         argv[0]
                                     ));
                                 } else {
@@ -530,7 +527,7 @@ impl<'a, 'b> builtin_printf_state_t<'a, 'b> {
                     let conversion = f.char_at(0);
                     if (conversion as usize) > 0xFF || !ok[conversion as usize] {
                         self.fatal_error(wgettext_fmt!(
-                            "%.*ls: invalid conversion specification",
+                            "%.*s: invalid conversion specification",
                             wstr_offset_in(f, directive_start) + 1,
                             directive_start
                         ));

--- a/src/builtins/printf.rs
+++ b/src/builtins/printf.rs
@@ -520,10 +520,6 @@ impl<'a, 'b> builtin_printf_state_t<'a, 'b> {
                         }
                     }
 
-                    while matches!(f.char_at(0), 'l' | 'L' | 'h' | 'j' | 't' | 'z') {
-                        f = &f[1..];
-                    }
-
                     let conversion = f.char_at(0);
                     if (conversion as usize) > 0xFF || !ok[conversion as usize] {
                         self.fatal_error(wgettext_fmt!(

--- a/src/builtins/pwd.rs
+++ b/src/builtins/pwd.rs
@@ -53,7 +53,7 @@ pub fn pwd(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Buil
             pwd = real_pwd;
         } else {
             streams.err.append(wgettext_fmt!(
-                "%ls: realpath failed: %s\n",
+                "%s: realpath failed: %s\n",
                 cmd,
                 errno().to_string()
             ));

--- a/src/builtins/random.rs
+++ b/src/builtins/random.rs
@@ -58,7 +58,7 @@ pub fn random(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
         if arg_count == 1 {
             streams
                 .err
-                .append(wgettext_fmt!("%ls: nothing to choose from\n", cmd));
+                .append(wgettext_fmt!("%s: nothing to choose from\n", cmd));
             return Err(STATUS_INVALID_ARGS);
         }
 
@@ -71,7 +71,7 @@ pub fn random(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
         if res.is_err() {
             streams
                 .err
-                .append(wgettext_fmt!("%ls: %ls: invalid integer\n", cmd, num));
+                .append(wgettext_fmt!("%s: %s: invalid integer\n", cmd, num));
         }
         return res;
     }
@@ -80,7 +80,7 @@ pub fn random(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
         if res.is_err() {
             streams
                 .err
-                .append(wgettext_fmt!("%ls: %ls: invalid integer\n", cmd, num));
+                .append(wgettext_fmt!("%s: %s: invalid integer\n", cmd, num));
         }
         return res;
     }
@@ -126,7 +126,7 @@ pub fn random(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
                 Ok(0) => {
                     streams
                         .err
-                        .append(wgettext_fmt!("%ls: STEP must be a positive integer\n", cmd,));
+                        .append(wgettext_fmt!("%s: STEP must be a positive integer\n", cmd,));
                     return Err(STATUS_INVALID_ARGS);
                 }
                 Ok(x) => step = x,
@@ -140,7 +140,7 @@ pub fn random(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
         _ => {
             streams
                 .err
-                .append(wgettext_fmt!("%ls: too many arguments\n", cmd,));
+                .append(wgettext_fmt!("%s: too many arguments\n", cmd,));
             return Err(STATUS_CMD_ERROR);
         }
     }

--- a/src/builtins/read.rs
+++ b/src/builtins/read.rs
@@ -125,7 +125,7 @@ fn parse_cmd_opts(
             }
             'i' => {
                 streams.err.append(wgettext_fmt!(
-                    "%ls: usage of -i for --silent is deprecated. Please use -s or --silent instead.\n",
+                    "%s: usage of -i for --silent is deprecated. Please use -s or --silent instead.\n",
                     cmd
                 ));
                 return Err(STATUS_INVALID_ARGS);
@@ -150,7 +150,7 @@ fn parse_cmd_opts(
                     Ok(n) if n >= 0 => NonZeroUsize::new(n.try_into().unwrap()),
                     Err(wutil::Error::Overflow) => {
                         streams.err.append(wgettext_fmt!(
-                            "%ls: Argument '%ls' is out of range\n",
+                            "%s: Argument '%s' is out of range\n",
                             cmd,
                             w.woptarg.unwrap()
                         ));
@@ -457,7 +457,7 @@ fn validate_read_args(
 ) -> BuiltinResult {
     if opts.prompt.is_some() && opts.prompt_str.is_some() {
         streams.err.append(wgettext_fmt!(
-            "%ls: Options %ls and %ls cannot be used together\n",
+            "%s: Options %s and %s cannot be used together\n",
             cmd,
             "-p",
             "-P",
@@ -468,7 +468,7 @@ fn validate_read_args(
 
     if opts.delimiter.is_some() && opts.one_line {
         streams.err.append(wgettext_fmt!(
-            "%ls: Options %ls and %ls cannot be used together\n",
+            "%s: Options %s and %s cannot be used together\n",
             cmd,
             "--delimiter",
             "--line"
@@ -477,7 +477,7 @@ fn validate_read_args(
     }
     if opts.one_line && opts.split_null {
         streams.err.append(wgettext_fmt!(
-            "%ls: Options %ls and %ls cannot be used together\n",
+            "%s: Options %s and %s cannot be used together\n",
             cmd,
             "-z",
             "--line"
@@ -572,7 +572,7 @@ fn validate_read_args(
         }
         if EnvVar::flags_for(arg).contains(EnvVarFlags::READ_ONLY) {
             streams.err.append(wgettext_fmt!(
-                "%ls: %ls: cannot overwrite read-only variable",
+                "%s: %s: cannot overwrite read-only variable",
                 cmd,
                 arg
             ));
@@ -613,7 +613,7 @@ pub fn read(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
     if streams.stdin_fd < 0 {
         streams
             .err
-            .append(wgettext_fmt!("%ls: stdin is closed\n", cmd));
+            .append(wgettext_fmt!("%s: stdin is closed\n", cmd));
         return Err(STATUS_CMD_ERROR);
     }
 

--- a/src/builtins/realpath.rs
+++ b/src/builtins/realpath.rs
@@ -90,7 +90,7 @@ pub fn realpath(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) ->
                 // realpath() just couldn't do it. Report the error and make it clear
                 // this is an error from our builtin, not the system's realpath.
                 streams.err.append(wgettext_fmt!(
-                    "builtin %ls: %ls: %s\n",
+                    "builtin %s: %s: %s\n",
                     cmd,
                     arg,
                     errno.to_string()
@@ -99,7 +99,7 @@ pub fn realpath(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) ->
                 // Who knows. Probably a bug in our wrealpath() implementation.
                 streams
                     .err
-                    .append(wgettext_fmt!("builtin %ls: Invalid arg: %ls\n", cmd, arg));
+                    .append(wgettext_fmt!("builtin %s: Invalid arg: %s\n", cmd, arg));
             }
 
             return Err(STATUS_CMD_ERROR);
@@ -117,7 +117,7 @@ pub fn realpath(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) ->
             streams.out.append(normalize_path(&absolute_arg, false));
         } else {
             streams.err.append(wgettext_fmt!(
-                "builtin %ls: realpath failed: %s\n",
+                "builtin %s: realpath failed: %s\n",
                 cmd,
                 errno().to_string()
             ));

--- a/src/builtins/set.rs
+++ b/src/builtins/set.rs
@@ -22,10 +22,10 @@ use crate::{
 
 localizable_consts!(
     MISMATCHED_ARGS
-    "%ls: given %d indexes but %d values\n"
+    "%s: given %d indexes but %d values\n"
 
     UVAR_ERR
-    "%ls: successfully set universal '%ls'; but a global by that name shadows it\n"
+    "%s: successfully set universal '%s'; but a global by that name shadows it\n"
 );
 
 #[derive(Debug, Clone)]
@@ -327,28 +327,28 @@ fn handle_env_return(retval: EnvStackSetResult, cmd: &wstr, key: &wstr, streams:
         EnvStackSetResult::Ok => (),
         EnvStackSetResult::Perm => {
             streams.err.append(wgettext_fmt!(
-                "%ls: Tried to change the read-only variable '%ls'\n",
+                "%s: Tried to change the read-only variable '%s'\n",
                 cmd,
                 key
             ));
         }
         EnvStackSetResult::Scope => {
             streams.err.append(wgettext_fmt!(
-                "%ls: Tried to modify the special variable '%ls' with the wrong scope\n",
+                "%s: Tried to modify the special variable '%s' with the wrong scope\n",
                 cmd,
                 key
             ));
         }
         EnvStackSetResult::Invalid => {
             streams.err.append(wgettext_fmt!(
-                "%ls: Tried to modify the special variable '%ls' to an invalid value\n",
+                "%s: Tried to modify the special variable '%s' to an invalid value\n",
                 cmd,
                 key
             ));
         }
         EnvStackSetResult::NotFound => {
             streams.err.append(wgettext_fmt!(
-                "%ls: The variable '%ls' does not exist\n",
+                "%s: The variable '%s' does not exist\n",
                 cmd,
                 key
             ));
@@ -389,7 +389,7 @@ impl std::fmt::Display for EnvArrayParseError {
             "{}",
             match self {
                 EnvArrayParseError::InvalidIndex(varname) =>
-                    wgettext_fmt!("%ls: Invalid index starting at '%ls'\n", "set", varname)
+                    wgettext_fmt!("%s: Invalid index starting at '%s'\n", "set", varname)
                         .to_string(),
             }
         )
@@ -428,7 +428,7 @@ fn split_var_and_indexes<'a>(
         Ok(split) => Some(split),
         Err(EnvArrayParseError::InvalidIndex(varname)) => {
             streams.err.append(wgettext_fmt!(
-                "%ls: Invalid index starting at '%ls'\n",
+                "%s: Invalid index starting at '%s'\n",
                 "set",
                 &varname,
             ));
@@ -657,7 +657,7 @@ fn show_scope(var_name: &wstr, scope: EnvMode, streams: &mut IoStreams, vars: &d
     };
     let vals = var.as_list();
     streams.out.append(wgettext_fmt!(
-        "$%ls: set in %ls scope, %ls,%ls with %d elements",
+        "$%s: set in %s scope, %s,%s with %d elements",
         var_name,
         scope_name,
         exportv,
@@ -694,7 +694,7 @@ fn show_scope(var_name: &wstr, scope: EnvMode, streams: &mut IoStreams, vars: &d
         );
         streams
             .out
-            .append(sprintf!("$%ls[%d]: |%ls|\n", var_name, i + 1, &escaped_val));
+            .append(sprintf!("$%s[%d]: |%s|\n", var_name, i + 1, &escaped_val));
     }
 }
 
@@ -720,7 +720,7 @@ fn show(cmd: &wstr, parser: &Parser, streams: &mut IoStreams, args: &[&wstr]) ->
                     EscapeStringStyle::Script(EscapeFlags::NO_PRINTABLES | EscapeFlags::NO_QUOTED),
                 );
                 streams.out.append(wgettext_fmt!(
-                    "$%ls: originally inherited as |%ls|\n",
+                    "$%s: originally inherited as |%s|\n",
                     name,
                     escaped_val
                 ));
@@ -738,7 +738,7 @@ fn show(cmd: &wstr, parser: &Parser, streams: &mut IoStreams, args: &[&wstr]) ->
 
             if arg.contains('[') {
                 streams.err.append(wgettext_fmt!(
-                    "%ls: `set --show` does not allow slices with the var names\n",
+                    "%s: `set --show` does not allow slices with the var names\n",
                     cmd
                 ));
                 builtin_print_error_trailer(parser, streams.err, cmd);
@@ -754,7 +754,7 @@ fn show(cmd: &wstr, parser: &Parser, streams: &mut IoStreams, args: &[&wstr]) ->
                     EscapeStringStyle::Script(EscapeFlags::NO_PRINTABLES | EscapeFlags::NO_QUOTED),
                 );
                 streams.out.append(wgettext_fmt!(
-                    "$%ls: originally inherited as |%ls|\n",
+                    "$%s: originally inherited as |%s|\n",
                     arg,
                     escaped_val
                 ));
@@ -931,7 +931,7 @@ fn set_internal(
             .append(wgettext_fmt!(BUILTIN_ERR_VARNAME, cmd, split.varname));
         if let Some(pos) = split.varname.chars().position(|c| c == '=') {
             streams.err.append(wgettext_fmt!(
-                "%ls: Did you mean `set %ls %ls`?",
+                "%s: Did you mean `set %s %s`?",
                 cmd,
                 &escape(&split.varname[..pos]),
                 &escape(&split.varname[pos + 1..])
@@ -948,7 +948,7 @@ fn set_internal(
             if *ind <= 0 {
                 streams
                     .err
-                    .append(wgettext_fmt!("%ls: array index out of bounds\n", cmd));
+                    .append(wgettext_fmt!("%s: array index out of bounds\n", cmd));
                 builtin_print_error_trailer(parser, streams.err, cmd);
                 return Err(STATUS_INVALID_ARGS);
             }
@@ -956,7 +956,7 @@ fn set_internal(
         // Append and prepend are disallowed.
         if opts.append || opts.prepend {
             streams.err.append(wgettext_fmt!(
-                "%ls: Cannot use --append or --prepend when assigning to a slice",
+                "%s: Cannot use --append or --prepend when assigning to a slice",
                 cmd
             ));
             builtin_print_error_trailer(parser, streams.err, cmd);

--- a/src/builtins/set_color.rs
+++ b/src/builtins/set_color.rs
@@ -99,12 +99,12 @@ pub fn set_color(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
             Err(UnknownColor(arg)) => {
                 streams
                     .err
-                    .append(wgettext_fmt!("%ls: Unknown color '%ls'\n", argv[0], arg));
+                    .append(wgettext_fmt!("%s: Unknown color '%s'\n", argv[0], arg));
                 return Err(STATUS_INVALID_ARGS);
             }
             Err(UnknownUnderlineStyle(arg)) => {
                 streams.err.append(wgettext_fmt!(
-                    "%ls: invalid underline style: %ls\n",
+                    "%s: invalid underline style: %s\n",
                     argv[0],
                     arg
                 ));

--- a/src/builtins/shared.rs
+++ b/src/builtins/shared.rs
@@ -24,84 +24,84 @@ pub const DEFAULT_READ_PROMPT: &wstr =
 localizable_consts!(
     /// Error message on missing argument.
     pub BUILTIN_ERR_MISSING
-    "%ls: %ls: option requires an argument\n"
+    "%s: %s: option requires an argument\n"
 
     /// Error message on unexpected argument.
     pub BUILTIN_ERR_UNEXP_ARG
-    "%ls: %ls: option does not take an argument\n"
+    "%s: %s: option does not take an argument\n"
 
     /// Error message on missing man page.
     pub BUILTIN_ERR_MISSING_HELP
-    "fish: %ls: missing man page\nDocumentation may not be installed.\n`help %ls` will show an online version\n"
+    "fish: %s: missing man page\nDocumentation may not be installed.\n`help %s` will show an online version\n"
 
     /// Error message on multiple scope levels for variables.
     pub BUILTIN_ERR_GLOCAL
-    "%ls: scope can be only one of: universal function global local\n"
+    "%s: scope can be only one of: universal function global local\n"
 
     /// Error message for specifying both export and unexport to set/read.
     pub BUILTIN_ERR_EXPUNEXP
-    "%ls: cannot both export and unexport\n"
+    "%s: cannot both export and unexport\n"
 
     /// Error message for specifying both path and unpath to set/read.
     pub BUILTIN_ERR_PATHUNPATH
-    "%ls: cannot both path and unpath\n"
+    "%s: cannot both path and unpath\n"
 
     /// Error message for unknown switch.
     pub BUILTIN_ERR_UNKNOWN
-    "%ls: %ls: unknown option\n"
+    "%s: %s: unknown option\n"
 
     /// Error message for invalid bind mode name.
     pub BUILTIN_ERR_BIND_MODE
-    "%ls: %ls: invalid mode name. See `help identifiers`\n"
+    "%s: %s: invalid mode name. See `help identifiers`\n"
 
     /// Error message when too many arguments are supplied to a builtin.
     pub BUILTIN_ERR_TOO_MANY_ARGUMENTS
-    "%ls: too many arguments\n"
+    "%s: too many arguments\n"
 
     /// Error message when integer expected
     pub BUILTIN_ERR_NOT_NUMBER
-    "%ls: %ls: invalid integer\n"
+    "%s: %s: invalid integer\n"
 
     /// Command that requires a subcommand was invoked without a recognized subcommand.
     pub BUILTIN_ERR_MISSING_SUBCMD
-    "%ls: missing subcommand\n"
+    "%s: missing subcommand\n"
 
     pub BUILTIN_ERR_INVALID_SUBCMD
-    "%ls: %ls: invalid subcommand\n"
+    "%s: %s: invalid subcommand\n"
 
     /// Error messages for unexpected args.
     pub BUILTIN_ERR_ARG_COUNT0
-    "%ls: missing argument\n"
+    "%s: missing argument\n"
 
     pub BUILTIN_ERR_ARG_COUNT1
-    "%ls: expected %d arguments; got %d\n"
+    "%s: expected %d arguments; got %d\n"
 
     pub BUILTIN_ERR_ARG_COUNT2
-    "%ls: %ls: expected %d arguments; got %d\n"
+    "%s: %s: expected %d arguments; got %d\n"
 
     pub BUILTIN_ERR_MIN_ARG_COUNT1
-    "%ls: expected >= %d arguments; got %d\n"
+    "%s: expected >= %d arguments; got %d\n"
 
     pub BUILTIN_ERR_MAX_ARG_COUNT1
-    "%ls: expected <= %d arguments; got %d\n"
+    "%s: expected <= %d arguments; got %d\n"
 
     /// Error message for invalid variable name.
     pub BUILTIN_ERR_VARNAME
-    "%ls: %ls: invalid variable name. See `help identifiers`\n"
+    "%s: %s: invalid variable name. See `help identifiers`\n"
 
     /// Error message on invalid combination of options.
     pub BUILTIN_ERR_COMBO
-    "%ls: invalid option combination\n"
+    "%s: invalid option combination\n"
 
     pub BUILTIN_ERR_COMBO2
-    "%ls: invalid option combination, %ls\n"
+    "%s: invalid option combination, %s\n"
 
     pub BUILTIN_ERR_COMBO2_EXCLUSIVE
-    "%ls: %ls %ls: options cannot be used together\n"
+    "%s: %s %s: options cannot be used together\n"
 
     /// The send stuff to foreground message.
     pub FG_MSG
-    "Send job %d (%ls) to foreground\n"
+    "Send job %d (%s) to foreground\n"
 );
 
 // Return values (`$status` values for fish scripts) for various situations.
@@ -530,7 +530,7 @@ pub fn builtin_run(parser: &Parser, argv: &mut [&wstr], streams: &mut IoStreams)
         // and we avoid 0.
         FLOGF!(
             warning,
-            "builtin %ls returned invalid exit code %d",
+            "builtin %s returned invalid exit code %d",
             argv[0],
             code
         );
@@ -631,7 +631,7 @@ pub fn builtin_print_help(parser: &Parser, streams: &mut IoStreams, cmd: &wstr) 
         return;
     }
     let name_esc = escape(cmd);
-    let cmd = sprintf!("__fish_print_help %ls ", &name_esc);
+    let cmd = sprintf!("__fish_print_help %s ", &name_esc);
     let res = parser.eval(&cmd, streams.io_chain);
     if res.status.normal_exited() && res.status.exit_code() == 2 {
         streams
@@ -708,7 +708,7 @@ pub fn builtin_print_error_trailer(parser: &Parser, b: &mut OutputStream, cmd: &
         b.push('\n');
     }
     b.append(wgettext_fmt!(
-        "(Type 'help %ls' for related documentation)\n",
+        "(Type 'help %s' for related documentation)\n",
         cmd
     ));
 }
@@ -991,7 +991,7 @@ fn builtin_break_continue(
     if !has_loop {
         streams
             .err
-            .append(wgettext_fmt!("%ls: Not inside of loop\n", argv[0]));
+            .append(wgettext_fmt!("%s: Not inside of loop\n", argv[0]));
         return Err(STATUS_CMD_ERROR);
     }
 
@@ -1034,7 +1034,7 @@ fn builtin_breakpoint(
             .map_or(true, |b| b.typ() == BlockType::breakpoint)
         {
             streams.err.append(wgettext_fmt!(
-                "%ls: Command not valid at an interactive prompt\n",
+                "%s: Command not valid at an interactive prompt\n",
                 cmd,
             ));
             return Err(STATUS_ILLEGAL_CMD);

--- a/src/builtins/source.rs
+++ b/src/builtins/source.rs
@@ -39,14 +39,14 @@ pub fn source(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
         if streams.stdin_fd < 0 {
             streams
                 .err
-                .append(wgettext_fmt!("%ls: stdin is closed\n", cmd));
+                .append(wgettext_fmt!("%s: stdin is closed\n", cmd));
             return Err(STATUS_CMD_ERROR);
         }
         // Either a bare `source` which means to implicitly read from stdin or an explicit `-`.
         if argc == optind && isatty(streams.stdin_fd) {
             // Don't implicitly read from the terminal.
             streams.err.append(wgettext_fmt!(
-                "%ls: missing filename argument or input redirection\n",
+                "%s: missing filename argument or input redirection\n",
                 cmd
             ));
             return Err(STATUS_CMD_ERROR);
@@ -61,7 +61,7 @@ pub fn source(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
             Err(_) => {
                 let esc = escape(args[optind]);
                 streams.err.append(wgettext_fmt!(
-                    "%ls: Error encountered while sourcing file '%ls':\n",
+                    "%s: Error encountered while sourcing file '%s':\n",
                     cmd,
                     &esc
                 ));
@@ -98,7 +98,7 @@ pub fn source(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
         Err(err) => {
             let esc = escape(&func_filename);
             streams.err.append(wgettext_fmt!(
-                "%ls: Error while reading file '%ls'\n",
+                "%s: Error while reading file '%s'\n",
                 cmd,
                 if esc == "-" { L!("<stdin>") } else { &esc }
             ));

--- a/src/builtins/status.rs
+++ b/src/builtins/status.rs
@@ -205,7 +205,7 @@ fn print_features(streams: &mut IoStreams) {
             L!("off")
         };
         streams.out.append(sprintf!(
-            "%-*ls%-3s %ls %ls\n",
+            "%-*s%-3s %s %s\n",
             max_len + 1,
             md.name,
             set,
@@ -237,7 +237,7 @@ fn parse_cmd_opts(
                         Ok(level) if level >= 0 => level,
                         Err(Error::Overflow) | Ok(_) => {
                             streams.err.append(wgettext_fmt!(
-                                "%ls: Invalid level value '%ls'\n",
+                                "%s: Invalid level value '%s'\n",
                                 cmd,
                                 arg
                             ));
@@ -273,7 +273,7 @@ fn parse_cmd_opts(
                 }
                 let Ok(job_mode) = w.woptarg.unwrap().try_into() else {
                     streams.err.append(wgettext_fmt!(
-                        "%ls: Invalid job control mode '%ls'\n",
+                        "%s: Invalid job control mode '%s'\n",
                         cmd,
                         w.woptarg.unwrap()
                     ));
@@ -340,7 +340,7 @@ struct Docs;
 pub fn status(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> BuiltinResult {
     localizable_consts!(
         #[allow(dead_code)]
-        NO_EMBEDDED_FILES_MSG "%ls: fish was not built with embedded files"
+        NO_EMBEDDED_FILES_MSG "%s: fish was not built with embedded files"
     );
 
     let cmd = args[0];
@@ -391,7 +391,7 @@ pub fn status(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
         };
         streams
             .out
-            .append(wgettext_fmt!("Job control: %ls\n", job_control_mode));
+            .append(wgettext_fmt!("Job control: %s\n", job_control_mode));
         streams.out.append(parser.stack_trace());
 
         return Ok(SUCCESS);
@@ -427,7 +427,7 @@ pub fn status(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
                     }
                     let Ok(new_mode) = args[0].try_into() else {
                         streams.err.append(wgettext_fmt!(
-                            "%ls: Invalid job control mode '%ls'\n",
+                            "%s: Invalid job control mode '%s'\n",
                             cmd,
                             args[0]
                         ));
@@ -554,7 +554,7 @@ pub fn status(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
             }
             if args[0] != "scroll-content-up" {
                 streams.err.appendln(wgettext_fmt!(
-                    "%s %s: unrecognized feature '%ls'",
+                    "%s %s: unrecognized feature '%s'",
                     cmd,
                     c.to_wstr(),
                     args[0]
@@ -727,7 +727,7 @@ pub fn status(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
                     let path = get_executable_path("fish");
                     if path.is_empty() {
                         streams.err.append(sprintf!(
-                            "%ls: Could not get executable path: '%s'\n",
+                            "%s: Could not get executable path: '%s'\n",
                             cmd,
                             Errno::last().to_string()
                         ));

--- a/src/builtins/string.rs
+++ b/src/builtins/string.rs
@@ -179,25 +179,25 @@ impl RegexError {
             Compile(pattern, e) => {
                 string_error!(
                     streams,
-                    "%ls: Regular expression compile error: %ls\n",
+                    "%s: Regular expression compile error: %s\n",
                     cmd,
                     &WString::from(e.error_message())
                 );
-                string_error!(streams, "%ls: %ls\n", cmd, pattern);
-                string_error!(streams, "%ls: %*ls\n", cmd, e.offset().unwrap_or(0), "^");
+                string_error!(streams, "%s: %s\n", cmd, pattern);
+                string_error!(streams, "%s: %*s\n", cmd, e.offset().unwrap_or(0), "^");
             }
             InvalidCaptureGroupName(name) => {
                 streams.err.append(wgettext_fmt!(
-                    "Modification of read-only variable \"%ls\" is not allowed\n",
+                    "Modification of read-only variable \"%s\" is not allowed\n",
                     name
                 ));
             }
             InvalidEscape(pattern) => {
                 string_error!(
                     streams,
-                    "%ls",
+                    "%s",
                     sprintf!(
-                        "%ls: Invalid escape sequence in pattern \"%ls\"\n",
+                        "%s: Invalid escape sequence in pattern \"%s\"\n",
                         cmd,
                         pattern
                     )

--- a/src/builtins/string/escape.rs
+++ b/src/builtins/string/escape.rs
@@ -21,7 +21,7 @@ impl StringSubCommand<'_> for Escape {
                 self.style = arg
                     .unwrap()
                     .try_into()
-                    .map_err(|_| invalid_args!("%ls: Invalid escape style '%ls'\n", name, arg))?
+                    .map_err(|_| invalid_args!("%s: Invalid escape style '%s'\n", name, arg))?
             }
             _ => return Err(StringError::UnknownOption),
         }

--- a/src/builtins/string/match.rs
+++ b/src/builtins/string/match.rs
@@ -54,7 +54,7 @@ impl<'args> StringSubCommand<'args> for Match<'args> {
                         .and_then(|v| NonZeroUsize::new(v as usize))
                         .ok_or_else(|| {
                             StringError::InvalidArgs(wgettext_fmt!(
-                                "%ls: Invalid max matches value '%ls'\n",
+                                "%s: Invalid max matches value '%s'\n",
                                 _n,
                                 arg
                             ))
@@ -324,7 +324,7 @@ impl<'opts, 'args> RegexMatcher<'opts, 'args> {
         let Some(cg) = cg else {
             if self.opts.invert_match && !self.opts.quiet {
                 if self.opts.index {
-                    streams.out.append(sprintf!("1 %lu\n", arg.len()));
+                    streams.out.append(sprintf!("1 %u\n", arg.len()));
                 } else {
                     streams.out.appendln(arg);
                 }
@@ -353,7 +353,7 @@ impl<'opts, 'args> RegexMatcher<'opts, 'args> {
             if self.opts.index {
                 streams
                     .out
-                    .append(sprintf!("%lu %lu\n", m.start() + 1, m.end() - m.start()));
+                    .append(sprintf!("%u %u\n", m.start() + 1, m.end() - m.start()));
             } else {
                 streams.out.appendln(&arg[m.start()..m.end()]);
             }
@@ -401,7 +401,7 @@ impl<'opts, 'args> WildCardMatcher<'opts, 'args> {
             self.total_matched += 1;
             if !self.opts.quiet {
                 if self.opts.index {
-                    streams.out.append(sprintf!("1 %lu\n", arg.len()));
+                    streams.out.append(sprintf!("1 %u\n", arg.len()));
                 } else {
                     streams.out.appendln(arg);
                 }

--- a/src/builtins/string/pad.rs
+++ b/src/builtins/string/pad.rs
@@ -36,7 +36,7 @@ impl StringSubCommand<'_> for Pad {
             'c' => {
                 let [pad_char] = arg.unwrap().as_char_slice() else {
                     return Err(invalid_args!(
-                        "%ls: Padding should be a character '%ls'\n",
+                        "%s: Padding should be a character '%s'\n",
                         name,
                         arg
                     ));
@@ -44,7 +44,7 @@ impl StringSubCommand<'_> for Pad {
                 let pad_char_width = fish_wcwidth(*pad_char);
                 if pad_char_width <= 0 {
                     return Err(invalid_args!(
-                        "%ls: Invalid padding character of width zero '%ls'\n",
+                        "%s: Invalid padding character of width zero '%s'\n",
                         name,
                         arg
                     ));
@@ -56,7 +56,7 @@ impl StringSubCommand<'_> for Pad {
             'w' => {
                 self.width = fish_wcstol(arg.unwrap())?
                     .try_into()
-                    .map_err(|_| invalid_args!("%ls: Invalid width value '%ls'\n", name, arg))?
+                    .map_err(|_| invalid_args!("%s: Invalid width value '%s'\n", name, arg))?
             }
             'C' => self.center = true,
             _ => return Err(StringError::UnknownOption),

--- a/src/builtins/string/repeat.rs
+++ b/src/builtins/string/repeat.rs
@@ -20,16 +20,17 @@ impl StringSubCommand<'_> for Repeat {
     fn parse_opt(&mut self, name: &wstr, c: char, arg: Option<&wstr>) -> Result<(), StringError> {
         match c {
             'n' => {
-                self.count =
-                    Some(fish_wcstol(arg.unwrap())?.try_into().map_err(|_| {
-                        invalid_args!("%ls: Invalid count value '%ls'\n", name, arg)
-                    })?)
+                self.count = Some(
+                    fish_wcstol(arg.unwrap())?
+                        .try_into()
+                        .map_err(|_| invalid_args!("%s: Invalid count value '%s'\n", name, arg))?,
+                )
             }
             'm' => {
                 self.max = Some(
                     fish_wcstol(arg.unwrap())?
                         .try_into()
-                        .map_err(|_| invalid_args!("%ls: Invalid max value '%ls'\n", name, arg))?,
+                        .map_err(|_| invalid_args!("%s: Invalid max value '%s'\n", name, arg))?,
                 )
             }
             'q' => self.quiet = true,
@@ -58,7 +59,7 @@ impl StringSubCommand<'_> for Repeat {
         *optind += 1;
 
         let Ok(Ok(count)) = fish_wcstol(arg).map(|count| count.try_into()) else {
-            string_error!(streams, "%ls: Invalid count value '%ls'\n", name, arg);
+            string_error!(streams, "%s: Invalid count value '%s'\n", name, arg);
             return Err(STATUS_INVALID_ARGS);
         };
 

--- a/src/builtins/string/replace.rs
+++ b/src/builtins/string/replace.rs
@@ -43,7 +43,7 @@ impl<'args> StringSubCommand<'args> for Replace<'args> {
                         .and_then(|v| NonZeroUsize::new(v as usize))
                         .ok_or_else(|| {
                             StringError::InvalidArgs(wgettext_fmt!(
-                                "%ls: Invalid max matches value '%ls'\n",
+                                "%s: Invalid max matches value '%s'\n",
                                 _n,
                                 arg
                             ))
@@ -104,7 +104,7 @@ impl<'args> StringSubCommand<'args> for Replace<'args> {
                 Err(e) => {
                     string_error!(
                         streams,
-                        "%ls: Regular expression substitute error: %ls\n",
+                        "%s: Regular expression substitute error: %s\n",
                         cmd,
                         e.error_message()
                     );

--- a/src/builtins/string/shorten.rs
+++ b/src/builtins/string/shorten.rs
@@ -49,7 +49,7 @@ impl<'args> StringSubCommand<'args> for Shorten<'args> {
                 self.max = Some(
                     fish_wcstol(arg.unwrap())?
                         .try_into()
-                        .map_err(|_| invalid_args!("%ls: Invalid max value '%ls'\n", name, arg))?,
+                        .map_err(|_| invalid_args!("%s: Invalid max value '%s'\n", name, arg))?,
                 )
             }
             'N' => self.no_newline = true,

--- a/src/builtins/string/split.rs
+++ b/src/builtins/string/split.rs
@@ -119,17 +119,17 @@ impl<'args> StringSubCommand<'args> for Split<'args> {
             'm' => {
                 self.max = fish_wcstol(arg.unwrap())?
                     .try_into()
-                    .map_err(|_| invalid_args!("%ls: Invalid max value '%ls'\n", name, arg))?
+                    .map_err(|_| invalid_args!("%s: Invalid max value '%s'\n", name, arg))?
             }
             'n' => self.no_empty = true,
             'f' => {
                 self.fields = arg.unwrap().try_into().map_err(|e| match e {
                     FieldParseError::Number => StringError::NotANumber,
                     FieldParseError::Range => {
-                        invalid_args!("%ls: Invalid range value for field '%ls'\n", name, arg)
+                        invalid_args!("%s: Invalid range value for field '%s'\n", name, arg)
                     }
                     FieldParseError::Field => {
-                        invalid_args!("%ls: Invalid fields value '%ls'\n", name, arg)
+                        invalid_args!("%s: Invalid fields value '%s'\n", name, arg)
                     }
                 })?;
             }

--- a/src/builtins/string/sub.rs
+++ b/src/builtins/string/sub.rs
@@ -22,22 +22,24 @@ impl StringSubCommand<'_> for Sub {
     fn parse_opt(&mut self, name: &wstr, c: char, arg: Option<&wstr>) -> Result<(), StringError> {
         match c {
             'l' => {
-                self.length =
-                    Some(fish_wcstol(arg.unwrap())?.try_into().map_err(|_| {
-                        invalid_args!("%ls: Invalid length value '%ls'\n", name, arg)
-                    })?)
+                self.length = Some(
+                    fish_wcstol(arg.unwrap())?
+                        .try_into()
+                        .map_err(|_| invalid_args!("%s: Invalid length value '%s'\n", name, arg))?,
+                )
             }
             's' => {
-                self.start =
-                    Some(fish_wcstol(arg.unwrap())?.try_into().map_err(|_| {
-                        invalid_args!("%ls: Invalid start value '%ls'\n", name, arg)
-                    })?)
+                self.start = Some(
+                    fish_wcstol(arg.unwrap())?
+                        .try_into()
+                        .map_err(|_| invalid_args!("%s: Invalid start value '%s'\n", name, arg))?,
+                )
             }
             'e' => {
                 self.end = Some(
                     fish_wcstol(arg.unwrap())?
                         .try_into()
-                        .map_err(|_| invalid_args!("%ls: Invalid end value '%ls'\n", name, arg))?,
+                        .map_err(|_| invalid_args!("%s: Invalid end value '%s'\n", name, arg))?,
                 )
             }
             'q' => self.quiet = true,

--- a/src/builtins/string/unescape.rs
+++ b/src/builtins/string/unescape.rs
@@ -23,7 +23,7 @@ impl StringSubCommand<'_> for Unescape {
                 self.style = arg
                     .unwrap()
                     .try_into()
-                    .map_err(|_| invalid_args!("%ls: Invalid style value '%ls'\n", name, arg))?
+                    .map_err(|_| invalid_args!("%s: Invalid style value '%s'\n", name, arg))?
             }
             _ => return Err(StringError::UnknownOption),
         }

--- a/src/builtins/test.rs
+++ b/src/builtins/test.rs
@@ -757,14 +757,14 @@ mod test_expressions {
                 if !parser.errors.is_empty() {
                     err.push_utfstr(&parser.errors[0]);
                 } else {
-                    sprintf!(=> err, "unexpected argument at index %lu: '%ls'",
+                    sprintf!(=> err, "unexpected argument at index %u: '%s'",
                              result.as_ref().unwrap().range().end + 1,
                              args[result.as_ref().unwrap().range().end]);
                 }
                 err.push('\n');
                 err.push_utfstr(&commandline);
                 err.push('\n');
-                err.push_utfstr(&sprintf!("%*ls%ls\n", len_to_err + 1, " ", "^"));
+                err.push_utfstr(&sprintf!("%*s%s\n", len_to_err + 1, " ", "^"));
             }
 
             if result.is_some() {
@@ -846,12 +846,12 @@ mod test_expressions {
                 if let Ok(prefix_int) = wcstoi_opts(arg, options) {
                     let _: i64 = prefix_int; // to help type inference
                     errors.push(wgettext_fmt!(
-                        "Integer %lld in '%ls' followed by non-digit",
+                        "Integer %d in '%s' followed by non-digit",
                         prefix_int,
                         arg
                     ));
                 } else {
-                    errors.push(wgettext_fmt!("Argument is not a number: '%ls'", arg));
+                    errors.push(wgettext_fmt!("Argument is not a number: '%s'", arg));
                 }
             } else if floating.is_ok_and(|x| x.is_nan()) {
                 // NaN is an error as far as we're concerned.
@@ -859,9 +859,9 @@ mod test_expressions {
             } else if floating.is_ok_and(|x| x.is_infinite()) {
                 errors.push(wgettext!("Number is infinite").to_owned());
             } else if integral == Err(Error::Overflow) {
-                errors.push(wgettext_fmt!("Result too large: %ls", arg));
+                errors.push(wgettext_fmt!("Result too large: %s", arg));
             } else {
-                errors.push(wgettext_fmt!("Invalid number: %ls", arg));
+                errors.push(wgettext_fmt!("Invalid number: %s", arg));
             }
             false
         }
@@ -1023,7 +1023,7 @@ pub fn test(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
     if feature_test(FeatureFlag::test_require_arg) {
         if argc == 0 {
             streams.err.appendln(wgettext_fmt!(
-                "%ls: Expected at least one argument",
+                "%s: Expected at least one argument",
                 program_name
             ));
             builtin_print_error_trailer(parser, streams.err, program_name);
@@ -1038,7 +1038,7 @@ pub fn test(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
     } else if argc == 0 {
         if should_flog!(deprecated_test) {
             streams.err.appendln(wgettext_fmt!(
-                "%ls: called with no arguments. This will be an error in future.",
+                "%s: called with no arguments. This will be an error in future.",
                 program_name
             ));
             streams.err.append(parser.current_line());
@@ -1048,7 +1048,7 @@ pub fn test(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
         if should_flog!(deprecated_test) {
             if args[0] != "-z" {
                 streams.err.appendln(wgettext_fmt!(
-                    "%ls: called with one argument. This will return false in future.",
+                    "%s: called with one argument. This will return false in future.",
                     program_name
                 ));
                 streams.err.append(parser.current_line());

--- a/src/builtins/type.rs
+++ b/src/builtins/type.rs
@@ -103,7 +103,7 @@ pub fn r#type(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
                     } else {
                         let lineno: i32 = props.definition_lineno();
                         comment.push_utfstr(&wgettext_fmt!(
-                            "Defined in %ls @ line %d",
+                            "Defined in %s @ line %d",
                             path,
                             lineno
                         ));
@@ -118,7 +118,7 @@ pub fn r#type(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
                         } else {
                             let lineno = props.copy_definition_lineno();
                             comment.push_utfstr(&wgettext_fmt!(
-                                ", copied in %ls @ line %d",
+                                ", copied in %s @ line %d",
                                 path,
                                 lineno
                             ));
@@ -131,11 +131,11 @@ pub fn r#type(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
                             streams.out.appendln(path);
                         }
                     } else if !opts.short_output {
-                        streams.out.append(wgettext_fmt!("%ls is a function", arg));
+                        streams.out.append(wgettext_fmt!("%s is a function", arg));
                         streams.out.appendln(wgettext!(" with definition"));
                         let mut def = WString::new();
                         def.push_utfstr(&sprintf!(
-                            "# %ls\n%ls",
+                            "# %s\n%s",
                             comment,
                             props.annotated_definition(arg)
                         ));
@@ -158,8 +158,8 @@ pub fn r#type(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
                             streams.out.append(def);
                         }
                     } else {
-                        streams.out.append(wgettext_fmt!("%ls is a function", arg));
-                        streams.out.append(wgettext_fmt!(" (%ls)\n", comment));
+                        streams.out.append(wgettext_fmt!("%s is a function", arg));
+                        streams.out.append(wgettext_fmt!(" (%s)\n", comment));
                     }
                 } else if opts.get_type {
                     streams.out.appendln(L!("function"));
@@ -177,7 +177,7 @@ pub fn r#type(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
                 return Ok(SUCCESS);
             }
             if !opts.get_type {
-                streams.out.append(wgettext_fmt!("%ls is a builtin\n", arg));
+                streams.out.append(wgettext_fmt!("%s is a builtin\n", arg));
             } else if opts.get_type {
                 streams.out.append(L!("builtin\n"));
             }
@@ -205,7 +205,7 @@ pub fn r#type(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
                 if opts.path || opts.force_path {
                     streams.out.appendln(path);
                 } else {
-                    streams.out.append(wgettext_fmt!("%ls is %ls\n", arg, path));
+                    streams.out.append(wgettext_fmt!("%s is %s\n", arg, path));
                 }
             } else if opts.get_type {
                 streams.out.appendln(L!("file"));
@@ -221,11 +221,9 @@ pub fn r#type(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
         }
 
         if found == 0 && !opts.query && !opts.path {
-            streams.err.append(wgettext_fmt!(
-                "%ls: Could not find '%ls'\n",
-                L!("type"),
-                arg
-            ));
+            streams
+                .err
+                .append(wgettext_fmt!("%s: Could not find '%s'\n", L!("type"), arg));
         }
     }
 

--- a/src/builtins/ulimit.rs
+++ b/src/builtins/ulimit.rs
@@ -40,7 +40,7 @@ fn print(resource: c_uint, hard: bool, streams: &mut IoStreams) {
     } else {
         streams
             .out
-            .append(wgettext_fmt!("%lu\n", l / get_multiplier(resource)));
+            .append(wgettext_fmt!("%u\n", l / get_multiplier(resource)));
     }
 }
 
@@ -65,7 +65,7 @@ fn print_all(hard: bool, streams: &mut IoStreams) {
             "(kB, "
         };
         streams.out.append(sprintf!(
-            "%-*ls %10ls-%lc) ",
+            "%-*s %10s-%c) ",
             w,
             resource.desc,
             unit,
@@ -75,10 +75,9 @@ fn print_all(hard: bool, streams: &mut IoStreams) {
         if l == RLIM_INFINITY {
             streams.out.append(wgettext!("unlimited\n"));
         } else {
-            streams.out.append(wgettext_fmt!(
-                "%lu\n",
-                l / get_multiplier(resource.resource)
-            ));
+            streams
+                .out
+                .append(wgettext_fmt!("%u\n", l / get_multiplier(resource.resource)));
         }
     }
 }
@@ -120,7 +119,7 @@ fn set_limit(
     if let Err(errno) = setrlimit(resource, rlim_cur, rlim_max) {
         if errno == Errno::EPERM {
             streams.err.append(wgettext_fmt!(
-                "ulimit: Permission denied when changing resource of type '%ls'\n",
+                "ulimit: Permission denied when changing resource of type '%s'\n",
                 get_desc(resource)
             ));
         } else {
@@ -257,7 +256,7 @@ pub fn ulimit(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
 
     if opts.what == -1 {
         streams.err.append(wgettext_fmt!(
-            "%ls: Resource limit not available on this operating system\n",
+            "%s: Resource limit not available on this operating system\n",
             cmd
         ));
 
@@ -291,7 +290,7 @@ pub fn ulimit(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
 
     let new_limit: rlim_t = if w.wopt_index == argc {
         streams.err.append(wgettext_fmt!(
-            "%ls: New limit cannot be an empty string\n",
+            "%s: New limit cannot be an empty string\n",
             cmd
         ));
         builtin_print_error_trailer(parser, streams.err, cmd);
@@ -311,7 +310,7 @@ pub fn ulimit(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
     } else if let Ok(limit) = fish_wcstol(w.argv[w.wopt_index]) {
         let Some(x) = get_multiplier(what).checked_mul(limit as rlim_t) else {
             streams.err.append(wgettext_fmt!(
-                "%ls: Invalid limit '%ls'\n",
+                "%s: Invalid limit '%s'\n",
                 cmd,
                 w.argv[w.wopt_index]
             ));
@@ -321,7 +320,7 @@ pub fn ulimit(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
         x
     } else {
         streams.err.append(wgettext_fmt!(
-            "%ls: Invalid limit '%ls'\n",
+            "%s: Invalid limit '%s'\n",
             cmd,
             w.argv[w.wopt_index]
         ));

--- a/src/builtins/wait.rs
+++ b/src/builtins/wait.rs
@@ -199,7 +199,7 @@ pub fn wait(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
             let mpid: i32 = fish_wcstoi(item).unwrap_or(-1);
             let Some(mpid) = Pid::new(mpid) else {
                 streams.err.append(wgettext_fmt!(
-                    "%ls: '%ls' is not a valid process id\n",
+                    "%s: '%s' is not a valid process id\n",
                     cmd,
                     item,
                 ));
@@ -207,7 +207,7 @@ pub fn wait(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
             };
             if !find_wait_handles(WaitHandleQuery::Pid(mpid), parser, &mut wait_handles) {
                 streams.err.append(wgettext_fmt!(
-                    "%ls: Could not find a job with process id '%d'\n",
+                    "%s: Could not find a job with process id '%d'\n",
                     cmd,
                     mpid,
                 ));
@@ -216,7 +216,7 @@ pub fn wait(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
             // argument is process name
             if !find_wait_handles(WaitHandleQuery::ProcName(item), parser, &mut wait_handles) {
                 streams.err.append(wgettext_fmt!(
-                    "%ls: Could not find child processes with the name '%ls'\n",
+                    "%s: Could not find child processes with the name '%s'\n",
                     cmd,
                     item,
                 ));

--- a/src/common.rs
+++ b/src/common.rs
@@ -1443,7 +1443,7 @@ pub fn reformat_for_screen(msg: &wstr, termsize: &Termsize) -> WString {
                 if line_width != 0 {
                     buff.push('\n');
                 }
-                buff += &sprintf!("%ls-\n", token)[..];
+                buff += &sprintf!("%s-\n", token)[..];
                 line_width = 0;
             } else {
                 // Print the token.

--- a/src/complete.rs
+++ b/src/complete.rs
@@ -62,13 +62,13 @@ use crate::{
 // description strings should be defined in the same file?
 
 /// Description for ~USER completion.
-static COMPLETE_USER_DESC: Lazy<&wstr> = Lazy::new(|| wgettext!("Home for %ls"));
+static COMPLETE_USER_DESC: Lazy<&wstr> = Lazy::new(|| wgettext!("Home for %s"));
 
 /// Description for short variables. The value is concatenated to this description.
-static COMPLETE_VAR_DESC_VAL: Lazy<&wstr> = Lazy::new(|| wgettext!("Variable: %ls"));
+static COMPLETE_VAR_DESC_VAL: Lazy<&wstr> = Lazy::new(|| wgettext!("Variable: %s"));
 
 /// Description for abbreviations.
-static ABBR_DESC: Lazy<&wstr> = Lazy::new(|| wgettext!("Abbreviation: %ls"));
+static ABBR_DESC: Lazy<&wstr> = Lazy::new(|| wgettext!("Abbreviation: %s"));
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, Debug)]
 pub struct CompletionMode {
@@ -1481,7 +1481,7 @@ impl<'ctx> Completer<'ctx> {
                     // a completion. By default we avoid using '=' and instead rely on '--switch
                     // switch-arg', since it is more commonly supported by homebrew getopt-like
                     // functions.
-                    let completion = sprintf!("%ls=", whole_opt.slice_from(offset));
+                    let completion = sprintf!("%s=", whole_opt.slice_from(offset));
 
                     // Append a long-style option with a mandatory trailing equal sign
                     if !self.completions.add(Completion::new(
@@ -1590,7 +1590,7 @@ impl<'ctx> Completer<'ctx> {
                     .result,
                 ExpandResultCode::error | ExpandResultCode::overflow,
             ) {
-                FLOGF!(complete, "Error while expanding string '%ls'", s);
+                FLOGF!(complete, "Error while expanding string '%s'", s);
             }
             Self::escape_opening_brackets(&mut self.completions[first_from_start..], s);
         }
@@ -1624,7 +1624,7 @@ impl<'ctx> Completer<'ctx> {
             .result,
             ExpandResultCode::error | ExpandResultCode::overflow
         ) {
-            FLOGF!(complete, "Error while expanding string '%ls'", sep_string);
+            FLOGF!(complete, "Error while expanding string '%s'", sep_string);
         }
 
         Self::escape_opening_brackets(&mut local_completions, s);
@@ -1823,7 +1823,7 @@ impl<'ctx> Completer<'ctx> {
                     ));
                     result = true;
                 } else if string_prefixes_string_case_insensitive(user_name, &pw_name) {
-                    let name = sprintf!("~%ls", &pw_name);
+                    let name = sprintf!("~%s", &pw_name);
                     let desc = sprintf!(*COMPLETE_USER_DESC, &pw_name);
 
                     // Append a user name
@@ -2367,20 +2367,20 @@ fn append_switch_short_arg(out: &mut WString, opt: char, arg: &wstr) {
         return;
     }
 
-    sprintf!(=> out, " -%lc %ls", opt, escape(arg));
+    sprintf!(=> out, " -%c %s", opt, escape(arg));
 }
 fn append_switch_long_arg(out: &mut WString, opt: &wstr, arg: &wstr) {
     if arg.is_empty() {
         return;
     }
 
-    sprintf!(=> out, " --%ls %ls", opt, escape(arg));
+    sprintf!(=> out, " --%s %s", opt, escape(arg));
 }
 fn append_switch_short(out: &mut WString, opt: char) {
-    sprintf!(=> out, " -%lc", opt);
+    sprintf!(=> out, " -%c", opt);
 }
 fn append_switch_long(out: &mut WString, opt: &wstr) {
-    sprintf!(=> out, " --%ls", opt);
+    sprintf!(=> out, " --%s", opt);
 }
 
 fn completion2string(index: &CompletionEntryIndex, o: &CompleteEntryOpt) -> WString {

--- a/src/env/config_paths.rs
+++ b/src/env/config_paths.rs
@@ -30,12 +30,12 @@ impl ConfigPaths {
         let paths = Self::from_exec_path(exec_path);
         FLOGF!(
             config,
-            "paths.sysconf: %ls",
+            "paths.sysconf: %s",
             paths.sysconf.display().to_string()
         );
         FLOGF!(
             config,
-            "paths.bin: %ls",
+            "paths.bin: %s",
             paths
                 .bin
                 .clone()
@@ -43,9 +43,9 @@ impl ConfigPaths {
                 .unwrap_or("|not found|".to_string()),
         );
         #[cfg(not(feature = "embed-data"))]
-        FLOGF!(config, "paths.data: %ls", paths.data.display().to_string());
+        FLOGF!(config, "paths.data: %s", paths.data.display().to_string());
         #[cfg(not(feature = "embed-data"))]
-        FLOGF!(config, "paths.doc: %ls", paths.doc.display().to_string());
+        FLOGF!(config, "paths.doc: %s", paths.doc.display().to_string());
         paths
     }
 

--- a/src/env_universal_common.rs
+++ b/src/env_universal_common.rs
@@ -633,7 +633,7 @@ pub fn default_vars_path() -> WString {
 }
 
 /// Error message.
-const PARSE_ERR: &wstr = L!("Unable to parse universal variable message: '%ls'");
+const PARSE_ERR: &wstr = L!("Unable to parse universal variable message: '%s'");
 
 /// Small note about not editing ~/.fishd manually. Inserted at the top of all .fishd files.
 const SAVE_MSG: &[u8] = b"# This file contains fish universal variable definitions.\n";
@@ -747,7 +747,7 @@ fn append_file_entry(
 
     // Append variable name like "fish_color_cwd".
     if !valid_var_name(key_in) {
-        FLOGF!(error, "Illegal variable name: '%ls'", key_in);
+        FLOGF!(error, "Illegal variable name: '%s'", key_in);
         success = false;
     }
     if success {

--- a/src/event.rs
+++ b/src/event.rs
@@ -632,7 +632,7 @@ pub fn print(streams: &mut IoStreams, type_filter: &wstr) {
             }
 
             last_type = std::mem::discriminant(&evt.desc);
-            streams.out.append(sprintf!("Event %ls\n", evt.desc.name()));
+            streams.out.append(sprintf!("Event %s\n", evt.desc.name()));
         }
 
         match &evt.desc {
@@ -640,18 +640,18 @@ pub fn print(streams: &mut IoStreams, type_filter: &wstr) {
                 let name: WString = signal.name().into();
                 streams
                     .out
-                    .append(sprintf!("%ls %ls\n", name, evt.function_name));
+                    .append(sprintf!("%s %s\n", name, evt.function_name));
             }
             EventDescription::ProcessExit { .. } | EventDescription::JobExit { .. } => {}
             EventDescription::CallerExit { .. } => {
                 streams
                     .out
-                    .append(sprintf!("caller-exit %ls\n", evt.function_name));
+                    .append(sprintf!("caller-exit %s\n", evt.function_name));
             }
             EventDescription::Variable { name: param } | EventDescription::Generic { param } => {
                 streams
                     .out
-                    .append(sprintf!("%ls %ls\n", param, evt.function_name));
+                    .append(sprintf!("%s %s\n", param, evt.function_name));
             }
             EventDescription::Any => unreachable!(),
         }

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -212,7 +212,7 @@ pub fn exec_job(parser: &Parser, job: &Job, block_io: IoChain) -> bool {
 
     FLOGF!(
         exec_job_exec,
-        "Executed job %d from command '%ls'",
+        "Executed job %d from command '%s'",
         job.job_id(),
         job.command()
     );
@@ -573,7 +573,7 @@ fn run_internal_process(p: &Process, outdata: Vec<u8>, errdata: Vec<u8>, ios: &I
 
     FLOGF!(
         proc_internal_proc,
-        "Created internal proc %llu to write output for proc '%ls'",
+        "Created internal proc %u to write output for proc '%s'",
         internal_proc.get_id(),
         p.argv0().unwrap()
     );
@@ -645,7 +645,7 @@ fn run_internal_process_or_short_circuit(
         if p.is_last_in_job {
             FLOGF!(
                 exec_job_status,
-                "Set status of job %d (%ls) to %d using short circuit",
+                "Set status of job %d (%s) to %d using short circuit",
                 j.job_id(),
                 j.preview(),
                 p.status().status_value()
@@ -758,7 +758,7 @@ fn fork_child_for_process(
     let count = FORK_COUNT.fetch_add(1, Ordering::Relaxed) + 1;
     FLOGF!(
         exec_fork,
-        "Fork #%d, pid %d fork external command for '%ls'",
+        "Fork #%d, pid %d fork external command for '%s'",
         count,
         pid,
         p.argv0().unwrap()
@@ -894,7 +894,7 @@ fn exec_external_command(
         };
         FLOGF!(
             exec_fork,
-            "Fork #%d, pid %d: spawn external command '%s' from '%ls'",
+            "Fork #%d, pid %d: spawn external command '%s' from '%s'",
             count,
             pid,
             p.actual_cmd,
@@ -1016,7 +1016,7 @@ fn get_performer_for_function(
     let Some(props) = function::get_props(p.argv0().unwrap()) else {
         FLOG!(
             error,
-            wgettext_fmt!("Unknown function '%ls'", p.argv0().unwrap())
+            wgettext_fmt!("Unknown function '%s'", p.argv0().unwrap())
         );
         return Err(());
     };

--- a/src/flog.rs
+++ b/src/flog.rs
@@ -267,7 +267,7 @@ fn apply_one_wildcard(wc_esc: &wstr, sense: bool) {
         }
     }
     if !match_found {
-        eprintf!("Failed to match debug category: %ls\n", wc_esc);
+        eprintf!("Failed to match debug category: %s\n", wc_esc);
     }
 }
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -56,11 +56,7 @@ pub fn create_temporary_file(name_template: &wstr) -> std::io::Result<(File, WSt
                 _ => {
                     FLOG!(
                         error,
-                        wgettext_fmt!(
-                            "Unable to create temporary file '%ls': %s",
-                            name_template,
-                            e
-                        )
+                        wgettext_fmt!("Unable to create temporary file '%s': %s", name_template, e)
                     );
 
                     return Err(e);

--- a/src/function.rs
+++ b/src/function.rs
@@ -448,10 +448,10 @@ impl FunctionProperties {
             let d = &handler.desc;
             match d {
                 EventDescription::Signal { signal } => {
-                    sprintf!(=> &mut out, " --on-signal %ls", signal.name());
+                    sprintf!(=> &mut out, " --on-signal %s", signal.name());
                 }
                 EventDescription::Variable { name } => {
-                    sprintf!(=> &mut out, " --on-variable %ls", name);
+                    sprintf!(=> &mut out, " --on-variable %s", name);
                 }
                 EventDescription::ProcessExit { pid } => {
                     let pid = pid.map(|p| p.get()).unwrap_or(0);
@@ -465,7 +465,7 @@ impl FunctionProperties {
                     out.push_str(" --on-job-exit caller");
                 }
                 EventDescription::Generic { param } => {
-                    sprintf!(=> &mut out, " --on-event %ls", param);
+                    sprintf!(=> &mut out, " --on-event %s", param);
                 }
                 EventDescription::Any => {
                     panic!("Unexpected event handler type");
@@ -476,7 +476,7 @@ impl FunctionProperties {
         let named = &self.named_arguments;
         if !named.is_empty() {
             for name in named {
-                sprintf!(=> &mut out, " --argument-names %ls", name);
+                sprintf!(=> &mut out, " --argument-names %s", name);
             }
         }
 
@@ -490,7 +490,7 @@ impl FunctionProperties {
         for (name, values) in self.inherit_vars.iter() {
             // We don't know what indentation style the function uses,
             // so we do what fish_indent would.
-            sprintf!(=> &mut out, "\n    set -l %ls", name);
+            sprintf!(=> &mut out, "\n    set -l %s", name);
             for arg in values {
                 out.push(' ');
                 out.push_utfstr(&escape(arg));

--- a/src/history.rs
+++ b/src/history.rs
@@ -461,7 +461,7 @@ impl HistoryImpl {
             }
         }
 
-        FLOGF!(history, "Loaded %lu old items", self.old_item_offsets.len());
+        FLOGF!(history, "Loaded %u old items", self.old_item_offsets.len());
     }
 
     /// Loads old items if necessary.
@@ -619,7 +619,7 @@ impl HistoryImpl {
     fn save_internal_via_rewrite(&mut self, history_path: &wstr) -> std::io::Result<()> {
         FLOGF!(
             history,
-            "Saving %lu items via rewrite",
+            "Saving %u items via rewrite",
             self.new_items.len() - self.first_unwritten_new_item_index
         );
 
@@ -652,7 +652,7 @@ impl HistoryImpl {
     fn save_internal_via_appending(&mut self, history_path: &wstr) -> std::io::Result<()> {
         FLOGF!(
             history,
-            "Saving %lu items via appending",
+            "Saving %u items via appending",
             self.new_items.len() - self.first_unwritten_new_item_index
         );
         // No deleting allowed.
@@ -1725,7 +1725,7 @@ pub fn history_session_id_from_var(history_name_var: Option<EnvVar>) -> WString 
         FLOG!(
             error,
             wgettext_fmt!(
-                "History session ID '%ls' is not a valid variable name. Falling back to `%ls`.",
+                "History session ID '%s' is not a valid variable name. Falling back to `%s`.",
                 &session_id,
                 DFLT_FISH_HISTORY_SESSION_ID
             ),

--- a/src/input.rs
+++ b/src/input.rs
@@ -229,7 +229,7 @@ const _: () = _assert_sizes_match();
 #[allow(dead_code)]
 pub fn describe_char(c: i32) -> WString {
     if c > 0 && (c as usize) < R_END_INPUT_FUNCTIONS {
-        return sprintf!("%02x (%ls)", c, INPUT_FUNCTION_METADATA[c as usize].name);
+        return sprintf!("%02x (%s)", c, INPUT_FUNCTION_METADATA[c as usize].name);
     }
     return sprintf!("%02x", c);
 }

--- a/src/input_common.rs
+++ b/src/input_common.rs
@@ -681,7 +681,7 @@ pub fn update_wait_on_escape_ms(vars: &EnvStack) {
         _ => {
             eprintf!(
                 concat!(
-                    "ignoring fish_escape_delay_ms: value '%ls' ",
+                    "ignoring fish_escape_delay_ms: value '%s' ",
                     "is not an integer or is < 10 or >= 5000 ms\n"
                 ),
                 fish_escape_delay_ms
@@ -706,7 +706,7 @@ pub fn update_wait_on_sequence_key_ms(vars: &EnvStack) {
         _ => {
             eprintf!(
                 concat!(
-                    "ignoring fish_sequence_key_delay_ms: value '%ls' ",
+                    "ignoring fish_sequence_key_delay_ms: value '%s' ",
                     "is not an integer or is < 10 or >= 5000 ms\n"
                 ),
                 sequence_key_time_ms

--- a/src/io.rs
+++ b/src/io.rs
@@ -541,9 +541,9 @@ impl IoChain {
                     let next: &wstr = wdirname(dname);
                     if let Ok(md) = wstat(next) {
                         if !md.is_dir() {
-                            FLOGF!(warning, "Path '%ls' is not a directory", next);
+                            FLOGF!(warning, "Path '%s' is not a directory", next);
                         } else {
-                            FLOGF!(warning, "Path '%ls' does not exist", dname);
+                            FLOGF!(warning, "Path '%s' does not exist", dname);
                         }
                         break;
                     }
@@ -631,12 +631,12 @@ impl IoChain {
         }
 
         eprintf!(
-            "Chain %s (%ld items):\n",
+            "Chain %s (%d items):\n",
             format!("{:p}", std::ptr::addr_of!(self)),
             self.0.len()
         );
         for (i, io) in self.0.iter().enumerate() {
-            eprintf!("\t%lu: fd:%d, ", i, io.fd());
+            eprintf!("\t%u: fd:%d, ", i, io.fd());
             io.print();
         }
     }
@@ -910,8 +910,8 @@ impl<'a> IoStreams<'a> {
 }
 
 /// File redirection error message.
-const FILE_ERROR: &wstr = L!("An error occurred while redirecting file '%ls'");
-const NOCLOB_ERROR: &wstr = L!("The file '%ls' already exists");
+const FILE_ERROR: &wstr = L!("An error occurred while redirecting file '%s'");
+const NOCLOB_ERROR: &wstr = L!("The file '%s' already exists");
 
 /// Base open mode to pass to calls to open.
 const OPEN_MASK: Mode = Mode::from_bits_truncate(0o666);

--- a/src/key.rs
+++ b/src/key.rs
@@ -447,7 +447,7 @@ pub fn char_to_symbol(c: char, is_first_in_token: bool) -> WString {
         // Unmapped key from https://sw.kovidgoyal.net/kitty/keyboard-protocol/#functional-key-definitions
         sprintf!(=> buf, "\\u%04X", u32::from(c));
     } else if fish_wcwidth(c) > 0 {
-        sprintf!(=> buf, "%lc", c);
+        sprintf!(=> buf, "%c", c);
     } else if c <= '\u{FFFF}' {
         // BMP Unicode character
         sprintf!(=> buf, "\\u%04X", u32::from(c));

--- a/src/pager.rs
+++ b/src/pager.rs
@@ -273,7 +273,7 @@ impl Pager {
         assert_ne!(rendering.remaining_to_disclose, 1);
         if rendering.remaining_to_disclose > 1 {
             progress_text = wgettext_fmt!(
-                "%lsand %lu more rows",
+                "%sand %u more rows",
                 get_ellipsis_str(),
                 rendering.remaining_to_disclose
             );
@@ -282,7 +282,7 @@ impl Pager {
             // to present things as 1-indexed. We do not add 1 to stop_row or row_count because
             // these are the "past the last value".
             progress_text =
-                wgettext_fmt!("rows %lu to %lu of %lu", start_row + 1, stop_row, row_count);
+                wgettext_fmt!("rows %u to %u of %u", start_row + 1, stop_row, row_count);
         } else if self.search_field_shown && self.completion_infos.is_empty() {
             // Everything is filtered.
             progress_text = wgettext!("(no matches)").to_owned();

--- a/src/parse_constants.rs
+++ b/src/parse_constants.rs
@@ -416,7 +416,7 @@ pub fn token_type_user_presentable_description(
     keyword: ParseKeyword,
 ) -> WString {
     if keyword != ParseKeyword::None {
-        return sprintf!("keyword: '%ls'", keyword.to_wstr());
+        return sprintf!("keyword: '%s'", keyword.to_wstr());
     }
     match type_ {
         ParseTokenType::string => L!("a string").to_owned(),
@@ -432,7 +432,7 @@ pub fn token_type_user_presentable_description(
         ParseTokenType::error => L!("a parse error").to_owned(),
         ParseTokenType::tokenizer_error => L!("an incomplete token").to_owned(),
         ParseTokenType::comment => L!("a comment").to_owned(),
-        _ => sprintf!("a %ls", type_.to_wstr()),
+        _ => sprintf!("a %s", type_.to_wstr()),
     }
 }
 
@@ -464,7 +464,7 @@ pub const FISH_MAX_EVAL_DEPTH: isize = 500;
 localizable_consts!(
     /// Error message on a function that calls itself immediately.
     pub INFINITE_FUNC_RECURSION_ERR_MSG
-    "The function '%ls' calls itself immediately, which would result in an infinite loop."
+    "The function '%s' calls itself immediately, which would result in an infinite loop."
 
     /// Error message on reaching maximum call stack depth.
     pub CALL_STACK_LIMIT_EXCEEDED_ERR_MSG
@@ -472,19 +472,19 @@ localizable_consts!(
 
     /// Error message when encountering an unknown builtin name.
     pub UNKNOWN_BUILTIN_ERR_MSG
-    "Unknown builtin '%ls'"
+    "Unknown builtin '%s'"
 
     /// Error message when encountering a failed expansion, e.g. for the variable name in for loops.
     pub FAILED_EXPANSION_VARIABLE_NAME_ERR_MSG
-    "Unable to expand variable name '%ls'"
+    "Unable to expand variable name '%s'"
 
     /// Error message when encountering an illegal file descriptor.
     pub ILLEGAL_FD_ERR_MSG
-    "Illegal file descriptor in redirection '%ls'"
+    "Illegal file descriptor in redirection '%s'"
 
     /// Error message for wildcards with no matches.
     pub WILDCARD_ERR_MSG
-    "No matches for wildcard '%ls'. See `help wildcards-globbing`."
+    "No matches for wildcard '%s'. See `help wildcards-globbing`."
 
     /// Error when using break outside of loop.
     pub INVALID_BREAK_ERR_MSG
@@ -496,21 +496,21 @@ localizable_consts!(
 
     /// Error message when a command may not be in a pipeline.
     pub INVALID_PIPELINE_CMD_ERR_MSG
-    "The '%ls' command can not be used in a pipeline"
+    "The '%s' command can not be used in a pipeline"
 
     // Error messages. The number is a reminder of how many format specifiers are contained.
 
     /// Error for $^.
     pub ERROR_BAD_VAR_CHAR1
-    "$%lc is not a valid variable in fish."
+    "$%c is not a valid variable in fish."
 
     /// Error for ${a}.
     pub ERROR_BRACKETED_VARIABLE1
-    "Variables cannot be bracketed. In fish, please use {$%ls}."
+    "Variables cannot be bracketed. In fish, please use {$%s}."
 
     /// Error for "${a}".
     pub ERROR_BRACKETED_VARIABLE_QUOTED1
-    "Variables cannot be bracketed. In fish, please use \"$%ls\"."
+    "Variables cannot be bracketed. In fish, please use \"$%s\"."
 
     /// Error issued on $?.
     pub ERROR_NOT_STATUS
@@ -538,7 +538,7 @@ localizable_consts!(
 
     /// Error message for Posix-style assignment: foo=bar.
     pub ERROR_BAD_COMMAND_ASSIGN_ERR_MSG
-    "Unsupported use of '='. In fish, please use 'set %ls %ls'."
+    "Unsupported use of '='. In fish, please use 'set %s %s'."
 
     /// Error message for a command like `time foo &`.
     pub ERROR_TIME_BACKGROUND

--- a/src/parse_execution.rs
+++ b/src/parse_execution.rs
@@ -277,7 +277,7 @@ impl<'a> ExecutionContext<'a> {
                         ctx,
                         STATUS_NOT_EXECUTABLE,
                         &statement.command,
-                        "Unknown command. A component of '%ls' is not a directory. Check your $PATH.",
+                        "Unknown command. A component of '%s' is not a directory. Check your $PATH.",
                         cmd
                     );
                 } else {
@@ -286,7 +286,7 @@ impl<'a> ExecutionContext<'a> {
                         ctx,
                         STATUS_NOT_EXECUTABLE,
                         &statement.command,
-                        "Unknown command. A component of '%ls' is not a directory.",
+                        "Unknown command. A component of '%s' is not a directory.",
                         cmd
                     );
                 }
@@ -297,7 +297,7 @@ impl<'a> ExecutionContext<'a> {
                 ctx,
                 STATUS_NOT_EXECUTABLE,
                 &statement.command,
-                "Unknown command. '%ls' exists but is not an executable file.",
+                "Unknown command. '%s' exists but is not an executable file.",
                 cmd
             );
         }
@@ -903,7 +903,7 @@ impl<'a> ExecutionContext<'a> {
                 ctx,
                 STATUS_INVALID_ARGS,
                 header.var_name,
-                "%ls: %ls: cannot overwrite read-only variable",
+                "%s: %s: cannot overwrite read-only variable",
                 "for",
                 for_var_name
             );
@@ -1094,7 +1094,7 @@ impl<'a> ExecutionContext<'a> {
                         ctx,
                         STATUS_INVALID_ARGS,
                         &statement.argument,
-                        "switch: Expected at most one argument, got %lu\n",
+                        "switch: Expected at most one argument, got %u\n",
                         switch_values_expanded.len()
                     );
                 }
@@ -1286,7 +1286,7 @@ impl<'a> ExecutionContext<'a> {
 
         let errtext = errs.contents();
         if !errtext.is_empty() {
-            report_error!(self, ctx, err_code, header, "%ls", errtext);
+            report_error!(self, ctx, err_code, header, "%s", errtext);
         }
         result
     }
@@ -1419,7 +1419,7 @@ impl<'a> ExecutionContext<'a> {
                         ctx,
                         STATUS_INVALID_ARGS,
                         redir_node,
-                        "Invalid redirection: %ls",
+                        "Invalid redirection: %s",
                         self.node_source(redir_node)
                     );
                 }
@@ -1445,7 +1445,7 @@ impl<'a> ExecutionContext<'a> {
                     ctx,
                     STATUS_INVALID_ARGS,
                     redir_node,
-                    "Invalid redirection target: %ls",
+                    "Invalid redirection target: %s",
                     target
                 );
                 if oper.mode == RedirectionMode::input && {
@@ -1481,7 +1481,7 @@ impl<'a> ExecutionContext<'a> {
                     ctx,
                     STATUS_INVALID_ARGS,
                     redir_node,
-                    "Requested redirection to '%ls', which is not a valid file descriptor",
+                    "Requested redirection to '%s', which is not a valid file descriptor",
                     &spec.target
                 );
             }

--- a/src/parse_tree.rs
+++ b/src/parse_tree.rs
@@ -74,7 +74,7 @@ impl ParseToken {
     pub fn describe(&self) -> WString {
         let mut result = self.typ.to_wstr().to_owned();
         if self.keyword != ParseKeyword::None {
-            sprintf!(=> &mut result, " <%ls>", self.keyword.to_wstr())
+            sprintf!(=> &mut result, " <%s>", self.keyword.to_wstr())
         }
         result
     }

--- a/src/parse_util.rs
+++ b/src/parse_util.rs
@@ -1410,7 +1410,7 @@ pub fn parse_util_detect_errors_in_argument(
                             out_errors,
                             source_start + begin,
                             end - begin,
-                            "Incomplete escape sequence '%ls'",
+                            "Incomplete escape sequence '%s'",
                             arg_src
                         );
                         return ParserTestErrorBits::ERROR;
@@ -1419,7 +1419,7 @@ pub fn parse_util_detect_errors_in_argument(
                         out_errors,
                         source_start + begin,
                         end - begin,
-                        "Invalid token '%ls'",
+                        "Invalid token '%s'",
                         arg_src
                     );
                 }
@@ -1948,7 +1948,7 @@ pub fn parse_util_expand_variable_error(
 localizable_consts!(
     /// Error message for use of backgrounded commands before and/or.
     pub(crate) BOOL_AFTER_BACKGROUND_ERROR_MSG
-    "The '%ls' command can not be used immediately after a backgrounded job"
+    "The '%s' command can not be used immediately after a backgrounded job"
 
     /// Error message for backgrounded commands as conditionals.
     BACKGROUND_IN_CONDITIONAL_ERROR_MSG

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -133,7 +133,7 @@ impl Block {
             result.push_utfstr(&sprintf!(" (line %d)", src_lineno.get()));
         }
         if let Some(src_filename) = &self.src_filename {
-            result.push_utfstr(&sprintf!(" (file %ls)", src_filename));
+            result.push_utfstr(&sprintf!(" (file %s)", src_filename));
         }
         result
     }
@@ -762,7 +762,7 @@ impl Parser {
         if !self.is_interactive() || self.is_function() {
             if let Some(file) = file {
                 prefix.push_utfstr(&wgettext_fmt!(
-                    "%ls (line %d): ",
+                    "%s (line %d): ",
                     &user_presentable_path(&file, self.vars()),
                     lineno
                 ));
@@ -1126,12 +1126,12 @@ impl Parser {
         let prefix = if let Some(filename) = self.current_filename() {
             if which_line > 0 {
                 wgettext_fmt!(
-                    "%ls (line %lu): ",
+                    "%s (line %u): ",
                     user_presentable_path(&filename, self.vars()),
                     which_line
                 )
             } else {
-                sprintf!("%ls: ", user_presentable_path(&filename, self.vars()))
+                sprintf!("%s: ", user_presentable_path(&filename, self.vars()))
             }
         } else {
             L!("fish: ").to_owned()
@@ -1283,7 +1283,7 @@ fn append_block_description_to_stack_trace(parser: &Parser, b: &Block, trace: &m
             let Some(BlockData::Function { name, args, .. }) = b.data() else {
                 unreachable!()
             };
-            trace.push_utfstr(&wgettext_fmt!("in function '%ls'", name));
+            trace.push_utfstr(&wgettext_fmt!("in function '%s'", name));
             // Print arguments on the same line.
             let mut args_str = WString::new();
             for arg in args {
@@ -1303,7 +1303,7 @@ fn append_block_description_to_stack_trace(parser: &Parser, b: &Block, trace: &m
             }
             if !args_str.is_empty() {
                 // TODO: Escape these.
-                trace.push_utfstr(&wgettext_fmt!(" with arguments '%ls'", args_str));
+                trace.push_utfstr(&wgettext_fmt!(" with arguments '%s'", args_str));
             }
             trace.push('\n');
             print_call_site = true;
@@ -1318,7 +1318,7 @@ fn append_block_description_to_stack_trace(parser: &Parser, b: &Block, trace: &m
             };
             let source_dest = file;
             trace.push_utfstr(&wgettext_fmt!(
-                "from sourcing file %ls\n",
+                "from sourcing file %s\n",
                 &user_presentable_path(source_dest, parser.vars())
             ));
             print_call_site = true;
@@ -1328,7 +1328,7 @@ fn append_block_description_to_stack_trace(parser: &Parser, b: &Block, trace: &m
                 unreachable!()
             };
             let description = event::get_desc(parser, event);
-            trace.push_utfstr(&wgettext_fmt!("in event handler: %ls\n", &description));
+            trace.push_utfstr(&wgettext_fmt!("in event handler: %s\n", &description));
             print_call_site = true;
         }
         BlockType::top
@@ -1345,7 +1345,7 @@ fn append_block_description_to_stack_trace(parser: &Parser, b: &Block, trace: &m
         // Print where the function is called.
         if let Some(file) = b.src_filename.as_ref() {
             trace.push_utfstr(&sprintf!(
-                "\tcalled on line %d of file %ls\n",
+                "\tcalled on line %d of file %s\n",
                 b.src_lineno.map(|n| n.get()).unwrap_or(0),
                 user_presentable_path(file, parser.vars())
             ));

--- a/src/path.rs
+++ b/src/path.rs
@@ -150,12 +150,12 @@ fn maybe_issue_path_warning(
     if path.is_empty() {
         FLOG!(
             warning_path,
-            wgettext_fmt!("Unable to locate the %ls directory.", which_dir)
+            wgettext_fmt!("Unable to locate the %s directory.", which_dir)
         );
         FLOG!(
             warning_path,
             wgettext_fmt!(
-                "Please set the %ls or HOME environment variable before starting fish.",
+                "Please set the %s or HOME environment variable before starting fish.",
                 xdg_var
             )
         );
@@ -164,7 +164,7 @@ fn maybe_issue_path_warning(
         FLOG!(
             warning_path,
             wgettext_fmt!(
-                "Unable to locate %ls directory derived from $%ls: '%ls'.",
+                "Unable to locate %s directory derived from $%s: '%s'.",
                 which_dir,
                 env_var,
                 path
@@ -177,7 +177,7 @@ fn maybe_issue_path_warning(
         FLOG!(
             warning_path,
             wgettext_fmt!(
-                "Please set $%ls to a directory where you have write access.",
+                "Please set $%s to a directory where you have write access.",
                 env_var
             )
         );
@@ -236,7 +236,7 @@ fn path_check_executable(path: &wstr) -> Result<(), std::io::Error> {
 
 /// Return all the paths that match the given command.
 pub fn path_get_paths(cmd: &wstr, vars: &dyn Environment) -> Vec<WString> {
-    FLOGF!(path, "path_get_paths('%ls')", cmd);
+    FLOGF!(path, "path_get_paths('%s')", cmd);
     let mut paths = vec![];
 
     // If the command has a slash, it must be an absolute or relative path and thus we don't bother

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -782,7 +782,7 @@ impl Job {
     pub fn continue_job(&self, parser: &Parser) {
         FLOGF!(
             proc_job_run,
-            "Run job %d (%ls), %ls, %ls",
+            "Run job %d (%s), %s, %s",
             self.job_id(),
             self.command(),
             if self.is_completed() {
@@ -822,7 +822,7 @@ impl Job {
         if !self.signal(SIGCONT) {
             FLOGF!(
                 proc_pgroup,
-                "Failed to send SIGCONT to procs in job %ls",
+                "Failed to send SIGCONT to procs in job %s",
                 self.command()
             );
             return false;
@@ -991,7 +991,7 @@ pub fn print_exit_warning_for_jobs(jobs: &JobList) {
         // Unwrap safety: we can't have a background job that doesn't have an external process and
         // external processes always have a pid set.
         printf!(
-            "%6d  %ls\n",
+            "%6d  %s\n",
             j.external_procs().next().and_then(|p| p.pid()).unwrap(),
             j.command()
         );
@@ -1251,7 +1251,7 @@ fn process_mark_finished_children(parser: &Parser, block_ok: bool) {
             if status.normal_exited() || status.signal_exited() {
                 FLOGF!(
                     proc_reap_external,
-                    "Reaped external process '%ls' (pid %d, status %d)",
+                    "Reaped external process '%s' (pid %d, status %d)",
                     proc.argv0().unwrap(),
                     pid,
                     proc.status().status_value()
@@ -1260,7 +1260,7 @@ fn process_mark_finished_children(parser: &Parser, block_ok: bool) {
                 assert!(status.stopped() || status.continued());
                 FLOGF!(
                     proc_reap_external,
-                    "External process '%ls' (pid %d, %s)",
+                    "External process '%s' (pid %d, %s)",
                     proc.argv0().unwrap(),
                     proc.pid().unwrap(),
                     if proc.status().stopped() {
@@ -1305,7 +1305,7 @@ fn process_mark_finished_children(parser: &Parser, block_ok: bool) {
             handle_child_status(j, proc, status);
             FLOGF!(
                 proc_reap_internal,
-                "Reaped internal process '%ls' (id %llu, status %d)",
+                "Reaped internal process '%s' (id %u, status %d)",
                 proc.argv0().unwrap(),
                 internal_proc.get_id(),
                 proc.status().status_value(),

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -342,7 +342,7 @@ pub fn terminal_init(vars: &dyn Environment, inputfd: RawFd) -> InputEventQueue 
     assert!(input_data.event_storage.is_empty());
     FLOGF!(
         reader,
-        "Returning %lu pending input events",
+        "Returning %u pending input events",
         input_data.queue.len()
     );
 
@@ -956,7 +956,7 @@ fn read_ni(parser: &Parser, fd: RawFd, io: &IoChain) -> Result<(), ErrorCode> {
     match parser.eval_wstr(s, io, None, BlockType::top) {
         Ok(_) => Ok(()),
         Err(msg) => {
-            eprintf!("%ls", msg);
+            eprintf!("%s", msg);
             Err(STATUS_CMD_ERROR)
         }
     }
@@ -1750,7 +1750,7 @@ impl<'a> Reader<'a> {
     /// Paint the last rendered layout.
     /// `reason` is used in FLOG to explain why.
     fn paint_layout(&mut self, reason: &wstr, is_final_rendering: bool) {
-        FLOGF!(reader_render, "Repainting from %ls", reason);
+        FLOGF!(reader_render, "Repainting from %s", reason);
         let cmd_line = &self.data.command_line;
 
         let (full_line, autosuggested_range) = if self.conf.in_silent_mode {
@@ -5043,7 +5043,7 @@ impl<'a> Reader<'a> {
             if complete_load(to_load, self.parser) {
                 FLOGF!(
                     complete,
-                    "Autosuggest found new completions for %ls, restarting",
+                    "Autosuggest found new completions for %s, restarting",
                     to_load
                 );
                 loaded_new = true;
@@ -5452,7 +5452,7 @@ impl ReaderData {
             zelf.pager.extra_progress_text =
                 if !result.matched_commands.is_empty() && *history_pager != (0..history_size + 1) {
                     wgettext_fmt!(
-                        "Items %lu to %lu of %lu",
+                        "Items %u to %u of %u",
                         match history_pager.start {
                             0 => 1,
                             _ => result.first_shown,
@@ -5491,7 +5491,7 @@ fn expand_replacer(
         // Literal replacement cannot fail.
         FLOGF!(
             abbrs,
-            "Expanded literal abbreviation <%ls> -> <%ls>",
+            "Expanded literal abbreviation <%s> -> <%s>",
             token,
             &repl.replacement
         );
@@ -5524,7 +5524,7 @@ fn expand_replacer(
     let result = join_strings(&outputs, '\n');
     FLOGF!(
         abbrs,
-        "Expanded function abbreviation <%ls> -> <%ls>",
+        "Expanded function abbreviation <%s> -> <%s>",
         token,
         result
     );

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -863,7 +863,7 @@ pub fn setup() {
             let mut path = PathBuf::from(dir);
             path.push(first_char.clone());
             path.push(t.clone());
-            FLOGF!(term_support, "Trying path '%ls'", path.to_str().unwrap());
+            FLOGF!(term_support, "Trying path '%s'", path.to_str().unwrap());
             if let Ok(db) = terminfo::Database::from_path(path) {
                 return Ok(db);
             }

--- a/src/tests/history.rs
+++ b/src/tests/history.rs
@@ -228,7 +228,7 @@ fn time_barrier() {
 fn generate_history_lines(item_count: usize, idx: usize) -> Vec<WString> {
     let mut result = Vec::with_capacity(item_count);
     for i in 0..item_count {
-        result.push(sprintf!("%lu %lu", idx, i));
+        result.push(sprintf!("%u %u", idx, i));
     }
     result
 }
@@ -317,7 +317,7 @@ fn test_history_races() {
             // in this array were therefore not found in history.
             let removed = list.drain(position..);
             for line in removed.into_iter().rev() {
-                printf!("Item dropped from history: %ls\n", line);
+                printf!("Item dropped from history: %s\n", line);
             }
 
             found = true;
@@ -325,12 +325,12 @@ fn test_history_races() {
         }
         if !found {
             printf!(
-                "Line '%ls' found in history, but not found in some array\n",
+                "Line '%s' found in history, but not found in some array\n",
                 item.str()
             );
             for list in &expected_lines {
                 if !list.is_empty() {
-                    printf!("\tRemaining: %ls\n", list.last().unwrap())
+                    printf!("\tRemaining: %s\n", list.last().unwrap())
                 }
             }
         }

--- a/src/tests/parse_util.rs
+++ b/src/tests/parse_util.rs
@@ -21,7 +21,7 @@ fn test_error_messages() {
     // Given a format string, returns a list of non-empty strings separated by format specifiers. The
     // format specifiers themselves are omitted.
     fn separate_by_format_specifiers(format: &wstr) -> Vec<&wstr> {
-        let format_specifier_regex = Regex::new(L!(r"%l?[cds]").as_char_slice()).unwrap();
+        let format_specifier_regex = Regex::new(L!(r"%[cds]").as_char_slice()).unwrap();
         let mut result = vec![];
         let mut offset = 0;
         for mtch in format_specifier_regex.find_iter(format.as_char_slice()) {

--- a/src/tty_handoff.rs
+++ b/src/tty_handoff.rs
@@ -581,7 +581,7 @@ impl TtyHandoff {
             } else {
                 FLOGF!(
                     warning,
-                    "Could not send job %d ('%ls') with pgid %d to foreground",
+                    "Could not send job %d ('%s') with pgid %d to foreground",
                     jg.job_id.to_wstring(),
                     jg.command,
                     pgid

--- a/src/wutil/mod.rs
+++ b/src/wutil/mod.rs
@@ -351,7 +351,7 @@ mod path_cd_tests {
     fn relative_path() {
         let wd = L!("/home/user/");
         let path = L!("projects");
-        eprintf!("(%ls, %ls)\n", wd, path);
+        eprintf!("(%s, %s)\n", wd, path);
         assert_eq!(path_normalize_for_cd(wd, path), L!("/home/user/projects"));
     }
 
@@ -359,7 +359,7 @@ mod path_cd_tests {
     fn absolute_path() {
         let wd = L!("/home/user/");
         let path = L!("/etc");
-        eprintf!("(%ls, %ls)\n", wd, path);
+        eprintf!("(%s, %s)\n", wd, path);
         assert_eq!(path_normalize_for_cd(wd, path), L!("/etc"));
     }
 
@@ -367,7 +367,7 @@ mod path_cd_tests {
     fn parent_directory() {
         let wd = L!("/home/user/projects/");
         let path = L!("../docs");
-        eprintf!("(%ls, %ls)\n", wd, path);
+        eprintf!("(%s, %s)\n", wd, path);
         assert_eq!(path_normalize_for_cd(wd, path), L!("/home/user/docs"));
     }
 
@@ -375,7 +375,7 @@ mod path_cd_tests {
     fn current_directory() {
         let wd = L!("/home/user/");
         let path = L!("./");
-        eprintf!("(%ls, %ls)\n", wd, path);
+        eprintf!("(%s, %s)\n", wd, path);
         assert_eq!(path_normalize_for_cd(wd, path), L!("/home/user"));
     }
 
@@ -383,7 +383,7 @@ mod path_cd_tests {
     fn nested_parent_directory() {
         let wd = L!("/home/user/projects/");
         let path = L!("../../");
-        eprintf!("(%ls, %ls)\n", wd, path);
+        eprintf!("(%s, %s)\n", wd, path);
         assert_eq!(path_normalize_for_cd(wd, path), L!("/home"));
     }
 
@@ -391,7 +391,7 @@ mod path_cd_tests {
     fn complex_path() {
         let wd = L!("/home/user/projects/");
         let path = L!("./../other/projects/./.././../docs");
-        eprintf!("(%ls, %ls)\n", wd, path);
+        eprintf!("(%s, %s)\n", wd, path);
         assert_eq!(
             path_normalize_for_cd(wd, path),
             L!("/home/user/other/projects/./.././../docs")
@@ -402,7 +402,7 @@ mod path_cd_tests {
     fn root_directory() {
         let wd = L!("/");
         let path = L!("..");
-        eprintf!("(%ls, %ls)\n", wd, path);
+        eprintf!("(%s, %s)\n", wd, path);
         assert_eq!(path_normalize_for_cd(wd, path), L!("/.."));
     }
 
@@ -410,7 +410,7 @@ mod path_cd_tests {
     fn up_to_root_directory() {
         let wd = L!("/foo/");
         let path = L!("..");
-        eprintf!("(%ls, %ls)\n", wd, path);
+        eprintf!("(%s, %s)\n", wd, path);
         assert_eq!(path_normalize_for_cd(wd, path), L!("/"));
     }
 
@@ -418,7 +418,7 @@ mod path_cd_tests {
     fn empty_path() {
         let wd = L!("/home/user/");
         let path = L!("");
-        eprintf!("(%ls, %ls)\n", wd, path);
+        eprintf!("(%s, %s)\n", wd, path);
         assert_eq!(path_normalize_for_cd(wd, path), L!("/home/user/"));
     }
 
@@ -426,7 +426,7 @@ mod path_cd_tests {
     fn trailing_slash() {
         let wd = L!("/home/user/projects/");
         let path = L!("docs/");
-        eprintf!("(%ls, %ls)\n", wd, path);
+        eprintf!("(%s, %s)\n", wd, path);
         assert_eq!(
             path_normalize_for_cd(wd, path),
             L!("/home/user/projects/docs/")

--- a/src/wutil/printf.rs
+++ b/src/wutil/printf.rs
@@ -57,7 +57,7 @@ mod tests {
     #[test]
     fn test_sprintf() {
         assert_eq!(sprintf!("Hello, %s!", "world"), "Hello, world!");
-        assert_eq!(sprintf!("Hello, %ls!", "world"), "Hello, world!");
-        assert_eq!(sprintf!("Hello, %ls!", "world"), "Hello, world!");
+        assert_eq!(sprintf!("Hello, %s!", "world"), "Hello, world!");
+        assert_eq!(sprintf!("Hello, %s!", "world"), "Hello, world!");
     }
 }

--- a/tests/checks/printf.fish
+++ b/tests/checks/printf.fish
@@ -7,7 +7,7 @@ printf "%d %d\n" 1 2 3
 printf "Hello %d %i %f %F %g %G\n" 1 2 3 4 5 6
 # CHECK: Hello 1 2 3.000000 4.000000 5 6
 
-printf "%x %X %o %llu\n" 10 11 8 -1
+printf "%x %X %o %u\n" 10 11 8 -1
 # CHECK: a B 10 18446744073709551615
 
 # %a has OS-dependent output - see #1139

--- a/tests/fish_test_helper.c
+++ b/tests/fish_test_helper.c
@@ -102,12 +102,12 @@ static void print_stdout_stderr() {
 
 static void print_pid_then_sleep() {
     // On some systems getpid is a long, on others it's an int, let's just cast it.
-    fprintf(stdout, "%ld\n", (long)getpid());
+    fprintf(stdout, "%d\n", (long)getpid());
     fflush(NULL);
     usleep(1000000 / 2);  //.5 secs
 }
 
-static void print_pgrp() { fprintf(stdout, "%ld\n", (long)getpgrp()); }
+static void print_pgrp() { fprintf(stdout, "%d\n", (long)getpgrp()); }
 
 static void print_fds() {
     bool needs_space = false;


### PR DESCRIPTION
## Description

See commit messages.

## TODOs:
- [x] Changes to fish usage are reflected in user documentation/manpages. (Only really affects developer docs, length modifiers have not been documented in `printf` docs)
- [ ] User-visible changes noted in CHANGELOG.rst