### PR TITLE
l10n: implement `status language` builtin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,9 @@ Color and key binding variables are no longer set in universal scope
   2. universal variables as a source of truth are easy to misunderstand,
      compared to configuration files like ``config.fish``.
 
+Notable improvements and fixes
+------------------------------
+- New :ref:`status language <status-language>` commands allow showing and modifying language settings for fish messages without having to modify environment variables.
 
 Deprecations and removed features
 ---------------------------------

--- a/doc_src/cmds/_.rst
+++ b/doc_src/cmds/_.rst
@@ -23,6 +23,8 @@ If other programs launched via fish should respect these locale variables they h
 
 For :envvar:`LANGUAGE` you can use a list, or use colons to separate multiple languages.
 
+If the :ref:`status language set <status-language>` command was used, its arguments specify the language precedence, and the environment variables are ignored.
+
 Options
 -------
 

--- a/doc_src/cmds/status.rst
+++ b/doc_src/cmds/status.rst
@@ -33,6 +33,7 @@ Synopsis
     status list-files [PATH ...]
     status terminal
     status test-terminal-feature FEATURE
+    status language [list-available|set [LANGUAGE ...]|unset]
 
 Description
 -----------
@@ -145,6 +146,32 @@ The following operations (subcommands) are available:
 
     Currently the only available *FEATURE* is :ref:`scroll-content-up <term-compat-indn>`.
     An error will be printed when passed an unrecognized feature.
+
+.. _status-language:
+
+**language**
+    Show or modify message localization settings.
+    When invoked without arguments, the current language settings are shown.
+
+    Available subcommands:
+
+    **list-available**
+    prints the language names for which fish has translations.
+    These names can be used with the **set** subcommand.
+
+    **set**
+    sets the language precedence for fish's messages.
+    Overrides language settings configured via :ref:`environment variables <variables-locale>`, but only applies to fish itself, not to any child processes.
+    Takes a list of language names from the set shown by the **list-available** subcommand.
+    For some languages, fish's translation catalogs are incomplete, meaning not all messages can be shown in these languages.
+    Therefore, we allow specifying a list here, with translations taken from the first specified language which has a translation available for a message.
+    For example, after running ``status language set pt_BR fr``, all messages which have a translation into Brazilian Portuguese will be shown in that language.
+    The remaining messages will be shown in French, if a French translation is available.
+    If none of the specified languages have a translation available for a message, the message will be shown in English.
+
+    **unset**
+    undoes the effects of the **set** subcommand.
+    Language settings will be taken from environment variables again.
 
 Notes
 -----

--- a/doc_src/language.rst
+++ b/doc_src/language.rst
@@ -1549,7 +1549,8 @@ You can change the settings of fish by changing the values of certain variables.
 
 .. describe:: Locale Variables
 
-   Locale variables such as :envvar:`LANG`, :envvar:`LC_ALL`, :envvar:`LC_MESSAGES`, :envvar:`LC_NUMERIC` and :envvar:`LC_TIME`  set the language option for the shell and subprograms. See the section :ref:`Locale variables <variables-locale>` for more information.
+   Locale variables such as :envvar:`LANG`, :envvar:`LC_ALL`, :envvar:`LC_MESSAGES`, :envvar:`LC_NUMERIC` and :envvar:`LC_TIME` set the language option for the shell and subprograms.
+   See the section :ref:`Locale variables <variables-locale>` and :ref:`status language <status-language>` for more information.
 
 .. describe:: Color variables
 

--- a/po/de.po
+++ b/po/de.po
@@ -84,6 +84,10 @@ msgid "%s"
 msgstr ""
 
 #, c-format
+msgid "%s %s: %s: invalid subcommand\n"
+msgstr "%s %s: %s: ungültiger Unterbefehl\n"
+
+#, c-format
 msgid "%s %s: Abbreviation %s already exists for commands %s, cannot rename %s\n"
 msgstr ""
 
@@ -881,6 +885,10 @@ msgstr "Abbruch"
 msgid "Abort (Alias for SIGABRT)"
 msgstr ""
 
+#, c-format
+msgid "Active languages (%s):"
+msgstr ""
+
 msgid "Address boundary error"
 msgstr "Adressbereichsfehler"
 
