### PR TITLE
format strings: remove length modifier

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -83,10 +83,6 @@ msgid "%.*s: invalid conversion specification"
 msgstr "%.*s: Ungültige Umwandlungsspezifikation"
 
 #, c-format
-msgid "%ls: function name required"
-msgstr "%ls: Brauche Funktionsnamen"
-
-#, c-format
 msgid "%s"
 msgstr ""
 
@@ -717,6 +713,10 @@ msgstr "%s: Erwartete numerischen Wert"
 #, c-format
 msgid "%s: fish was not built with embedded files"
 msgstr ""
+
+#, c-format
+msgid "%s: function name required"
+msgstr "%s: Brauche Funktionsnamen"
 
 #, c-format
 msgid "%s: given %d indexes but %d values\n"

--- a/po/en.po
+++ b/po/en.po
@@ -81,10 +81,6 @@ msgid "%.*s: invalid conversion specification"
 msgstr "%.*s: invalid conversion specification"
 
 #, c-format
-msgid "%ls: function name required"
-msgstr ""
-
-#, c-format
 msgid "%s"
 msgstr ""
 
@@ -714,6 +710,10 @@ msgstr "%s: expected a numeric value"
 
 #, c-format
 msgid "%s: fish was not built with embedded files"
+msgstr ""
+
+#, c-format
+msgid "%s: function name required"
 msgstr ""
 
 #, c-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -182,10 +182,6 @@ msgid "%.*s: invalid conversion specification"
 msgstr "%.*s : spécification de conversion invalide"
 
 #, c-format
-msgid "%ls: function name required"
-msgstr ""
-
-#, c-format
 msgid "%s"
 msgstr ""
 
@@ -815,6 +811,10 @@ msgstr "%s : valeur numérique attendue"
 
 #, c-format
 msgid "%s: fish was not built with embedded files"
+msgstr ""
+
+#, c-format
+msgid "%s: function name required"
 msgstr ""
 
 #, c-format

--- a/po/pl.po
+++ b/po/pl.po
@@ -77,10 +77,6 @@ msgid "%.*s: invalid conversion specification"
 msgstr ""
 
 #, c-format
-msgid "%ls: function name required"
-msgstr ""
-
-#, c-format
 msgid "%s"
 msgstr ""
 
@@ -710,6 +706,10 @@ msgstr "%s: oczekiwano wartości liczbowej"
 
 #, c-format
 msgid "%s: fish was not built with embedded files"
+msgstr ""
+
+#, c-format
+msgid "%s: function name required"
 msgstr ""
 
 #, c-format

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -82,10 +82,6 @@ msgid "%.*s: invalid conversion specification"
 msgstr "%.*s: especificação de conversão inválida"
 
 #, c-format
-msgid "%ls: function name required"
-msgstr ""
-
-#, c-format
 msgid "%s"
 msgstr ""
 
@@ -715,6 +711,10 @@ msgstr "%s: esperava valor numérico"
 
 #, c-format
 msgid "%s: fish was not built with embedded files"
+msgstr ""
+
+#, c-format
+msgid "%s: function name required"
 msgstr ""
 
 #, c-format

--- a/po/sv.po
+++ b/po/sv.po
@@ -78,10 +78,6 @@ msgid "%.*s: invalid conversion specification"
 msgstr ""
 
 #, c-format
-msgid "%ls: function name required"
-msgstr ""
-
-#, c-format
 msgid "%s"
 msgstr ""
 
@@ -711,6 +707,10 @@ msgstr ""
 
 #, c-format
 msgid "%s: fish was not built with embedded files"
+msgstr ""
+
+#, c-format
+msgid "%s: function name required"
 msgstr ""
 
 #, c-format

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -104,10 +104,6 @@ msgid "%.*s: invalid conversion specification"
 msgstr "%.*s: 无效的转换规范"
 
 #, c-format
-msgid "%ls: function name required"
-msgstr "%ls: 函数名称是必须的"
-
-#, c-format
 msgid "%s"
 msgstr "%s"
 
@@ -738,6 +734,10 @@ msgstr "%s: 预期收到数值"
 #, c-format
 msgid "%s: fish was not built with embedded files"
 msgstr "%s: fish 构建时未包含嵌入文件"
+
+#, c-format
+msgid "%s: function name required"
+msgstr "%s: 函数名称是必须的"
 
 #, c-format
 msgid "%s: given %d indexes but %d values\n"

--- a/src/builtins/function.rs
+++ b/src/builtins/function.rs
@@ -244,7 +244,7 @@ fn validate_function_name(
     if argv.len() < 2 {
         streams
             .err
-            .append(wgettext_fmt!("%ls: function name required", cmd));
+            .append(wgettext_fmt!("%s: function name required", cmd));
         return Err(STATUS_INVALID_ARGS);
     }
     *function_name = argv[1].to_owned();


### PR DESCRIPTION
This length modifier was reintroduced in
b7fe3190bba1e7d314d3b4e65000f9cd8b6d6e38, which reverts 993b977c9b1d730c66c132b875e7e0db122e881d, a commit predating the removal of redundant length modifiers in format strings.
