### PR TITLE
Fix build on Linux/SPARC by disabling SIGSTKFLT

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -49,7 +49,7 @@ For distributors and developers
   To turn this off (which should not be necessary),
   patch out the ``embed-data`` feature from ``cmake/Rust.cmake``.
   This option will be removed in future.
-
+- Fix build on Linux/SPARC by disabling SIGSTKFLT
 
 fish 4.1.3 (released ???)
 =========================

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -424,6 +424,8 @@ const SIGNAL_TABLE : &[LookupEntry] = &[
             target_arch = "mips32r6",
             target_arch = "mips64",
             target_arch = "mips64r6",
+            target_arch = "sparc",
+            target_arch = "sparc64",
         ))
     ))]
     signal_entry!(SIGSTKFLT, SIGSTKFLT_DESC),


### PR DESCRIPTION
Similar to [MIPS](https://github.com/fish-shell/fish-shell/issues/11965), SPARC does not have the SIGSTKSZ signal on Linux.