### PR TITLE
fix Make completions not block #23

### DIFF
--- a/src/complete.rs
+++ b/src/complete.rs
@@ -1240,6 +1240,9 @@ impl<'ctx> Completer<'ctx> {
     ) -> bool {
         let mut use_files = true;
         let mut has_force = false;
+        // When we're completing an explicit option prefix (starts with '-') we should not invoke
+        // argument completions because they may execute arbitrary commands (#23).
+        let completing_option_prefix = use_switches && !s.is_empty() && s.char_at(0) == '-';
 
         let CmdString { cmd, path } = parse_cmd_string(cmd_orig, self.ctx.vars());
 
@@ -1425,6 +1428,9 @@ impl<'ctx> Completer<'ctx> {
                     continue;
                 }
                 if o.option.is_empty() {
+                    if completing_option_prefix {
+                        continue;
+                    }
                     use_files &= !o.result_mode.no_files;
                     has_force |= o.result_mode.force_files;
                     self.complete_from_args(s, &o.comp, o.desc.localize(), o.flags);

--- a/tests/checks/complete.fish
+++ b/tests/checks/complete.fish
@@ -135,6 +135,14 @@ complete -C'foo -y' | string match -- -y-single-long
 # CHECK: -zARGZ
 complete -C'foo -z'
 
+# Regression test for issue #23: argument providers should not run while completing an option.
+complete -c complete_test_issue23 -f -s q -d option
+complete -c complete_test_issue23 -f -a '(printf "%s\n" arg-one arg-two)'
+count (complete -C'complete_test_issue23 -')
+# CHECK: 1
+count (complete -C'complete_test_issue23 ')
+# CHECK: 2
+
 function foo2; end
 complete -c foo2 -s s -l long -xa "hello-world goodbye-friend"
 complete -C"foo2 -sfrie"


### PR DESCRIPTION
## Description

Added completing_option_prefix detection in complete_param_for_command() so we know when the user is typing an option (token starts with -) and should not invoke any --arguments providers that might run arbitrary commands while they are still exploring switches

Fixes #23

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
