### PR TITLE
ci: disable pexpect and tmux tests in sanitizer jobs

### DIFF
--- a/tests/checks/check-all-fish-files.fish
+++ b/tests/checks/check-all-fish-files.fish
@@ -1,6 +1,4 @@
 #RUN: fish=%fish %fish %s
-# disable on CI ASAN because it's suuuper slow
-#REQUIRES: test -z "$FISH_CI_SAN"
 
 set -l workspace_root (path resolve -- (status dirname)/../../)
 set timestamp_file $workspace_root/tests/.last-check-all-files

--- a/tests/checks/check-completions.fish
+++ b/tests/checks/check-completions.fish
@@ -1,6 +1,4 @@
 #RUN: fish=%fish %fish %s
-# disable on CI ASAN because it's suuuper slow
-#REQUIRES: test -z "$FISH_CI_SAN"
 # Test all completions where the command exists
 
 # No output is good output

--- a/tests/checks/noshebang.fish
+++ b/tests/checks/noshebang.fish
@@ -1,9 +1,5 @@
 # RUN: %fish %s
 
-# Do not run under sanitizers in CI, as they intercept a busted posix_spawn
-# which mishandles shebangless scripts.
-# REQUIRES: test -z "$FISH_CI_SAN"
-
 # Test for shebangless scripts - see 7802.
 
 set testdir (mktemp -d)

--- a/tests/checks/tmux-first-prompt.fish
+++ b/tests/checks/tmux-first-prompt.fish
@@ -1,6 +1,5 @@
 # RUN: %fish %s
 # REQUIRES: command -v tmux
-# REQUIRES: test -z "$FISH_CI_SAN"
 
 tmux_wait=false \
     isolated-tmux-start -C '

--- a/tests/pexpects/autosuggest.py
+++ b/tests/pexpects/autosuggest.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 from pexpect_helper import SpawnedProc
-import os
 
 sp = SpawnedProc()
 send, sendline, sleep, expect_prompt = (
@@ -12,8 +11,6 @@ send, sendline, sleep, expect_prompt = (
 
 
 def use_suggestion(*, delay=0.1):
-    if "FISH_CI_SAN" in os.environ:
-        delay *= 5
     sleep(delay)
     send("\033[C")
     sendline("")

--- a/tests/pexpects/eval-stack-overflow.py
+++ b/tests/pexpects/eval-stack-overflow.py
@@ -1,12 +1,7 @@
 #!/usr/bin/env python3
 from pexpect_helper import SpawnedProc
 import re
-import os
 import sys
-
-# Disable under SAN - keeps failing because the timing is too tight
-if "FISH_CI_SAN" in os.environ:
-    sys.exit(0)
 
 sp = SpawnedProc()
 send, sendline, sleep, expect_prompt, expect_re, expect_str = (

--- a/tests/pexpects/terminal.py
+++ b/tests/pexpects/terminal.py
@@ -2,12 +2,7 @@
 from pexpect_helper import SpawnedProc
 import platform
 
-import os
 import sys
-
-# Disable under SAN - keeps failing because the timing is too tight
-if "FISH_CI_SAN" in os.environ:
-    sys.exit(0)
 
 
 # Set a 0 terminal size
@@ -58,9 +53,6 @@ sendline("stty ixon ixoff")
 expect_prompt()
 sendline("stty -a | string match -q '*ixon ixoff*'; echo $status")
 expect_prompt("0")
-
-# TODO
-import sys
 
 sys.exit(0)
 # HACK: This fails on FreeBSD, macOS and NetBSD for some reason, maybe

--- a/tests/pexpects/wait.py
+++ b/tests/pexpects/wait.py
@@ -1,13 +1,6 @@
 #!/usr/bin/env python3
 from pexpect_helper import SpawnedProc
 
-import os
-import sys
-
-# Disable under SAN - keeps failing because the timing is too tight
-if "FISH_CI_SAN" in os.environ:
-    sys.exit(0)
-
 sp = SpawnedProc()
 send, sendline, sleep, expect_prompt, expect_re, expect_str = (
     sp.send,

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -1,21 +1,18 @@
 #!/usr/bin/env python3
 import argparse
 import asyncio
-from datetime import datetime
 import os
-from pathlib import Path
 import resource
 import shutil
 import subprocess
 import sys
 import tempfile
-from typing import Optional
+from datetime import datetime
+from pathlib import Path
 
 # TODO(python>3.8): use dict
-from typing import Dict
-
 # TODO(python>3.8): use |
-from typing import Union
+from typing import Dict, Optional, Union
 
 import littlecheck
 
@@ -162,6 +159,16 @@ async def main():
             for path in sorted(script_path.glob("checks/*.fish"))
             + sorted(script_path.glob("pexpects/*.py"))
         ]
+    if os.environ.get("FISH_CI_SAN"):
+
+        def run_in_ci_san(path) -> bool:
+            if path.endswith(".py"):
+                return False
+            if os.path.basename(path).startswith("tmux-"):
+                return False
+            return True
+
+        files = [path_pair for path_pair in files if run_in_ci_san(path_pair[0])]
 
     if not PEXPECT and any(x.endswith(".py") for (x, _) in files):
         print(f"{RED}Skipping pexpect tests because pexpect is not installed{RESET}")


### PR DESCRIPTION
These tests are unreliable in CI when running with address sanitiation enabled, resulting in intermittent CI failures.
Disable them to get rid of the many false positives to reduce annoyance and to avoid desensitization regarding failures of the asan CI job.

Suggested in
https://github.com/fish-shell/fish-shell/pull/12132#issuecomment-3605639954

This makes #12126 and #12132 obsolete.