### PR TITLE
fix: `__fish_systemctl_services` mode handling

### DIFF
--- a/share/functions/__fish_systemctl_services.fish
+++ b/share/functions/__fish_systemctl_services.fish
@@ -3,15 +3,34 @@ function __fish_systemctl_services
     # We don't want to complete with ANSI color codes
     set -lu SYSTEMD_COLORS
 
-    if type -q systemctl
-        if __fish_contains_opt user
-            systemctl --user list-unit-files --full --no-legend --no-pager --plain --type=service 2>/dev/null $argv | string split -f 1 ' '
-            systemctl --user list-units --state=loaded --full --no-legend --no-pager --plain --type=service 2>/dev/null | string split -f 1 ' '
-        else
-            # list-unit-files will also show disabled units
-            systemctl list-unit-files --full --no-legend --no-pager --plain --type=service 2>/dev/null $argv | string split -f 1 ' '
-            # list-units will not show disabled units but will show instances (like wpa_supplicant@wlan0.service)
-            systemctl list-units --state=loaded --full --no-legend --no-pager --plain --type=service 2>/dev/null | string split -f 1 ' '
+    if not type -q systemctl
+        return
+    end
+
+    # use the user specified mode, also exclude user defined alias
+    set -l tokens (commandline -xp)
+    # for determining whether user is using `journalctl`
+    set -l command $tokens[1]
+    set -l mode
+    for t in $tokens[2..]
+        switch $t
+            case --system --user
+                set mode $t
+            case --global
+                # `journalctl` does not have `global` option
+                if test "$command" != journalctl
+                    set mode $t
+                end
+            case --
+                break
         end
     end
+
+    set -l common_args --full --no-legend --no-pager --plain --type=service
+    begin
+        # `list-unit-files` will also show disabled units
+        systemctl $mode list-unit-files $common_args 2>/dev/null $argv
+        # `list-units`      will not show disabled units but will show instances (like wpa_supplicant@wlan0.service)
+        systemctl $mode list-units --state=loaded $common_args 2>/dev/null $argv
+    end | string split -f 1 ' '
 end


### PR DESCRIPTION
## Description

when `journalctl` or `systemd-analyze` invoke the function, fish should determined user's intention of the 「mode」

for example, user might defined a alias:
```fish
alias journalctl='journalctl --user'
```
the function should not determined user will always be using the `--user` option in journalctl,
as in when user override the「mode」to `--system` or `--global`, the function should use the overrideed「mode」
```console
$ journalctl --system -u<TAB>
a-system-unit.service
...
```

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
