### PR TITLE
gettext: fall back to all language variants

### DIFF
--- a/doc_src/language.rst
+++ b/doc_src/language.rst
@@ -1836,7 +1836,16 @@ In UNIX, these are made up of several categories. The categories used by fish ar
 
    This is treated like :envvar:`LC_MESSAGES` except that it can hold multiple values,
    which allows to specify a priority list of languages for translation.
-   It's a :ref:`PATH variable <variables-path>`, like in `GNU gettext <https://www.gnu.org/software/gettext/manual/html_node/The-LANGUAGE-variable.html>`__. 
+   It's a :ref:`PATH variable <variables-path>`, like in `GNU gettext <https://www.gnu.org/software/gettext/manual/html_node/The-LANGUAGE-variable.html>`__.
+
+   Language identifiers without a region specified (e.g. ``zh``) result in all available variants of this language being tried in arbitrary order.
+   In this example, we might first look for messages in the ``zh_CN`` catalog, followed by ``zh_TW``, or the other way around.
+   This is different from GNU gettext, which uses a "default" variant of the language instead.
+   If you prefer a certain variant, specify it earlier in the list,
+   e.g. ``zh_TW:zh`` if your preferred language is ``zh_TW``, and you prefer any other variants of ``zh`` over the English default.
+   If ``zh_TW`` is the only variant of ``zh`` you want,
+   specifying ``zh_TW`` in the ``LANGUAGE`` variable will result in messages which are not available in ``zh_TW`` being displayed in English.
+
    See also :doc:`builtin _ (underscore) <cmds/_>`.
 
 .. envvar:: LC_ALL


### PR DESCRIPTION
If a language is specified using only the language code, without a region identifier, assume that the user prefers translations from any variant of the language over the next fallback option. For example, when a user sets `LANGUAGE=zh:pt`, assume that the user prefers both `zh_CN` and `zh_TW` over the next fallback option. The precedence of the different variants of a language will be arbitrary. In this example, with the current set of relevant available catalogs (`pt_BR`, `zh_CN`, `zh_TW`), the effective precedence will be either `zh_CN:zh_TW:pt_BR` or `zh_TW:zh_CN:pt_BR`.

Users who want more control over the order can
specify variants to get the results they want.
For example:
- `LANGUAGE=zh_TW:zh:pt` will result in `zh_TW:zh_CN:pt_BR`.
- `LANGUAGE=zh_CN:pt:zh` will result  in `zh_CN:pt_BR:zh_TW`.
- `LANGUAGE=zh_CN:pt` will result  in `zh_CN:pt_BR`. English is always used as the last fallback.

This approach (like the previous approach) differs from GNU gettext semantics, which map region-less language codes to on specific "default" variant of the language, without specifying how this default is chosen. We want to avoid making such choices and believe it is better to utilize translations from all language variants we have available when users do not explicitly specify their preferred variant. This way, users have an easier time discovering localization availability, and can be more explicit in their preferences if they don't like the defaults. If there are conflicts with gettext semantics, users can also set locale variables without exporting them, so fish uses different values than its child processes.
