### PR TITLE
fix(edit_command_buffer): ignore `cat` alias

### DIFF
--- a/share/functions/edit_command_buffer.fish
+++ b/share/functions/edit_command_buffer.fish
@@ -97,7 +97,7 @@ function edit_command_buffer --description 'Edit the command buffer in an extern
         echo (_ "or the file was empty")
     end
     if set -q cursor_from_editor[1]
-        eval set -l pos "$(cat $cursor_from_editor)"
+        eval set -l pos "$(command cat $cursor_from_editor)"
         if set -q pos[1] && test $pos[1] = $f
             set -l line $pos[2]
             set -l indent (math (string length -- "$raw_lines[$line]") - (string length -- "$unindented_lines[$line]"))


### PR DESCRIPTION
If I set a `cat` alias like this:

```fish
function cat
    bat -S --style 'numbers,grid' $argv
end
```

After pressing the `option + e` shortcut to launch the editor, I get the following error:

```text
/opt/homebrew/Cellar/fish/4.1.2/share/fish/functions/edit_command_buffer.fish (line 2):
   1 │ '/private/var/folders/66/yvs964v16_b14ryk0bwnv3nc0000gn/T/fish.9wiXA1/command-line.fish' 1 1
   ^
in function 'edit_command_buffer'
fish: Unknown command: ─────┴──────────────────────────────────────────────────────────────────────────
/opt/homebrew/Cellar/fish/4.1.2/share/fish/functions/edit_command_buffer.fish (line 3):
─────┴──────────────────────────────────────────────────────────────────────────
```
