### PR TITLE
lints: warn on needless_return

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,6 @@ clippy.len_without_is_empty = "allow"     # we're not a library crate
 clippy.let_and_return = "allow"
 clippy.manual_range_contains = "allow"
 clippy.needless_lifetimes = "allow"
-clippy.needless_return = "allow"
 clippy.new_without_default = "allow"
 clippy.option_map_unit_fn = "allow"
 

--- a/crates/wchar/src/lib.rs
+++ b/crates/wchar/src/lib.rs
@@ -197,10 +197,10 @@ impl<'a> Iterator for WStrCharSplitIter<'a> {
         if let Some(idx) = chars.iter().position(|c| *c == self.split) {
             let (prefix, rest) = chars.split_at(idx);
             self.chars = Some(&rest[1..]);
-            return Some(wstr::from_char_slice(prefix));
+            Some(wstr::from_char_slice(prefix))
         } else {
             self.chars = None;
-            return Some(wstr::from_char_slice(chars));
+            Some(wstr::from_char_slice(chars))
         }
     }
 }

--- a/src/abbrs.rs
+++ b/src/abbrs.rs
@@ -114,7 +114,7 @@ impl Abbreviation {
 
     // Return if we expand in a given position.
     fn matches_position(&self, position: Position) -> bool {
-        return self.position == Position::Anywhere || self.position == position;
+        self.position == Position::Anywhere || self.position == position
     }
 }
 
@@ -194,7 +194,7 @@ impl AbbreviationSet {
                 });
             }
         }
-        return result;
+        result
     }
 
     /// Return whether we would have at least one replacer for a given token.

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -2519,7 +2519,7 @@ impl<'s> Populator<'s> {
                     "Expected a command, but found %s",
                     self.peek_token(0).user_presentable_description()
                 );
-                return got_error(self);
+                got_error(self)
             }
             _ => new_decorated_statement(self),
         }

--- a/src/builtins/abbr.rs
+++ b/src/builtins/abbr.rs
@@ -100,7 +100,7 @@ impl Options {
             return false;
         }
 
-        return true;
+        true
     }
 }
 
@@ -175,7 +175,7 @@ fn abbr_show(streams: &mut IoStreams) -> BuiltinResult {
         }
     });
 
-    return Ok(SUCCESS);
+    Ok(SUCCESS)
 }
 
 // Print the list of abbreviation names.
@@ -198,7 +198,7 @@ fn abbr_list(opts: &Options, streams: &mut IoStreams) -> BuiltinResult {
         }
     });
 
-    return Ok(SUCCESS);
+    Ok(SUCCESS)
 }
 
 // Rename an abbreviation, deleting any existing one with the given name.
@@ -299,7 +299,7 @@ fn abbr_query(opts: &Options) -> BuiltinResult {
                 return Ok(SUCCESS);
             }
         }
-        return Err(STATUS_CMD_ERROR);
+        Err(STATUS_CMD_ERROR)
     })
 }
 
@@ -437,7 +437,7 @@ fn abbr_add(opts: &Options, streams: &mut IoStreams) -> BuiltinResult {
         })
     });
 
-    return Ok(SUCCESS);
+    Ok(SUCCESS)
 }
 
 // Erase the named abbreviations.

--- a/src/builtins/argparse.rs
+++ b/src/builtins/argparse.rs
@@ -285,7 +285,7 @@ fn parse_flag_modifiers<'args>(
     }
 
     *opt_spec_str = s;
-    return true;
+    true
 }
 
 /// Parse the text following the short flag letter.
@@ -384,7 +384,7 @@ fn parse_option_spec_sep<'args>(
     }
 
     *opt_spec_str = s.slice_from(i);
-    return true;
+    true
 }
 
 fn parse_option_spec<'args>(
@@ -457,7 +457,7 @@ fn parse_option_spec<'args>(
     // Record our option under its short flag.
     opts.options.insert(opt_spec.short_flag, opt_spec);
 
-    return true;
+    true
 }
 
 fn collect_option_specs<'args>(
@@ -506,7 +506,7 @@ fn collect_option_specs<'args>(
         return Err(STATUS_INVALID_ARGS);
     }
 
-    return Ok(SUCCESS);
+    Ok(SUCCESS)
 }
 
 fn parse_cmd_opts<'args>(
@@ -655,7 +655,7 @@ fn parse_cmd_opts<'args>(
     }
 
     *optind = w.wopt_index;
-    return collect_option_specs(opts, optind, argc, args, streams);
+    collect_option_specs(opts, optind, argc, args, streams)
 }
 
 fn populate_option_strings<'args>(
@@ -1080,7 +1080,7 @@ fn argparse_parse_flags<'args>(
     opts.args_opts = w.argv_opts;
 
     *optind = w.wopt_index;
-    return Ok(SUCCESS);
+    Ok(SUCCESS)
 }
 
 // This function mimics the `next_opt()` usage found elsewhere in our other builtin commands.

