### PR TITLE
fix: invoke the `rm` command, bypassing custom rm functions which might block

### DIFF
--- a/share/completions/scp.fish
+++ b/share/completions/scp.fish
@@ -54,7 +54,7 @@ complete -c scp -d "Remote Path" -f -n "commandline -ct | string match -e ':'" -
                 set -g __fish_scp_sftp false
             end
             if set -q tmp[1]
-                rm $tmp
+                command rm $tmp
             end
         end
         if $__fish_scp_sftp


### PR DESCRIPTION
## Description

Preface: I have a customized shell, this issue doesn't occur when I remove said customization. It's on me.

```
❯ fish --version
fish, version 4.2.1

❯ echo $version
4.2.1

❯ uname
Linux
```

The `rm` command in the `scp.fish` autocompletion: https://github.com/fish-shell/fish-shell/blob/47c773300a40adf66e59e83ca2492f87b7ccb57d/share/completions/scp.fish#L57

fails in the case that `core-utils` is installed, combined with the following function:

```fish
❯ cat --plain rm.fish
function rm --wraps='command grm --interactive --verbose' --description 'alias rm command grm --interactive --verbose'
  if status is-interactive
    command grm --interactive --verbose $argv
  else
    command rm $argv
  end
end
```

I do:

```fish
scp -r kristof@server:/path/to/folder/<tab>
```

which yields

```
scp -r kristof@server:/path/to/folder/grm: remove regular empty file '/tmp/fish-scp.rRuMnE'?
```

Copying the `scp.fish` completion in `/usr/share/fish/completions` to `~/.config/fish/completions` and applying this PR fixes the issue.


Is it correct to say that `status is-interactive` returns true even when the function is called from ANOTHER script? 


Fixes issue #12141 (ergo this PR)

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
