### PR TITLE
gettext: rebuild extract macro on env var change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,7 @@ name = "fish-gettext-extraction"
 version = "0.0.0"
 dependencies = [
  "proc-macro2",
+ "rsconf",
 ]
 
 [[package]]

--- a/build.rs
+++ b/build.rs
@@ -42,9 +42,6 @@ fn main() {
 
     fish_build_helper::rebuild_if_embedded_path_changed("share");
 
-    #[cfg(feature = "gettext-extract")]
-    rsconf::rebuild_if_env_changed("FISH_GETTEXT_EXTRACTION_FILE");
-
     let build = cc::Build::new();
     let mut target = Target::new_from(build).unwrap();
     // Keep verbose mode on until we've ironed out rust build script stuff

--- a/crates/gettext-extraction/Cargo.toml
+++ b/crates/gettext-extraction/Cargo.toml
@@ -13,5 +13,8 @@ proc-macro = true
 [dependencies]
 proc-macro2.workspace = true
 
+[build-dependencies]
+rsconf.workspace = true
+
 [lints]
 workspace = true

--- a/crates/gettext-extraction/build.rs
+++ b/crates/gettext-extraction/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    rsconf::rebuild_if_env_changed("FISH_GETTEXT_EXTRACTION_FILE");
+}


### PR DESCRIPTION
While it's not necessary to rebuild the proc macro for extraction when the env var controlling the output location changes, this way everything using the macro will automatically be rebuilt when this env var changes, making it impossible to forget adding this to other `build.rs` files.

For now, keeping the rebuild instructions in fish's main crate's `build.rs` would be fine as well, but if we start breaking this crate into smaller parts, it would become annoying to add the rebuild command in every crate depending on gettext extraction.