### PR TITLE
check.sh: rename template to gettext template

### DIFF
--- a/build_tools/check.sh
+++ b/build_tools/check.sh
@@ -38,8 +38,8 @@ cargo() {
 }
 
 cleanup () {
-    if [ -n "$template_dir" ] && [ -e "$template_dir" ]; then
-        rm -r "$template_dir"
+    if [ -n "$gettext_template_dir" ] && [ -e "$gettext_template_dir" ]; then
+        rm -r "$gettext_template_dir"
     fi
 }
 
@@ -64,9 +64,9 @@ if [ -n "$FISH_TEST_MAX_CONCURRENCY" ]; then
     export CARGO_BUILD_JOBS="$FISH_TEST_MAX_CONCURRENCY"
 fi
 
-template_dir=$(mktemp -d)
+gettext_template_dir=$(mktemp -d)
 (
-    export FISH_GETTEXT_EXTRACTION_DIR="$template_dir"
+    export FISH_GETTEXT_EXTRACTION_DIR="$gettext_template_dir"
     cargo build --workspace --all-targets --features=gettext-extract
 )
 if $lint; then
@@ -83,7 +83,7 @@ cargo test --doc --workspace
 if $lint; then
     cargo doc --workspace --no-deps
 fi
-FISH_GETTEXT_EXTRACTION_DIR=$template_dir "$workspace_root/tests/test_driver.py" "$build_dir"
+FISH_GETTEXT_EXTRACTION_DIR=$gettext_template_dir "$workspace_root/tests/test_driver.py" "$build_dir"
 
 exit
 }


### PR DESCRIPTION
This is done in preparation for a second temporary directory used to for Fluent ID extraction.