### PR TITLE
Fix error squiggles when they run into a newline

### DIFF
--- a/src/parse_constants.rs
+++ b/src/parse_constants.rs
@@ -340,6 +340,10 @@ impl ParseError {
             .position(|c| *c == '\n')
             .map(|pos| pos + last_char_in_range)
             .unwrap_or(src.len());
+        // We can only report squiggles on one line
+        if start + len > line_end {
+            len = line_end - start;
+        }
 
         assert!(line_end >= line_start);
         assert!(start >= line_start);

--- a/tests/checks/eval.fish
+++ b/tests/checks/eval.fish
@@ -67,7 +67,7 @@ function eval
 end
 # CHECKERR: {{.*}}checks/eval.fish (line {{\d+}}): function: eval: cannot use reserved keyword as function name
 # CHECKERR: function eval
-# CHECKERR: ^
+# CHECKERR: ^~~~~~~~~~~~^
 
 
 function evil --no-scope-shadowing

--- a/tests/checks/function.fish
+++ b/tests/checks/function.fish
@@ -62,7 +62,7 @@ function -a arg1 arg2 name2
 end
 #CHECKERR: {{.*}}checks/function.fish (line {{\d+}}): function: -a: invalid function name
 #CHECKERR: function -a arg1 arg2 name2
-#CHECKERR: ^
+#CHECKERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~^
 function name3 --argument-names arg1 arg2
     echo hello
     echo goodbye
@@ -71,12 +71,12 @@ function --argument-names arg1 arg2 name4
 end
 #CHECKERR: {{.*}}checks/function.fish (line {{\d+}}): function: --argument-names: invalid function name
 #CHECKERR: function --argument-names arg1 arg2 name4
-#CHECKERR: ^
+#CHECKERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
 function name5 abc --argument-names def
 end
 #CHECKERR: {{.*}}checks/function.fish (line {{\d+}}): function: abc: unexpected positional argument
 #CHECKERR: function name5 abc --argument-names def
-#CHECKERR: ^
+#CHECKERR: ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
 functions -q name1; and echo "Function name1 found"
 functions -q name2; or echo "Function name2 not found as expected"
 functions -q name3; and echo "Function name3 found"
@@ -124,7 +124,7 @@ function test
 end
 #CHECKERR: {{.*}}checks/function.fish (line {{\d+}}): function: test: cannot use reserved keyword as function name
 #CHECKERR: function test
-#CHECKERR: ^
+#CHECKERR: ^~~~~~~~~~~~^
 
 functions -q; or echo False
 #CHECK: False
@@ -190,7 +190,7 @@ function ()
 end
 # CHECKERR: {{.*}}/tests/checks/function.fish (line {{\d+}}): function: function name required
 # CHECKERR: function ()
-# CHECKERR: ^
+# CHECKERR: ^~~~~~~~~~^
 
 # Tests the --argument-names and --inherit-variable can overwrite argv
 function t --argument-names a argv c
@@ -221,22 +221,22 @@ for flag in --on-process-exit --on-job-exit
     end
     # CHECKERR: {{.*}}/function.fish (line {{\d+}}): function: '2147483648' is not a valid process ID
     # CHECKERR:     function invalid $flag=$invalid_pid
-    # CHECKERR:     ^
+    # CHECKERR:     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
     # CHECKERR: {{.*}}/function.fish (line {{\d+}}): function: '-1' is not a valid process ID
     # CHECKERR:     function invalid $flag=$invalid_pid
-    # CHECKERR:     ^
+    # CHECKERR:     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
     # CHECKERR: {{.*}}/function.fish (line {{\d+}}): function: '-2147483648' is not a valid process ID
     # CHECKERR:     function invalid $flag=$invalid_pid
-    # CHECKERR:     ^
+    # CHECKERR:     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
     # CHECKERR: {{.*}}/function.fish (line {{\d+}}): function: '2147483648' is not a valid process ID
     # CHECKERR:     function invalid $flag=$invalid_pid
-    # CHECKERR:     ^
+    # CHECKERR:     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
     # CHECKERR: {{.*}}/function.fish (line {{\d+}}): function: '-1' is not a valid process ID
     # CHECKERR:     function invalid $flag=$invalid_pid
-    # CHECKERR:     ^
+    # CHECKERR:     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
     # CHECKERR: {{.*}}/function.fish (line {{\d+}}): function: '-2147483648' is not a valid process ID
     # CHECKERR:     function invalid $flag=$invalid_pid
-    # CHECKERR:     ^
+    # CHECKERR:     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
 end
 
 exit 0

--- a/tests/checks/string.fish
+++ b/tests/checks/string.fish
@@ -936,7 +936,7 @@ function string
 end
 # CHECKERR: {{.*}}checks/string.fish (line {{\d+}}): function: string: cannot use reserved keyword as function name
 # CHECKERR: function string
-# CHECKERR: ^
+# CHECKERR: ^~~~~~~~~~~~~~^
 
 string escape \x7F
 # CHECK: \x7f


### PR DESCRIPTION
Our error marking code:

```
function foobar
^~~~~~~^
```

runs fish_wcswidth to figure out how wide the squiggly line should be.

That function returns -1 when it runs into a codepoint that wcwidth returns -1 for, so the marking would stop at a single `^`.

In some cases, this happens because the error range includes a newline.

Since we already find the end of the line, and can only mark one line, we clamp the squiggles at the end of that line.

This improves some markings.

See discussion in #12171

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [n/a] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->

The next step is probably to remove the call to libc::wcwidth, which is an awkward function that can't distinguish between "dunno the width of this one, boss" and "this is a backspace".