@@ -1229,6 +1237,9 @@ msgstr ""
 msgid "Jobs getting started or continued"
 msgstr ""
 
+msgid "Language specifiers appear repeatedly:"
+msgstr ""
+
 msgid "List or remove functions"
 msgstr "Funktionen auflisten oder entfernen"
 
@@ -1278,6 +1289,9 @@ msgstr "Nie"
 
 msgid "No TTY for interactive shell (tcgetpgrp failed)"
 msgstr "Kein TTY für interaktive Shell (tcgetpgrp schlug fehl)"
+
+msgid "No catalogs available for language specifiers:"
+msgstr ""
 
 #, c-format
 msgid "No matches for wildcard '%s'. See `help %s`."
@@ -1775,6 +1789,9 @@ msgstr "Befehlsersetzung sind in Befehlsposition nicht erlaubt. Probier stattdes
 msgid "completion reached maximum recursion depth, possible cycle?"
 msgstr "Vervollständigung hat die maximale Rekursionstiefe erreicht, möglicher Kreis?"
 
+msgid "default"
+msgstr ""
+
 msgid "dir symlink"
 msgstr "Verweis auf ein Verzeichnis"
 
@@ -1800,9 +1817,16 @@ msgid ""
 "`help %s` will show an online version\n"
 msgstr ""
 
+msgid "from command `status language set`"
+msgstr ""
+
 #, c-format
 msgid "from sourcing file %s\n"
 msgstr "aus der Quelldatei %s\n"
+
+#, c-format
+msgid "from variable %s"
+msgstr ""
 
 msgid "in command substitution\n"
 msgstr "in der Befehlsersetzung\n"
@@ -3385,6 +3409,9 @@ msgstr ""
 
 msgid "Show modification time"
 msgstr "Änderungsdatum anzeigen"
+
+msgid "Show or change fish's language settings"
+msgstr ""
 
 msgid "Show seconds since the modification time"
 msgstr ""

--- a/po/en.po
+++ b/po/en.po
@@ -82,6 +82,10 @@ msgid "%s"
 msgstr ""
 
 #, c-format
+msgid "%s %s: %s: invalid subcommand\n"
+msgstr ""
+
+#, c-format
 msgid "%s %s: Abbreviation %s already exists for commands %s, cannot rename %s\n"
 msgstr ""
 
@@ -879,6 +883,10 @@ msgstr "Abort"
 msgid "Abort (Alias for SIGABRT)"
 msgstr "Abort (Alias for SIGABRT)"
 
+#, c-format
+msgid "Active languages (%s):"
+msgstr ""
+
 msgid "Address boundary error"
 msgstr "Address boundary error"
 
@@ -1227,6 +1235,9 @@ msgstr ""
 msgid "Jobs getting started or continued"
 msgstr ""
 
+msgid "Language specifiers appear repeatedly:"
+msgstr ""
+
 msgid "List or remove functions"
 msgstr "List or remove functions"
 
@@ -1276,6 +1287,9 @@ msgstr "Never"
 
 msgid "No TTY for interactive shell (tcgetpgrp failed)"
 msgstr "No TTY for interactive shell (tcgetpgrp failed)"
+
+msgid "No catalogs available for language specifiers:"
+msgstr ""
 
 #, c-format
 msgid "No matches for wildcard '%s'. See `help %s`."
@@ -1773,6 +1787,9 @@ msgstr ""
 msgid "completion reached maximum recursion depth, possible cycle?"
 msgstr ""
 
+msgid "default"
+msgstr ""
+
 msgid "dir symlink"
 msgstr ""
 
@@ -1798,9 +1815,16 @@ msgid ""
 "`help %s` will show an online version\n"
 msgstr ""
 
+msgid "from command `status language set`"
+msgstr ""
+
 #, c-format
 msgid "from sourcing file %s\n"
 msgstr "from sourcing file %s\n"
+
+#, c-format
+msgid "from variable %s"
+msgstr ""
 
 msgid "in command substitution\n"
 msgstr "in command substitution\n"
@@ -3383,6 +3407,9 @@ msgstr ""
 
 msgid "Show modification time"
 msgstr "Show modification time"
+
+msgid "Show or change fish's language settings"
+msgstr ""
 
 msgid "Show seconds since the modification time"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -213,6 +213,10 @@ msgid "%s"
 msgstr "%s"
 
 #, c-format
