### PR TITLE
add git shortlog completion

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -16121,6 +16121,9 @@ msgstr ""
 msgid "Disable curlrc"
 msgstr ""
 
+msgid "Disable custom groupings"
+msgstr ""
+
 msgid "Disable data"
 msgstr ""
 
@@ -17386,6 +17389,9 @@ msgstr ""
 
 msgid "Display each file's MAC label"
 msgstr "MAC-Markierung jeder Datei anzeigen"
+
+msgid "Display email address alongside each name"
+msgstr ""
 
 msgid "Display environment variables as an s-expression"
 msgstr ""
@@ -29654,6 +29660,15 @@ msgstr ""
 msgid "Grep through source files recursively"
 msgstr ""
 
+msgid "Group commits by author (default)"
+msgstr ""
+
+msgid "Group commits by author, committer, trailer, or format"
+msgstr ""
+
+msgid "Group commits by committer instead of author"
+msgstr ""
+
 msgid "Group directories before files"
 msgstr ""
 
@@ -29928,6 +29943,9 @@ msgid "Hide accounts/postings deeper than this"
 msgstr ""
 
 msgid "Hide attached picture for audio"
+msgstr ""
+
+msgid "Hide email addresses in the output"
 msgstr ""
 
 msgid "Hide errors"
@@ -33493,6 +33511,9 @@ msgstr "Zeilen nach EOF sind leer"
 
 msgid "Lines end with 0 byte"
 msgstr "Zeilen enden mit Null-Byte"
+
+msgid "Linewrap entries as width[,indent1[,indent2]]"
+msgstr ""
 
 msgid "Link against framework (Darwin)"
 msgstr ""
@@ -39578,6 +39599,9 @@ msgstr ""
 msgid "Only show basic information in JSON format (bits/s)"
 msgstr ""
 
+msgid "Only show commit counts per group"
+msgstr ""
+
 msgid "Only show differences to the previously saved database and exit"
 msgstr ""
 
@@ -42963,6 +42987,9 @@ msgid "Pretend the symbol symbol is undefined, to force linking of library modul
 msgstr ""
 
 msgid "Prettify the format of displayed values, make it more human readable"
+msgstr ""
+
+msgid "Pretty format string or preset name"
 msgstr ""
 
 msgid "Pretty-print JSON"
@@ -57326,10 +57353,16 @@ msgstr ""
 msgid "Show commit shortlog"
 msgstr ""
 
+msgid "Show commit subjects for each entry"
+msgstr ""
+
 msgid "Show commit summary"
 msgstr ""
 
 msgid "Show commit time"
+msgstr ""
+
+msgid "Show commits more recent than date without stopping traversal early"
 msgstr ""
 
 msgid "Show commits more recent than specified date"
@@ -60452,7 +60485,13 @@ msgstr ""
 msgid "Sort object keys in output"
 msgstr ""
 
+msgid "Sort output alphabetically by author"
+msgstr ""
+
 msgid "Sort output by file location"
+msgstr ""
+
+msgid "Sort output by number of commits per group"
 msgstr ""
 
 msgid "Sort output by slots/versions (toggle)"

--- a/po/en.po
+++ b/po/en.po
@@ -16119,6 +16119,9 @@ msgstr ""
 msgid "Disable curlrc"
 msgstr ""
 
+msgid "Disable custom groupings"
+msgstr ""
+
 msgid "Disable data"
 msgstr ""
 
@@ -17384,6 +17387,9 @@ msgstr ""
 
 msgid "Display each file's MAC label"
 msgstr "Display each file's MAC label"
+
+msgid "Display email address alongside each name"
+msgstr ""
 
 msgid "Display environment variables as an s-expression"
 msgstr ""
@@ -29652,6 +29658,15 @@ msgstr ""
 msgid "Grep through source files recursively"
 msgstr ""
 
+msgid "Group commits by author (default)"
+msgstr ""
+
+msgid "Group commits by author, committer, trailer, or format"
+msgstr ""
+
+msgid "Group commits by committer instead of author"
+msgstr ""
+
 msgid "Group directories before files"
 msgstr ""
 
@@ -29926,6 +29941,9 @@ msgid "Hide accounts/postings deeper than this"
 msgstr ""
 
 msgid "Hide attached picture for audio"
+msgstr ""
+
+msgid "Hide email addresses in the output"
 msgstr ""
 
 msgid "Hide errors"
@@ -33491,6 +33509,9 @@ msgstr "Lines after EOF are blank"
 
 msgid "Lines end with 0 byte"
 msgstr "Lines end with 0 byte"
+
+msgid "Linewrap entries as width[,indent1[,indent2]]"
+msgstr ""
 
 msgid "Link against framework (Darwin)"
 msgstr ""
@@ -39576,6 +39597,9 @@ msgstr ""
 msgid "Only show basic information in JSON format (bits/s)"
 msgstr ""
 
+msgid "Only show commit counts per group"
+msgstr ""
+
 msgid "Only show differences to the previously saved database and exit"
 msgstr ""
 
@@ -42961,6 +42985,9 @@ msgid "Pretend the symbol symbol is undefined, to force linking of library modul
 msgstr ""
 
 msgid "Prettify the format of displayed values, make it more human readable"
