### PR TITLE
fish_vi_key_bindings: add support for count

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -100,6 +100,7 @@ New or improved bindings
 ------------------------
 - :kbd:`ctrl-w` (``backward-kill-path-component``) also deletes escaped spaces (:issue:`2016`).
 - New special input functions ``backward-path-component``, ``forward-path-component`` and ``kill-path-component`` (:issue:`12127`).
+- Vi mode key bindings now support counts for movement and deletion commands (e.g. `d3w` or `3l`), via a new operator mode (:issue:`2192`).
 
 Improved terminal support
 -------------------------

--- a/doc_src/cmds/fish_mode_prompt.rst
+++ b/doc_src/cmds/fish_mode_prompt.rst
@@ -20,7 +20,7 @@ Description
 
 The ``fish_mode_prompt`` function outputs the mode indicator for use in vi mode.
 
-The default ``fish_mode_prompt`` function will output indicators about the current vi editor mode displayed to the left of the regular prompt. Define your own function to customize the appearance of the mode indicator. The ``$fish_bind_mode variable`` can be used to determine the current mode. It will be one of ``default``, ``insert``, ``replace_one``, ``replace``, or ``visual``.
+The default ``fish_mode_prompt`` function will output indicators about the current vi editor mode displayed to the left of the regular prompt. Define your own function to customize the appearance of the mode indicator. The ``$fish_bind_mode variable`` can be used to determine the current mode. It will be one of ``default``, ``insert``, ``replace_one``, ``replace``, ``visual``, or ``operator``.
 
 You can also define an empty ``fish_mode_prompt`` function to remove the vi mode indicators::
 
@@ -55,6 +55,9 @@ Example
         case visual
           set_color --bold brmagenta
           echo 'V'
+        case operator
+          set_color --bold cyan
+          echo 'N'
         case '*'
           set_color --bold red
           echo '?'

--- a/localization/po/de.po
+++ b/localization/po/de.po
@@ -2383,6 +2383,9 @@ msgstr ""
 msgid "A right prompt to be used when `breakpoint` is executed"
 msgstr ""
 
+msgid "Accumulate a digit for the next command"
+msgstr ""
+
 msgid "Add abbreviation"
 msgstr "Abkürzung hinzufügen"
 
@@ -3299,6 +3302,9 @@ msgid "Reverse color text"
 msgstr ""
 
 msgid "Reverse the order"
+msgstr ""
+
+msgid "Run a command $__fish_vi_count times"
 msgstr ""
 
 msgid "Run as a login shell"

--- a/localization/po/en.po
+++ b/localization/po/en.po
@@ -2381,6 +2381,9 @@ msgstr "(Used together with -o) Do not overwrite but append"
 msgid "A right prompt to be used when `breakpoint` is executed"
 msgstr ""
 
+msgid "Accumulate a digit for the next command"
+msgstr ""
+
 msgid "Add abbreviation"
 msgstr ""
 
@@ -3297,6 +3300,9 @@ msgid "Reverse color text"
 msgstr ""
 
 msgid "Reverse the order"
+msgstr ""
+
+msgid "Run a command $__fish_vi_count times"
 msgstr ""
 
 msgid "Run as a login shell"

--- a/localization/po/fr.po
+++ b/localization/po/fr.po
@@ -2512,6 +2512,9 @@ msgstr "(Utilisé avec -o) Ne pas écraser le fichier, y concaténer les résult
 msgid "A right prompt to be used when `breakpoint` is executed"
 msgstr ""
 
+msgid "Accumulate a digit for the next command"
+msgstr ""
+
 msgid "Add abbreviation"
 msgstr "Ajouter une abréviation"
 
@@ -3428,6 +3431,9 @@ msgid "Reverse color text"
 msgstr ""
 
 msgid "Reverse the order"
+msgstr ""
+
+msgid "Run a command $__fish_vi_count times"
 msgstr ""
 
 msgid "Run as a login shell"

--- a/localization/po/pl.po
+++ b/localization/po/pl.po
@@ -2377,6 +2377,9 @@ msgstr ""
 msgid "A right prompt to be used when `breakpoint` is executed"
 msgstr ""
 
+msgid "Accumulate a digit for the next command"
+msgstr ""
+
 msgid "Add abbreviation"
 msgstr ""
 
@@ -3293,6 +3296,9 @@ msgid "Reverse color text"
 msgstr ""
 
 msgid "Reverse the order"
+msgstr ""
+
+msgid "Run a command $__fish_vi_count times"
 msgstr ""
 
 msgid "Run as a login shell"

--- a/localization/po/pt_BR.po
+++ b/localization/po/pt_BR.po
@@ -2382,6 +2382,9 @@ msgstr "(Used together with -o) Do not overwrite but append"
 msgid "A right prompt to be used when `breakpoint` is executed"
 msgstr ""
 
+msgid "Accumulate a digit for the next command"
+msgstr ""
+
 msgid "Add abbreviation"
 msgstr ""
 
@@ -3298,6 +3301,9 @@ msgid "Reverse color text"
 msgstr ""
 
 msgid "Reverse the order"
+msgstr ""
+
+msgid "Run a command $__fish_vi_count times"
 msgstr ""
 
 msgid "Run as a login shell"

--- a/localization/po/sv.po
+++ b/localization/po/sv.po
@@ -2378,6 +2378,9 @@ msgstr "(Används tillsamans med -o) Skriv inte över utan lägg till"
 msgid "A right prompt to be used when `breakpoint` is executed"
 msgstr ""
 