+msgid "%s %s: %s: invalid subcommand\n"
+msgstr "%s %s : %s : sous-commande invalide\n"
+
+#, c-format
 msgid "%s %s: Abbreviation %s already exists for commands %s, cannot rename %s\n"
 msgstr ""
 
@@ -1010,6 +1014,10 @@ msgstr "Abandon"
 msgid "Abort (Alias for SIGABRT)"
 msgstr "Abandon (Alias pour SIGABRT)"
 
+#, c-format
+msgid "Active languages (%s):"
+msgstr ""
+
 msgid "Address boundary error"
 msgstr "Erreur de frontière d’adresse"
 
@@ -1358,6 +1366,9 @@ msgstr ""
 msgid "Jobs getting started or continued"
 msgstr ""
 
+msgid "Language specifiers appear repeatedly:"
+msgstr ""
+
 msgid "List or remove functions"
 msgstr "Lister ou supprimer des fonctions"
 
@@ -1407,6 +1418,9 @@ msgstr "Jamais"
 
 msgid "No TTY for interactive shell (tcgetpgrp failed)"
 msgstr "Pas de TTY pour shell interactif (tcgetpgrp a échoué)"
+
+msgid "No catalogs available for language specifiers:"
+msgstr ""
 
 #, c-format
 msgid "No matches for wildcard '%s'. See `help %s`."
@@ -1904,6 +1918,9 @@ msgstr ""
 msgid "completion reached maximum recursion depth, possible cycle?"
 msgstr ""
 
+msgid "default"
+msgstr ""
+
 msgid "dir symlink"
 msgstr ""
 
@@ -1929,9 +1946,16 @@ msgid ""
 "`help %s` will show an online version\n"
 msgstr ""
 
+msgid "from command `status language set`"
+msgstr ""
+
 #, c-format
 msgid "from sourcing file %s\n"
 msgstr "du fichier source %s\n"
+
+#, c-format
+msgid "from variable %s"
+msgstr ""
 
 msgid "in command substitution\n"
 msgstr "dans la substitution de commande\n"
@@ -3514,6 +3538,9 @@ msgstr ""
 
 msgid "Show modification time"
 msgstr "Afficher l’horodatage de modification"
+
+msgid "Show or change fish's language settings"
+msgstr ""
 
 msgid "Show seconds since the modification time"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -78,6 +78,10 @@ msgid "%s"
 msgstr ""
 
 #, c-format
+msgid "%s %s: %s: invalid subcommand\n"
+msgstr ""
+
+#, c-format
 msgid "%s %s: Abbreviation %s already exists for commands %s, cannot rename %s\n"
 msgstr ""
 
@@ -875,6 +879,10 @@ msgstr "Przerwij"
 msgid "Abort (Alias for SIGABRT)"
 msgstr ""
 
+#, c-format
+msgid "Active languages (%s):"
+msgstr ""
+
 msgid "Address boundary error"
 msgstr ""
 
@@ -1223,6 +1231,9 @@ msgstr ""
 msgid "Jobs getting started or continued"
 msgstr ""
 
+msgid "Language specifiers appear repeatedly:"
+msgstr ""
+
 msgid "List or remove functions"
 msgstr "Wypisz lub usuń funkcje"
 
@@ -1271,6 +1282,9 @@ msgid "Never"
 msgstr "Nigdy"
 
 msgid "No TTY for interactive shell (tcgetpgrp failed)"
+msgstr ""
+
+msgid "No catalogs available for language specifiers:"
 msgstr ""
 
 #, c-format
@@ -1769,6 +1783,9 @@ msgstr ""
 msgid "completion reached maximum recursion depth, possible cycle?"
 msgstr ""
 
+msgid "default"
+msgstr ""
+
 msgid "dir symlink"
 msgstr ""
 
@@ -1794,8 +1811,15 @@ msgid ""
 "`help %s` will show an online version\n"
 msgstr ""
 
+msgid "from command `status language set`"
+msgstr ""
+
 #, c-format
 msgid "from sourcing file %s\n"
+msgstr ""
+
+#, c-format
+msgid "from variable %s"
 msgstr ""
 
 msgid "in command substitution\n"
@@ -3378,6 +3402,9 @@ msgid "Show man page entries or function description related to the token under 
 msgstr ""
 
 msgid "Show modification time"
