### PR TITLE
completions: add `docker`

### DIFF
--- a/share/completions/docker.fish
+++ b/share/completions/docker.fish
@@ -1,2 +1,1 @@
-# Completions for Docker are maintained upstream.
-# They should be installed with the Docker package.
+docker completion fish 2>/dev/null | source


### PR DESCRIPTION
## Description

The [upstream completions](https://github.com/docker/cli/blob/master/contrib/completion/fish/docker.fish) are rarely updated and stale (see [commit history](https://github.com/docker/cli/commits/master/contrib/completion/fish/docker.fish)). Meanwhile, docker now uses cobra's generated completions (which supports the same dynamic completions of [images](https://github.com/docker/cli/blob/0e38eec554cbaa2406354b5ab29aabfaa12d8537/cli/command/container/run.go#L48) etc as the old version, so no reason not to use them): https://docs.docker.com/engine/cli/completion/#fish

## TODOs:

<!-- Just check off what what we know been done so far. We can help you with this stuff. -->

- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
