### PR TITLE
ci: rename workflows

### DIFF
--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -1,4 +1,4 @@
-name: Docker test image builds
+name: Build Docker test images
 
 on:
   push:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Rust checks
+name: Lint
 
 on: [push, pull_request]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: make fish_run_tests
+name: Test
 
 on: [push, pull_request]
 


### PR DESCRIPTION
The new names are consistently formulated as commands.

`main` is not very descriptive, so change it to `test`, which is more informative and accurate.

`rust_checks` are replaced be the more general `lint` in preparation for non-Rust-related checks.

These changes were suggested in
https://github.com/fish-shell/fish-shell/pull/11918#discussion_r2415957733