+msgstr ""
+
+msgid "Show or change fish's language settings"
 msgstr ""
 
 msgid "Show seconds since the modification time"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -83,6 +83,10 @@ msgid "%s"
 msgstr ""
 
 #, c-format
+msgid "%s %s: %s: invalid subcommand\n"
+msgstr ""
+
+#, c-format
 msgid "%s %s: Abbreviation %s already exists for commands %s, cannot rename %s\n"
 msgstr ""
 
@@ -880,6 +884,10 @@ msgstr "Abortado"
 msgid "Abort (Alias for SIGABRT)"
 msgstr "Abortado (Outro nome para SIGABRT)"
 
+#, c-format
+msgid "Active languages (%s):"
+msgstr ""
+
 msgid "Address boundary error"
 msgstr "Erro de fronteira de endereço (Falha de segmentação)"
 
@@ -1228,6 +1236,9 @@ msgstr ""
 msgid "Jobs getting started or continued"
 msgstr ""
 
+msgid "Language specifiers appear repeatedly:"
+msgstr ""
+
 msgid "List or remove functions"
 msgstr "Lista ou remove funções"
 
@@ -1277,6 +1288,9 @@ msgstr "Nunca"
 
 msgid "No TTY for interactive shell (tcgetpgrp failed)"
 msgstr "Não há TTY para shell interativo (falha em tcgetpgrp)"
+
+msgid "No catalogs available for language specifiers:"
+msgstr ""
 
 #, c-format
 msgid "No matches for wildcard '%s'. See `help %s`."
@@ -1774,6 +1788,9 @@ msgstr ""
 msgid "completion reached maximum recursion depth, possible cycle?"
 msgstr ""
 
+msgid "default"
+msgstr ""
+
 msgid "dir symlink"
 msgstr ""
 
@@ -1799,9 +1816,16 @@ msgid ""
 "`help %s` will show an online version\n"
 msgstr ""
 
+msgid "from command `status language set`"
+msgstr ""
+
 #, c-format
 msgid "from sourcing file %s\n"
 msgstr "do arquivo %s\n"
+
+#, c-format
+msgid "from variable %s"
+msgstr ""
 
 msgid "in command substitution\n"
 msgstr "na substituição de comando\n"
@@ -3384,6 +3408,9 @@ msgstr ""
 
 msgid "Show modification time"
 msgstr "Mostra horário de modificação"
+
+msgid "Show or change fish's language settings"
+msgstr ""
 
 msgid "Show seconds since the modification time"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -79,6 +79,10 @@ msgid "%s"
 msgstr ""
 
 #, c-format
+msgid "%s %s: %s: invalid subcommand\n"
+msgstr ""
+
+#, c-format
 msgid "%s %s: Abbreviation %s already exists for commands %s, cannot rename %s\n"
 msgstr ""
 
@@ -876,6 +880,10 @@ msgstr "Avbrott"
 msgid "Abort (Alias for SIGABRT)"
 msgstr "Avbrott (Alias för SIGABRT)"
 
+#, c-format
+msgid "Active languages (%s):"
+msgstr ""
+
 msgid "Address boundary error"
 msgstr "Minnesadress korsar segmentgräns"
 
@@ -1224,6 +1232,9 @@ msgstr ""
 msgid "Jobs getting started or continued"
 msgstr ""
 
+msgid "Language specifiers appear repeatedly:"
+msgstr ""
+
 msgid "List or remove functions"
 msgstr "Visa eller ta bort funktioner"
 
@@ -1272,6 +1283,9 @@ msgid "Never"
 msgstr "Aldrig"
 
 msgid "No TTY for interactive shell (tcgetpgrp failed)"
+msgstr ""
+
+msgid "No catalogs available for language specifiers:"
 msgstr ""
 
 #, c-format
@@ -1770,6 +1784,9 @@ msgstr ""
 msgid "completion reached maximum recursion depth, possible cycle?"
 msgstr ""
 
+msgid "default"
+msgstr ""
+
 msgid "dir symlink"
 msgstr ""
 
@@ -1795,8 +1812,15 @@ msgid ""
 "`help %s` will show an online version\n"
 msgstr ""
 
+msgid "from command `status language set`"
+msgstr ""
+
 #, c-format
 msgid "from sourcing file %s\n"