+msgstr ""
+
+msgid "Pretty format string or preset name"
 msgstr ""
 
 msgid "Pretty-print JSON"
@@ -57324,10 +57351,16 @@ msgstr ""
 msgid "Show commit shortlog"
 msgstr ""
 
+msgid "Show commit subjects for each entry"
+msgstr ""
+
 msgid "Show commit summary"
 msgstr ""
 
 msgid "Show commit time"
+msgstr ""
+
+msgid "Show commits more recent than date without stopping traversal early"
 msgstr ""
 
 msgid "Show commits more recent than specified date"
@@ -60450,7 +60483,13 @@ msgstr ""
 msgid "Sort object keys in output"
 msgstr ""
 
+msgid "Sort output alphabetically by author"
+msgstr ""
+
 msgid "Sort output by file location"
+msgstr ""
+
+msgid "Sort output by number of commits per group"
 msgstr ""
 
 msgid "Sort output by slots/versions (toggle)"

--- a/po/fr.po
+++ b/po/fr.po
@@ -16250,6 +16250,9 @@ msgstr "Désactiver la création de fichiers creux"
 msgid "Disable curlrc"
 msgstr ""
 
+msgid "Disable custom groupings"
+msgstr ""
+
 msgid "Disable data"
 msgstr ""
 
@@ -17514,6 +17517,9 @@ msgid "Display dynamic symbols instead of normal symbols"
 msgstr ""
 
 msgid "Display each file's MAC label"
+msgstr ""
+
+msgid "Display email address alongside each name"
 msgstr ""
 
 msgid "Display environment variables as an s-expression"
@@ -29783,6 +29789,15 @@ msgstr ""
 msgid "Grep through source files recursively"
 msgstr ""
 
+msgid "Group commits by author (default)"
+msgstr ""
+
+msgid "Group commits by author, committer, trailer, or format"
+msgstr ""
+
+msgid "Group commits by committer instead of author"
+msgstr ""
+
 msgid "Group directories before files"
 msgstr "Regrouper les dossiers avant les fichiers"
 
@@ -30057,6 +30072,9 @@ msgid "Hide accounts/postings deeper than this"
 msgstr ""
 
 msgid "Hide attached picture for audio"
+msgstr ""
+
+msgid "Hide email addresses in the output"
 msgstr ""
 
 msgid "Hide errors"
@@ -33622,6 +33640,9 @@ msgstr "Ne pas afficher de tilde pour les lignes au-delà de la fin du fichier"
 
 msgid "Lines end with 0 byte"
 msgstr "Utiliser \\0 comme fin de ligne"
+
+msgid "Linewrap entries as width[,indent1[,indent2]]"
+msgstr ""
 
 msgid "Link against framework (Darwin)"
 msgstr ""
@@ -39707,6 +39728,9 @@ msgstr ""
 msgid "Only show basic information in JSON format (bits/s)"
 msgstr ""
 
+msgid "Only show commit counts per group"
+msgstr ""
+
 msgid "Only show differences to the previously saved database and exit"
 msgstr "Se contenter d’afficher les différences avec la dernière sauvegarde de la base de données, puis quitter"
 
@@ -43092,6 +43116,9 @@ msgid "Pretend the symbol symbol is undefined, to force linking of library modul
 msgstr "Annoncer comme indéfini le symbole spécifié, afin de forcer sa définition lors de la liaison des modules de bibliothèque"
 
 msgid "Prettify the format of displayed values, make it more human readable"
+msgstr ""
+
+msgid "Pretty format string or preset name"
 msgstr ""
 
 msgid "Pretty-print JSON"
@@ -57455,11 +57482,17 @@ msgstr "Afficher les journaux des validations"
 msgid "Show commit shortlog"
 msgstr "Afficher le journal concis de la validation"
 
+msgid "Show commit subjects for each entry"
+msgstr ""
+
 msgid "Show commit summary"
 msgstr "Afficher le résumé des validations"
 
 msgid "Show commit time"
 msgstr "Afficher l’horodatage de validation"
+
+msgid "Show commits more recent than date without stopping traversal early"
+msgstr ""
 
 msgid "Show commits more recent than specified date"
 msgstr "Afficher les validations effectuées après une date spécifiée"
@@ -60581,7 +60614,13 @@ msgstr ""
 msgid "Sort object keys in output"
 msgstr "Trier les clés d’objet dans la sortie"
 
+msgid "Sort output alphabetically by author"
+msgstr ""
+
 msgid "Sort output by file location"
+msgstr ""
+
+msgid "Sort output by number of commits per group"
 msgstr ""
 
 msgid "Sort output by slots/versions (toggle)"

--- a/po/pl.po
+++ b/po/pl.po
@@ -16115,6 +16115,9 @@ msgstr ""
 msgid "Disable curlrc"
 msgstr ""
 
+msgid "Disable custom groupings"
+msgstr ""
+
 msgid "Disable data"
 msgstr ""
 
@@ -17379,6 +17382,9 @@ msgid "Display dynamic symbols instead of normal symbols"
 msgstr ""
 
 msgid "Display each file's MAC label"
+msgstr ""
+
+msgid "Display email address alongside each name"
 msgstr ""
 
 msgid "Display environment variables as an s-expression"