--- a/src/builtins/bg.rs
+++ b/src/builtins/bg.rs
@@ -41,7 +41,7 @@ fn send_to_bg(
     }
     parser.job_promote_at(job_pos);
 
-    return Ok(SUCCESS);
+    Ok(SUCCESS)
 }
 
 /// Builtin for putting a job in the background.
@@ -107,5 +107,5 @@ pub fn bg(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Built
         }
     }
 
-    return Ok(SUCCESS);
+    Ok(SUCCESS)
 }

--- a/src/builtins/bind.rs
+++ b/src/builtins/bind.rs
@@ -493,7 +493,7 @@ fn parse_cmd_opts(
         }
     }
     *optind = w.wopt_index;
-    return Ok(SUCCESS);
+    Ok(SUCCESS)
 }
 
 impl BuiltinBind {

--- a/src/builtins/block.rs
+++ b/src/builtins/block.rs
@@ -139,5 +139,5 @@ pub fn block(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Bu
         parser.global_event_blocks.fetch_add(1, Ordering::Relaxed);
     }
 
-    return Ok(SUCCESS);
+    Ok(SUCCESS)
 }

--- a/src/builtins/cd.rs
+++ b/src/builtins/cd.rs
@@ -172,5 +172,5 @@ pub fn cd(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Built
         streams.err.append(parser.current_line());
     }
 
-    return Err(STATUS_CMD_ERROR);
+    Err(STATUS_CMD_ERROR)
 }

--- a/src/builtins/commandline.rs
+++ b/src/builtins/commandline.rs
@@ -130,7 +130,7 @@ fn strip_dollar_prefixes(insert_mode: AppendMode, prefix: &wstr, insert: &wstr) 
         }
     }
     stripped.push_utfstr(&source[have..]);
-    return Some(stripped);
+    Some(stripped)
 }
 
 /// Output the specified selection.
@@ -189,11 +189,9 @@ fn write_part(
                         // Maybe hit expansion limit, forward the unexpanded string.
                         args.push(Completion::from_completion(token_text.to_owned()));
                     }
-                    ExpandResultCode::cancel => {
-                        return;
-                    }
+                    ExpandResultCode::cancel => {}
                     ExpandResultCode::ok => (),
-                };
+                }
             }
             TokenOutputMode::Raw => {
                 args.push(Completion::from_completion(token_text.to_owned()));

--- a/src/builtins/contains.rs
+++ b/src/builtins/contains.rs
@@ -76,5 +76,5 @@ pub fn contains(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) ->
             .append(wgettext_fmt!("%s: Key not specified\n", cmd));
     }
 
-    return Err(STATUS_CMD_ERROR);
+    Err(STATUS_CMD_ERROR)
 }

--- a/src/builtins/path.rs
+++ b/src/builtins/path.rs
@@ -991,7 +991,7 @@ pub fn path(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Bui
         return Ok(SUCCESS);
     }
     let args = &mut args[1..];
-    return subcmd(parser, streams, args);
+    subcmd(parser, streams, args)
 }
 
 #[cfg(test)]

--- a/src/builtins/printf.rs
+++ b/src/builtins/printf.rs
@@ -171,7 +171,7 @@ impl RawStringToScalarType for f64 {
         if result.is_ok() {
             *end = s.slice_from(consumed);
         }
-        return result;
+        result
     }
 }
 
@@ -694,7 +694,7 @@ impl<'a, 'b> builtin_printf_state_t<'a, 'b> {
                 p = &p[1..];
             }
         }
-        return wstr_offset_in(p, escstart) - 1;
+        wstr_offset_in(p, escstart) - 1
     }
 
     /// Print string str, evaluating \ escapes.
@@ -800,5 +800,5 @@ pub fn printf(_parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> 
             break;
         }
     }
-    return state.exit_code;
+    state.exit_code
 }

--- a/src/builtins/random.rs
+++ b/src/builtins/random.rs
@@ -74,7 +74,7 @@ pub fn random(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
                 .err
                 .append(wgettext_fmt!("%s: %s: invalid integer\n", cmd, num));
         }
-        return res;
+        res
     }
     fn parse_ull(streams: &mut IoStreams, cmd: &wstr, num: &wstr) -> Result<u64, wutil::Error> {
         let res = fish_wcstoul(num);
@@ -83,7 +83,7 @@ pub fn random(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
                 .err
                 .append(wgettext_fmt!("%s: %s: invalid integer\n", cmd, num));
         }
-        return res;
+        res
     }
 
     match arg_count {
@@ -164,5 +164,5 @@ pub fn random(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
     let result: i64 = start.checked_add_unsigned(rand * step).unwrap();
 
     streams.out.appendln(result.to_wstring());
-    return Ok(SUCCESS);
+    Ok(SUCCESS)
 }

--- a/src/builtins/set.rs
+++ b/src/builtins/set.rs
@@ -1021,5 +1021,5 @@ pub fn set(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Buil
         });
     }
 
