### PR TITLE
refactor: use `bytes` instead of `string`

### DIFF
--- a/src/autoload.rs
+++ b/src/autoload.rs
@@ -2,7 +2,7 @@
 
 use crate::FLOGF;
 #[cfg(feature = "embed-data")]
-use crate::common::wcs2string;
+use crate::common::wcs2bytes;
 use crate::common::{ScopeGuard, escape};
 use crate::env::Environment;
 use crate::io::IoChain;
@@ -150,11 +150,11 @@ impl Autoload {
             }
             #[cfg(feature = "embed-data")]
             AutoloadPath::Embedded(name) => {
-                use crate::common::str2wcstring;
+                use crate::common::bytes2wcstring;
                 use std::sync::Arc;
                 FLOGF!(autoload, "Loading embedded: %s", name);
                 let emfile = Asset::get(name).expect("Embedded file not found");
-                let src = str2wcstring(&emfile.data);
+                let src = bytes2wcstring(&emfile.data);
                 let mut widename = L!("embedded:").to_owned();
                 widename.push_str(name);
                 let ret = parser.eval_file_wstr(src, Arc::new(widename), &IoChain::new(), None);
@@ -474,7 +474,7 @@ impl AutoloadFileCache {
         if cfg!(test) {
             return None;
         }
-        let narrow = wcs2string(cmd);
+        let narrow = wcs2bytes(cmd);
         let cmdstr = std::str::from_utf8(&narrow).ok()?;
         let p = match asset_dir {
             AssetDir::Functions => "functions/".to_owned() + cmdstr + ".fish",

--- a/src/builtins/bind.rs
+++ b/src/builtins/bind.rs
@@ -2,7 +2,7 @@
 
 use super::prelude::*;
 use crate::common::{
-    EscapeFlags, EscapeStringStyle, escape, escape_string, str2wcstring, valid_var_name,
+    EscapeFlags, EscapeStringStyle, bytes2wcstring, escape, escape_string, valid_var_name,
 };
 use crate::highlight::{colorize, highlight_shell};
 use crate::input::{InputMappingSet, KeyNameStyle, input_function_get_names, input_mappings};
@@ -157,7 +157,7 @@ impl BuiltinBind {
             let mut colors = Vec::new();
             highlight_shell(&out, &mut colors, &parser.context(), false, None);
             let colored = colorize(&out, &colors, parser.vars());
-            streams.out.append(str2wcstring(&colored));
+            streams.out.append(bytes2wcstring(&colored));
         } else {
             streams.out.append(out);
         }

--- a/src/builtins/complete.rs
+++ b/src/builtins/complete.rs
@@ -12,7 +12,7 @@ use crate::proc::is_interactive_session;
 use crate::reader::{commandline_get_state, completion_apply_to_command_line};
 use crate::wcstringutil::string_suffixes_string;
 use crate::{
-    common::str2wcstring,
+    common::bytes2wcstring,
     complete::{
         CompleteFlags, CompleteOptionType, CompletionMode, complete_add, complete_print,
         complete_remove, complete_remove_all,
@@ -207,7 +207,7 @@ fn builtin_complete_print(cmd: &wstr, streams: &mut IoStreams, parser: &Parser) 
         highlight_shell(&repr, &mut colors, &parser.context(), false, None);
         streams
             .out
-            .append(str2wcstring(&colorize(&repr, &colors, parser.vars())));
+            .append(bytes2wcstring(&colorize(&repr, &colors, parser.vars())));
     } else {
         streams.out.append(repr);
     }

--- a/src/builtins/fish_indent.rs
+++ b/src/builtins/fish_indent.rs
@@ -17,7 +17,7 @@ use libc::LC_ALL;
 use super::prelude::*;
 use crate::ast::{self, Ast, Kind, Leaf, Node, NodeVisitor, SourceRangeList, Traversal};
 use crate::common::{
-    PROGRAM_NAME, UnescapeFlags, UnescapeStringStyle, str2wcstring, unescape_string, wcs2string,
+    PROGRAM_NAME, UnescapeFlags, UnescapeStringStyle, bytes2wcstring, unescape_string, wcs2bytes,
 };
 use crate::env::EnvStack;
 use crate::env::env_init;
@@ -914,7 +914,7 @@ fn throwing_main() -> i32 {
     }
 
     let args: Vec<WString> = std::env::args_os()
-        .map(|osstr| str2wcstring(osstr.as_bytes()))
+        .map(|osstr| bytes2wcstring(osstr.as_bytes()))
         .collect();
     do_indent(&mut streams, args).builtin_status_code()
 }
@@ -1014,10 +1014,10 @@ fn do_indent(streams: &mut IoStreams, args: Vec<WString>) -> BuiltinResult {
                 }
             }
             std::mem::forget(fd);
-            src = str2wcstring(&buf);
+            src = bytes2wcstring(&buf);
         } else {
             let arg = args[i];
-            match fs::File::open(OsStr::from_bytes(&wcs2string(arg))) {
+            match fs::File::open(OsStr::from_bytes(&wcs2bytes(arg))) {
                 Ok(file) => {
                     match read_file(file) {
                         Ok(s) => src = s,
@@ -1038,7 +1038,7 @@ fn do_indent(streams: &mut IoStreams, args: Vec<WString>) -> BuiltinResult {
 
         if output_type == OutputType::PygmentsCsv {
             let output = make_pygments_csv(&src);
-            streams.out.append(str2wcstring(&output));
+            streams.out.append(bytes2wcstring(&output));
             i += 1;
             continue;
         }
@@ -1102,9 +1102,9 @@ fn do_indent(streams: &mut IoStreams, args: Vec<WString>) -> BuiltinResult {
             }
             OutputType::File => {
                 if output_wtext != src {
-                    match fs::File::create(OsStr::from_bytes(&wcs2string(output_location))) {
+                    match fs::File::create(OsStr::from_bytes(&wcs2bytes(output_location))) {
                         Ok(mut file) => {
-                            let _ = file.write_all(&wcs2string(&output_wtext));
+                            let _ = file.write_all(&wcs2bytes(&output_wtext));
                         }
                         Err(err) => {
                             streams.err.appendln(wgettext_fmt!(
@@ -1136,7 +1136,7 @@ fn do_indent(streams: &mut IoStreams, args: Vec<WString>) -> BuiltinResult {
             }
         }
 
-        streams.out.append(str2wcstring(&colored_output));
+        streams.out.append(bytes2wcstring(&colored_output));
         i += 1;
     }
     if retval == 0 {
@@ -1152,7 +1152,7 @@ static DUMP_PARSE_TREE: RelaxedAtomicBool = RelaxedAtomicBool::new(false);
 fn read_file(mut f: impl Read) -> Result<WString, ()> {
     let mut buf = vec![];
     f.read_to_end(&mut buf).map_err(|_| ())?;
-    Ok(str2wcstring(&buf))
+    Ok(bytes2wcstring(&buf))
 }
 
 fn highlight_role_to_string(role: HighlightRole) -> &'static wstr {
@@ -1314,9 +1314,9 @@ fn html_colorize(text: &wstr, colors: &[HighlightSpec]) -> Vec<u8> {
         }
     }
     html.push_str("</span></code></pre>");
-    wcs2string(&html)
+    wcs2bytes(&html)
 }
 
 fn no_colorize(text: &wstr) -> Vec<u8> {
-    wcs2string(text)
+    wcs2bytes(text)
 }

--- a/src/builtins/fish_key_reader.rs
+++ b/src/builtins/fish_key_reader.rs
@@ -15,7 +15,7 @@ use libc::{STDIN_FILENO, VEOF, VINTR};
 use crate::future::IsSomeAnd;
 use crate::{
     builtins::shared::BUILTIN_ERR_UNKNOWN,
-    common::{PROGRAM_NAME, shell_modes, str2wcstring},
+    common::{PROGRAM_NAME, bytes2wcstring, shell_modes},
     env::{EnvStack, Environment, env_init},
     future_feature_flags,
     input_common::{
@@ -299,7 +299,7 @@ fn throwing_main() -> i32 {
     let mut verbose = false;
 
     let args: Vec<WString> = std::env::args_os()
-        .map(|osstr| str2wcstring(osstr.as_bytes()))
+        .map(|osstr| bytes2wcstring(osstr.as_bytes()))
         .collect();
     if let ControlFlow::Break(s) =
         parse_flags(&mut streams, args, &mut continuous_mode, &mut verbose)

--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -1,7 +1,7 @@
 use super::prelude::*;
+use crate::common::bytes2wcstring;
 use crate::common::escape_string;
 use crate::common::reformat_for_screen;
-use crate::common::str2wcstring;
 use crate::common::valid_func_name;
 use crate::common::{EscapeFlags, EscapeStringStyle};
 use crate::event::{self};
@@ -437,7 +437,7 @@ pub fn functions(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -
             highlight_shell(&def, &mut colors, &parser.context(), false, None);
             streams
                 .out
-                .append(str2wcstring(&colorize(&def, &colors, parser.vars())));
+                .append(bytes2wcstring(&colorize(&def, &colors, parser.vars())));
         } else {
             streams.out.append(def);
         }

--- a/src/builtins/read.rs
+++ b/src/builtins/read.rs
@@ -2,9 +2,9 @@
 
 use super::prelude::*;
 use crate::common::UnescapeStringStyle;
+use crate::common::bytes2wcstring;
 use crate::common::escape;
 use crate::common::read_blocked;
-use crate::common::str2wcstring;
 use crate::common::unescape_string;
 use crate::common::valid_var_name;
 use crate::env::EnvMode;
@@ -366,7 +366,7 @@ fn read_in_chunks(fd: RawFd, buff: &mut WString, split_null: bool, do_seek: bool
         }
     }
 
-    *buff = str2wcstring(&narrow_buff);
+    *buff = bytes2wcstring(&narrow_buff);
     if buff.is_empty() && eof {
         exit_res = Err(STATUS_CMD_ERROR);
     }

--- a/src/builtins/set_color.rs
+++ b/src/builtins/set_color.rs
@@ -2,7 +2,7 @@
 
 use super::prelude::*;
 use crate::color::Color;
-use crate::common::str2wcstring;
+use crate::common::bytes2wcstring;
 use crate::screen::{is_dumb, only_grayscale};
 use crate::terminal::{Outputter, use_terminfo};
 use crate::text_face::{
@@ -47,7 +47,7 @@ fn print_colors(
     } // conveniently, 'normal' is always the last color so we don't need to reset here
 
     let contents = outp.contents();
-    streams.out.append(str2wcstring(contents));
+    streams.out.append(bytes2wcstring(contents));
 }
 
 /// set_color builtin.
@@ -147,7 +147,7 @@ pub fn set_color(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
 
     // Output the collected string.
     let contents = outp.contents();
-    streams.out.append(str2wcstring(contents));
+    streams.out.append(bytes2wcstring(contents));
 
     Ok(SUCCESS)
 }

--- a/src/builtins/shared.rs
+++ b/src/builtins/shared.rs
@@ -1,5 +1,5 @@
 use super::prelude::*;
-use crate::common::{Named, escape, get_by_sorted_name, str2wcstring};
+use crate::common::{Named, bytes2wcstring, escape, get_by_sorted_name};
 use crate::io::OutputStream;
 use crate::parse_constants::UNKNOWN_BUILTIN_ERR_MSG;
 use crate::parse_util::parse_util_argument_is_help;
@@ -895,7 +895,7 @@ impl<'args, 'iter> Arguments<'args, 'iter> {
             _ => unreachable!(),
         };
 
-        let parsed = str2wcstring(&self.buffer[..end]);
+        let parsed = bytes2wcstring(&self.buffer[..end]);
 
         let retval = Some((Cow::Owned(parsed), want_newline));
         self.buffer.clear();

--- a/src/builtins/string.rs
+++ b/src/builtins/string.rs
@@ -290,7 +290,7 @@ fn width_without_escapes(ins: &wstr, start_pos: usize) -> usize {
 
 /// Empirically determined.
 /// This is probably down to some pipe buffer or some such,
-/// but too small means we need to call `read(2)` and str2wcstring a lot.
+/// but too small means we need to call `read(2)` and bytes2wcstring a lot.
 const STRING_CHUNK_SIZE: usize = 1024;
 fn arguments<'iter, 'args>(
     args: &'iter [&'args wstr],

--- a/src/builtins/type.rs
+++ b/src/builtins/type.rs
@@ -1,5 +1,5 @@
 use super::prelude::*;
-use crate::common::str2wcstring;
+use crate::common::bytes2wcstring;
 use crate::function;
 use crate::highlight::{colorize, highlight_shell};
 
@@ -152,7 +152,7 @@ pub fn r#type(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
                                 /*io_ok=*/ false,
                                 /*cursor=*/ None,
                             );
-                            let col = str2wcstring(&colorize(&def, &color, parser.vars()));
+                            let col = bytes2wcstring(&colorize(&def, &color, parser.vars()));
                             streams.out.append(col);
                         } else {
                             streams.out.append(def);

--- a/src/env/config_paths.rs
+++ b/src/env/config_paths.rs
@@ -1,5 +1,5 @@
 use crate::common::BUILD_DIR;
-use crate::common::wcs2string;
+use crate::common::wcs2bytes;
 use crate::wchar::prelude::*;
 use crate::{FLOG, FLOGF, common::get_executable_path};
 use fish_build_helper::workspace_root;
@@ -24,7 +24,7 @@ const DOC_DIR: &str = env!("DOCDIR");
 
 impl ConfigPaths {
     pub fn new(argv0: &wstr) -> Self {
-        let argv0 = PathBuf::from(OsString::from_vec(wcs2string(argv0)));
+        let argv0 = PathBuf::from(OsString::from_vec(wcs2bytes(argv0)));
         let exec_path = get_executable_path(argv0);
         FLOG!(config, format!("executable path: {}", exec_path.display()));
         let paths = Self::from_exec_path(exec_path);

--- a/src/flog.rs
+++ b/src/flog.rs
@@ -1,4 +1,4 @@
-use crate::common::wcs2string;
+use crate::common::wcs2bytes;
 use crate::wchar::prelude::*;
 use crate::wildcard::wildcard_match;
 use crate::wutil::write_to_fd;
@@ -161,13 +161,13 @@ pub trait FloggableDisplay: std::fmt::Display {
 // Special handling for `WString` to decode PUA codepoints back into the original bytes.
 impl FloggableDisplay for WString {
     fn to_flog_str(&self) -> Vec<u8> {
-        wcs2string(self)
+        wcs2bytes(self)
     }
 }
 
 impl FloggableDisplay for &wstr {
     fn to_flog_str(&self) -> Vec<u8> {
-        wcs2string(self)
+        wcs2bytes(self)
     }
 }
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,6 +1,6 @@
 use crate::{
     FLOG, FLOGF,
-    common::{str2wcstring, wcs2osstring, wcs2zstring},
+    common::{bytes2wcstring, wcs2osstring, wcs2zstring},
     fds::wopen_cloexec,
     path::{DirRemoteness, path_remoteness},
     wchar::prelude::*,
@@ -64,7 +64,7 @@ pub fn create_temporary_file(name_template: &wstr) -> std::io::Result<(File, WSt
             },
         }
     };
-    Ok((fd, str2wcstring(c_string_template.to_bytes())))
+    Ok((fd, bytes2wcstring(c_string_template.to_bytes())))
 }
 
 /// Use this struct for all accesses to file which need mutual exclusion.

--- a/src/function.rs
+++ b/src/function.rs
@@ -240,7 +240,7 @@ pub fn exists_no_autoload(cmd: &wstr) -> bool {
         return true;
     }
 
-    let narrow = crate::common::wcs2string(cmd);
+    let narrow = crate::common::wcs2bytes(cmd);
     if let Ok(cmdstr) = std::str::from_utf8(&narrow) {
         let cmd = "functions/".to_owned() + cmdstr + ".fish";
         crate::autoload::has_asset(&cmd)

--- a/src/history.rs
+++ b/src/history.rs
@@ -43,7 +43,7 @@ use rand::Rng;
 
 use crate::{
     ast::{self, Kind, Node},
-    common::{CancelChecker, UnescapeStringStyle, str2wcstring, unescape_string, valid_var_name},
+    common::{CancelChecker, UnescapeStringStyle, bytes2wcstring, unescape_string, valid_var_name},
     env::{EnvMode, EnvStack, Environment},
     expand::{ExpandFlags, expand_one},
     fds::wopen_cloexec,
@@ -967,7 +967,7 @@ impl HistoryImpl {
             let Ok(line) = line else {
                 break;
             };
-            let wide_line = trim(str2wcstring(&line), None);
+            let wide_line = trim(bytes2wcstring(&line), None);
             // Add this line if it doesn't contain anything we know we can't handle.
             if should_import_bash_history_line(&wide_line) {
                 self.add(

--- a/src/history/file.rs
+++ b/src/history/file.rs
@@ -13,7 +13,7 @@ use libc::{ENODEV, MAP_ANONYMOUS, MAP_FAILED, MAP_PRIVATE, PROT_READ, PROT_WRITE
 
 use super::{HistoryItem, PersistenceMode};
 use crate::{
-    common::{str2wcstring, subslice_position, wcs2string},
+    common::{bytes2wcstring, subslice_position, wcs2bytes},
     flog::FLOG,
     path::{DirRemoteness, path_get_data_remoteness},
 };
@@ -218,7 +218,7 @@ impl TryFrom<MmapRegion> for HistoryFileContents {
 pub fn append_history_item_to_buffer(item: &HistoryItem, buffer: &mut Vec<u8>) {
     assert!(item.should_write_to_disk(), "Item should not be persisted");
 
-    let mut cmd = wcs2string(item.str());
+    let mut cmd = wcs2bytes(item.str());
     escape_yaml_fish_2_0(&mut cmd);
     buffer.extend(b"- cmd: ");
     buffer.extend(&cmd);
@@ -229,7 +229,7 @@ pub fn append_history_item_to_buffer(item: &HistoryItem, buffer: &mut Vec<u8>) {
     if !paths.is_empty() {
         writeln!(buffer, "  paths:").unwrap();
         for path in paths {
-            let mut path = wcs2string(path);
+            let mut path = wcs2bytes(path);
             escape_yaml_fish_2_0(&mut path);
             buffer.extend(b"    - ");
             buffer.extend(&path);
@@ -374,7 +374,7 @@ fn decode_item_fish_2_0(mut data: &[u8]) -> Option<HistoryItem> {
     let (_key, value) = extract_prefix_and_unescape_yaml(line)?;
 
     data = &data[advance..];
-    let cmd = str2wcstring(&value);
+    let cmd = bytes2wcstring(&value);
 
     // Read the remaining lines.
     let mut indent = None;
@@ -421,7 +421,7 @@ fn decode_item_fish_2_0(mut data: &[u8]) -> Option<HistoryItem> {
                 data = &data[advance..];
 
                 let line = maybe_unescape_yaml_fish_2_0(line);
-                paths.push(str2wcstring(&line));
+                paths.push(bytes2wcstring(&line));
             }
         }
     }

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,4 +1,4 @@
-use crate::common::{Named, escape, get_by_sorted_name, str2wcstring};
+use crate::common::{Named, bytes2wcstring, escape, get_by_sorted_name};
 use crate::env::Environment;
 use crate::event;
 use crate::flog::FLOG;
@@ -437,7 +437,7 @@ impl<'a> InputEventQueuer for Reader<'a> {
         };
         self.push_front(CharEvent::Command(sprintf!(
             "__fish_paste %s",
-            escape(&str2wcstring(&buffer))
+            escape(&bytes2wcstring(&buffer))
         )));
     }
 }

--- a/src/input_common.rs
+++ b/src/input_common.rs
@@ -1,6 +1,6 @@
 use crate::common::{
-    WSL, fish_reserved_codepoint, get_is_multibyte_locale, is_windows_subsystem_for_linux,
-    read_blocked, shell_modes, str2wcstring,
+    WSL, bytes2wcstring, fish_reserved_codepoint, get_is_multibyte_locale,
+    is_windows_subsystem_for_linux, read_blocked, shell_modes,
 };
 use crate::env::{EnvStack, Environment};
 use crate::fd_readable_set::{FdReadableSet, Timeout};
@@ -1421,7 +1421,7 @@ pub trait InputEventQueuer {
             return None;
         }
         XTVERSION.get_or_init(|| {
-            let xtversion = str2wcstring(&buffer[4..buffer.len()]);
+            let xtversion = bytes2wcstring(&buffer[4..buffer.len()]);
             FLOG!(
                 reader,
                 format!("Received XTVERSION response: {}", xtversion)
@@ -1460,7 +1460,7 @@ pub trait InputEventQueuer {
                 reader,
                 format!(
                     "Received XTGETTCAP failure response: {}",
-                    str2wcstring(&parse_hex(buffer)?),
+                    bytes2wcstring(&parse_hex(buffer)?),
                 )
             );
             return None;
@@ -1474,14 +1474,14 @@ pub trait InputEventQueuer {
                 reader,
                 format!(
                     "Received XTGETTCAP response: {}={:?}",
-                    str2wcstring(&key),
-                    str2wcstring(&value)
+                    bytes2wcstring(&key),
+                    bytes2wcstring(&value)
                 )
             );
         } else {
             FLOG!(
                 reader,
-                format!("Received XTGETTCAP response: {}", str2wcstring(&key))
+                format!("Received XTGETTCAP response: {}", bytes2wcstring(&key))
             );
         }
         if key == SCROLL_CONTENT_UP_TERMINFO_CODE.as_bytes() {

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,5 +1,5 @@
 use crate::builtins::shared::{STATUS_CMD_ERROR, STATUS_CMD_OK, STATUS_READ_TOO_MUCH};
-use crate::common::{EMPTY_STRING, str2wcstring, wcs2string};
+use crate::common::{EMPTY_STRING, bytes2wcstring, wcs2bytes};
 use crate::fd_monitor::{Callback, FdMonitor, FdMonitorItemId};
 use crate::fds::{
     AutoCloseFd, PIPE_ERROR, make_autoclose_pipes, make_fd_nonblocking, wopen_cloexec,
@@ -731,7 +731,7 @@ impl OutputStream {
     pub fn append_narrow_buffer(&mut self, buffer: &SeparatedBuffer) -> bool {
         for rhs_elem in buffer.elements() {
             if !self.append_with_separation(
-                &str2wcstring(&rhs_elem.contents),
+                &bytes2wcstring(&rhs_elem.contents),
                 rhs_elem.separation,
                 false,
             ) {
@@ -745,7 +745,7 @@ impl OutputStream {
 impl Output for OutputStream {
     fn write_bytes(&mut self, command_part: &[u8]) {
         // TODO Retry on interrupt.
-        self.append(str2wcstring(command_part));
+        self.append(bytes2wcstring(command_part));
     }
 }
 
@@ -834,7 +834,7 @@ impl BufferedOutputStream {
         Self { buffer }
     }
     fn append(&mut self, s: &wstr) -> bool {
-        self.buffer.append(&wcs2string(s), SeparationType::inferred)
+        self.buffer.append(&wcs2bytes(s), SeparationType::inferred)
     }
     fn append_with_separation(
         &mut self,
@@ -842,7 +842,7 @@ impl BufferedOutputStream {
         typ: SeparationType,
         _want_newline: bool,
     ) -> bool {
-        self.buffer.append(&wcs2string(s), typ)
+        self.buffer.append(&wcs2bytes(s), typ)
     }
     fn flush_and_check_error(&mut self) -> libc::c_int {
         if self.buffer.discarded() {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,7 +4,7 @@ use crate::ast::{self, Node};
 use crate::builtins::shared::STATUS_ILLEGAL_CMD;
 use crate::common::{
     CancelChecker, EscapeFlags, EscapeStringStyle, FilenameRef, PROFILING_ACTIVE, ScopeGuarding,
-    ScopedCell, ScopedRefCell, escape_string, wcs2string,
+    ScopedCell, ScopedRefCell, escape_string, wcs2bytes,
 };
 use crate::complete::CompletionList;
 use crate::env::{EnvMode, EnvStack, EnvStackSetResult, Environment, Statuses};
@@ -1270,7 +1270,7 @@ fn print_profile(items: &[ProfileItem], out: &mut File) {
             L!("\n"),
             &(WString::from("\n") + &wstr::repeat(L!(" "), indentation_level)[..]),
         );
-        let _ = out.write_all(&wcs2string(&indented_cmd));
+        let _ = out.write_all(&wcs2bytes(&indented_cmd));
         let _ = out.write_all(b"\n");
     }
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -585,7 +585,7 @@ fn make_base_directory(xdg_var: &wstr, non_xdg_homepath: &wstr) -> BaseDirectory
     // the actual $HOME or $XDG_XXX directories. This prevents the tests from failing and/or stops
     // the tests polluting the user's actual $HOME if a sandbox environment has not been set up.
     {
-        use crate::common::{BUILD_DIR, str2wcstring};
+        use crate::common::{BUILD_DIR, bytes2wcstring};
         use std::path::PathBuf;
 
         let mut build_dir = PathBuf::from(BUILD_DIR);
@@ -599,7 +599,7 @@ fn make_base_directory(xdg_var: &wstr, non_xdg_homepath: &wstr) -> BaseDirectory
         };
 
         return BaseDirectory {
-            path: str2wcstring(build_dir.as_os_str().as_bytes()),
+            path: bytes2wcstring(build_dir.as_os_str().as_bytes()),
             remoteness: DirRemoteness::unknown,
             used_xdg: false,
             err,

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -54,10 +54,10 @@ use crate::builtins::shared::STATUS_CMD_ERROR;
 use crate::builtins::shared::STATUS_CMD_OK;
 use crate::common::ScopeGuarding;
 use crate::common::{
-    EscapeFlags, EscapeStringStyle, PROGRAM_NAME, ScopeGuard, UTF8_BOM_WCHAR, escape,
-    escape_string, exit_without_destructors, get_ellipsis_char, get_is_multibyte_locale,
+    EscapeFlags, EscapeStringStyle, PROGRAM_NAME, ScopeGuard, UTF8_BOM_WCHAR, bytes2wcstring,
+    escape, escape_string, exit_without_destructors, get_ellipsis_char, get_is_multibyte_locale,
     get_obfuscation_read_char, restore_term_foreground_process_group_for_exit, shell_modes,
-    str2wcstring, write_loop,
+    write_loop,
 };
 use crate::complete::{
     CompleteFlags, Completion, CompletionList, CompletionRequestOptions, complete, complete_load,
@@ -943,7 +943,7 @@ fn read_ni(parser: &Parser, fd: RawFd, io: &IoChain) -> Result<(), ErrorCode> {
         }
     }
 
-    let mut s = str2wcstring(&fd_contents);
+    let mut s = bytes2wcstring(&fd_contents);
 
     // Eagerly deallocate to save memory.
     drop(fd_contents);

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -2,7 +2,7 @@
 use crate::FLOGF;
 use crate::color::{Color, Color24};
 use crate::common::ToCString;
-use crate::common::{self, EscapeStringStyle, escape_string, wcs2string, wcs2string_appending};
+use crate::common::{self, EscapeStringStyle, escape_string, wcs2bytes, wcs2bytes_appending};
 use crate::future_feature_flags::{self, FeatureFlag};
 use crate::screen::{is_dumb, only_grayscale};
 use crate::text_face::{TextFace, TextStyling, UnderlineStyle};
@@ -374,7 +374,7 @@ fn query_kitty_progressive_enhancements(out: &mut impl Output) -> bool {
 fn osc_0_window_title(out: &mut impl Output, title: &[WString]) -> bool {
     out.write_bytes(b"\x1b]0;");
     for title_line in title {
-        out.write_bytes(&wcs2string(title_line));
+        out.write_bytes(&wcs2bytes(title_line));
     }
     out.write_bytes(b"\x07"); // BEL
     true
@@ -636,7 +636,7 @@ impl Outputter {
 
     /// Write a wide string.
     pub fn write_wstr(&mut self, str: &wstr) {
-        wcs2string_appending(&mut self.contents, str);
+        wcs2bytes_appending(&mut self.contents, str);
         self.maybe_flush();
     }
 

--- a/src/tests/encoding.rs
+++ b/src/tests/encoding.rs
@@ -1,11 +1,11 @@
-use crate::common::{str2wcstring, wcs2string};
+use crate::common::{bytes2wcstring, wcs2bytes};
 use crate::wchar::prelude::*;
 
 /// Verify correct behavior with embedded nulls.
 #[test]
 fn test_convert_nulls() {
     let input = L!("AAA\0BBB");
-    let out_str = wcs2string(input);
+    let out_str = wcs2bytes(input);
     assert_eq!(
         input.chars().collect::<Vec<_>>(),
         std::str::from_utf8(&out_str)
@@ -14,20 +14,20 @@ fn test_convert_nulls() {
             .collect::<Vec<_>>()
     );
 
-    let out_wstr = str2wcstring(&out_str);
+    let out_wstr = bytes2wcstring(&out_str);
     assert_eq!(input, &out_wstr);
 }
 
 #[cfg(feature = "benchmark")]
 mod bench {
     extern crate test;
-    use crate::tests::encoding::str2wcstring;
+    use crate::tests::encoding::bytes2wcstring;
     use test::Bencher;
 
     #[bench]
     fn bench_convert_ascii(b: &mut Bencher) {
         let s: [u8; 128 * 1024] = std::array::from_fn(|i| b'0' + u8::try_from(i % 10).unwrap());
         b.bytes = u64::try_from(s.len()).unwrap();
-        b.iter(|| str2wcstring(&s));
+        b.iter(|| bytes2wcstring(&s));
     }
 }

--- a/src/tests/history.rs
+++ b/src/tests/history.rs
@@ -1,4 +1,4 @@
-use crate::common::{ScopeGuard, str2wcstring, wcs2osstring, wcs2string};
+use crate::common::{ScopeGuard, bytes2wcstring, wcs2bytes, wcs2osstring};
 use crate::env::{EnvMode, EnvStack};
 use crate::fs::{LockedFile, WriteMethod};
 use crate::history::{
@@ -260,7 +260,7 @@ fn test_history_races() {
     });
     if LockedFile::new(
         crate::fs::LockingMode::Exclusive(WriteMethod::RenameIntoPlace),
-        &str2wcstring(tmp_path.as_os_str().as_bytes()),
+        &bytes2wcstring(tmp_path.as_os_str().as_bytes()),
     )
     .is_err()
     {
@@ -497,7 +497,7 @@ fn test_history_path_detection() {
     let tmpdirbuff = CString::new("/tmp/fish_test_history.XXXXXX").unwrap();
     let tmpdir = unsafe { libc::mkdtemp(tmpdirbuff.into_raw()) };
     let tmpdir = unsafe { CString::from_raw(tmpdir) };
-    let mut tmpdir = str2wcstring(tmpdir.to_bytes());
+    let mut tmpdir = bytes2wcstring(tmpdir.to_bytes());
     if !tmpdir.ends_with('/') {
         tmpdir.push('/');
     }
@@ -602,7 +602,7 @@ fn install_sample_history(name: &wstr) {
     std::fs::copy(
         workspace_root()
             .join("tests")
-            .join(std::str::from_utf8(&wcs2string(name)).unwrap()),
+            .join(std::str::from_utf8(&wcs2bytes(name)).unwrap()),
         wcs2osstring(&(path + L!("/") + name + L!("_history"))),
     )
     .unwrap();

--- a/src/wcstringutil.rs
+++ b/src/wcstringutil.rs
@@ -298,11 +298,11 @@ pub fn string_fuzzy_match_string(
     StringFuzzyMatch::try_create(string, match_against, anchor_start)
 }
 
-/// Implementation of wcs2string that accepts a callback.
+/// Implementation of wcs2bytes that accepts a callback.
 /// This invokes `func` with (const char*, size_t) pairs.
 /// If `func` returns false, it stops; otherwise it continues.
 /// Return false if the callback returned false, otherwise true.
-pub fn wcs2string_callback(input: &wstr, mut func: impl FnMut(&[u8]) -> bool) -> bool {
+pub fn wcs2bytes_callback(input: &wstr, mut func: impl FnMut(&[u8]) -> bool) -> bool {
     let mut state = zero_mbstate();
     let mut converted = [0_u8; AT_LEAST_MB_LEN_MAX];
 
@@ -331,7 +331,7 @@ pub fn wcs2string_callback(input: &wstr, mut func: impl FnMut(&[u8]) -> bool) ->
                 )
             };
             if len == 0_usize.wrapping_sub(1) {
-                wcs2string_bad_char(c);
+                wcs2bytes_bad_char(c);
                 state = zero_mbstate();
             } else if !func(&converted[..len]) {
                 return false;
@@ -341,7 +341,7 @@ pub fn wcs2string_callback(input: &wstr, mut func: impl FnMut(&[u8]) -> bool) ->
     true
 }
 
-fn wcs2string_bad_char(c: char) {
+fn wcs2bytes_bad_char(c: char) {
     FLOGF!(
         char_encoding,
         L!("Wide character U+%4X has no narrow representation"),

--- a/src/wutil/dir_iter.rs
+++ b/src/wutil/dir_iter.rs
@@ -1,5 +1,5 @@
 use super::wopendir;
-use crate::common::{str2wcstring, wcs2zstring};
+use crate::common::{bytes2wcstring, wcs2zstring};
 use crate::wchar::{WString, wstr};
 use crate::wutil::DevInode;
 use cfg_if::cfg_if;
@@ -285,7 +285,7 @@ impl DirIter {
         }
 
         self.entry.reset();
-        self.entry.name = str2wcstring(d_name);
+        self.entry.name = bytes2wcstring(d_name);
         cfg_if!(
             if #[cfg(bsd)] {
                 self.entry.inode = dent.d_fileno;

--- a/src/wutil/tests.rs
+++ b/src/wutil/tests.rs
@@ -76,7 +76,7 @@ fn test_wwrite_to_fd() {
         }
 
         let amt = wwrite_to_fd(&input, fd.fd()).unwrap();
-        let narrow = wcs2string(&input);
+        let narrow = wcs2bytes(&input);
         assert_eq!(amt, narrow.len());
 
         assert!(unsafe { libc::lseek(fd.fd(), 0, SEEK_SET) } >= 0);


### PR DESCRIPTION
Some string handling functions deal with `Vec<u8>` or `&[u8]`, which have been referred to as `string` or `str` in the function names. This is confusing, since they don't deal with Rust's `String` type. Use `bytes` in the function names instead to reduce confusion.