@@ -29648,6 +29654,15 @@ msgstr ""
 msgid "Grep through source files recursively"
 msgstr ""
 
+msgid "Group commits by author (default)"
+msgstr ""
+
+msgid "Group commits by author, committer, trailer, or format"
+msgstr ""
+
+msgid "Group commits by committer instead of author"
+msgstr ""
+
 msgid "Group directories before files"
 msgstr ""
 
@@ -29922,6 +29937,9 @@ msgid "Hide accounts/postings deeper than this"
 msgstr ""
 
 msgid "Hide attached picture for audio"
+msgstr ""
+
+msgid "Hide email addresses in the output"
 msgstr ""
 
 msgid "Hide errors"
@@ -33486,6 +33504,9 @@ msgid "Lines after EOF are blank"
 msgstr ""
 
 msgid "Lines end with 0 byte"
+msgstr ""
+
+msgid "Linewrap entries as width[,indent1[,indent2]]"
 msgstr ""
 
 msgid "Link against framework (Darwin)"
@@ -39572,6 +39593,9 @@ msgstr ""
 msgid "Only show basic information in JSON format (bits/s)"
 msgstr ""
 
+msgid "Only show commit counts per group"
+msgstr ""
+
 msgid "Only show differences to the previously saved database and exit"
 msgstr ""
 
@@ -42957,6 +42981,9 @@ msgid "Pretend the symbol symbol is undefined, to force linking of library modul
 msgstr ""
 
 msgid "Prettify the format of displayed values, make it more human readable"
+msgstr ""
+
+msgid "Pretty format string or preset name"
 msgstr ""
 
 msgid "Pretty-print JSON"
@@ -57320,10 +57347,16 @@ msgstr ""
 msgid "Show commit shortlog"
 msgstr ""
 
+msgid "Show commit subjects for each entry"
+msgstr ""
+
 msgid "Show commit summary"
 msgstr ""
 
 msgid "Show commit time"
+msgstr ""
+
+msgid "Show commits more recent than date without stopping traversal early"
 msgstr ""
 
 msgid "Show commits more recent than specified date"
@@ -60446,7 +60479,13 @@ msgstr ""
 msgid "Sort object keys in output"
 msgstr ""
 
+msgid "Sort output alphabetically by author"
+msgstr ""
+
 msgid "Sort output by file location"
+msgstr ""
+
+msgid "Sort output by number of commits per group"
 msgstr ""
 
 msgid "Sort output by slots/versions (toggle)"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -16120,6 +16120,9 @@ msgstr ""
 msgid "Disable curlrc"
 msgstr ""
 
+msgid "Disable custom groupings"
+msgstr ""
+
 msgid "Disable data"
 msgstr ""
 
@@ -17385,6 +17388,9 @@ msgstr ""
 
 msgid "Display each file's MAC label"
 msgstr "Mostra etiqueta MAC para cada arquivo"
+
+msgid "Display email address alongside each name"
+msgstr ""
 
 msgid "Display environment variables as an s-expression"
 msgstr ""
@@ -29653,6 +29659,15 @@ msgstr ""
 msgid "Grep through source files recursively"
 msgstr ""
 
+msgid "Group commits by author (default)"
+msgstr ""
+
+msgid "Group commits by author, committer, trailer, or format"
+msgstr ""
+
+msgid "Group commits by committer instead of author"
+msgstr ""
+
 msgid "Group directories before files"
 msgstr ""
 
@@ -29927,6 +29942,9 @@ msgid "Hide accounts/postings deeper than this"
 msgstr ""
 
 msgid "Hide attached picture for audio"
+msgstr ""
+
+msgid "Hide email addresses in the output"
 msgstr ""
 
 msgid "Hide errors"
@@ -33492,6 +33510,9 @@ msgstr "Lines after EOF are blank"
 
 msgid "Lines end with 0 byte"
 msgstr "Lines end with 0 byte"
+
+msgid "Linewrap entries as width[,indent1[,indent2]]"
+msgstr ""
 
 msgid "Link against framework (Darwin)"
 msgstr ""
@@ -39577,6 +39598,9 @@ msgstr ""
 msgid "Only show basic information in JSON format (bits/s)"
 msgstr ""
 
+msgid "Only show commit counts per group"
+msgstr ""
+
 msgid "Only show differences to the previously saved database and exit"
 msgstr ""
 
@@ -42962,6 +42986,9 @@ msgid "Pretend the symbol symbol is undefined, to force linking of library modul
 msgstr ""
 
 msgid "Prettify the format of displayed values, make it more human readable"
+msgstr ""
+
+msgid "Pretty format string or preset name"
 msgstr ""
 
 msgid "Pretty-print JSON"
@@ -57325,10 +57352,16 @@ msgstr ""
 msgid "Show commit shortlog"
 msgstr ""
 
+msgid "Show commit subjects for each entry"
+msgstr ""
+
 msgid "Show commit summary"
 msgstr ""
 
 msgid "Show commit time"
+msgstr ""
+
+msgid "Show commits more recent than date without stopping traversal early"
 msgstr ""
 
 msgid "Show commits more recent than specified date"