-    return retval;
+    retval
 }

--- a/src/builtins/shared.rs
+++ b/src/builtins/shared.rs
@@ -937,7 +937,7 @@ impl<'args> Iterator for Arguments<'args, '_> {
             /*want_newline=*/ true,
         );
         *self.argidx += 1;
-        return Some(retval);
+        Some(retval)
     }
 }
 

--- a/src/builtins/string.rs
+++ b/src/builtins/string.rs
@@ -99,7 +99,7 @@ trait StringSubCommand<'args> {
             }
         }
 
-        return Ok(w.wopt_index);
+        Ok(w.wopt_index)
     }
 
     /// Take any positional arguments after options have been parsed.
@@ -157,7 +157,7 @@ trait StringSubCommand<'args> {
             return Err(STATUS_INVALID_ARGS);
         }
 
-        return self.handle(parser, streams, &mut optind, args);
+        self.handle(parser, streams, &mut optind, args)
     }
 }
 
@@ -366,7 +366,7 @@ pub fn string(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
                 .err
                 .append(wgettext_fmt!(BUILTIN_ERR_INVALID_SUBCMD, cmd, args[0]));
             builtin_print_error_trailer(parser, streams.err, cmd);
-            return Err(STATUS_INVALID_ARGS);
+            Err(STATUS_INVALID_ARGS)
         }
     }
 }

--- a/src/builtins/string/escape.rs
+++ b/src/builtins/string/escape.rs
@@ -25,7 +25,7 @@ impl StringSubCommand<'_> for Escape {
             }
             _ => return Err(StringError::UnknownOption),
         }
-        return Ok(());
+        Ok(())
     }
 
     fn handle(

--- a/src/builtins/string/join.rs
+++ b/src/builtins/string/join.rs
@@ -31,7 +31,7 @@ impl<'args> StringSubCommand<'args> for Join<'args> {
             'n' => self.no_empty = true,
             _ => return Err(StringError::UnknownOption),
         }
-        return Ok(());
+        Ok(())
     }
 
     fn take_args(

--- a/src/builtins/string/length.rs
+++ b/src/builtins/string/length.rs
@@ -19,7 +19,7 @@ impl StringSubCommand<'_> for Length {
             'V' => self.visible = true,
             _ => return Err(StringError::UnknownOption),
         }
-        return Ok(());
+        Ok(())
     }
 
     fn handle(

--- a/src/builtins/string/match.rs
+++ b/src/builtins/string/match.rs
@@ -64,7 +64,7 @@ impl<'args> StringSubCommand<'args> for Match<'args> {
             }
             _ => return Err(StringError::UnknownOption),
         }
-        return Ok(());
+        Ok(())
     }
 
     fn take_args(
@@ -188,7 +188,7 @@ impl<'opts, 'args> StringMatcher<'opts, 'args> {
             Ok(Self::Regex(m))
         } else {
             let m = WildCardMatcher::new(pattern, opts);
-            return Ok(Self::WildCard(m));
+            Ok(Self::WildCard(m))
         }
     }
 
@@ -243,7 +243,7 @@ impl<'opts, 'args> RegexMatcher<'opts, 'args> {
             first_match_captures,
             opts,
         };
-        return Ok(m);
+        Ok(m)
     }
 
     fn report_matches(&mut self, arg: &wstr, streams: &mut IoStreams) -> Result<(), pcre2::Error> {
@@ -312,7 +312,7 @@ impl<'opts, 'args> RegexMatcher<'opts, 'args> {
                 return Err(RegexError::InvalidCaptureGroupName(wname));
             }
         }
-        return Ok(());
+        Ok(())
     }
 
     fn report_match<'a>(
@@ -359,7 +359,7 @@ impl<'opts, 'args> RegexMatcher<'opts, 'args> {
             }
         }
 
-        return MatchResult::Match(Some(cg));
+        MatchResult::Match(Some(cg))
     }
 }
 

--- a/src/builtins/string/pad.rs
+++ b/src/builtins/string/pad.rs
@@ -61,7 +61,7 @@ impl StringSubCommand<'_> for Pad {
             'C' => self.center = true,
             _ => return Err(StringError::UnknownOption),
         }
-        return Ok(());
+        Ok(())
     }
 
     fn handle<'args>(

--- a/src/builtins/string/repeat.rs
+++ b/src/builtins/string/repeat.rs
@@ -37,7 +37,7 @@ impl StringSubCommand<'_> for Repeat {
             'N' => self.no_newline = true,
             _ => return Err(StringError::UnknownOption),
         }
-        return Ok(());
+        Ok(())
     }
 
     fn take_args(

--- a/src/builtins/string/replace.rs
+++ b/src/builtins/string/replace.rs
@@ -53,7 +53,7 @@ impl<'args> StringSubCommand<'args> for Replace<'args> {
             }
             _ => return Err(StringError::UnknownOption),
         }
