### PR TITLE
io: retry writes on interrupts

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1201,8 +1201,9 @@ pub fn wcs2zstring(input: &wstr) -> CString {
     let mut vec = Vec::with_capacity(input.len() + 1);
     wcs2bytes_callback(input, |buff| {
         vec.extend_from_slice(buff);
-        true
-    });
+        Ok(())
+    })
+    .unwrap();
     vec.push(b'\0');
 
     match CString::from_vec_with_nul(vec) {
@@ -1223,8 +1224,9 @@ pub fn wcs2bytes_appending(output: &mut Vec<u8>, input: &wstr) {
     output.reserve(input.len());
     wcs2bytes_callback(input, |buff| {
         output.extend_from_slice(buff);
-        true
-    });
+        Ok(())
+    })
+    .unwrap();
 }
 
 /// Stored in blocks to reference the file which created the block.

--- a/src/flog.rs
+++ b/src/flog.rs
@@ -1,8 +1,10 @@
 use crate::common::wcs2bytes;
 use crate::wchar::prelude::*;
 use crate::wildcard::wildcard_match;
-use crate::wutil::write_to_fd;
-use crate::{parse_util::parse_util_unescape_wildcards, wutil::wwrite_to_fd};
+use crate::{
+    parse_util::parse_util_unescape_wildcards,
+    wutil::{write_to_fd, wwrite_to_fd},
+};
 use libc::c_int;
 use std::sync::atomic::{AtomicI32, Ordering};
 
@@ -302,5 +304,5 @@ pub fn get_flog_file_fd() -> c_int {
 }
 
 pub fn log_extra_to_flog_file(s: &wstr) {
-    wwrite_to_fd(s, get_flog_file_fd());
+    let _ = wwrite_to_fd(s, get_flog_file_fd());
 }

--- a/src/wutil/printf.rs
+++ b/src/wutil/printf.rs
@@ -26,7 +26,7 @@ macro_rules! fprintf {
     ($fd:expr, $fmt:expr $(, $arg:expr)* $(,)?) => {
         {
             let wide = $crate::wutil::sprintf!($fmt, $( $arg ),*);
-            $crate::wutil::wwrite_to_fd(&wide, $fd);
+            let _ = $crate::wutil::wwrite_to_fd(&wide, $fd);
         }
     }
 }


### PR DESCRIPTION
Interrupts should not prevent output from being completed, unless they
result in control flow not continuing where it was interrupted.

Return results containing errors, so callers have more options for error
handling. Returning the number of bytes written on success is no longer
necessary, since success now means that all input bytes were written.

In `src/io.rs` some changes are needed since `EINTR` is no longer a
possible return value. I also removed the comments on the old code and
the `sigcheck` code. Not sure if this should be kept.