@@ -60451,7 +60484,13 @@ msgstr ""
 msgid "Sort object keys in output"
 msgstr ""
 
+msgid "Sort output alphabetically by author"
+msgstr ""
+
 msgid "Sort output by file location"
+msgstr ""
+
+msgid "Sort output by number of commits per group"
 msgstr ""
 
 msgid "Sort output by slots/versions (toggle)"

--- a/po/sv.po
+++ b/po/sv.po
@@ -16116,6 +16116,9 @@ msgstr ""
 msgid "Disable curlrc"
 msgstr ""
 
+msgid "Disable custom groupings"
+msgstr ""
+
 msgid "Disable data"
 msgstr ""
 
@@ -17381,6 +17384,9 @@ msgstr ""
 
 msgid "Display each file's MAC label"
 msgstr "Visa varje file MAC-etikett"
+
+msgid "Display email address alongside each name"
+msgstr ""
 
 msgid "Display environment variables as an s-expression"
 msgstr ""
@@ -29649,6 +29655,15 @@ msgstr ""
 msgid "Grep through source files recursively"
 msgstr ""
 
+msgid "Group commits by author (default)"
+msgstr ""
+
+msgid "Group commits by author, committer, trailer, or format"
+msgstr ""
+
+msgid "Group commits by committer instead of author"
+msgstr ""
+
 msgid "Group directories before files"
 msgstr ""
 
@@ -29923,6 +29938,9 @@ msgid "Hide accounts/postings deeper than this"
 msgstr ""
 
 msgid "Hide attached picture for audio"
+msgstr ""
+
+msgid "Hide email addresses in the output"
 msgstr ""
 
 msgid "Hide errors"
@@ -33488,6 +33506,9 @@ msgstr "Gör rader efter filslut tomma"
 
 msgid "Lines end with 0 byte"
 msgstr "Rader slutar ned nolltecken"
+
+msgid "Linewrap entries as width[,indent1[,indent2]]"
+msgstr ""
 
 msgid "Link against framework (Darwin)"
 msgstr ""
@@ -39573,6 +39594,9 @@ msgstr ""
 msgid "Only show basic information in JSON format (bits/s)"
 msgstr ""
 
+msgid "Only show commit counts per group"
+msgstr ""
+
 msgid "Only show differences to the previously saved database and exit"
 msgstr ""
 
@@ -42958,6 +42982,9 @@ msgid "Pretend the symbol symbol is undefined, to force linking of library modul
 msgstr ""
 
 msgid "Prettify the format of displayed values, make it more human readable"
+msgstr ""
+
+msgid "Pretty format string or preset name"
 msgstr ""
 
 msgid "Pretty-print JSON"
@@ -57321,10 +57348,16 @@ msgstr ""
 msgid "Show commit shortlog"
 msgstr ""
 
+msgid "Show commit subjects for each entry"
+msgstr ""
+
 msgid "Show commit summary"
 msgstr ""
 
 msgid "Show commit time"
+msgstr ""
+
+msgid "Show commits more recent than date without stopping traversal early"
 msgstr ""
 
 msgid "Show commits more recent than specified date"
@@ -60447,7 +60480,13 @@ msgstr ""
 msgid "Sort object keys in output"
 msgstr ""
 
+msgid "Sort output alphabetically by author"
+msgstr ""
+
 msgid "Sort output by file location"
+msgstr ""
+
+msgid "Sort output by number of commits per group"
 msgstr ""
 
 msgid "Sort output by slots/versions (toggle)"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -16148,6 +16148,9 @@ msgstr ""
 msgid "Disable curlrc"
 msgstr ""
 
+msgid "Disable custom groupings"
+msgstr ""
+
 msgid "Disable data"
 msgstr ""
 
@@ -17412,6 +17415,9 @@ msgid "Display dynamic symbols instead of normal symbols"
 msgstr ""
 
 msgid "Display each file's MAC label"
+msgstr ""
+
+msgid "Display email address alongside each name"
 msgstr ""
 
 msgid "Display environment variables as an s-expression"
@@ -29681,6 +29687,15 @@ msgstr ""
 msgid "Grep through source files recursively"
 msgstr ""
 
+msgid "Group commits by author (default)"
+msgstr ""
+
+msgid "Group commits by author, committer, trailer, or format"
+msgstr ""
+
+msgid "Group commits by committer instead of author"
+msgstr ""
+
 msgid "Group directories before files"
 msgstr ""
 
@@ -29955,6 +29970,9 @@ msgid "Hide accounts/postings deeper than this"
 msgstr ""
 
 msgid "Hide attached picture for audio"
+msgstr ""
+
+msgid "Hide email addresses in the output"
 msgstr ""
 
 msgid "Hide errors"
@@ -33519,6 +33537,9 @@ msgid "Lines after EOF are blank"
 msgstr ""
 
 msgid "Lines end with 0 byte"
+msgstr ""
+
+msgid "Linewrap entries as width[,indent1[,indent2]]"
 msgstr ""
 
 msgid "Link against framework (Darwin)"
@@ -39605,6 +39626,9 @@ msgstr ""
 msgid "Only show basic information in JSON format (bits/s)"
 msgstr ""
 