+msgstr ""
+
+#, c-format
+msgid "from variable %s"
 msgstr ""
 
 msgid "in command substitution\n"
@@ -3380,6 +3404,9 @@ msgstr ""
 
 msgid "Show modification time"
 msgstr "Visa ändringstid"
+
+msgid "Show or change fish's language settings"
+msgstr ""
 
 msgid "Show seconds since the modification time"
 msgstr ""

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -105,6 +105,10 @@ msgid "%s"
 msgstr "%s"
 
 #, c-format
+msgid "%s %s: %s: invalid subcommand\n"
+msgstr "%s %s: %s: 无效的子命令\n"
+
+#, c-format
 msgid "%s %s: Abbreviation %s already exists for commands %s, cannot rename %s\n"
 msgstr "%s %s: 名为 %s 且适用于命令 %s 的缩写已存在，无法重命名 %s\n"
 
@@ -902,6 +906,10 @@ msgstr "中止"
 msgid "Abort (Alias for SIGABRT)"
 msgstr "中止 (SIGABRT 的别名)"
 
+#, c-format
+msgid "Active languages (%s):"
+msgstr ""
+
 msgid "Address boundary error"
 msgstr "地址边界错误"
 
@@ -1253,6 +1261,9 @@ msgstr "正在改变状况的作业"
 msgid "Jobs getting started or continued"
 msgstr "正在启动或继续的作业"
 
+msgid "Language specifiers appear repeatedly:"
+msgstr ""
+
 msgid "List or remove functions"
 msgstr "列出或移除函数"
 
@@ -1302,6 +1313,9 @@ msgstr "从不"
 
 msgid "No TTY for interactive shell (tcgetpgrp failed)"
 msgstr "交互 shell 没有 TTY (tcgetpgrp 失败)"
+
+msgid "No catalogs available for language specifiers:"
+msgstr ""
 
 #, c-format
 msgid "No matches for wildcard '%s'. See `help %s`."
@@ -1799,6 +1813,9 @@ msgstr "在命令位置不允许替换命令。试使用 var=(你的命令) $var
 msgid "completion reached maximum recursion depth, possible cycle?"
 msgstr "补全达到了最大的递归深度，可能存在循环？"
 
+msgid "default"
+msgstr ""
+
 msgid "dir symlink"
 msgstr "目录符号链接"
 
@@ -1827,9 +1844,16 @@ msgstr ""
 "文档可能未安装。\n"
 "`help %s` 将显示在线版本\n"
 
+msgid "from command `status language set`"
+msgstr ""
+
 #, c-format
 msgid "from sourcing file %s\n"
 msgstr "从源文件 %s\n"
+
+#, c-format
+msgid "from variable %s"
+msgstr ""
 
 msgid "in command substitution\n"
 msgstr "在命令替换中\n"
@@ -3412,6 +3436,9 @@ msgstr "显示与光标下记号相关的 man 页面条目或函数描述"
 
 msgid "Show modification time"
 msgstr "显示修改时间"
+
+msgid "Show or change fish's language settings"
+msgstr ""
 
 msgid "Show seconds since the modification time"
 msgstr "显示自修改时间以来的秒数"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -78,6 +78,10 @@ msgid "%s"
 msgstr "%s"
 
 #, c-format
+msgid "%s %s: %s: invalid subcommand\n"
+msgstr "%s %s：%s：無效的子命令\n"
+
+#, c-format
 msgid "%s %s: Abbreviation %s already exists for commands %s, cannot rename %s\n"
 msgstr "%s %s：名為 %s 且適用於命令 %s 的縮寫已存在，無法重新命名 %s\n"
 
@@ -876,6 +880,10 @@ msgstr "中止"
 msgid "Abort (Alias for SIGABRT)"
 msgstr "中止（SIGABRT 的別名）"
 
+#, c-format
+msgid "Active languages (%s):"
+msgstr ""
+
 msgid "Address boundary error"
 msgstr "位址邊界錯誤"
 
@@ -1227,6 +1235,9 @@ msgstr "作業變更狀態"
 msgid "Jobs getting started or continued"
 msgstr "作業開始或繼續"
 
+msgid "Language specifiers appear repeatedly:"
+msgstr ""
+
 msgid "List or remove functions"
 msgstr "列出或移除函式"
 