-        return Ok(());
+        Ok(())
     }
 
     fn take_args(
@@ -172,7 +172,7 @@ impl<'args, 'opts> StringReplacer<'args, 'opts> {
                 cursor = cursor.slice_from(1);
             }
         }
-        return Some(result);
+        Some(result)
     }
 
     fn new(
@@ -236,7 +236,7 @@ impl<'args, 'opts> StringReplacer<'args, 'opts> {
                     Cow::Borrowed(_slice_of_arg) => (false, arg),
                     Cow::Owned(s) => (true, Cow::Owned(WString::from_chars(s))),
                 };
-                return Ok(res);
+                Ok(res)
             }
             StringReplacer::Literal {
                 pattern,

--- a/src/builtins/string/shorten.rs
+++ b/src/builtins/string/shorten.rs
@@ -57,7 +57,7 @@ impl<'args> StringSubCommand<'args> for Shorten<'args> {
             'q' => self.quiet = true,
             _ => return Err(StringError::UnknownOption),
         }
-        return Ok(());
+        Ok(())
     }
 
     fn handle(

--- a/src/builtins/string/split.rs
+++ b/src/builtins/string/split.rs
@@ -136,7 +136,7 @@ impl<'args> StringSubCommand<'args> for Split<'args> {
             'a' => self.allow_empty = true,
             _ => return Err(StringError::UnknownOption),
         }
-        return Ok(());
+        Ok(())
     }
 
     fn take_args(
@@ -154,7 +154,7 @@ impl<'args> StringSubCommand<'args> for Split<'args> {
         };
         *optind += 1;
         self.sep = arg;
-        return Ok(());
+        Ok(())
     }
 
     fn handle(
@@ -271,11 +271,11 @@ impl<'args> StringSubCommand<'args> for Split<'args> {
         }
 
         // We split something if we have more split values than args.
-        return if split_count > arg_count {
+        if split_count > arg_count {
             Ok(())
         } else {
             Err(STATUS_CMD_ERROR)
-        };
+        }
     }
 }
 

--- a/src/builtins/string/sub.rs
+++ b/src/builtins/string/sub.rs
@@ -45,7 +45,7 @@ impl StringSubCommand<'_> for Sub {
             'q' => self.quiet = true,
             _ => return Err(StringError::UnknownOption),
         }
-        return Ok(());
+        Ok(())
     }
 
     fn handle(

--- a/src/builtins/string/transform.rs
+++ b/src/builtins/string/transform.rs
@@ -13,7 +13,7 @@ impl StringSubCommand<'_> for Transform {
             'q' => self.quiet = true,
             _ => return Err(StringError::UnknownOption),
         }
-        return Ok(());
+        Ok(())
     }
 
     fn handle(

--- a/src/builtins/string/trim.rs
+++ b/src/builtins/string/trim.rs
@@ -41,7 +41,7 @@ impl<'args> StringSubCommand<'args> for Trim<'args> {
             'q' => self.quiet = true,
             _ => return Err(StringError::UnknownOption),
         }
-        return Ok(());
+        Ok(())
     }
 
     fn handle(

--- a/src/builtins/string/unescape.rs
+++ b/src/builtins/string/unescape.rs
@@ -27,7 +27,7 @@ impl StringSubCommand<'_> for Unescape {
             }
             _ => return Err(StringError::UnknownOption),
         }
-        return Ok(());
+        Ok(())
     }
 
     fn handle(

--- a/src/builtins/test.rs
+++ b/src/builtins/test.rs
@@ -404,7 +404,7 @@ mod test_expressions {
                 // OR it in.
                 or_result = or_result || and_result;
             }
-            return or_result;
+            or_result
         }
 
         fn range(&self) -> Range {
@@ -555,11 +555,11 @@ mod test_expressions {
                 return self.error(start, sprintf!("Unknown option at index %u", start));
             }
 
-            return JustAString {
+            JustAString {
                 arg: self.arg(start).to_owned(),
                 range: start..start + 1,
             }
-            .into_some_box();
+            .into_some_box()
         }
 
         fn parse_binary_primary(

--- a/src/builtins/wait.rs
+++ b/src/builtins/wait.rs
@@ -219,5 +219,5 @@ pub fn wait(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
     if wait_handles.is_empty() {
         return Err(STATUS_INVALID_ARGS);
     }
-    return wait_for_completion(parser, &wait_handles, any_flag);
+    wait_for_completion(parser, &wait_handles, any_flag)
 }

--- a/src/complete.rs
+++ b/src/complete.rs
@@ -282,7 +282,7 @@ impl CompletionReceiver {
             return false;
         }
         self.completions.push(comp.into());
-        return true;
+        true
     }
 
     /// Adds a completion with the given string, and default other properties. Returns `true` on
@@ -1650,9 +1650,7 @@ impl<'ctx> Completer<'ctx> {
             comp.prepend_token_prefix(prefix_with_sep);
             comp.r#match.from_separator = true;
         }
-        if !self.completions.extend(local_completions) {
-            return;
-        }
+        if !self.completions.extend(local_completions) {}
     }
 
     /// Complete the specified string as an environment variable.