+msgid "Only show commit counts per group"
+msgstr ""
+
 msgid "Only show differences to the previously saved database and exit"
 msgstr ""
 
@@ -42990,6 +43014,9 @@ msgid "Pretend the symbol symbol is undefined, to force linking of library modul
 msgstr ""
 
 msgid "Prettify the format of displayed values, make it more human readable"
+msgstr ""
+
+msgid "Pretty format string or preset name"
 msgstr ""
 
 msgid "Pretty-print JSON"
@@ -57353,10 +57380,16 @@ msgstr ""
 msgid "Show commit shortlog"
 msgstr ""
 
+msgid "Show commit subjects for each entry"
+msgstr ""
+
 msgid "Show commit summary"
 msgstr ""
 
 msgid "Show commit time"
+msgstr ""
+
+msgid "Show commits more recent than date without stopping traversal early"
 msgstr ""
 
 msgid "Show commits more recent than specified date"
@@ -60479,7 +60512,13 @@ msgstr ""
 msgid "Sort object keys in output"
 msgstr ""
 
+msgid "Sort output alphabetically by author"
+msgstr ""
+
 msgid "Sort output by file location"
+msgstr ""
+
+msgid "Sort output by number of commits per group"
 msgstr ""
 
 msgid "Sort output by slots/versions (toggle)"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -16125,6 +16125,9 @@ msgstr ""
 msgid "Disable curlrc"
 msgstr ""
 
+msgid "Disable custom groupings"
+msgstr ""
+
 msgid "Disable data"
 msgstr ""
 
@@ -17389,6 +17392,9 @@ msgid "Display dynamic symbols instead of normal symbols"
 msgstr ""
 
 msgid "Display each file's MAC label"
+msgstr ""
+
+msgid "Display email address alongside each name"
 msgstr ""
 
 msgid "Display environment variables as an s-expression"
@@ -29658,6 +29664,15 @@ msgstr ""
 msgid "Grep through source files recursively"
 msgstr ""
 
+msgid "Group commits by author (default)"
+msgstr ""
+
+msgid "Group commits by author, committer, trailer, or format"
+msgstr ""
+
+msgid "Group commits by committer instead of author"
+msgstr ""
+
 msgid "Group directories before files"
 msgstr ""
 
@@ -29932,6 +29947,9 @@ msgid "Hide accounts/postings deeper than this"
 msgstr ""
 
 msgid "Hide attached picture for audio"
+msgstr ""
+
+msgid "Hide email addresses in the output"
 msgstr ""
 
 msgid "Hide errors"
@@ -33496,6 +33514,9 @@ msgid "Lines after EOF are blank"
 msgstr ""
 
 msgid "Lines end with 0 byte"
+msgstr ""
+
+msgid "Linewrap entries as width[,indent1[,indent2]]"
 msgstr ""
 
 msgid "Link against framework (Darwin)"
@@ -39582,6 +39603,9 @@ msgstr ""
 msgid "Only show basic information in JSON format (bits/s)"
 msgstr ""
 
+msgid "Only show commit counts per group"
+msgstr ""
+
 msgid "Only show differences to the previously saved database and exit"
 msgstr ""
 
@@ -42967,6 +42991,9 @@ msgid "Pretend the symbol symbol is undefined, to force linking of library modul
 msgstr ""
 
 msgid "Prettify the format of displayed values, make it more human readable"
+msgstr ""
+
+msgid "Pretty format string or preset name"
 msgstr ""
 
 msgid "Pretty-print JSON"
@@ -57330,10 +57357,16 @@ msgstr ""
 msgid "Show commit shortlog"
 msgstr ""
 
+msgid "Show commit subjects for each entry"
+msgstr ""
+
 msgid "Show commit summary"
 msgstr ""
 
 msgid "Show commit time"
+msgstr ""
+
+msgid "Show commits more recent than date without stopping traversal early"
 msgstr ""
 
 msgid "Show commits more recent than specified date"
@@ -60456,7 +60489,13 @@ msgstr ""
 msgid "Sort object keys in output"
 msgstr ""
 
+msgid "Sort output alphabetically by author"
+msgstr ""
+
 msgid "Sort output by file location"
+msgstr ""
+
+msgid "Sort output by number of commits per group"
 msgstr ""
 
 msgid "Sort output by slots/versions (toggle)"

--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -1611,8 +1611,23 @@ complete -f -c git -n '__fish_git_using_command init' -s q -l quiet -d 'Only pri
 complete -f -c git -n '__fish_git_using_command init' -l bare -d 'Create a bare repository'
 # TODO options
 
-### log
+### shortlog
 complete -c git -n __fish_git_needs_command -a shortlog -d 'Show commit shortlog'
