### PR TITLE
man: fix variable assignment syntax

### DIFF
--- a/share/functions/man.fish
+++ b/share/functions/man.fish
@@ -47,13 +47,13 @@ function man
         # So we override them with the good name.
         switch $argv
             case !
-                set $argv not
+                set argv not
             case .
-                set $argv source
+                set argv source
             case :
-                set $argv true
+                set argv true
             case '['
-                set $argv test
+                set argv test
         end
     end
 


### PR DESCRIPTION
The leading `$` should not be there. They were introduced in 00639921955454255269fc9127a622697035a5ca, which claims to match __fish_print_help, but in that file, the variable assignment is done correctly.

Fixes #11655
