### PR TITLE
feat(math): add `logb` function

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,10 @@ Notable improvements and fixes
 Deprecations and removed features
 ---------------------------------
 
+Scripting improvements
+----------------------
+- ``math`` gained a new ``logb`` function.
+
 Interactive improvements
 ------------------------
 - When typing immediately after starting fish, the first prompt is now rendered correctly.
@@ -130,7 +134,7 @@ This release fixes the following regressions identified in 4.1.0:
   This will not affect fish's child processes unless ``LC_MESSAGES`` was already exported.
 
 - Some :doc:`fish_config <cmds/fish_config>` subcommands for showing prompts and themes had been broken in standalone Linux builds (those using the ``embed-data`` cargo feature), which has been fixed (:issue:`11832`).
-- On Windows Terminal, we observed an issue where fish would fail to read the terminal's response to our new startup queries, causing noticeable lags and a misleading error message. A workaround has been added (:issue:`11841`). 
+- On Windows Terminal, we observed an issue where fish would fail to read the terminal's response to our new startup queries, causing noticeable lags and a misleading error message. A workaround has been added (:issue:`11841`).
 - A WezTerm `issue breaking shifted key input <https://github.com/wezterm/wezterm/issues/6087>`__ has resurfaced on some versions of WezTerm; our workaround has been extended to cover all versions for now (:issue:`11204`).
 - Fixed a crash in :doc:`the web-based configuration tool <cmds/fish_config>` when using the new underline styles (:issue:`11840`).
 

--- a/doc_src/cmds/math.rst
+++ b/doc_src/cmds/math.rst
@@ -156,6 +156,8 @@ Functions
     the base-10 logarithm
 ``log2``
     the base-2 logarithm
+``logb(b,x)``
+    returns the logarithm with base b of x
 ``max``
     returns the largest of the given numbers - this takes an arbitrary number of arguments (but at least one)
 ``min``

--- a/src/tinyexpr.rs
+++ b/src/tinyexpr.rs
@@ -291,6 +291,7 @@ const BUILTINS: &[(&wstr, Function)] = &[
     (L!("log"), Function::Fn1(f64::log10)),
     (L!("log10"), Function::Fn1(f64::log10)),
     (L!("log2"), Function::Fn1(f64::log2)),
+    (L!("logb"), Function::Fn2(|a, b| b.log(a))),
     (L!("max"), Function::FnN(maximum)),
     (L!("min"), Function::FnN(minimum)),
     (L!("ncr"), Function::Fn2(ncr)),

--- a/tests/checks/math.fish
+++ b/tests/checks/math.fish
@@ -276,6 +276,21 @@ echo $status
 math 'log2(8)'
 # CHECK: 3
 
+math 'logb(2, 8)'
+# CHECK: 3
+math 'logb(67, 406067677556641)'
+# CHECK: 8
+math 'logb(42, 230539333248)'
+# CHECK: 7
+math 'logb(12, 8916100448256)'
+# CHECK: 12
+math 'logb(3, 5559060566555523)'
+# CHECK: 33
+math 'logb(5, 2384185791015625)'
+# CHECK: 22
+math 'logb(7, 343)'
+# CHECK: 3
+
 # same as sin(cos(2 x pi))
 math sin cos 2 x pi
 # CHECK: 0.841471


### PR DESCRIPTION
## Description

This adds a builtin function called `logb` for taking the logarithm of a number with a given base.

Fixes issue #12111

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