+complete -c git -n '__fish_git_using_command shortlog' -a '(__fish_git ls-files)'
+complete -c git -n '__fish_git_using_command shortlog' -n 'not contains -- -- (commandline -xpc)' -ka '(__fish_git_ranges)'
+complete -c git -n '__fish_git_using_command shortlog' -s n -l numbered -d 'Sort output by number of commits per group'
+complete -c git -n '__fish_git_using_command shortlog' -l no-numbered -d 'Sort output alphabetically by author'
+complete -c git -n '__fish_git_using_command shortlog' -s s -l summary -d 'Only show commit counts per group'
+complete -c git -n '__fish_git_using_command shortlog' -l no-summary -d 'Show commit subjects for each entry'
+complete -c git -n '__fish_git_using_command shortlog' -s e -l email -d 'Display email address alongside each name'
+complete -c git -n '__fish_git_using_command shortlog' -l no-email -d 'Hide email addresses in the output'
+complete -c git -n '__fish_git_using_command shortlog' -s c -l committer -d 'Group commits by committer instead of author'
+complete -c git -n '__fish_git_using_command shortlog' -l no-committer -d 'Group commits by author (default)'
+complete -x -c git -n '__fish_git_using_command shortlog' -l group -a 'author\tGroup\ by\ author committer\tGroup\ by\ committer trailer:\tGroup\ by\ trailer format:\tGroup\ by\ pretty\ format' -d 'Group commits by author, committer, trailer, or format'
+complete -c git -n '__fish_git_using_command shortlog' -l no-group -d 'Disable custom groupings'
+complete -c git -n '__fish_git_using_command shortlog' -s w -d 'Linewrap entries as width[,indent1[,indent2]]'
+
+### log
 complete -c git -n __fish_git_needs_command -a log -d 'Show commit logs'
 complete -c git -n '__fish_git_using_command log' -a '(__fish_git ls-files)'
 complete -c git -n '__fish_git_using_command log' -n 'not contains -- -- (commandline -xpc)' -ka '(__fish_git_ranges)'
@@ -1624,64 +1639,65 @@ complete -c git -n '__fish_git_using_command log' -l use-mailmap
 complete -c git -n '__fish_git_using_command log' -l full-diff
 complete -c git -n '__fish_git_using_command log' -l log-size
 complete -r -F -c git -n '__fish_git_using_command log' -s L -d 'Trace the evolution of the line range given by <start>,<end>, or regex <funcname>, within the <file>'
-complete -x -c git -n '__fish_git_using_command log rev-list' -s n -l max-count -d 'Limit the number of commits before starting to show the commit output'
-complete -x -c git -n '__fish_git_using_command log rev-list' -l skip -d 'Skip given number of commits'
-complete -x -c git -n '__fish_git_using_command log rev-list' -l since -d 'Show commits more recent than specified date'
-complete -x -c git -n '__fish_git_using_command log rev-list' -l after -d 'Show commits more recent than specified date'
-complete -x -c git -n '__fish_git_using_command log rev-list' -l until -d 'Show commits older than specified date'
-complete -x -c git -n '__fish_git_using_command log rev-list' -l before -d 'Show commits older than specified date'
-complete -x -c git -n '__fish_git_using_command log rev-list' -l author -d 'Limit commits from given author'
+complete -x -c git -n '__fish_git_using_command log shortlog rev-list' -s n -l max-count -d 'Limit the number of commits before starting to show the commit output'
+complete -x -c git -n '__fish_git_using_command log shortlog rev-list' -l skip -d 'Skip given number of commits'
+complete -x -c git -n '__fish_git_using_command log shortlog rev-list' -l since -d 'Show commits more recent than specified date'
+complete -x -c git -n '__fish_git_using_command log shortlog rev-list' -l since-as-filter -d 'Show commits more recent than date without stopping traversal early'
+complete -x -c git -n '__fish_git_using_command log shortlog rev-list' -l after -d 'Show commits more recent than specified date'
+complete -x -c git -n '__fish_git_using_command log shortlog rev-list' -l until -d 'Show commits older than specified date'
+complete -x -c git -n '__fish_git_using_command log shortlog rev-list' -l before -d 'Show commits older than specified date'
+complete -x -c git -n '__fish_git_using_command log shortlog rev-list' -l author -d 'Limit commits from given author'
 complete -x -c git -n '__fish_git_using_command log rev-list' -l committer -d 'Limit commits from given committer'