--- a/src/env/environment_impl.rs
+++ b/src/env/environment_impl.rs
@@ -371,10 +371,10 @@ impl EnvScopedImpl {
                 let session_id = history_session_id_from_var(fish_history_var);
                 History::with_name(&session_id)
             });
-            return Some(EnvVar::new_from_name_vec(
+            Some(EnvVar::new_from_name_vec(
                 L!("history"),
                 history.get_history(),
-            ));
+            ))
         } else if key == "fish_killring" {
             Some(EnvVar::new_from_name_vec(
                 L!("fish_killring"),
@@ -593,7 +593,7 @@ impl EnvScopedImpl {
         if cursor.next().is_some() {
             mismatch = true;
         }
-        return mismatch;
+        mismatch
     }
 
     /// Get the exported variables into a variable table.
@@ -646,7 +646,7 @@ impl EnvScopedImpl {
             str.push_utfstr(&val.as_string());
             export_list.push(wcs2zstring(&str));
         }
-        return Arc::new(OwningNullTerminatedArray::new(export_list));
+        Arc::new(OwningNullTerminatedArray::new(export_list))
     }
 
     // Exported variable array used by execv.
@@ -660,7 +660,7 @@ impl EnvScopedImpl {
             self.enumerate_generations(|r#gen| generations.push(r#gen));
             self.export_array_generations = generations;
         }
-        return self.export_array.as_ref().unwrap().clone();
+        self.export_array.as_ref().unwrap().clone()
     }
 }
 
@@ -986,7 +986,7 @@ impl EnvStackImpl {
             pathvar: Some(false),
         };
         Self::set_in_node(&mut self.base.globals, key, val, flags);
-        return Some(EnvStackSetResult::Ok);
+        Some(EnvStackSetResult::Ok)
     }
 
     /// Set a universal variable, inheriting as applicable from the given old variable.
@@ -1068,7 +1068,7 @@ impl EnvStackImpl {
                 return cursor;
             }
         }
-        return self.base.globals.clone();
+        self.base.globals.clone()
     }
 
     /// Get an existing variable, or None.

--- a/src/env_universal_common.rs
+++ b/src/env_universal_common.rs
@@ -305,7 +305,7 @@ impl EnvUniversal {
             };
         }
         // No version found, assume 2.x
