### PR TITLE
sprintf: remove signed int size info

### DIFF
--- a/crates/printf/src/printf_impl.rs
+++ b/crates/printf/src/printf_impl.rs
@@ -472,7 +472,7 @@ pub fn sprintf_locale(
                 // If someone passes us a negative value, format it with the width
                 // we were given.
                 let lower = conv_spec.is_lower();
-                let (_, uint) = arg.as_wrapping_sint()?;
+                let uint = arg.as_wrapping_sint()?;
                 if uint != 0 {
                     if flags.alt_form {
                         prefix = if lower { "0x" } else { "0X" };

--- a/crates/printf/src/tests.rs
+++ b/crates/printf/src/tests.rs
@@ -225,7 +225,7 @@ fn test_int() {
     assert_fmt!("%d", -123 => "-123");
     assert_fmt!("~%d~", 148 => "~148~");
     assert_fmt!("00%dxx", -91232 => "00-91232xx");
-    assert_fmt!("%x", -9232 => "ffffdbf0");
+    assert_fmt!("%x", -9232 => "ffffffffffffdbf0");
     assert_fmt!("%X", 432 => "1B0");
     assert_fmt!("%09X", 432 => "0000001B0");
     assert_fmt!("%9X", 432 => "      1B0");


### PR DESCRIPTION
The size was used to keep track of the number of bits of the input type the `Arg::SInt` variant was created from. This was only relevant for arguments defined in Rust, since the `printf` command takes all arguments as strings.

The only thing the size was used for is for printing negative numbers with the `x` and `X` format specifiers. In these cases, the `i64` stored in the `SInt` variant would be cast to a `u64`, but only the number of bits present in the original argument would be kept, so `-1i8` would be formatted as `ff` instead of `ffffffffffffffff`.

There are no users of this feature, so let's simplify the code by removing it. While we're at it, also remove the unused `bool` returned by `as_wrapping_sint`.

https://github.com/fish-shell/fish-shell/pull/11874#discussion_r2404524838