-complete -x -c git -n '__fish_git_using_command log rev-list' -l grep-reflog -d 'Limit commits to ones with reflog entries matching given pattern'
-complete -x -c git -n '__fish_git_using_command log rev-list' -l grep -d 'Limit commits with message that match given pattern'
-complete -c git -n '__fish_git_using_command log rev-list' -l all-match -d 'Limit commits to ones that match all given --grep'
-complete -c git -n '__fish_git_using_command log rev-list' -l invert-grep -d 'Limit commits to ones with message that don\'t match --grep'
-complete -c git -n '__fish_git_using_command log rev-list' -l regexp-ignore-case -s i -d 'Case insensitive match'
-complete -c git -n '__fish_git_using_command log rev-list' -l basic-regexp -d 'Patterns are basic regular expressions (default)'
-complete -c git -n '__fish_git_using_command log rev-list' -l extended-regexp -s E -d 'Patterns are extended regular expressions'
-complete -c git -n '__fish_git_using_command log rev-list' -l fixed-strings -s F -d 'Patterns are fixed strings'
-complete -c git -n '__fish_git_using_command log rev-list' -l perl-regexp -d 'Patterns are Perl-compatible regular expressions'
-complete -c git -n '__fish_git_using_command log rev-list' -l remove-empty -d 'Stop when given path disappears from tree'
-complete -c git -n '__fish_git_using_command log rev-list' -l merges -d 'Print only merge commits'
-complete -c git -n '__fish_git_using_command log rev-list' -l no-merges -d 'Don\'t print commits with more than one parent'
-complete -x -c git -n '__fish_git_using_command log rev-list' -l min-parents -d 'Show only commit with at least the given number of parents'
-complete -x -c git -n '__fish_git_using_command log rev-list' -l max-parents -d 'Show only commit with at most the given number of parents'
-complete -c git -n '__fish_git_using_command log rev-list' -l no-min-parents -d 'Show only commit without a minimum number of parents'
-complete -c git -n '__fish_git_using_command log rev-list' -l no-max-parents -d 'Show only commit without a maximum number of parents'
-complete -c git -n '__fish_git_using_command log rev-list' -l first-parent -d 'Follow only the first parent commit upon seeing a merge commit'
-complete -c git -n '__fish_git_using_command log rev-list' -l not -d 'Reverse meaning of ^ prefix'
-complete -c git -n '__fish_git_using_command log rev-list' -l all -d 'Show log for all branches, tags, and remotes'
-complete -f -c git -n '__fish_git_using_command log rev-list' -l branches -d 'Show log for all matching branches'
-complete -f -c git -n '__fish_git_using_command log rev-list' -l tags -d 'Show log for all matching tags'
-complete -f -c git -n '__fish_git_using_command log rev-list' -l remotes -d 'Show log for all matching remotes'
-complete -x -c git -n '__fish_git_using_command log rev-list' -l glob -d 'Show log for all matching branches, tags, and remotes'
-complete -x -c git -n '__fish_git_using_command log rev-list' -l exclude -d 'Do not include refs matching given glob pattern'
-complete -c git -n '__fish_git_using_command log rev-list' -l reflog -d 'Show log for all reflogs entries'
-complete -c git -n '__fish_git_using_command log rev-list' -l ignore-missing -d 'Ignore invalid object names'
-complete -c git -n '__fish_git_using_command log rev-list' -l bisect
-complete -c git -n '__fish_git_using_command log rev-list' -l stdin -d 'Read commits from stdin'
-complete -c git -n '__fish_git_using_command log rev-list' -l cherry-mark -d 'Mark equivalent commits with = and inequivalent with +'
-complete -c git -n '__fish_git_using_command log rev-list' -l cherry-pick -d 'Omit equivalent commits'
+complete -x -c git -n '__fish_git_using_command log shortlog rev-list' -l grep-reflog -d 'Limit commits to ones with reflog entries matching given pattern'
+complete -x -c git -n '__fish_git_using_command log shortlog rev-list' -l grep -d 'Limit commits with message that match given pattern'
+complete -c git -n '__fish_git_using_command log shortlog rev-list' -l all-match -d 'Limit commits to ones that match all given --grep'
+complete -c git -n '__fish_git_using_command log shortlog rev-list' -l invert-grep -d 'Limit commits to ones with message that don\'t match --grep'
+complete -c git -n '__fish_git_using_command log shortlog rev-list' -l regexp-ignore-case -s i -d 'Case insensitive match'
+complete -c git -n '__fish_git_using_command log shortlog rev-list' -l basic-regexp -d 'Patterns are basic regular expressions (default)'
+complete -c git -n '__fish_git_using_command log shortlog rev-list' -l extended-regexp -s E -d 'Patterns are extended regular expressions'
+complete -c git -n '__fish_git_using_command log shortlog rev-list' -l fixed-strings -s F -d 'Patterns are fixed strings'
+complete -c git -n '__fish_git_using_command log shortlog rev-list' -l perl-regexp -d 'Patterns are Perl-compatible regular expressions'
+complete -c git -n '__fish_git_using_command log shortlog rev-list' -l remove-empty -d 'Stop when given path disappears from tree'
+complete -c git -n '__fish_git_using_command log shortlog rev-list' -l merges -d 'Print only merge commits'
+complete -c git -n '__fish_git_using_command log shortlog rev-list' -l no-merges -d 'Don\'t print commits with more than one parent'
+complete -x -c git -n '__fish_git_using_command log shortlog rev-list' -l min-parents -d 'Show only commit with at least the given number of parents'
+complete -x -c git -n '__fish_git_using_command log shortlog rev-list' -l max-parents -d 'Show only commit with at most the given number of parents'
+complete -c git -n '__fish_git_using_command log shortlog rev-list' -l no-min-parents -d 'Show only commit without a minimum number of parents'
+complete -c git -n '__fish_git_using_command log shortlog rev-list' -l no-max-parents -d 'Show only commit without a maximum number of parents'
+complete -c git -n '__fish_git_using_command log shortlog rev-list' -l first-parent -d 'Follow only the first parent commit upon seeing a merge commit'
+complete -c git -n '__fish_git_using_command log shortlog rev-list' -l not -d 'Reverse meaning of ^ prefix'
+complete -c git -n '__fish_git_using_command log shortlog rev-list' -l all -d 'Show log for all branches, tags, and remotes'
+complete -f -c git -n '__fish_git_using_command log shortlog rev-list' -l branches -d 'Show log for all matching branches'
+complete -f -c git -n '__fish_git_using_command log shortlog rev-list' -l tags -d 'Show log for all matching tags'
+complete -f -c git -n '__fish_git_using_command log shortlog rev-list' -l remotes -d 'Show log for all matching remotes'
+complete -x -c git -n '__fish_git_using_command log shortlog rev-list' -l glob -d 'Show log for all matching branches, tags, and remotes'
+complete -x -c git -n '__fish_git_using_command log shortlog rev-list' -l exclude -d 'Do not include refs matching given glob pattern'
+complete -c git -n '__fish_git_using_command log shortlog rev-list' -l reflog -d 'Show log for all reflogs entries'
+complete -c git -n '__fish_git_using_command log shortlog rev-list' -l ignore-missing -d 'Ignore invalid object names'
+complete -c git -n '__fish_git_using_command log shortlog rev-list' -l bisect
+complete -c git -n '__fish_git_using_command log shortlog rev-list' -l stdin -d 'Read commits from stdin'
+complete -c git -n '__fish_git_using_command log shortlog rev-list' -l cherry-mark -d 'Mark equivalent commits with = and inequivalent with +'
+complete -c git -n '__fish_git_using_command log shortlog rev-list' -l cherry-pick -d 'Omit equivalent commits'
 complete -f -c git -n '__fish_git_using_command rev-list' -l filter -ra '(__fish_git_filters)' -d 'Omits objects from the list of printed objects'
