### PR TITLE
checks: make `tmux-multiline-prompt` less affected by `less` config

### DIFF
--- a/tests/checks/tmux-multiline-prompt.fish
+++ b/tests/checks/tmux-multiline-prompt.fish
@@ -50,7 +50,7 @@ isolated-tmux capture-pane -p | tail -n 5
 # CHECK:
 
 # Test repainint after running an external program that uses the alternate screen.
-isolated-tmux send-keys "bind ctrl-r 'echo | less +q; commandline \"echo Hello World\"'" Enter C-l
+isolated-tmux send-keys "bind ctrl-r 'echo | less -+F -+X +q; commandline \"echo Hello World\"'" Enter C-l
 isolated-tmux send-keys C-r
 tmux-sleep
 isolated-tmux send-keys Enter


### PR DESCRIPTION
See commit description. This is a more didactic version of the fix. If we can make sure `less` uses stock config, that might be better, but `less` seems to have several ways to be configured, and I don't fully understand it.

Fixes issue #11881

Thanks, @krobelus, for the help with debugging this!
