### PR TITLE
check.sh: export gettext extraction file variable

### DIFF
--- a/build_tools/check.sh
+++ b/build_tools/check.sh
@@ -49,7 +49,8 @@ if [ -n "$FISH_TEST_MAX_CONCURRENCY" ]; then
 fi
 
 template_file=$(mktemp)
-FISH_GETTEXT_EXTRACTION_FILE=$template_file cargo build --workspace --all-targets --features=gettext-extract
+export FISH_GETTEXT_EXTRACTION_FILE="$template_file"
+cargo build --workspace --all-targets --features=gettext-extract
 if $lint; then
     PATH="$build_dir:$PATH" "$workspace_root/build_tools/style.fish" --all --check
     for features in "" --no-default-features; do
@@ -61,7 +62,7 @@ cargo test --doc --workspace
 if $lint; then
     cargo doc --workspace
 fi
-FISH_GETTEXT_EXTRACTION_FILE=$template_file "$workspace_root/tests/test_driver.py" "$build_dir"
+"$workspace_root/tests/test_driver.py" "$build_dir"
 
 exit
 }


### PR DESCRIPTION
Some versions of `/bin/sh`, e.g. the one on FreeBSD, do not propagate variables set on a command through shell functions. This results in `FISH_GETTEXT_EXTRACTION_FILE` being set in the `cargo` function, but not for the actual `cargo` process spawned from the function, which breaks our localization scripts and tests. Exporting the variable prevents that.

Fixes #11896