-complete -c git -n '__fish_git_using_command log' -l left-only
-complete -c git -n '__fish_git_using_command log' -l right-only
-complete -c git -n '__fish_git_using_command log' -l cherry
-complete -c git -n '__fish_git_using_command log' -l walk-reflogs -s g
-complete -c git -n '__fish_git_using_command log' -l merge
-complete -c git -n '__fish_git_using_command log' -l boundary
-complete -c git -n '__fish_git_using_command log' -l simplify-by-decoration
-complete -c git -n '__fish_git_using_command log' -l full-history
-complete -c git -n '__fish_git_using_command log' -l dense
-complete -c git -n '__fish_git_using_command log' -l sparse
-complete -c git -n '__fish_git_using_command log' -l simplify-merges
-complete -c git -n '__fish_git_using_command log' -l ancestry-path
-complete -c git -n '__fish_git_using_command log' -l date-order
-complete -c git -n '__fish_git_using_command log' -l author-date-order
-complete -c git -n '__fish_git_using_command log' -l topo-order
-complete -c git -n '__fish_git_using_command log' -l reverse
-complete -f -c git -n '__fish_git_using_command log' -l no-walk -a "sorted unsorted"
-complete -c git -n '__fish_git_using_command log' -l do-walk
-complete -c git -n '__fish_git_using_command log' -l format
+complete -c git -n '__fish_git_using_command log shortlog' -l left-only
+complete -c git -n '__fish_git_using_command log shortlog' -l right-only
+complete -c git -n '__fish_git_using_command log shortlog' -l cherry
+complete -c git -n '__fish_git_using_command log shortlog' -l walk-reflogs -s g
+complete -c git -n '__fish_git_using_command log shortlog' -l merge
+complete -c git -n '__fish_git_using_command log shortlog' -l boundary
+complete -c git -n '__fish_git_using_command log shortlog' -l simplify-by-decoration
+complete -c git -n '__fish_git_using_command log shortlog' -l full-history
+complete -c git -n '__fish_git_using_command log shortlog' -l dense
+complete -c git -n '__fish_git_using_command log shortlog' -l sparse
+complete -c git -n '__fish_git_using_command log shortlog' -l simplify-merges
+complete -c git -n '__fish_git_using_command log shortlog' -l ancestry-path
+complete -c git -n '__fish_git_using_command log shortlog' -l date-order
+complete -c git -n '__fish_git_using_command log shortlog' -l author-date-order
+complete -c git -n '__fish_git_using_command log shortlog' -l topo-order
+complete -c git -n '__fish_git_using_command log shortlog' -l reverse
+complete -f -c git -n '__fish_git_using_command log shortlog' -l no-walk -a "sorted unsorted"
+complete -c git -n '__fish_git_using_command log shortlog' -l do-walk
+complete -x -c git -n '__fish_git_using_command log shortlog' -l format -a '(__fish_git_show_opt format)' -d 'Pretty format string or preset name'
 complete -c git -n '__fish_git_using_command log' -l abbrev-commit
 complete -c git -n '__fish_git_using_command log' -l no-abbrev-commit
 complete -c git -n '__fish_git_using_command log' -l oneline
@@ -1695,7 +1711,7 @@ complete -c git -n '__fish_git_using_command log' -l standard-notes
 complete -c git -n '__fish_git_using_command log' -l no-standard-notes
 complete -c git -n '__fish_git_using_command log' -l show-signature
 complete -c git -n '__fish_git_using_command log' -l relative-date
-complete -x -c git -n '__fish_git_using_command log' -l date -a '
+complete -x -c git -n '__fish_git_using_command log shortlog' -l date -a '
   relative
   local
   iso


### PR DESCRIPTION
## Description

Talk about your changes here.

add git shortlog completion

ref https://git-scm.com/docs/git-shortlog and https://git-scm.com/docs/git-log

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
