### PR TITLE
rust-embed: update to 8.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed"
-version = "8.8.0"
+version = "8.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb44e1917075637ee8c7bcb865cf8830e3a92b5b1189e44e3a0ab5a0d5be314b"
+checksum = "947d7f3fad52b283d261c4c99a084937e2fe492248cb9a68a8435a861b8798ca"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -664,9 +664,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.8.0"
+version = "8.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "382499b49db77a7c19abd2a574f85ada7e9dbe125d5d1160fa5cad7c4cf71fc9"
+checksum = "5fa2c8c9e8711e10f9c4fd2d64317ef13feaab820a4c51541f1a8c8e2e851ab2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -678,9 +678,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.8.0"
+version = "8.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21fcbee55c2458836bcdbfffb6ec9ba74bbc23ca7aa6816015a3dd2c4d8fc185"
+checksum = "60b161f275cb337fe0a44d924a5f4df0ed69c2c39519858f931ce61c779d3475"
 dependencies = [
  "globset",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ proc-macro2 = "1.0"
 # minimum supported version to 10.12.
 rand = { version = "0.8.5", default-features = false, features = ["small_rng"] }
 rsconf = "0.2.2"
-rust-embed = { version = "8.7.2", features = [
+rust-embed = { version = "8.9.0", features = [
     "deterministic-timestamps",
     "include-exclude",
     "interpolate-folder-path",


### PR DESCRIPTION
This eliminates the proc-macro panic occasionally observed in CI, instead ignoring paths which cannot be canonicalized. See #12120.

While this does not address the underlying issue of why the proc-macro fail happens, it should result in builds no longer failing, and since they failed in the case where no embedding is desired, there should be no issue with ignoring failed path canonicalization, since we do not want to embed anything in these cases.