### PR TITLE
test_driver: print littlecheck errors after result

### DIFF
--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -313,11 +313,17 @@ async def run_test(
         )
 
         # littlecheck
+        error_message = ""
+
+        def append_error_message(x):
+            nonlocal error_message
+            error_message += x.message()
+
         ret = await littlecheck.check_path_async(
             test_file_path,
             subs,
             lconfig,
-            lambda x: print(x.message()),
+            append_error_message,
             env=test_env,
             cwd=home,
         )
@@ -328,7 +334,7 @@ async def run_test(
         elif ret:
             return TestPass(arg, duration_ms)
         else:
-            return TestFail(arg, duration_ms, f"Tmpdir is {home}")
+            return TestFail(arg, duration_ms, f"{error_message}\nTmpdir is {home}")
     elif test_file_path.endswith(".py"):
         test_env.update(
             {


### PR DESCRIPTION
Before this, our test driver printed littlecheck's output before the test result (test name, duration, PASSED/FAILED/SKIPPED). This makes it harder to read the output and is inconsistent with the way pexpect test failures are shown.

Starting with this commit, the result is printed first for both test types, followed by details about failures, if any.