### PR TITLE
Nim sample prompt: Don't print `replace_one` mode twice

### DIFF
--- a/share/tools/web_config/sample_prompts/nim.fish
+++ b/share/tools/web_config/sample_prompts/nim.fish
@@ -93,7 +93,6 @@ function fish_prompt
                 set mode (set_color --bold green)I
             case replace_one
                 set mode (set_color --bold green)R
-                echo '[R]'
             case replace
                 set mode (set_color --bold cyan)R
             case visual


### PR DESCRIPTION
## Description

Previously, it showed `[R]` twice when  `fish_bind_mode` is `replace_one` (under `fish_vi_key_bindings`, press escape and then "r"):

```console
┬─[user@hostname:~]─[00:00:01 PM][R]
─[R]
╰─>$ 
```

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