@@ -1276,6 +1287,9 @@ msgstr "永不"
 
 msgid "No TTY for interactive shell (tcgetpgrp failed)"
 msgstr "沒有互動式 shell 所需的 TTY（tcgetpgrp 失敗了）"
+
+msgid "No catalogs available for language specifiers:"
+msgstr ""
 
 #, c-format
 msgid "No matches for wildcard '%s'. See `help %s`."
@@ -1774,6 +1788,9 @@ msgstr "不允許在命令處進行命令替換。試試 var=(命令) $var ..."
 msgid "completion reached maximum recursion depth, possible cycle?"
 msgstr "補全達到最大遞迴深度，可能是循環？"
 
+msgid "default"
+msgstr ""
+
 msgid "dir symlink"
 msgstr "目錄象徵式連結"
 
@@ -1802,9 +1819,16 @@ msgstr ""
 "可能未安裝文件。\n"
 "「help %s」將顯示線上版本\n"
 
+msgid "from command `status language set`"
+msgstr ""
+
 #, c-format
 msgid "from sourcing file %s\n"
 msgstr "在載入的檔案 %s\n"
+
+#, c-format
+msgid "from variable %s"
+msgstr ""
 
 msgid "in command substitution\n"
 msgstr "在命令替換\n"
@@ -3387,6 +3411,9 @@ msgstr "顯示和游標處的詞元有關的手冊頁或函式說明"
 
 msgid "Show modification time"
 msgstr "顯示修改時間"
+
+msgid "Show or change fish's language settings"
+msgstr ""
 
 msgid "Show seconds since the modification time"
 msgstr "顯示自修改時間以來的秒數"

--- a/share/completions/status.fish
+++ b/share/completions/status.fish
@@ -23,6 +23,7 @@ set -l __fish_status_all_commands \
     is-login \
     is-no-job-control \
     job-control \
+    language \
     line-number \
     list-files \
     print-stack-trace \
@@ -80,3 +81,19 @@ complete -f -c status -n "__fish_seen_subcommand_from job-control" -a none -d "S
 
 complete -f -c status -n "__fish_seen_subcommand_from get-file" -a '(status list-files 2>/dev/null)'
 complete -f -c status -n "__fish_seen_subcommand_from list-files" -a '(status list-files 2>/dev/null)'
+
+# Tests equality between the command line with the first item removed
+# and the function's arguments.
+function __fish_status_is_exact_subcommand
+    set -l line (commandline -pxc)[2..]
+    test "$line" = "$argv"
+end
+# Tests if the command line with the first item removed starts with the provided arguments.
+function __fish_status_is_subcommand_prefix
+    set -l prefix (string escape --style=regex -- (string join -- ' ' $argv))
+    set -l line (string join -- ' ' (commandline -pxc)[2..])
+    string match -rq -- "^$prefix" $line
+end
+complete -f -c status -n "not __fish_seen_subcommand_from $__fish_status_all_commands" -a language -d "Show or change fish's language settings"
+complete -f -c status -n "__fish_status_is_exact_subcommand language" -a "(echo list-available\tShow languages usable with \'status language set\'\nset\tSet the language\(s\) used for fish\'s messages\nunset\tUndo effects of \'status language set\'\n)"
+complete -f -c status -n "__fish_status_is_subcommand_prefix language set" -a "(status language list-available)"

