### PR TITLE
completions/git: fix remotes missing in e.g. git fetch

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -109,7 +109,7 @@ end
 function __fish_git_remotes
     # Example of output parsed:
     # "remote.upstream.url git@github.com:fish-shell/fish-shell.git" -> "upstream\tgit@github.com:fish-shell/fish-shell.git"
-    __fish_git config --get-regexp 'remote\.[a-z]+\.url' | string replace -rf 'remote\.(.*)\.url (.*)' '$1\t$2'
+    __fish_git config --get-regexp 'remote\..+\.url' | string replace -rf 'remote\.(.*)\.url (.*)' '$1\t$2'
 end
 
 set -g __fish_git_recent_commits_arg


### PR DESCRIPTION
## Description

Update the regex to allow remote names which are allowed in git, like `foo-bar`, `foo.bar` or `😜`. Do not try to artificially limit the allowed remote names through the regex.

~~Fixes issue #~~

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
