### PR TITLE
fix Multi-line auto-suggestion doesn't show soft-wrapped portion of line #12045

### DIFF
--- a/src/screen.rs
+++ b/src/screen.rs
@@ -11,7 +11,6 @@ use crate::FLOG;
 use crate::editable_line::line_at_cursor;
 use crate::key::ViewportPosition;
 use crate::pager::{PAGER_MIN_HEIGHT, PageRendering, Pager};
-use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::LinkedList;
 use std::io::Write;
@@ -1954,21 +1953,6 @@ struct ScreenLayout {
     pub(crate) autosuggestion: WString,
 }
 
-// Given a vector whose indexes are offsets and whose values are the widths of the string if
-// truncated at that offset, return the offset that fits in the given width. Returns
-// width_by_offset.size() - 1 if they all fit. The first value in width_by_offset is assumed to be
-// 0.
-fn truncation_offset_for_width(str: &wstr, max_width: usize) -> usize {
-    let mut i = 0;
-    let mut width = 0;
-    while i < str.len() && width <= max_width {
-        width += wcwidth_rendered_min_0(str.char_at(i));
-        i += 1;
-    }
-    // i is the first index that did not fit; i - 1 is therefore the last that did.
-    i - 1
-}
-
 #[allow(clippy::too_many_arguments)]
 fn compute_layout(
     ellipsis_char: char,
@@ -2044,8 +2028,9 @@ fn compute_layout(
     // Now we should definitely fit.
     assert!(left_prompt_width + right_prompt_width <= screen_width);
 
-    // Truncate each logical line from the autosuggestion to fit on a single screen line.
-    // In future, we should truncate only once, at the end (#12004).
+    // Track each logical line from the autosuggestion so we can determine how much of it fits
+    // on screen. We allow the lines to soft wrap naturally and we only truncate vertically if
+    // we would exceed the screen height.
     let cursor_y = left_prompt_layout.line_starts.len() - 1
         + commandline_before_suggestion
             .chars()
@@ -2053,9 +2038,7 @@ fn compute_layout(
             .count();
 
     struct SuggestionLine<'a> {
-        available_autosuggest_space: usize,
         autosuggestion_line: &'a wstr,
-        autosuggest_total_width: usize,
     }
     let mut suggestion_lines = vec![];
 
@@ -2071,10 +2054,6 @@ fn compute_layout(
         .enumerate()
     {
         let autosuggestion_line = wstr::from_char_slice(autosuggestion_line);
-        let autosuggest_total_width = autosuggestion_line
-            .chars()
-            .map(wcwidth_rendered_min_0)
-            .sum();
 
         // Calculate space available for autosuggestion.
         let indent_width = |pos| usize::try_from(indent[pos]).unwrap() * INDENT_STEP;
@@ -2088,17 +2067,13 @@ fn compute_layout(
             } else {
                 indent_width(suggestion_start - "\n".len())
             };
-        let available_horizontal_space = screen_width - (width % screen_width);
-
+        let start_column = if screen_width == 0 {
+            0
+        } else {
+            width % screen_width
+        };
         let suggestion_line_height =
-            if width >= screen_width || autosuggest_total_width >= available_horizontal_space {
-                // As per the comment above, we truncate and autosuggestion lines that would wrap.
-                // We truncate them at the very end of the screen, so they (barely) soft wrap,
-                // and take up two screen lines.
-                2
-            } else {
-                1
-            };
+            autosuggestion_line_height(start_column, autosuggestion_line, screen_width);
         match available_vertical_space.checked_sub(suggestion_line_height) {
             Some(lines) => available_vertical_space = lines,
             None => {
@@ -2108,65 +2083,77 @@ fn compute_layout(
         };
 
         suggestion_lines.push(SuggestionLine {
-            available_autosuggest_space: available_horizontal_space,
             autosuggestion_line,
-            autosuggest_total_width,
         });
 
         suggestion_start += autosuggestion_line.len() + "\n".len();
     }
 
     let mut autosuggestion = WString::new();
-    let mut erased = 0;
-    let mut suggestion_start = commandline_before_suggestion.len();
+    let mut displayed_len = 0;
     for (
-        line,
+        line_idx,
         &SuggestionLine {
-            available_autosuggest_space,
             autosuggestion_line,
-            autosuggest_total_width,
         },
     ) in suggestion_lines.iter().enumerate()
     {
-        let truncated_suggestion_line;
-        let mut vertical_truncation_marker = None;
-        if autosuggest_total_width > 0 && autosuggest_total_width >= available_autosuggest_space {
-            // horizontal truncation
-            let truncation_offset =
-                truncation_offset_for_width(autosuggestion_line, available_autosuggest_space - 1);
-            truncated_suggestion_line = Cow::Owned(
-                autosuggestion_line[..truncation_offset].to_owned()
-                    + wstr::from_char_slice(&[ellipsis_char]),
-            );
-        } else if truncated_vertically && line == suggestion_lines.len() - 1 {
-            // vertical truncation
-            truncated_suggestion_line = Cow::Borrowed(autosuggestion_line);
-            vertical_truncation_marker = Some(ellipsis_char);
-        } else {
-            // no truncation
-            assert!(available_autosuggest_space >= autosuggest_total_width);
-            truncated_suggestion_line = Cow::Borrowed(autosuggestion_line);
-        }
-
-        let truncation_range = suggestion_start - erased + truncated_suggestion_line.len()
-            ..suggestion_start - erased + autosuggestion_line.len();
-        colors.drain(truncation_range.clone());
-        indent.drain(truncation_range.clone());
-        erased += truncation_range.len();
-        suggestion_start += autosuggestion_line.len() + "\n".len();
-        if line != 0 {
+        if line_idx != 0 {
             autosuggestion.push('\n');
+            displayed_len += "\n".len();
         }
-        autosuggestion.push_utfstr(&truncated_suggestion_line);
-        if let Some(extra) = vertical_truncation_marker {
-            autosuggestion.push(extra);
-            colors.insert(truncation_range.end, colors[truncation_range.end - 1]);
-            indent.insert(truncation_range.end, indent[truncation_range.end - 1]);
+        autosuggestion.push_utfstr(autosuggestion_line);
+        displayed_len += autosuggestion_line.len();
+    }
+
+    let total_autosuggestion_len = autosuggestion_str.len();
+    let truncated_chars = total_autosuggestion_len.saturating_sub(displayed_len);
+    if truncated_chars > 0 {
+        let tail_start = commandline_before_suggestion.len() + displayed_len;
+        colors.drain(tail_start..tail_start + truncated_chars);
+        indent.drain(tail_start..tail_start + truncated_chars);
+
+        if truncated_vertically && displayed_len > 0 {
+            let ellipsis_color = colors
+                .get(tail_start.saturating_sub(1))
+                .copied()
+                .unwrap_or_else(|| HighlightSpec::with_fg(HighlightRole::autosuggestion));
+            let ellipsis_indent = indent
+                .get(tail_start.saturating_sub(1))
+                .copied()
+                .unwrap_or_default();
+            autosuggestion.push(ellipsis_char);
+            colors.insert(tail_start, ellipsis_color);
+            indent.insert(tail_start, ellipsis_indent);
         }
     }
     result.autosuggestion = autosuggestion;
 
     result
+}
+
+fn autosuggestion_line_height(start_column: usize, line: &wstr, screen_width: usize) -> usize {
+    if screen_width == 0 {
+        return 0;
+    }
+    let mut column = start_column % screen_width;
+    let mut lines = 1;
+    for ch in line.chars() {
+        let ch_width = wcwidth_rendered_min_0(ch);
+        if ch_width == 0 {
+            continue;
+        }
+        if column + ch_width > screen_width {
+            lines += 1;
+            column = 0;
+        }
+        column += ch_width;
+        if column == screen_width {
+            column = 0;
+            lines += 1;
+        }
+    }
+    lines
 }
 
 // Display non-printable control characters as a graphic symbol.
@@ -2503,7 +2490,7 @@ mod tests {
                 "left>",
                 5,
                 "<right",
-                " autosugges…",
+                " autosuggesTION",
             )
         );
         validate!(
@@ -2523,7 +2510,7 @@ mod tests {
                 "left>",
                 5,
                 "<right",
-                " autosuggestion t…",
+                " autosuggestion tRUNCATED",
             )
         );
         validate!(
@@ -2533,7 +2520,7 @@ mod tests {
                 "left>",
                 5,
                 "<right",
-                " autosuggesti…",
+                " autosuggestiON  TRUNCATED",
             )
         );
         let indent = validate!(
@@ -2543,10 +2530,10 @@ mod tests {
                 "left>",
                 5,
                 "<right",
-                " autosuggesti…",
+                " autosuggestiON  TRUNCATED",
             )
         );
-        assert_eq!(indent["if :\ncommand autosuggesti…\n".len()], 1);
+        assert_eq!(indent["if :\ncommand autosuggestiON  TRUNCATED\n".len()], 1);
 
         validate!(
             (
@@ -2555,7 +2542,7 @@ mod tests {
                 "left>",
                 5,
                 "",
-                " auto…",
+                " autoSUGGESTION",
             )
         );
         validate!(
@@ -2565,7 +2552,7 @@ mod tests {
                 "left>",
                 5,
                 "",
-                "…",
+                "s",
             )
         );
         validate!(
@@ -2575,7 +2562,7 @@ mod tests {
                 "left>",
                 5,
                 "",
-                "…",
+                "SUGGESTION",
             )
         );
         validate!(
@@ -2585,7 +2572,7 @@ mod tests {
                 "left>",
                 5,
                 "",
-                "uggestion long so…",
+                "uggestion long soFT WRAP",
             )
         );
         validate!(
@@ -2595,7 +2582,7 @@ mod tests {
                 "left>",
                 5,
                 "<right",
-                "and …",
+                "and AUTOSUGGESTION",
             )
         );
         validate!(
@@ -2605,7 +2592,7 @@ mod tests {
                 "left>",
                 5,
                 "<right",
-                "…",
+                "AUTOSUGGESTION",
             )
         );
         validate!( //
@@ -2615,7 +2602,7 @@ mod tests {
                 "left>",
                 5,
                 "<right",
-                "utosuggestion sof…",
+                "utosuggestion sofT WRAP",
             )
         );
         validate!(
@@ -2625,7 +2612,7 @@ mod tests {
                 "left>",
                 5,
                 "",
-                "and …",
+                "and AUTOSUGGESTION",
             )
         );
         validate!(
@@ -2635,7 +2622,7 @@ mod tests {
                 "left>",
                 5,
                 "",
-                "…",
+                "AUTOSUGGESTION",
             )
         );
         validate!(
@@ -2645,7 +2632,7 @@ mod tests {
                 "left>",
                 5,
                 "",
-                "utosuggestion sof…",
+                "utosuggestion sofT WRAP",
             )
         );
     }

--- a/tests/checks/tmux-autosuggestion-multiline.fish
+++ b/tests/checks/tmux-autosuggestion-multiline.fish
@@ -16,8 +16,8 @@ tmux-sleep
 isolated-tmux capture-pane -p | sed /if/,/end/s/^/^/
 # CHECK: ^prompt> if true
 # CHECK: ^            echo 00000000000000000000000000000000000000000000000000
-# CHECK: ^            echo 00000000000000000000000000000000000000000000000000000000000000…
-# CHECK: ^
+# CHECK: ^            echo 000000000000000000000000000000000000000000000000000000000000000
+# CHECK: ^0000000000000000000000000000000000000
 # CHECK: ^        end
 
 # Enter does not invalidate autosuggestion.
@@ -26,8 +26,8 @@ tmux-sleep
 isolated-tmux capture-pane -p | sed /if/,/end/s/^/^/
 # CHECK: ^prompt> if true
 # CHECK: ^            echo 00000000000000000000000000000000000000000000000000
-# CHECK: ^            echo 00000000000000000000000000000000000000000000000000000000000000…
-# CHECK: ^
+# CHECK: ^            echo 000000000000000000000000000000000000000000000000000000000000000
+# CHECK: ^0000000000000000000000000000000000000
 # CHECK: ^        end
 
 # Autosuggestion is also computed after Enter.
@@ -36,8 +36,8 @@ tmux-sleep
 isolated-tmux capture-pane -p  \; send-keys C-u C-u C-u C-l | sed /if/,/end/s/^/^/
 # CHECK: ^prompt> if true
 # CHECK: ^            echo 00000000000000000000000000000000000000000000000000
-# CHECK: ^            echo 00000000000000000000000000000000000000000000000000000000000000…
-# CHECK: ^
+# CHECK: ^            echo 000000000000000000000000000000000000000000000000000000000000000
+# CHECK: ^0000000000000000000000000000000000000
 # CHECK: ^        end
 
 # Test smaller windows; only the lines that fit will be shown.
@@ -46,8 +46,8 @@ tmux-sleep
 isolated-tmux capture-pane -p | sed s/^/^/
 # CHECK: ^prompt> if true
 # CHECK: ^            echo 00000000000000000000000000000000000000000000000000
-# CHECK: ^            echo 00000000000000000000000000000000000000000000000000000000000000…
-# CHECK: ^
+# CHECK: ^            echo 000000000000000000000000000000000000000000000000000000000000000
+# CHECK: ^0000000000000000000000000000000000000…
 
 # Currently, we take either all or nothing from soft-wrapped suggestion-lines.
 # The ellipsis means that we'll get more lines.
@@ -73,8 +73,8 @@ isolated-tmux capture-pane -p | sed s/^/^/
 # CHECK: ^prompt>
 # CHECK: ^prompt> if true
 # CHECK: ^            echo 00000000000000000000000000000000000000000000000000
-# CHECK: ^            echo 00000000000000000000000000000000000000000000000000000000000000…
-# CHECK: ^
+# CHECK: ^            echo 000000000000000000000000000000000000000000000000000000000000000
+# CHECK: ^0000000000000000000000000000000000000…
 
 # Again, we take all or nothing from a soft-wrapped line.
 isolated-tmux send-keys C-u Enter if
@@ -114,8 +114,8 @@ isolated-tmux capture-pane -p | sed s/^/^/
 # CHECK: ^prompt-line1/2>
 # CHECK: ^prompt-line2/2> if true
 # CHECK: ^                    echo 00000000000000000000000000000000000000000000000000
-# CHECK: ^                    echo 000000000000000000000000000000000000000000000000000000…
-# CHECK: ^
+# CHECK: ^                    echo 0000000000000000000000000000000000000000000000000000000
+# CHECK: ^000000000000000000000000000000000000000000000…
 
 # Autosuggestion with a line that barely wraps.
 isolated-tmux resize-window -x 80 -y 4 \; send-keys C-u \
@@ -131,8 +131,8 @@ tmux-sleep
 isolated-tmux capture-pane -p | sed s/^/^/
 # CHECK: ^prompt-line1
 # CHECK: ^> begin
-# CHECK: ^      : 00000000000000000000000000000000000000000000000000000000000000000000000…
-# CHECK: ^
+# CHECK: ^      : 000000000000000000000000000000000000000000000000000000000000000000000000
+# CHECK: ^…
 
 # Autosuggestions on a soft-wrapped commandline don't push the prompt.
 isolated-tmux resize-window -x 6 -y 4 \; send-keys C-u \
@@ -142,8 +142,8 @@ isolated-tmux resize-window -x 6 -y 4 \; send-keys C-u \
 tmux-sleep
 isolated-tmux capture-pane -p | sed s/^/^/
 # CHECK: ^>
-# CHECK: ^> ech…
-# CHECK: ^
+# CHECK: ^> echo
+# CHECK: ^ l1 \…
 # CHECK: ^
 
 isolated-tmux resize-window -x 6 -y 4 \; send-keys C-u \
@@ -156,7 +156,7 @@ isolated-tmux resize-window -x 6 -y 4 \; send-keys C-u \
     'echo'
 tmux-sleep
 isolated-tmux capture-pane -p | sed s/^/^/
-# CHECK: ^>
-# CHECK: ^>
 # CHECK: ^> echo
-# CHECK: ^ wrap…
+# CHECK: ^ wrapp
+# CHECK: ^ed \
+# CHECK: ^


### PR DESCRIPTION
## Description

rewrote compute_layout so autosuggestion lines are no longer truncated per screen line. Each line now records its actual screen-column start, we allow it to soft-wrap, and we only drop text if we’d exceed the available vertical space;

added autosuggestion_line_height, which simulates how many terminal rows a line will occupy (including wraps) so the vertical budgeting matches what the renderer really draws.

refreshed the test_compute_layout cases so expected autosuggestions now contain the full soft-wrapped text instead of ellipsized fragments, proving that multi-line suggestions render completely.

fix #12045

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