-        return UvarFormat::Fish_2_x;
+        UvarFormat::Fish_2_x
     }
 
     /// Serialize a variable list.

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -1332,14 +1332,12 @@ impl<'a, 'b, 'c> Expander<'a, 'b, 'c> {
         if self.flags.contains(ExpandFlags::FAIL_ON_CMDSUBST) {
             let mut cursor = 0;
             match parse_util_locate_cmdsubst_range(&input, &mut cursor, true, None, None) {
-                MaybeParentheses::Error => {
-                    return ExpandResult::make_error(STATUS_EXPAND_ERROR);
-                }
+                MaybeParentheses::Error => ExpandResult::make_error(STATUS_EXPAND_ERROR),
                 MaybeParentheses::None => {
                     if !out.add(input) {
                         return append_overflow_error(self.errors, None);
                     }
-                    return ExpandResult::ok();
+                    ExpandResult::ok()
                 }
                 MaybeParentheses::CommandSubstitution(parens) => {
                     append_cmdsub_error!(
@@ -1348,7 +1346,7 @@ impl<'a, 'b, 'c> Expander<'a, 'b, 'c> {
                         parens.end() - 1,
                         "command substitutions not allowed in command position. Try var=(your-cmd) $var ..."
                     );
-                    return ExpandResult::make_error(STATUS_EXPAND_ERROR);
+                    ExpandResult::make_error(STATUS_EXPAND_ERROR)
                 }
             }
         } else {

--- a/src/fd_monitor.rs
+++ b/src/fd_monitor.rs
@@ -45,7 +45,7 @@ impl FdEventSignaller {
     /// The default constructor will abort on failure (fd exhaustion).
     /// This should only be used during startup.
     pub fn new() -> Self {
-        cfg_if!(
+        cfg_if! {
             if #[cfg(have_eventfd)] {
                 // Note we do not want to use EFD_SEMAPHORE because we are binary (not counting) semaphore.
                 let fd = unsafe { libc::eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK) };
@@ -53,9 +53,9 @@ impl FdEventSignaller {
                     perror("eventfd");
                     exit_without_destructors(1);
                 }
-                return Self {
+                Self {
                     fd: unsafe { OwnedFd::from_raw_fd(fd) },
-                };
+                }
             } else {
                 // Implementation using pipes.
                 let Ok(pipes) = make_autoclose_pipes() else {
@@ -63,12 +63,12 @@ impl FdEventSignaller {
                 };
                 make_fd_nonblocking(pipes.read.as_raw_fd()).unwrap();
                 make_fd_nonblocking(pipes.write.as_raw_fd()).unwrap();
-                return Self {
+                Self {
                     fd: pipes.read,
                     write: pipes.write,
-                };
+                }
             }
-        );
+        }
     }
 
     /// Return the fd to read from, for notification.
@@ -155,13 +155,13 @@ impl FdEventSignaller {
 
     /// Return the fd to write to.
     fn write_fd(&self) -> RawFd {
-        cfg_if!(
+        cfg_if! {
             if #[cfg(have_eventfd)] {
-                return self.fd.as_raw_fd();
+                self.fd.as_raw_fd()
             } else {
-                return self.write.as_raw_fd();
+                self.write.as_raw_fd()
             }
-        );
+        }
     }
 }
 

--- a/src/fd_readable_set.rs
+++ b/src/fd_readable_set.rs
@@ -181,19 +181,19 @@ impl FdReadableSet {
             debug_assert_eq!(pollfd.fd, fd);
             return pollfd.revents & (libc::POLLIN | libc::POLLHUP) != 0;
         }
-        return false;
+        false
     }
 
     fn do_poll(fds: &mut [libc::pollfd], timeout: Timeout) -> c_int {
         let count = fds.len();
         assert!(count <= libc::nfds_t::MAX as usize, "count too big");
-        return unsafe {
+        unsafe {
             libc::poll(
                 fds.as_mut_ptr(),
                 count as libc::nfds_t,
                 timeout.as_poll_msecs(),
             )
-        };
+        }
     }
 
     /// Call poll(). Note this destructively modifies the set. Return the result of poll().
@@ -201,7 +201,7 @@ impl FdReadableSet {
         if self.pollfds_.is_empty() {
             return 0;
         }
-        return Self::do_poll(&mut self.pollfds_, timeout);
+        Self::do_poll(&mut self.pollfds_, timeout)
     }
 
     /// Check if a single fd is readable, with a given timeout.
@@ -216,12 +216,12 @@ impl FdReadableSet {
             revents: 0,
         };
         let ret = Self::do_poll(std::slice::from_mut(&mut pfd), timeout);
-        return ret > 0 && (pfd.revents & libc::POLLIN) != 0;
+        ret > 0 && (pfd.revents & libc::POLLIN) != 0
     }
 
     /// Check if a single fd is readable, without blocking.
     /// Return true if readable, false if not.
     pub fn poll_fd_readable(fd: RawFd) -> bool {
-        return Self::is_fd_readable(fd, Timeout::ZERO);
+        Self::is_fd_readable(fd, Timeout::ZERO)
     }
 }

--- a/src/fork_exec/postfork.rs
+++ b/src/fork_exec/postfork.rs
@@ -29,9 +29,9 @@ fn clear_cloexec(fd: i32) -> i32 {
     }
     let new_flags = flags & !libc::FD_CLOEXEC;
     if flags == new_flags {
-        return 0;
+        0
     } else {
-        return unsafe { libc::fcntl(fd, libc::F_SETFD, new_flags) };
+        unsafe { libc::fcntl(fd, libc::F_SETFD, new_flags) }
     }
 }
 

--- a/src/function.rs
+++ b/src/function.rs
@@ -318,7 +318,7 @@ pub fn copy(name: &wstr, new_name: WString, parser: &Parser) -> bool {
     // Note this will NOT overwrite an existing function with the new name.
     // TODO: rationalize if this behavior is desired.
     funcset.funcs.entry(new_name).or_insert(Arc::new(new_props));
-    return true;
+    true
 }
 
 /// Returns all function names.

--- a/src/highlight/highlight.rs
+++ b/src/highlight/highlight.rs
@@ -266,7 +266,7 @@ fn command_is_valid(
     }
 
     // Return what we got.
