### PR TITLE
refactor: replace `std::ptr::addr_of!` with raw pointers

### DIFF
--- a/src/fork_exec/postfork.rs
+++ b/src/fork_exec/postfork.rs
@@ -495,13 +495,7 @@ fn get_interpreter<'a>(command: &CStr, buffer: &'a mut [u8]) -> Option<&'a CStr>
     if fd >= 0 {
         while idx + 1 < buffer.len() {
             let mut ch = b'\0';
-            let amt = unsafe {
-                libc::read(
-                    fd,
-                    std::ptr::addr_of_mut!(ch).cast(),
-                    std::mem::size_of_val(&ch),
-                )
-            };
+            let amt = unsafe { libc::read(fd, (&raw mut ch).cast(), std::mem::size_of_val(&ch)) };
             if amt <= 0 || ch == b'\n' {
                 break;
             }

--- a/src/io.rs
+++ b/src/io.rs
@@ -417,13 +417,8 @@ impl IoBuffer {
 
         // We want to swallow EINTR only; in particular EAGAIN needs to be returned back to the caller.
         let amt = loop {
-            let amt = unsafe {
-                libc::read(
-                    fd,
-                    std::ptr::addr_of_mut!(bytes).cast(),
-                    std::mem::size_of_val(&bytes),
-                )
-            };
+            let amt =
+                unsafe { libc::read(fd, bytes.as_mut_ptr().cast(), std::mem::size_of_val(&bytes)) };
             if amt < 0 && errno::errno().0 == EINTR {
                 continue;
             }
@@ -623,16 +618,13 @@ impl IoChain {
     /// Output debugging information to stderr.
     pub fn print(&self) {
         if self.0.is_empty() {
-            eprintf!(
-                "Empty chain %s\n",
-                format!("{:p}", std::ptr::addr_of!(self))
-            );
+            eprintf!("Empty chain %s\n", format!("{:p}", &raw const self));
             return;
         }
 
         eprintf!(
             "Chain %s (%d items):\n",
-            format!("{:p}", std::ptr::addr_of!(self)),
+            format!("{:p}", &raw const self),
             self.0.len()
         );
         for (i, io) in self.0.iter().enumerate() {

--- a/src/wutil/dir_iter.rs
+++ b/src/wutil/dir_iter.rs
@@ -12,7 +12,7 @@ use std::cell::Cell;
 use std::io;
 use std::mem::MaybeUninit;
 use std::os::fd::RawFd;
-use std::ptr::{NonNull, addr_of};
+use std::ptr::NonNull;
 use std::rc::Rc;
 
 /// Types of files that may be in a directory.
@@ -273,11 +273,9 @@ impl DirIter {
 
         // Do not rely on `libc::dirent::d_name.len()` as dirent names may exceed
         // the nominal buffer size; instead use the terminating nul byte.
-        // TODO: This should use &raw from Rust 1.82 on
         // https://github.com/rust-lang/libc/issues/2669
         // https://github.com/fish-shell/fish-shell/issues/11221
-        let d_name_ptr = addr_of!(dent.d_name);
-        let d_name = unsafe { std::ffi::CStr::from_ptr(d_name_ptr.cast()) }.to_bytes();
+        let d_name = unsafe { std::ffi::CStr::from_ptr(dent.d_name.as_ptr().cast()) }.to_bytes();
 
         // Skip . and ..,
         // unless we've been told not to.

--- a/src/wutil/mod.rs
+++ b/src/wutil/mod.rs
@@ -115,13 +115,7 @@ pub fn wreadlink(file_name: &wstr) -> Option<WString> {
     let bufsize = usize::try_from(md.len()).unwrap() + 1;
     let mut target_buf = vec![b'\0'; bufsize];
     let tmp = wcs2zstring(file_name);
-    let nbytes = unsafe {
-        libc::readlink(
-            tmp.as_ptr(),
-            std::ptr::addr_of_mut!(target_buf[0]).cast(),
-            bufsize,
-        )
-    };
+    let nbytes = unsafe { libc::readlink(tmp.as_ptr(), target_buf.as_mut_ptr().cast(), bufsize) };
     if nbytes == -1 {
         perror("readlink");
         return None;


### PR DESCRIPTION
The `addr_of!(expr)` and `addr_of_mut!(expr)` macros were soft-deprecated in Rust 1.82.0.