### PR TITLE
printf-c: restore length modifiers

### DIFF
--- a/tests/fish_test_helper.c
+++ b/tests/fish_test_helper.c
@@ -102,12 +102,12 @@ static void print_stdout_stderr() {
 
 static void print_pid_then_sleep() {
     // On some systems getpid is a long, on others it's an int, let's just cast it.
-    fprintf(stdout, "%d\n", (long)getpid());
+    fprintf(stdout, "%ld\n", (long)getpid());
     fflush(NULL);
     usleep(1000000 / 2);  //.5 secs
 }
 
-static void print_pgrp() { fprintf(stdout, "%d\n", (long)getpgrp()); }
+static void print_pgrp() { fprintf(stdout, "%ld\n", (long)getpgrp()); }
 
 static void print_fds() {
     bool needs_space = false;


### PR DESCRIPTION
These were accidentally removed when semi-automatically removing length modifiers from Rust code and shell scripts.

In C, the length modifiers are required.