--- a/src/builtins/shared.rs
+++ b/src/builtins/shared.rs
@@ -67,6 +67,9 @@ localizable_consts!(
     pub BUILTIN_ERR_INVALID_SUBCMD
     "%s: %s: invalid subcommand\n"
 
+    pub BUILTIN_ERR_INVALID_SUBSUBCMD
+    "%s %s: %s: invalid subcommand\n"
+
     /// Error messages for unexpected args.
     pub BUILTIN_ERR_ARG_COUNT0
     "%s: missing argument\n"

--- a/src/env_dispatch.rs
+++ b/src/env_dispatch.rs
@@ -540,7 +540,7 @@ fn init_locale(vars: &EnvStack) {
     invalidate_numeric_locale();
 
     #[cfg(feature = "localize-messages")]
-    crate::wutil::gettext::update_locale_from_env(vars);
+    crate::wutil::gettext::update_from_env(vars);
 }
 
 pub fn use_posix_spawn() -> bool {

--- a/tests/checks/message-localization.fish
+++ b/tests/checks/message-localization.fish
@@ -55,6 +55,12 @@ begin
     set -l LANG C
     echo (_ file)
     # CHECK: file
+    set -l LANG POSIX
+    echo (_ file)
+    # CHECK: file
+    set -l LANG C.UTF-8
+    echo (_ file)
+    # CHECK: file
 end
 echo (_ file)
 # CHECK: arquivo
@@ -72,6 +78,13 @@ begin
 end
 echo (_ file)
 # CHECK: arquivo
+
+# Check that empty vars are ignored
+begin
+    set -l LC_ALL
+    echo (_ file)
+    # CHECK: arquivo
+end
 
 # Check that all relevant locale variables are respected.
 set --erase LANG
@@ -104,3 +117,71 @@ echo (_ file)
 set -l LC_ALL de_DE.utf8
 echo (_ file)
 # CHECK: Datei
+
+# Check `status language` builtin
+set --erase LANG
+set --erase LC_MESSAGES
+set --erase LC_ALL
+set --erase LANGUAGE
+status language
+# CHECK: Active languages (default):
+echo (_ file)
+# CHECK: file
+
+set -l LANGUAGE pt_BR de_DE
+status language
+# CHECK: Active languages (from variable LANGUAGE): pt_BR de
+echo (_ file)
+# CHECK: arquivo
+
+# We have fr but not fr_FR. For the builtin command, only exact matches are allowed.
+status language set fr_FR de pt_BR
+# CHECKERR: No catalogs available for language specifiers: fr_FR
+status language
+# CHECK: Active languages (from command `status language set`): de pt_BR
+echo (_ file)
+# CHECK: Datei
+
+set -l LANGUAGE zh_TW
+status language
+# CHECK: Active languages (from command `status language set`): de pt_BR
+echo (_ file)
+# CHECK: Datei
+
+set -l LC_MESSAGES C
+status language
+# CHECK: Active languages (from command `status language set`): de pt_BR
+echo (_ file)
+# CHECK: Datei
+
+status language unset
+status language
+# CHECK: Active languages (from variable LC_MESSAGES):
+echo (_ file)
+# CHECK: file
+
+set --erase LC_MESSAGES
+status language
+# CHECK: Active languages (from variable LANGUAGE): zh_TW
+echo (_ file)
+# CHECK: 檔案
+
+set --erase LANGUAGE
+status language
+# CHECK: Active languages (default):
+echo (_ file)
+# CHECK: file
+
+# Check `status language set` warnings
+status language set asdf
+# CHECKERR: No catalogs available for language specifiers: asdf
+
+# This will have to be changed if we add catalogs for languages used here.
+status language set zh_HK it_IT
+# CHECKERR: No catalogs available for language specifiers: zh_HK it_IT
+
+status language set de de
+# CHECKERR: Language specifiers appear repeatedly: de
+
+status language set \xff quote\"
+# CHECKERR: No catalogs available for language specifiers: \Xff 'quote"'


### PR DESCRIPTION
Based on the discussion in
https://github.com/fish-shell/fish-shell/pull/11967

Introduce a `status language` builtin, which has subcommands for
controlling and inspecting fish's message localization status.

The motivation for this is that using only the established environment
variables `LANGUAGE`, `LC_ALL`, `LC_MESSAGES`, and `LANG` can cause
problems when fish interprets them differently from GNU gettext.
In addition, these are not well-suited for users who want to override
their normal localization settings only for fish, since fish would
propagate the values of these variables to its child processes.

Configuration via these variables still works as before, but now there
is the `status language set` command, which allows overriding the
localization configuration.
If `status language set` is used, the language precedence list will be
taken from its remaining arguments.
Warnings will be shown for invalid arguments.
Once this command was used, the localization related environment
variables are ignored.
To go back to taking the configuration from the environment variables
after `status language set` was executed, users can run `status language
unset`.

Running `status language` without arguments shows information about the
current message localization status, allowing users to better understand
how their settings are interpreted by fish.

The `status language list-available` command shows which languages are
available to choose from, which is used for completions.

This commit eliminates dependencies from the `gettext_impl` module to
code in fish's main crate, allowing for extraction of this module into
its own crate in a future commit.