### PR TITLE
man.fish: fix for commands ! . : [

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,7 @@ fish 4.1.3 (released ???)
 This release fixes the following regressions identified in 4.1.0:
 
 - Crash on invalid :doc:`function <cmds/function>` command (:issue:`11912`).
+- Fixed the fish ``man`` function for the commands ``!`` ``.`` ``:`` ``[`` (:issue:`11955`).
 
 as well as the following regressions identified in 4.0.0:
 

--- a/share/functions/man.fish
+++ b/share/functions/man.fish
@@ -47,13 +47,13 @@ function man
         # So we override them with the good name.
         switch $argv
             case !
-                set $argv not
+                set argv not
             case .
-                set $argv source
+                set argv source
             case :
-                set $argv true
+                set argv true
             case '['
-                set $argv test
+                set argv test
         end
     end
 


### PR DESCRIPTION
## Description

Fix a syntax error in **man.fish**, change `set $argv` to `set argv`.

Fixes issue #11955

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [X] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
