### PR TITLE
doc: correct example of fish_should_add_to_history

### DIFF
--- a/doc_src/cmds/fish_should_add_to_history.rst
+++ b/doc_src/cmds/fish_should_add_to_history.rst
@@ -48,7 +48,7 @@ This refuses to store any immediate "vault", "mysql" or "ls" calls. Commands sta
 
     function fish_should_add_to_history
         # I don't want `git pull`s in my history when I'm in a specific repository
-        if string match -qr '^git pull'
+        if string match -qr '^git pull' -- "$argv"
         and string match -qr "^/home/me/my-secret-project/" -- (pwd -P)
             return 1
         end


### PR DESCRIPTION
## Description

The second example for `fish_should_add_to_history` has an error, it is missing the second part of the string comparison when testing the command executed, leading to it comparing to nothing.


## TODOs:
- [Not Applicable] Changes to fish usage are reflected in user documentation/manpages.
- [Not Applicable] Tests have been added for regressions fixed
- [Not Applicable] User-visible changes noted in CHANGELOG.rst
