### PR TITLE
Fix broken translations

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -2325,10 +2325,7 @@ msgstr ""
 msgid "foo=bar variable overrides"
 msgstr ""
 
-msgid "funced: The value for $EDITOR '$editor' could not be used because the command '$editor[1]' could not be found"
-msgstr ""
-
-msgid "funced: The value for $VISUAL '$editor' could not be used because the command '$editor[1]' could not be found"
+msgid "funced: The value for %s '%s' could not be used because the command '%s' could not be found\\n"
 msgstr ""
 
 msgid "help: %s is not a valid command: %s\\n"

--- a/po/en.po
+++ b/po/en.po
@@ -2323,10 +2323,7 @@ msgstr ""
 msgid "foo=bar variable overrides"
 msgstr ""
 
-msgid "funced: The value for $EDITOR '$editor' could not be used because the command '$editor[1]' could not be found"
-msgstr ""
-
-msgid "funced: The value for $VISUAL '$editor' could not be used because the command '$editor[1]' could not be found"
+msgid "funced: The value for %s '%s' could not be used because the command '%s' could not be found\\n"
 msgstr ""
 
 msgid "help: %s is not a valid command: %s\\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -2454,10 +2454,7 @@ msgstr ""
 msgid "foo=bar variable overrides"
 msgstr ""
 
-msgid "funced: The value for $EDITOR '$editor' could not be used because the command '$editor[1]' could not be found"
-msgstr ""
-
-msgid "funced: The value for $VISUAL '$editor' could not be used because the command '$editor[1]' could not be found"
+msgid "funced: The value for %s '%s' could not be used because the command '%s' could not be found\\n"
 msgstr ""
 
 msgid "help: %s is not a valid command: %s\\n"

--- a/po/pl.po
+++ b/po/pl.po
@@ -2319,10 +2319,7 @@ msgstr ""
 msgid "foo=bar variable overrides"
 msgstr ""
 
-msgid "funced: The value for $EDITOR '$editor' could not be used because the command '$editor[1]' could not be found"
-msgstr ""
-
-msgid "funced: The value for $VISUAL '$editor' could not be used because the command '$editor[1]' could not be found"
+msgid "funced: The value for %s '%s' could not be used because the command '%s' could not be found\\n"
 msgstr ""
 
 msgid "help: %s is not a valid command: %s\\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -2324,10 +2324,7 @@ msgstr ""
 msgid "foo=bar variable overrides"
 msgstr ""
 
-msgid "funced: The value for $EDITOR '$editor' could not be used because the command '$editor[1]' could not be found"
-msgstr ""
-
-msgid "funced: The value for $VISUAL '$editor' could not be used because the command '$editor[1]' could not be found"
+msgid "funced: The value for %s '%s' could not be used because the command '%s' could not be found\\n"
 msgstr ""
 
 msgid "help: %s is not a valid command: %s\\n"

--- a/po/sv.po
+++ b/po/sv.po
@@ -2320,10 +2320,7 @@ msgstr ""
 msgid "foo=bar variable overrides"
 msgstr ""
 
-msgid "funced: The value for $EDITOR '$editor' could not be used because the command '$editor[1]' could not be found"
-msgstr ""
-
-msgid "funced: The value for $VISUAL '$editor' could not be used because the command '$editor[1]' could not be found"
+msgid "funced: The value for %s '%s' could not be used because the command '%s' could not be found\\n"
 msgstr ""
 
 msgid "help: %s is not a valid command: %s\\n"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -2352,11 +2352,8 @@ msgstr "fish: 未知的命令：%s\\n"
 msgid "foo=bar variable overrides"
 msgstr "foo=bar 变量覆盖"
 
-msgid "funced: The value for $EDITOR '$editor' could not be used because the command '$editor[1]' could not be found"
-msgstr "funced: 无法使用 $EDITOR '$editor' 的值，因为找不到命令 '$editor[1]'"
-
-msgid "funced: The value for $VISUAL '$editor' could not be used because the command '$editor[1]' could not be found"
-msgstr "funced: 无法使用 $VISUAL '$editor' 的值，因为找不到命令 '$editor[1]'"
+msgid "funced: The value for %s '%s' could not be used because the command '%s' could not be found\\n"
+msgstr "funced: 无法使用 %s '%s' 的值，因为找不到命令 '%s'\\n"
 
 msgid "help: %s is not a valid command: %s\\n"
 msgstr "help: %s 不是有效的命令：%s\\n"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -2327,11 +2327,8 @@ msgstr "fish：未知命令：%s\\n"
 msgid "foo=bar variable overrides"
 msgstr "foo=bar 變數覆寫"
 
-msgid "funced: The value for $EDITOR '$editor' could not be used because the command '$editor[1]' could not be found"
-msgstr "funced：$EDITOR 的值「$editor」無法使用，找不到命令「$editor[1]」"
-
-msgid "funced: The value for $VISUAL '$editor' could not be used because the command '$editor[1]' could not be found"
-msgstr "funced：$VISUAL 的值「$editor」無法使用，找不到命令「$editor[1]」"
+msgid "funced: The value for %s '%s' could not be used because the command '%s' could not be found\\n"
+msgstr "funced：%s 的值「%s」無法使用，找不到命令「%s」\\n"
 
 msgid "help: %s is not a valid command: %s\\n"
 msgstr "help：%s 不是有效的命令：%s\\n"

--- a/share/functions/funced.fish
+++ b/share/functions/funced.fish
@@ -39,11 +39,13 @@ function funced --description 'Edit function definition'
     end
 
     if not type -q -f "$editor[1]"
+        set -l used_env_var
         if set -q VISUAL
-            echo (_ "funced: The value for \$VISUAL '$editor' could not be used because the command '$editor[1]' could not be found") >&2
+            set used_env_var \$VISUAL
         else
-            echo (_ "funced: The value for \$EDITOR '$editor' could not be used because the command '$editor[1]' could not be found") >&2
+            set used_env_var \$EDITOR
         end
+        printf (_ "funced: The value for %s '%s' could not be used because the command '%s' could not be found\n") "$used_env_var" "$editor" "$editor[1]" >&2
         set editor fish
     end
 


### PR DESCRIPTION
## Description

Fix previously broken translations:
```fish
vagrant@debian ~/scratch/fish-shell/build (fix-translations)
$ LANG=zh_TW ./fish
vagrant@debian ~/scratch/fish-shell/build (fix-translations)
$ set -x VISUAL asdkjqwkldjqklwjd
vagrant@debian ~/scratch/fish-shell/build (fix-translations)
$ funced foo
funced：$VISUAL 的值「asdkjqwkldjqklwjd」無法使用，找不到命令「asdkjqwkldjqklwjd」
foo> function foo

     end
```

Fixes: https://github.com/fish-shell/fish-shell/pull/12059#discussion_r2527915618.
## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