-    return is_valid;
+    is_valid
 }
 
 fn has_expand_reserved(s: &wstr) -> bool {
@@ -1085,9 +1085,9 @@ impl<'s> Highlighter<'s> {
 fn has_cmdsub(src: &wstr) -> bool {
     let mut cursor = 0;
     match parse_util_locate_cmdsubst_range(src, &mut cursor, true, None, None) {
-        MaybeParentheses::Error => return false,
-        MaybeParentheses::None => return false,
-        MaybeParentheses::CommandSubstitution(_) => return true,
+        MaybeParentheses::Error => false,
+        MaybeParentheses::None => false,
+        MaybeParentheses::CommandSubstitution(_) => true,
     }
 }
 

--- a/src/history/history.rs
+++ b/src/history/history.rs
@@ -1086,7 +1086,7 @@ impl HistoryImpl {
 
 fn string_could_be_path(potential_path: &wstr) -> bool {
     // Assume that things with leading dashes aren't paths.
-    return !(potential_path.is_empty() || potential_path.starts_with('-'));
+    !(potential_path.is_empty() || potential_path.starts_with('-'))
 }
 
 /// Perform a search of `hist` for `search_string`. Invoke a function `func` for each match. If

--- a/src/input_common.rs
+++ b/src/input_common.rs
@@ -1460,7 +1460,7 @@ pub trait InputEventQueuer {
                 TERMINAL_OS_NAME.get_or_init(|| Some(bytes2wcstring(&value)));
             }
         }
-        return None;
+        None
     }
 
     fn readch_timed_esc(&mut self) -> Option<CharEvent> {

--- a/src/key.rs
+++ b/src/key.rs
@@ -209,7 +209,7 @@ pub(crate) fn canonicalize_unkeyed_control_char(c: u8) -> char {
     // Represent Ctrl-symbol combinations in "upper-case", as they are
     // traditionally-rendered.
     assert!(c < 32);
-    return char::from(c - 1 + b'A');
+    char::from(c - 1 + b'A')
 }
 
 pub(crate) fn canonicalize_key(mut key: Key) -> Result<Key, WString> {

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -126,17 +126,17 @@ impl ProcStatus {
 
     /// Encode a return value `ret` and signal `sig` into a status value like waitpid() does.
     const fn w_exitcode(ret: i32, sig: i32) -> i32 {
-        cfg_if!(
+        cfg_if! {
             if #[cfg(waitstatus_signal_ret)] {
                 // It's encoded signal and then status
                 // The return status is in the lower byte.
-                return (sig << 8) | ret;
+                (sig << 8) | ret
             } else {
                 // The status is encoded in the upper byte.
                 // This should be W_EXITCODE(ret, sig) but that's not available everywhere.
-                return (ret << 8) | sig;
+                (ret << 8) | sig
             }
-        );
+        }
     }
 
     /// Construct from a status returned from a waitpid call.

--- a/src/reader/reader.rs
+++ b/src/reader/reader.rs
@@ -2268,7 +2268,7 @@ impl ReaderData {
             }
             tmp_r_pos += 1;
         }
-        return false;
+        false
     }
 
     fn jump_and_remember_last_jump(
@@ -2332,7 +2332,7 @@ impl ReaderData {
                     }
                     tmp_pos += 1;
                 }
-                return false;
+                false
             }
         }
     }

--- a/src/threads/debounce.rs
+++ b/src/threads/debounce.rs
@@ -91,7 +91,7 @@ impl<R: Send + 'static> Debounce<R> {
 
         // Execute request after unlocking the mutex.
         (request)();
-        return true;
+        true
     }
 
     /// Enqueue `handler` to be performed on a background thread. If another function is already

--- a/src/tinyexpr.rs
+++ b/src/tinyexpr.rs
@@ -346,7 +346,7 @@ impl<'s> State<'s> {
     }
 
     pub fn eval(&mut self) -> f64 {
-        return self.expr();
+        self.expr()
     }
 
     fn set_error(&mut self, kind: ErrorKind, pos_len: Option<(usize, usize)>) {
@@ -385,11 +385,11 @@ impl<'s> State<'s> {
                 Ok(num) => Some((consumed, Some(Token::Number(num)))),
                 Err(wcstodError::InvalidChar) => {
                     self.set_error(ErrorKind::Unknown, Some((self.pos + consumed, 1)));
-                    return Some((consumed, Some(Token::Error)));
+                    Some((consumed, Some(Token::Error)))
                 }
                 Err(wcstodError::Overflow) => {
                     self.set_error(ErrorKind::NumberTooLarge, Some((self.pos, consumed)));
-                    return Some((consumed, Some(Token::Error)));
+                    Some((consumed, Some(Token::Error)))
                 }
                 Err(wcstodError::Empty) => {
                     // We have a matches! above, this can't be?

--- a/src/topic_monitor.rs
+++ b/src/topic_monitor.rs
@@ -100,7 +100,7 @@ impl GenerationsList {
                 result.push_str(&r#gen.to_string());
             }
         }
-        return result;
+        result
     }
 
     /// Sets the generation for `topic` to `value`.
@@ -438,13 +438,13 @@ impl TopicMonitor {
         }
         // Report our change.
         self.data_notifier_.notify_all();
-        return data.current.clone();
+        data.current.clone()
     }
 
     /// Return the current generation list, opportunistically applying any pending updates.
     fn updated_gens(&self) -> GenerationsList {
         let mut data = self.data_.lock().unwrap();
-        return self.updated_gens_in_data(&mut data);
+        self.updated_gens_in_data(&mut data)
     }
 
     /// Access the current generations.
@@ -515,7 +515,7 @@ impl TopicMonitor {
                 break;
             }
         }
-        return become_reader;
+        become_reader
     }
 
     /// Wait for some entry in the list of generations to change.
@@ -546,7 +546,7 @@ impl TopicMonitor {
                 self.data_notifier_.notify_all();
             }
         }
