### PR TITLE
Fixed typo

### DIFF
--- a/doc_src/cmds/fish_opt.rst
+++ b/doc_src/cmds/fish_opt.rst
@@ -72,7 +72,7 @@ Same as above but the value of the second flag cannot be the empty string:
 ::
 
     set -l options (fish_opt -s h -l help)
-    set options $options (fish_opt -s m -l max -rv test \$_flag_valu != "''")
+    set options $options (fish_opt -s m -l max -rv test \$_flag_value != "''")
     argparse $options -- $argv
 
 Same as above but with a third flag that can be given multiple times saving the value of each instance seen and only a long flag name (``--token``) is defined:
@@ -82,7 +82,7 @@ Same as above but with a third flag that can be given multiple times saving the 
 ::
 
     set -l options (fish_opt --short=h --long=help)
-    set options $options (fish_opt --short=m --long=max --required-val --validate test \$_flag_valu != "''")
+    set options $options (fish_opt --short=m --long=max --required-val --validate test \$_flag_value != "''")
     set options $options (fish_opt --long=token --multiple-vals)
     argparse $options -- $argv
 

--- a/tests/checks/argparse.fish
+++ b/tests/checks/argparse.fish
@@ -756,10 +756,10 @@ argparse a/alpha -- --alpha=value --banna=value
 
 # Check behaviour without -S/--strict-longopts option
 begin
-    argparse long valu=+ -- --lon -long -lon -valu=3 -valu 4 -val=3 -val 4
+    argparse long value=+ -- --lon -long -lon -valu=3 -valu 4 -val=3 -val 4
     set -lL
     # CHECK: _flag_long '--long' '--long' '--long'
-    # CHECK: _flag_valu '3' '4' '3' '4'
+    # CHECK: _flag_value '3' '4' '3' '4'
     # CHECK: argv
     # CHECK: argv_opts '--lon' '-long' '-lon' '-valu=3' '-valu' '4' '-val=3' '-val' '4'
     argparse amb ambig -- -am


### PR DESCRIPTION
Missed a spot in the first attempt #12135 as pointed out by [xtqqczze](https://github.com/fish-shell/fish-shell/pull/12135#issuecomment-3609441130)

Small typo found in doc_src/cmds/fish_opt.rst and tests/checks/argparse.fish. `valu` to `value`

