### PR TITLE
build_helper: add rebuild function for embedded path change

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -43,8 +43,7 @@ fn main() {
     // These are necessary if built with embedded functions,
     // but only in release builds (because rust-embed in debug builds reads from the filesystem).
     #[cfg(feature = "embed-data")]
-    #[cfg(any(windows, not(debug_assertions)))]
-    rsconf::rebuild_if_path_changed("share");
+    fish_build_helper::rebuild_if_embedded_path_changed("share");
 
     #[cfg(feature = "gettext-extract")]
     rsconf::rebuild_if_env_changed("FISH_GETTEXT_EXTRACTION_FILE");

--- a/crates/build-helper/src/lib.rs
+++ b/crates/build-helper/src/lib.rs
@@ -45,3 +45,9 @@ pub fn rebuild_if_paths_changed<P: AsRef<Path>, I: IntoIterator<Item = P>>(paths
         rsconf::rebuild_if_path_changed(path.as_ref().to_str().unwrap());
     }
 }
+
+pub fn rebuild_if_embedded_path_changed<P: AsRef<Path>>(path: P) {
+    if cfg!(any(not(debug_assertions), windows)) {
+        rebuild_if_path_changed(path);
+    }
+}


### PR DESCRIPTION
For paths embedded via `rust-embed`, we only need to rebuild on path changes if the files are actually embedded. For debug builds, data is read from the file system instead of being embedded, so we don't need to rebuild then. This is apparently broken on Cygwin, so we always rebuild there. See
012b50712 (Workaround for embed-data debug builds on Cygwin, 2025-09-16) for details.

To avoid having to remember and duplicate this logic for all embedded paths, extract it into the build helper.

https://github.com/fish-shell/fish-shell/pull/11928#discussion_r2534457892