### PR TITLE
ci: disable tmux-prompt test in sanitizer jobs

### DIFF
--- a/tests/checks/tmux-prompt.fish
+++ b/tests/checks/tmux-prompt.fish
@@ -1,5 +1,7 @@
 #RUN: %fish %s
 #REQUIRES: command -v tmux
+# This failed repeatedly in the ubuntu-asan job.
+#REQUIRES: test -z "$FISH_CI_SAN"
 
 isolated-tmux-start -C '
     function fish_prompt


### PR DESCRIPTION
This test frequently fails for the ubuntu-asan job, causing annoying CI failure warnings.
