### PR TITLE
ci: disable tmux-invocation test in sanitizer jobs

### DIFF
--- a/tests/checks/tmux-invocation.fish
+++ b/tests/checks/tmux-invocation.fish
@@ -1,5 +1,7 @@
 #RUN: %fish %s
 #REQUIRES: command -v tmux
+# This failed repeatedly in the ubuntu-asan job.
+#REQUIRES: test -z "$FISH_CI_SAN"
 
 isolated-tmux-start -C '
     set -g fish (status fish-path)


### PR DESCRIPTION
This test frequently fails for the ubuntu-asan job, causing annoying CI failure warnings. Since it consistently passes in the other CI jobs, it's probably timing-related.
