### PR TITLE
fs: open file with O_RDWR before fsync

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -115,7 +115,7 @@ impl LockingMode {
             Self::Exclusive(WriteMethod::Append) => {
                 OFlag::O_WRONLY | OFlag::O_APPEND | OFlag::O_CREAT
             }
-            Self::Exclusive(WriteMethod::RenameIntoPlace) => OFlag::O_RDONLY | OFlag::O_CREAT,
+            Self::Exclusive(WriteMethod::RenameIntoPlace) => OFlag::O_RDWR | OFlag::O_CREAT,
         }
     }
 }
@@ -192,6 +192,7 @@ pub fn fsync(file: &File) -> std::io::Result<()> {
             -1 => {
                 let os_error = std::io::Error::last_os_error();
                 if os_error.kind() != std::io::ErrorKind::Interrupted {
+                    FLOGF!(synced_file_access, "fsync failed: %s", os_error);
                     return Err(os_error);
                 }
             }


### PR DESCRIPTION
## Description

I'm not sure if it's OK for all POSIX platforms, but I think that it would be fine?

Also added a piece of log when `fsync` fails.

Closes #11934 

Closes #11947