+msgid "Accumulate a digit for the next command"
+msgstr ""
+
 msgid "Add abbreviation"
 msgstr ""
 
@@ -3294,6 +3297,9 @@ msgid "Reverse color text"
 msgstr ""
 
 msgid "Reverse the order"
+msgstr ""
+
+msgid "Run a command $__fish_vi_count times"
 msgstr ""
 
 msgid "Run as a login shell"

--- a/localization/po/zh_CN.po
+++ b/localization/po/zh_CN.po
@@ -2410,6 +2410,9 @@ msgstr "(与 -o 一起使用) 不覆写但追加"
 msgid "A right prompt to be used when `breakpoint` is executed"
 msgstr "执行 `breakpoint` 时使用的正确提示符"
 
+msgid "Accumulate a digit for the next command"
+msgstr ""
+
 msgid "Add abbreviation"
 msgstr "添加缩写"
 
@@ -3327,6 +3330,9 @@ msgstr "反色文本"
 
 msgid "Reverse the order"
 msgstr "倒转顺序"
+
+msgid "Run a command $__fish_vi_count times"
+msgstr ""
 
 msgid "Run as a login shell"
 msgstr "作为登录 shell 运行"

--- a/localization/po/zh_TW.po
+++ b/localization/po/zh_TW.po
@@ -2385,6 +2385,9 @@ msgstr "（和 -o 同時使用）加到結尾而不覆寫"
 msgid "A right prompt to be used when `breakpoint` is executed"
 msgstr "breakpoint 執行時要使用的右側提示"
 
+msgid "Accumulate a digit for the next command"
+msgstr ""
+
 msgid "Add abbreviation"
 msgstr "新增縮寫"
 
@@ -3302,6 +3305,9 @@ msgstr "反轉文字顏色"
 
 msgid "Reverse the order"
 msgstr "反轉順序"
+
+msgid "Run a command $__fish_vi_count times"
+msgstr ""
 
 msgid "Run as a login shell"
 msgstr "作為登入 shell 執行"

--- a/share/functions/fish_default_mode_prompt.fish
+++ b/share/functions/fish_default_mode_prompt.fish
@@ -18,6 +18,9 @@ function fish_default_mode_prompt --description "Display vi prompt mode"
             case visual
                 set_color --bold magenta
                 echo '[V]'
+            case operator
+                set_color --bold cyan
+                echo '[N]'
         end
         set_color normal
         echo -n ' '

--- a/share/prompts/nim.fish
+++ b/share/prompts/nim.fish
@@ -86,6 +86,8 @@ function fish_prompt
         switch $fish_bind_mode
             case default
                 set mode (set_color --bold red)N
+            case operator
+                set mode (set_color --bold cyan)N
             case insert
                 set mode (set_color --bold green)I
             case replace_one

--- a/tests/pexpects/bind.py
+++ b/tests/pexpects/bind.py
@@ -270,10 +270,58 @@ sleep(0.200)
 send("0$i34\r")
 expect_prompt("echo 12345")
 
+# Test operator mode with count (d3w)
+send("echo one two three four five")
+send("\033")
+sleep(0.200)
+send("0w")
+send("d3w")
+sendline("")
+expect_prompt("echo four five")
+
+# Test count before operator (3dw)
+send("echo one two three four five")
+send("\033")
+sleep(0.200)
+send("0w")
+send("3dw")
+sendline("")
+expect_prompt("echo four five")
+
+# Test count on both (2d2w -> 4 words)
+send("echo one two three four five six")
+send("\033")
+sleep(0.200)
+send("0w")
+send("2d2w")
+sendline("")
+expect_prompt("echo five six")
+
+# Test change operator with count (c2w)
+send("echo one two three")
+send("\033")
+sleep(0.200)
+send("0w")
+send("c2wREPLACED")
+sendline("")
+expect_prompt("echo REPLACEDthree")
+
+# Test escape cancelling count
+send("echo one two three")
+send("\033")
+sleep(0.200)
+send("0w")
+send("3")
+send("\033")
+sleep(0.100)
+send("dw")
+sendline("")
+expect_prompt("echo two three")
+
 # Now test that exactly the expected bind modes are defined
 sendline("bind --list-modes")
 expect_prompt(
-    "default\r\ninsert\r\nreplace\r\nreplace_one\r\nvisual\r\n",
+    "default\r\ninsert\r\noperator\r\nreplace\r\nreplace_one\r\nvisual\r\n",
     unmatched="Unexpected vi bind modes",
 )
 

--- a/tests/pexpects/bind_mode_events.py
+++ b/tests/pexpects/bind_mode_events.py
@@ -37,12 +37,20 @@ sleep(10 if "CI" in os.environ else 1)
 send("\033")
 sleep(10 if "CI" in os.environ else 1)
 
+# operator mode
+send("d")
+sleep(10 if "CI" in os.environ else 1)
+
+# back to normal mode
+send("\033")
+sleep(10 if "CI" in os.environ else 1)
+
 # insert mode again
 send("i")
 sleep(10 if "CI" in os.environ else 1)
 
 send("echo mode changes: $MODE_CHANGES\r")
-expect_prompt("\r\n.*mode changes: default insert default insert\r\n")
+expect_prompt("\r\n.*mode changes: default insert default operator default insert\r\n")
 
 # Regression test for #8125.
 # Control-C should return us to insert mode.


### PR DESCRIPTION
## Description

Adds support for v:count in vi keybinds, also added functions for simplifying e/E definitions.
Adds a new operator mode for handling bindings such as `d3w`

Fixes issue #2192

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
