### PR TITLE
cleanup: remove unused message

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -716,10 +716,6 @@ msgid "%s: expected a numeric value"
 msgstr "%s: Erwartete numerischen Wert"
 
 #, c-format
-msgid "%s: fish was not built with embedded files"
-msgstr ""
-
-#, c-format
 msgid "%s: function name required"
 msgstr "%s: Brauche Funktionsnamen"
 

--- a/po/en.po
+++ b/po/en.po
@@ -714,10 +714,6 @@ msgid "%s: expected a numeric value"
 msgstr "%s: expected a numeric value"
 
 #, c-format
-msgid "%s: fish was not built with embedded files"
-msgstr ""
-
-#, c-format
 msgid "%s: function name required"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -845,10 +845,6 @@ msgid "%s: expected a numeric value"
 msgstr "%s : valeur numérique attendue"
 
 #, c-format
-msgid "%s: fish was not built with embedded files"
-msgstr "%s : fish n’a pas été compilé avec les fichiers embarqués"
-
-#, c-format
 msgid "%s: function name required"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -710,10 +710,6 @@ msgid "%s: expected a numeric value"
 msgstr "%s: oczekiwano wartości liczbowej"
 
 #, c-format
-msgid "%s: fish was not built with embedded files"
-msgstr ""
-
-#, c-format
 msgid "%s: function name required"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -715,10 +715,6 @@ msgid "%s: expected a numeric value"
 msgstr "%s: esperava valor numérico"
 
 #, c-format
-msgid "%s: fish was not built with embedded files"
-msgstr ""
-
-#, c-format
 msgid "%s: function name required"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -711,10 +711,6 @@ msgid "%s: expected a numeric value"
 msgstr ""
 
 #, c-format
-msgid "%s: fish was not built with embedded files"
-msgstr ""
-
-#, c-format
 msgid "%s: function name required"
 msgstr ""
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -737,10 +737,6 @@ msgid "%s: expected a numeric value"
 msgstr "%s: 预期收到数值"
 
 #, c-format
-msgid "%s: fish was not built with embedded files"
-msgstr "%s: fish 构建时未包含嵌入文件"
-
-#, c-format
 msgid "%s: function name required"
 msgstr "%s: 函数名称是必须的"
 

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -710,10 +710,6 @@ msgid "%s: expected a numeric value"
 msgstr "%s：預期一個數字"
 
 #, c-format
-msgid "%s: fish was not built with embedded files"
-msgstr "%s：fish 未嵌入檔案建置"
-
-#, c-format
 msgid "%s: function name required"
 msgstr "%s：需要函式名稱"
 

--- a/src/builtins/status.rs
+++ b/src/builtins/status.rs
@@ -357,11 +357,6 @@ cfg_if!(
 struct CMakeBinaryDir;
 
 pub fn status(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> BuiltinResult {
-    localizable_consts!(
-        #[allow(dead_code)]
-        NO_EMBEDDED_FILES_MSG "%s: fish was not built with embedded files"
-    );
-
     let cmd = args[0];
     let argc = args.len();
 


### PR DESCRIPTION
This message is no longer used since we unconditionally embed files now. The `#[allow(dead_code)]` annotation was needed to avoid warnings while ensuring that message extraction was not broken.