-        return gens;
+        gens
     }
 
     /// For each valid topic in `gens`, check to see if the current topic is larger than
@@ -584,7 +584,7 @@ impl TopicMonitor {
             // Wait until our gens change.
             current = self.await_gens(&current);
         }
-        return changed;
+        changed
     }
 }
 

--- a/src/wildcard.rs
+++ b/src/wildcard.rs
@@ -216,14 +216,7 @@ fn wildcard_complete_internal(
             if s.is_empty() {
                 return WildcardResult::NoMatch;
             }
-            return wildcard_complete_internal(
-                s.slice_from(1),
-                wc.slice_from(1),
-                params,
-                flags,
-                out,
-                false,
-            );
+            wildcard_complete_internal(s.slice_from(1), wc.slice_from(1), params, flags, out, false)
         }
         ANY_STRING => {
             // Hackish. If this is the last character of the wildcard, then just complete with
@@ -268,10 +261,10 @@ fn wildcard_complete_internal(
                 }
             }
 
-            return match has_match {
+            match has_match {
                 true => WildcardResult::Match,
                 false => WildcardResult::NoMatch,
-            };
+            }
         }
         // We don't even try with this one.
         ANY_STRING_RECURSIVE => WildcardResult::NoMatch,
@@ -293,7 +286,7 @@ pub fn wildcard_complete(
         expand_flags,
     };
 
-    return wildcard_complete_internal(s, wc, &params, flags, out, true);
+    wildcard_complete_internal(s, wc, &params, flags, out, true)
 }
 
 /// Obtain a description string for the file specified by the filename.
@@ -315,7 +308,7 @@ fn file_get_desc(
     let is_executable =
         |filename: &wstr| -> bool { definitely_executable || waccess(filename, X_OK) == 0 };
 
-    return if is_link {
+    if is_link {
         if is_dir {
             wgettext!(COMPLETE_DIRECTORY_SYMLINK_DESC)
         } else if is_executable(filename) {
@@ -329,7 +322,7 @@ fn file_get_desc(
         wgettext!(COMPLETE_EXEC_DESC)
     } else {
         wgettext!(COMPLETE_FILE_DESC)
-    };
+    }
 }
 
 /// Test if the given file is an executable (if executables_only) or directory (if
@@ -675,9 +668,9 @@ mod expander {
 
         pub fn status_code(&self) -> WildcardResult {
             if self.did_interrupt {
-                return WildcardResult::Cancel;
+                WildcardResult::Cancel
             } else if self.did_overflow {
-                return WildcardResult::Overflow;
+                WildcardResult::Overflow
             } else if self.did_add {
                 WildcardResult::Match
             } else {
@@ -975,7 +968,7 @@ mod expander {
                 abs_unique_hierarchy.push('/');
             }
 
-            return unique_hierarchy;
+            unique_hierarchy
         }
 
         fn try_add_completion_result(
@@ -1051,10 +1044,10 @@ mod expander {
                 path = normalize_path(&path, true);
             }
 
-            return match dotdot {
+            match dotdot {
                 true => DirIter::new_with_dots(&path),
                 false => DirIter::new(&path),
-            };
+            }
         }
     }
 }
@@ -1127,7 +1120,7 @@ pub fn wildcard_expand_string<'closure>(
 
     let mut expander = WildCardExpander::new(prefix, flags, &mut cancel_checker, output);
     expander.expand(base_dir, effective_wc, base_dir, ParentInfo::default());
-    return expander.status_code();
+    expander.status_code()
 }
 
 /// Test whether the given wildcard matches the string. Does not perform any I/O.
@@ -1236,7 +1229,7 @@ pub fn wildcard_has(s: impl AsRef<wstr>) -> bool {
     }
     let unescaped =
         unescape_string(s, UnescapeStringStyle::Script(UnescapeFlags::SPECIAL)).unwrap_or_default();
-    return wildcard_has_internal(unescaped);
+    wildcard_has_internal(unescaped)
 }
 
 #[cfg(test)]

--- a/src/wutil/wcstod.rs
+++ b/src/wutil/wcstod.rs
@@ -98,7 +98,7 @@ pub fn parse_inf_nan(
         }
         return Some(f64::NEG_INFINITY);
     }
-    return None;
+    None
 }
 
 fn wcstod_inner<I>(mut chars: I, decimal_sep: char, consumed: &mut usize) -> Result<f64, Error>


### PR DESCRIPTION
The needless_return lint was disabled almost two years ago, alongside several other lints. It might have been helpful for porting from C++. Now, I think we can enable that lint again, since omitting the returns results in equivalent, more concise code, which should not be harder to read.

The only manual changes in this commit are removing the lint exception from `Cargo.toml` and removing the unnecessary returns inside `cfg_if!` macro invocations (in `src/fd_monitor.rs` and `src/proc.rs`). All other changes were generated by
`cargo clippy --workspace --all-targets --fix && cargo fmt`