### PR TITLE
history: move consts into function

### DIFF
--- a/src/history/history.rs
+++ b/src/history/history.rs
@@ -31,6 +31,7 @@ use std::{
     fs::File,
     io::{BufRead, Read, Write},
     mem::MaybeUninit,
+    num::NonZeroUsize,
     ops::ControlFlow,
     sync::{Arc, Mutex, MutexGuard},
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -104,12 +105,6 @@ use super::file::time_to_seconds;
 
 /// This is the history session ID we use by default if the user has not set env var fish_history.
 const DFLT_FISH_HISTORY_SESSION_ID: &wstr = L!("fish");
-
-/// When we rewrite the history, the number of items we keep.
-const HISTORY_SAVE_MAX: usize = 1024 * 256;
-
-/// Default buffer size for flushing to the history file.
-const HISTORY_OUTPUT_BUFFER_SIZE: usize = 64 * 1024;
 
 pub const VACUUM_FREQUENCY: usize = 25;
 
@@ -501,7 +496,10 @@ impl HistoryImpl {
         // We are reading FROM existing_file and writing TO dst
 
         // Make an LRU cache to save only the last N elements.
-        let mut lru = LruCache::new(HISTORY_SAVE_MAX.try_into().unwrap());
+
+        /// When we rewrite the history, the number of items we keep.
+        const HISTORY_SAVE_MAX: NonZeroUsize = NonZeroUsize::new(1024 * 256).unwrap();
+        let mut lru = LruCache::new(HISTORY_SAVE_MAX);
 
         // Read in existing items (which may have changed out from underneath us, so don't trust our
         // old file contents).
@@ -549,6 +547,8 @@ impl HistoryImpl {
         let mut items: Vec<_> = lru.into_iter().map(|(_key, item)| item).collect();
         items.sort_by_key(HistoryItem::timestamp);
 
+        /// Default buffer size for flushing to the history file.
+        const HISTORY_OUTPUT_BUFFER_SIZE: usize = 64 * 1024;
         // Write them out.
         let mut err = None;
         let mut buffer = Vec::with_capacity(HISTORY_OUTPUT_BUFFER_SIZE + 128);


### PR DESCRIPTION
These consts are only used in a single function, so they don't need to be defined outside of the function.

https://github.com/fish-shell/fish-shell/commit/c323a2d5fe69375ee12d428de6b4dc7812be34c8#r170141065
