### PR TITLE
gettext: enable default features for extraction

### DIFF
--- a/build_tools/fish_xgettext.fish
+++ b/build_tools/fish_xgettext.fish
@@ -27,7 +27,7 @@ begin
     else
         set rust_extraction_file (mktemp)
         # We need to build to ensure that the proc macro for extracting strings runs.
-        FISH_GETTEXT_EXTRACTION_FILE=$rust_extraction_file cargo check --no-default-features --features=gettext-extract
+        FISH_GETTEXT_EXTRACTION_FILE=$rust_extraction_file cargo check --features=gettext-extract
         or exit 1
     end
 


### PR DESCRIPTION
There was a mismatch between the extraction done from `build_tools/check.sh` and the one done in
`build_tools/fish_xgettext.fish`, resulting in messages guarded by default features being extracted by the former but not the latter. This brings them in sync.

Ideally, we would enable all features for extraction, but compiling with `--all-features` is broken and manually keeping the features lists updated is tedious and error prone, so we'll settle on only using default features for now.
