### PR TITLE
Make command run by __fish_echo output to TTY for color detection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ This release fixes the following regressions identified in 4.1.0:
 - Added a workaround for old versions of Zellij where :kbd:`escape` processing was delayed (:issue:`11868`).
 - Fixed a case where the :doc:`web-based configuration tool <cmds/fish_config>` would generate invalid configuration (:issue:`11861`).
 - Fixed a case where upgrading fish would break old versions of fish that were still running.
+- Fix Alt+L binding not formatting ls output correctly (one entry per line, no colors).
 
   In general, fish still needs to be restarted after it is upgraded,
   except for `standalone builds <https://github.com/fish-shell/fish-shell/?tab=readme-ov-file#building-fish-with-embedded-data-experimental>`__.

--- a/share/functions/__fish_echo.fish
+++ b/share/functions/__fish_echo.fish
@@ -10,7 +10,8 @@ set -l erase_line "$(
 function __fish_echo --inherit-variable erase_line --description 'run the given command after the current commandline and redraw the prompt'
     set -l line (commandline --line)
     string >&2 repeat -N \n --count=(math (commandline | count) - $line + 1)
-    printf %s\n $erase_line($argv) >&2
+    printf %s $erase_line >&2
+    $argv >&2
     string >&2 repeat -N \n --count=(math (count (fish_prompt)) - 1)
     string >&2 repeat -N \n --count=(math $line - 1)
     commandline -f repaint


### PR DESCRIPTION
## Description

Without this, e.g. Alt-L shows the directory entries one per line and without colors.

## TODOs:
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
