### PR TITLE
io: allow unescape+write of `str`

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -12,7 +12,7 @@ use crate::parse_util::parse_util_escape_string_with_quote;
 use crate::prelude::*;
 use crate::terminal::Output;
 use crate::termsize::Termsize;
-use crate::wcstringutil::wcs2bytes_callback;
+use crate::wcstringutil::str2bytes_callback;
 use crate::wildcard::{ANY_CHAR, ANY_STRING, ANY_STRING_RECURSIVE};
 use crate::wutil::fish_iswalnum;
 use bitflags::bitflags;
@@ -1179,7 +1179,7 @@ pub fn wcs2zstring(input: &wstr) -> CString {
     }
 
     let mut vec = Vec::with_capacity(input.len() + 1);
-    wcs2bytes_callback(input, |buff| {
+    str2bytes_callback(input, |buff| {
         vec.extend_from_slice(buff);
         true
     });
@@ -1201,7 +1201,7 @@ pub fn wcs2zstring(input: &wstr) -> CString {
 /// Like [`wcs2bytes`], but appends to `output` instead of returning a new string.
 pub fn wcs2bytes_appending(output: &mut Vec<u8>, input: &wstr) {
     output.reserve(input.len());
-    wcs2bytes_callback(input, |buff| {
+    str2bytes_callback(input, |buff| {
         output.extend_from_slice(buff);
         true
     });

--- a/src/flog.rs
+++ b/src/flog.rs
@@ -2,7 +2,7 @@ use crate::common::wcs2bytes;
 use crate::prelude::*;
 use crate::wildcard::wildcard_match;
 use crate::wutil::write_to_fd;
-use crate::{parse_util::parse_util_unescape_wildcards, wutil::wwrite_to_fd};
+use crate::{parse_util::parse_util_unescape_wildcards, wutil::unescape_bytes_and_write_to_fd};
 use libc::c_int;
 use std::sync::atomic::{AtomicI32, Ordering};
 
@@ -303,5 +303,5 @@ pub fn get_flog_file_fd() -> c_int {
 }
 
 pub fn log_extra_to_flog_file(s: &wstr) {
-    wwrite_to_fd(s, get_flog_file_fd());
+    unescape_bytes_and_write_to_fd(s, get_flog_file_fd());
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -13,7 +13,7 @@ use crate::redirection::{RedirectionMode, RedirectionSpecList};
 use crate::signal::SigChecker;
 use crate::terminal::Output;
 use crate::topic_monitor::Topic;
-use crate::wutil::{perror, perror_io, wdirname, wstat, wwrite_to_fd};
+use crate::wutil::{perror, perror_io, unescape_bytes_and_write_to_fd, wdirname, wstat};
 use errno::Errno;
 use libc::{EAGAIN, EINTR, ENOENT, ENOTDIR, EPIPE, EWOULDBLOCK, STDOUT_FILENO};
 use nix::fcntl::OFlag;
@@ -762,7 +762,7 @@ impl FdOutputStream {
         if self.errored {
             return false;
         }
-        if wwrite_to_fd(s, self.fd).is_none() {
+        if unescape_bytes_and_write_to_fd(s, self.fd).is_none() {
             // Some of our builtins emit multiple screens worth of data sent to a pager (the primary
             // example being the `history` builtin) and receiving SIGINT should be considered normal and
             // non-exceptional (user request to abort via Ctrl-C), meaning we shouldn't print an error.

--- a/src/wcstringutil.rs
+++ b/src/wcstringutil.rs
@@ -313,11 +313,12 @@ pub fn string_fuzzy_match_string(
 }
 
 /// Implementation of wcs2bytes that accepts a callback.
+/// The first argument can be either a `&str` or `&wstr`.
 /// This invokes `func` with byte slices containing the UTF-8 encoding of the characters in the
 /// input, doing one invocation per character.
 /// If `func` returns false, it stops; otherwise it continues.
 /// Return false if the callback returned false, otherwise true.
-pub fn wcs2bytes_callback(input: &wstr, mut func: impl FnMut(&[u8]) -> bool) -> bool {
+pub fn str2bytes_callback(input: impl IntoCharIter, mut func: impl FnMut(&[u8]) -> bool) -> bool {
     // A `char` represents an Unicode scalar value, which takes up at most 4 bytes when encoded in UTF-8.
     let mut converted = [0_u8; 4];
 

--- a/src/wutil/printf.rs
+++ b/src/wutil/printf.rs
@@ -26,7 +26,7 @@ macro_rules! fprintf {
     ($fd:expr, $fmt:expr $(, $arg:expr)* $(,)?) => {
         {
             let wide = $crate::wutil::sprintf!($fmt, $( $arg ),*);
-            $crate::wutil::wwrite_to_fd(&wide, $fd);
+            $crate::wutil::unescape_bytes_and_write_to_fd(&wide, $fd);
         }
     }
 }


### PR DESCRIPTION
The existing functionality of converting a `&wstr` to bytes (unescaping PUA codepoints) and writing these to a file descriptor can be reused for Rust's built-in strings by making the input type generic. This is simple, because the only functionality we need is converting the input into a `char` iterator, which is available for both types.

While at it, rename the functions to have more accurate and informative names.

Extracted from the Fluent patch series. I realized that `IntoCharIter` already exists, and that's a better interface than the `ToChars` I came up with, so `ToChars` will no longer be used.