### PR TITLE
msrv: update to Rust 1.85

### DIFF
--- a/.github/actions/rust-toolchain/action.yml
+++ b/.github/actions/rust-toolchain/action.yml
@@ -26,7 +26,7 @@ runs:
         toolchain=$(
           case "$toolchain_channel" in
             (stable) echo 1.90 ;;
-            (msrv)   echo 1.70 ;;
+            (msrv)   echo 1.85 ;;
             (*)
               printf >&2 "error: unsupported toolchain channel %s" "$toolchain_channel"
               exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,13 +143,9 @@ jobs:
           # Workaround for https://github.com/actions/checkout/issues/882
           ref: ${{ inputs.version }}
       - name: Install Rust
-        uses: ./.github/actions/rust-toolchain@oldest-supported
-        with:
-          targets: x86_64-apple-darwin
-      - name: Install Rust Stable
         uses: ./.github/actions/rust-toolchain@stable
         with:
-          targets: aarch64-apple-darwin
+          targets: aarch64-apple-darwin,x86_64-apple-darwin
       - name: Install dependencies
         run: brew install gettext
       - name: Build and codesign

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,8 @@ For distributors
 - Fixed build on MIPS machines (:issue:`11965`).
 - Fixed broken universal variables on Cygwin (:issue:`11948`).
 
+The minimum supported Rust version (MSRV) has been updated to 1.85.
+
 
 fish 4.1.3 (released ???)
 =========================

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/*"]
 
 [workspace.package]
 # To build revisions that use Corrosion (those before 2024-01), use CMake 3.19, Rustc 1.78 and Rustup 1.27.
-rust-version = "1.70"
+rust-version = "1.85"
 edition = "2021"
 repository = "https://github.com/fish-shell/fish-shell"
 
@@ -100,9 +100,14 @@ widestring.workspace = true
 portable-atomic.workspace = true
 
 [target.'cfg(windows)'.dependencies]
-rust-embed = { workspace = true, optional = true, features = ["deterministic-timestamps", "debug-embed"] }
+rust-embed = { workspace = true, optional = true, features = [
+    "deterministic-timestamps",
+    "debug-embed",
+] }
 [target.'cfg(not(windows))'.dependencies]
-rust-embed = { workspace = true, optional = true, features = ["deterministic-timestamps"] }
+rust-embed = { workspace = true, optional = true, features = [
+    "deterministic-timestamps",
+] }
 
 [dev-dependencies]
 serial_test.workspace = true

--- a/README.rst
+++ b/README.rst
@@ -119,7 +119,7 @@ Dependencies
 
 Compiling fish requires:
 
--  Rust (version 1.70 or later)
+-  Rust (version 1.85 or later)
 -  CMake (version 3.15 or later)
 -  a C compiler (for system feature detection and the test helper binary)
 -  PCRE2 (headers and libraries) - optional, this will be downloaded if missing

--- a/crates/printf/src/tests.rs
+++ b/crates/printf/src/tests.rs
@@ -859,7 +859,7 @@ fn test_float_hex_prec() {
     let c_storage_ptr = c_storage.as_mut_ptr() as *mut c_char;
     let mut rust_str = String::with_capacity(256);
 
-    let c_fmt = b"%.*a\0".as_ptr() as *const c_char;
+    let c_fmt = c"%.*a".as_ptr() as *const c_char;
     let mut failed = false;
     for sign in [1.0, -1.0].into_iter() {
         for mut v in [0.0, 0.5, 1.0, 1.5, PI, TAU, E].into_iter() {
@@ -932,19 +932,19 @@ fn test_exhaustive(rust_fmt: &str, c_fmt: *const c_char) {
 #[ignore]
 fn test_float_g_exhaustive() {
     // To run: cargo test test_float_g_exhaustive --release -- --ignored --nocapture
-    test_exhaustive("%.*g", b"%.*g\0".as_ptr() as *const c_char);
+    test_exhaustive("%.*g", c"%.*g".as_ptr() as *const c_char);
 }
 
 #[test]
 #[ignore]
 fn test_float_e_exhaustive() {
     // To run: cargo test test_float_e_exhaustive --release -- --ignored --nocapture
-    test_exhaustive("%.*e", b"%.*e\0".as_ptr() as *const c_char);
+    test_exhaustive("%.*e", c"%.*e".as_ptr() as *const c_char);
 }
 
 #[test]
 #[ignore]
 fn test_float_f_exhaustive() {
     // To run: cargo test test_float_f_exhaustive --release -- --ignored --nocapture
-    test_exhaustive("%.*f", b"%.*f\0".as_ptr() as *const c_char);
+    test_exhaustive("%.*f", c"%.*f".as_ptr() as *const c_char);
 }

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Build-Depends: debhelper (>= 12),
  cmake (>= 3.15.0) | cmake-mozilla (>= 3.15.0),
  gettext,
  libpcre2-dev,
- rustc (>= 1.70),
+ rustc (>= 1.85),
 # Test dependencies
  locales-all,
  ncurses-base,

--- a/doc_internal/rust-devel.md
+++ b/doc_internal/rust-devel.md
@@ -18,7 +18,7 @@ We use forks of the last two - see the [FFI section](#ffi) below. No special act
 
 ### Build Dependencies
 
-fish-shell currently depends on Rust 1.70 or later. To install Rust, follow https://rustup.rs.
+fish-shell currently depends on Rust 1.85 or later. To install Rust, follow https://rustup.rs.
 
 ### Build via CMake
 

--- a/fish.spec.in
+++ b/fish.spec.in
@@ -11,7 +11,7 @@ URL:                    https://fishshell.com/
 Source0:                %{name}_@VERSION@.orig.tar.xz
 Source1:                %{name}_@VERSION@.orig-cargo-vendor.tar.xz
 BuildRequires:          cargo gettext gcc xz pcre2-devel
-BuildRequires:          rust >= 1.70
+BuildRequires:          rust >= 1.85
 # Packaging guidelines say to use a BuildRequires: rust-packaging, but it adds no value for our package
 
 BuildRequires: cmake >= 3.15

--- a/src/builtins/breakpoint.rs
+++ b/src/builtins/breakpoint.rs
@@ -26,7 +26,7 @@ pub fn breakpoint(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) 
     {
         if parser
             .block_at_index(1)
-            .map_or(true, |b| b.typ() == BlockType::breakpoint)
+            .is_none_or(|b| b.typ() == BlockType::breakpoint)
         {
             streams.err.append(wgettext_fmt!(
                 "%s: Command not valid at an interactive prompt\n",

--- a/src/builtins/fg.rs
+++ b/src/builtins/fg.rs
@@ -72,7 +72,7 @@ pub fn fg(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Built
             Ok(pid) => {
                 let j = parser.job_get_with_index_from_pid(pid);
                 if j.as_ref()
-                    .map_or(true, |(_pos, j)| !j.is_constructed() || j.is_completed())
+                    .is_none_or(|(_pos, j)| !j.is_constructed() || j.is_completed())
                 {
                     streams
                         .err

--- a/src/builtins/fish_indent.rs
+++ b/src/builtins/fish_indent.rs
@@ -464,8 +464,10 @@ impl<'source, 'ast> PrettyPrinterState<'source, 'ast> {
     // Emit a space or indent as necessary, depending on the previous output.
     fn emit_space_or_indent(&mut self, flags: GapFlags) {
         if self.at_line_start() {
-            self.output
-                .extend(std::iter::repeat(' ').take(SPACES_PER_INDENT * self.current_indent));
+            self.output.extend(std::iter::repeat_n(
+                ' ',
+                SPACES_PER_INDENT * self.current_indent,
+            ));
         } else if !flags.skip_space && !self.has_preceding_space() {
             self.output.push(' ');
         }

--- a/src/builtins/string/pad.rs
+++ b/src/builtins/string/pad.rs
@@ -85,8 +85,6 @@ impl StringSubCommand<'_> for Pad {
         let pad_width = max_width.max(self.width);
 
         for (input, width) in inputs {
-            use std::iter::repeat;
-
             let total_pad = pad_width - width;
             let (left_pad, right_pad) = match (self.pad_from, self.center) {
                 (Direction::Left, false) => (total_pad, 0),
@@ -95,8 +93,8 @@ impl StringSubCommand<'_> for Pad {
                 (Direction::Right, true) => (total_pad / 2, total_pad - total_pad / 2),
             };
 
-            let chars = |w| repeat(self.char_to_pad).take(w / self.pad_char_width);
-            let spaces = |w| repeat(' ').take(w % self.pad_char_width);
+            let chars = |w| std::iter::repeat_n(self.char_to_pad, w / self.pad_char_width);
+            let spaces = |w| std::iter::repeat_n(' ', w % self.pad_char_width);
             let mut padded: WString = chars(left_pad)
                 .chain(spaces(left_pad))
                 .chain(input.chars())

--- a/src/builtins/ulimit.rs
+++ b/src/builtins/ulimit.rs
@@ -55,7 +55,28 @@ pub mod limits {
     define_on!(RTPRIO, RLIMIT_RTPRIO; "linux");
     define_on!(RTTIME, RLIMIT_RTTIME; "linux");
     define_on!(RSS, RLIMIT_RSS; "linux", "freebsd", "netbsd", "openbsd", "dragonfly");
-    define_on!(AS, RLIMIT_AS; "linux", "ios", "macos", "cygwin", "freebsd", "netbsd", "dragonfly");
+    // TODO(MSRV >= 1.86): target_os = "cygwin" triggers a warning on Rust 1.85.
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "dragonfly",
+        cygwin
+    ))]
+    pub const AS: libc::c_int = libc::RLIMIT_AS as _;
+    // TODO(MSRV >= 1.86): target_os = "cygwin" triggers a warning on Rust 1.85.
+    #[cfg(not(any(
+        target_os = "linux",
+        target_os = "ios",
+        target_os = "macos",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "dragonfly",
+        cygwin
+    )))]
+    pub const AS: libc::c_int = -1;
     define_on!(SBSIZE, RLIMIT_SBSIZE; "freebsd", "netbsd", "dragonfly");
     define_on!(NICE, RLIMIT_NICE; "linux");
     define_on!(KQUEUES, RLIMIT_KQUEUES; "freebsd");

--- a/src/editable_line.rs
+++ b/src/editable_line.rs
@@ -52,7 +52,7 @@ pub fn apply_edit(target: &mut WString, colors: &mut Vec<HighlightSpec>, edit: &
         .unwrap_or_default();
     colors.splice(
         range.clone(),
-        std::iter::repeat(last_color).take(edit.replacement.len()),
+        std::iter::repeat_n(last_color, edit.replacement.len()),
     );
 }
 

--- a/src/env_dispatch.rs
+++ b/src/env_dispatch.rs
@@ -433,9 +433,9 @@ fn update_fish_color_support(vars: &EnvStack) {
         );
     } else {
         supports_24bit = !is_xterm_16color
-            && !vars
+            && vars
                 .get_unless_empty(L!("TERM_PROGRAM"))
-                .is_some_and(|term| term.as_list()[0] == "Apple_Terminal");
+                .is_none_or(|term| term.as_list()[0] != "Apple_Terminal");
         FLOG!(
             term_support,
             "True-color support",
@@ -533,7 +533,7 @@ fn init_locale(vars: &EnvStack) {
     }
 
     let user_locale = {
-        let loc_ptr = unsafe { libc::setlocale(libc::LC_ALL, b"\0".as_ptr().cast()) };
+        let loc_ptr = unsafe { libc::setlocale(libc::LC_ALL, c"".as_ptr().cast()) };
         if loc_ptr.is_null() {
             FLOG!(env_locale, "user has an invalid locale configured");
             None
@@ -571,7 +571,7 @@ fn init_locale(vars: &EnvStack) {
     }
 
     // We *always* use a C-locale for numbers because we want '.' (except for in printf).
-    let loc_ptr = unsafe { libc::setlocale(libc::LC_NUMERIC, b"C\0".as_ptr().cast()) };
+    let loc_ptr = unsafe { libc::setlocale(libc::LC_NUMERIC, c"C".as_ptr().cast()) };
     // should never fail, the C locale should always be defined
     assert_ne!(loc_ptr, ptr::null_mut());
 

--- a/src/env_universal_common.rs
+++ b/src/env_universal_common.rs
@@ -290,7 +290,7 @@ impl EnvUniversal {
             if unsafe {
                 libc::sscanf(
                     cstr.as_ptr(),
-                    b"# VERSION: %64s\0".as_ptr().cast(),
+                    c"# VERSION: %64s".as_ptr().cast(),
                     versionbuf.as_mut_ptr(),
                 )
             } != 1

--- a/src/fork_exec/flog_safe.rs
+++ b/src/fork_exec/flog_safe.rs
@@ -142,14 +142,13 @@ mod tests {
 
     #[test]
     fn test_str_to_flog_cstr() {
-        use std::ffi::CStr;
         let mut buffer = StackBuffer::uninit();
 
-        let str = CStr::from_bytes_with_nul(b"hello\0").unwrap();
+        let str = c"hello";
         let result = str.to_flog_str_async_safe(&mut buffer);
         assert_eq!(result, b"hello");
 
-        let str = CStr::from_bytes_with_nul(b"\0").unwrap();
+        let str = c"";
         let result = str.to_flog_str_async_safe(&mut buffer);
         assert_eq!(result, b"");
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -262,8 +262,7 @@ where
         // If the file id did not change, we assume that we loaded a consistent state.
         return Ok((final_file_id, loaded_data));
     }
-    Err(std::io::Error::new(
-        std::io::ErrorKind::Other,
+    Err(std::io::Error::other(
         "Failed to update the file. Locking is disabled, and the fallback code did not succeed within the permissible number of attempts.",
     ))
 }
@@ -473,8 +472,7 @@ where
             // (If we did write.)
             return Ok((final_file_id, potential_update));
         }
-        Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
+        Err(std::io::Error::other(
             "Failed to update the file. Locking is disabled, and the fallback code did not succeed within the permissible number of attempts.",
         ))
     }

--- a/src/history.rs
+++ b/src/history.rs
@@ -119,7 +119,7 @@ const DFLT_FISH_HISTORY_SESSION_ID: &wstr = L!("fish");
 
 /// When we rewrite the history, the number of items we keep.
 // FIXME: https://github.com/rust-lang/rust/issues/67441
-const HISTORY_SAVE_MAX: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(1024 * 256) };
+const HISTORY_SAVE_MAX: NonZeroUsize = NonZeroUsize::new(1024 * 256).unwrap();
 
 /// Default buffer size for flushing to the history file.
 const HISTORY_OUTPUT_BUFFER_SIZE: usize = 64 * 1024;
@@ -382,10 +382,9 @@ impl HistoryImpl {
         if let Some(canonicalized_path) = wrealpath(&path) {
             Ok(Some(canonicalized_path))
         } else {
-            Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("wrealpath failed to produce a canonical version of '{path}'."),
-            ))
+            Err(std::io::Error::other(format!(
+                "wrealpath failed to produce a canonical version of '{path}'."
+            )))
         }
     }
 

--- a/src/history/file.rs
+++ b/src/history/file.rs
@@ -129,8 +129,7 @@ impl HistoryFileContents {
             }
         };
         if len == 0 {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
+            return Err(std::io::Error::other(
                 "History file is empty. Cannot create memory mapping with length 0.",
             ));
         }

--- a/src/input_common.rs
+++ b/src/input_common.rs
@@ -887,7 +887,7 @@ pub trait InputEventQueuer {
                     if key.is_some_and(|key| key.key == Key::from_raw(key::Invalid)) {
                         continue;
                     }
-                    assert!(key.map_or(true, |key| key.codepoint != key::Invalid));
+                    assert!(key.is_none_or(|key| key.codepoint != key::Invalid));
                     let mut consumed = 0;
                     let mut state = zero_mbstate();
                     let mut i = 0;

--- a/src/pager.rs
+++ b/src/pager.rs
@@ -315,9 +315,10 @@ impl Pager {
         let mut search_field_text = self.search_field_line.text().to_owned();
         // Append spaces to make it at least the required width.
         if search_field_text.len() < PAGER_SEARCH_FIELD_WIDTH {
-            search_field_text.extend(
-                std::iter::repeat(' ').take(PAGER_SEARCH_FIELD_WIDTH - search_field_text.len()),
-            );
+            search_field_text.extend(std::iter::repeat_n(
+                ' ',
+                PAGER_SEARCH_FIELD_WIDTH - search_field_text.len(),
+            ));
         }
         let search_field = rendering.screen_data.insert_line_at_index(0);
 
@@ -609,7 +610,7 @@ impl Pager {
             // No description, or it won't fit. Just add spaces.
             print_max(
                 offset_in_cmdline,
-                &WString::from_iter(std::iter::repeat(' ').take(desc_remaining)),
+                &WString::from_iter(std::iter::repeat_n(' ', desc_remaining)),
                 bg,
                 desc_remaining,
                 false,

--- a/src/parse_util.rs
+++ b/src/parse_util.rs
@@ -830,9 +830,10 @@ pub fn apply_indents(src: &wstr, indents: &[i32]) -> WString {
         if c != '\n' || i + 1 == src.len() {
             continue;
         }
-        indented.extend(
-            std::iter::repeat(' ').take(SPACES_PER_INDENT * usize::try_from(indents[i]).unwrap()),
-        );
+        indented.extend(std::iter::repeat_n(
+            ' ',
+            SPACES_PER_INDENT * usize::try_from(indents[i]).unwrap(),
+        ));
     }
     indented
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -37,7 +37,7 @@ use libc::c_int;
 #[cfg(not(target_has_atomic = "64"))]
 use portable_atomic::AtomicU64;
 use std::cell::{Ref, RefCell, RefMut};
-use std::ffi::{CStr, OsStr};
+use std::ffi::OsStr;
 use std::fs::File;
 use std::io::Write;
 use std::num::NonZeroU32;
@@ -470,7 +470,7 @@ impl Parser {
             blocking_query_timeout: RefCell::new(None),
         };
 
-        match open_dir(CStr::from_bytes_with_nul(b".\0").unwrap(), BEST_O_SEARCH) {
+        match open_dir(c".", BEST_O_SEARCH) {
             Ok(fd) => {
                 result.libdata_mut().cwd_fd = Some(Arc::new(fd));
             }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -4254,7 +4254,7 @@ impl ReaderData {
         }
 
         let col = pager.get_selected_column(&self.current_page_rendering);
-        !col.is_some_and(|col| col != 0)
+        col.is_none_or(|col| col == 0)
     }
 }
 

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -435,7 +435,7 @@ impl<'c> Iterator for Tokenizer<'c> {
             '}' => {
                 let brace_count = self.brace_statement_parser.as_mut()
                     .map(|parser| &mut parser.unclosed_brace_statements);
-                if brace_count.as_ref().map_or(true, |count| **count == 0) {
+                if brace_count.as_ref().is_none_or(|count| **count == 0) {
                     return Some(self.call_error(
                         TokenizerError::closing_unopened_brace,
                         self.token_cursor,

--- a/src/wutil/dir_iter.rs
+++ b/src/wutil/dir_iter.rs
@@ -424,7 +424,7 @@ fn test_dir_iter() {
         ret = symlink(makepath(dirname).as_ptr(), makepath(dirlinkname).as_ptr());
         assert!(ret == 0);
         ret = symlink(
-            b"/this/is/an/invalid/path\0".as_ptr().cast(),
+            c"/this/is/an/invalid/path".as_ptr().cast(),
             makepath(badlinkname).as_ptr(),
         );
         assert!(ret == 0);


### PR DESCRIPTION
Update our MSRV to Rust 1.85.

Includes fixes for lints which were previously suppressed due to them relying on features added after Rust 1.70.