### PR TITLE
Add mutex around `flock` on Cygwin

### DIFF
--- a/src/history/history.rs
+++ b/src/history/history.rs
@@ -2015,11 +2015,6 @@ mod tests {
     fn test_history_races() {
         let _cleanup = test_init();
 
-        // Fail nearly every time on Cygwin (probably caused by flock issue, see #11933)
-        if cfg!(cygwin) {
-            return;
-        }
-
         let tmp_path = std::env::current_dir()
             .unwrap()
             .join("history-races-test-balloon");


### PR DESCRIPTION
This is a much better workaround for issue #11933. It actually fixes the failing test (instead of just preventing a freeze/deadlock but still failing), it's faster (5s to run the test instead of 15s), and it feels more reliable/universal (the previous one was more about "improving the odds" rather "making certain", and likely very dependent on the host performance)