### PR TITLE
completion/set: fix bug preventing showing `history` or `fish_killring`

### DIFF
--- a/share/completions/set.fish
+++ b/share/completions/set.fish
@@ -110,7 +110,7 @@ set -l maybe_filter_private_vars '
     )'
 # We do not *filter* these by the given scope because you might want to set e.g. a global to shadow a universal.
 complete -c set -n '__fish_is_nth_token 1; and not __fish_seen_argument -s e -l erase' -x -a "(set -U | $maybe_filter_private_vars | string replace ' ' \t'Universal Variable: ')"
-complete -c set -n '__fish_is_nth_token 1; and not __fish_seen_argument -s e -l erase' -x -a "(set -g | $maybe_filter_private_vars | string replace -r '^((?:history|fish_killring) ).*' '$1' | string replace ' ' \t'Global Variable: ')"
+complete -c set -n '__fish_is_nth_token 1; and not __fish_seen_argument -s e -l erase' -x -a "(set -g | $maybe_filter_private_vars | string replace -r '^((?:history|fish_killring) ).*' '\$1' | string replace ' ' \t'Global Variable: ')"
 complete -c set -n '__fish_is_nth_token 1; and not __fish_seen_argument -s e -l erase' -x -a "(set -l | $maybe_filter_private_vars | string replace ' ' \t'Local Variable: ')"
 # Complete some fish configuration variables even if they aren't set.
 complete -c set -n '__fish_is_nth_token 1; and not __fish_seen_argument -s e -l erase' -x -a "(__fish_complete_special_vars)"

--- a/tests/checks/complete.fish
+++ b/tests/checks/complete.fish
@@ -654,3 +654,11 @@ end
 complete complete-list -l desc -xa '(__fish_complete_list , esc_in_description)'
 complete -C 'complete-list --desc '
 # CHECK: completion{{\t}}escaped {{\\n}} newline
+
+# Tests for #11880
+complete -C "set -S fish_killri"
+# CHECK: fish_killring
+# Currently, the check below behaves the same as above. Ideally, a
+# feature would be added to skip read-only variables here.
+complete -C "set fish_killri"
+# CHECK: fish_killring


### PR DESCRIPTION
Previously, `set -S fish_kill<TAB>` did not list `fish_killring`. This was because `$1` wasn't sufficiently escaped, and so instead of referring to a regex capture group, it was always empty.

## TODOs:
- [n/a] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [n/a?] User-visible changes noted in CHANGELOG.rst
