### PR TITLE
strings: take `IntoCharIter` instead of `wstr`

### DIFF
--- a/src/builtins/abbr.rs
+++ b/src/builtins/abbr.rs
@@ -47,7 +47,7 @@ impl Options {
         };
 
         if cmds.len() > 1 {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "%s: Cannot combine options %s\n",
                 CMD,
                 join(&cmds, L!(", "))
@@ -63,25 +63,27 @@ impl Options {
         }
 
         if !self.add && self.position.is_some() {
-            streams
-                .err
-                .append(wgettext_fmt!("%s: --position option requires --add\n", CMD));
+            streams.err.append(&wgettext_fmt!(
+                "%s: --position option requires --add\n",
+                CMD
+            ));
             return false;
         }
         if !self.add && self.regex_pattern.is_some() {
             streams
                 .err
-                .append(wgettext_fmt!("%s: --regex option requires --add\n", CMD));
+                .append(&wgettext_fmt!("%s: --regex option requires --add\n", CMD));
             return false;
         }
         if !self.add && self.function.is_some() {
-            streams
-                .err
-                .append(wgettext_fmt!("%s: --function option requires --add\n", CMD));
+            streams.err.append(&wgettext_fmt!(
+                "%s: --function option requires --add\n",
+                CMD
+            ));
             return false;
         }
         if !self.add && self.set_cursor_marker.is_some() {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "%s: --set-cursor option requires --add\n",
                 CMD
             ));
@@ -92,7 +94,7 @@ impl Options {
             .as_ref()
             .is_some_and(|m| m.is_empty())
         {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "%s: --set-cursor argument cannot be empty\n",
                 CMD
             ));
@@ -181,7 +183,7 @@ fn abbr_show(streams: &mut IoStreams) -> BuiltinResult {
 fn abbr_list(opts: &Options, streams: &mut IoStreams) -> BuiltinResult {
     let subcmd = L!("--list");
     if !opts.args.is_empty() {
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             "%s %s: Unexpected argument -- '%s'\n",
             CMD,
             subcmd,
@@ -193,7 +195,7 @@ fn abbr_list(opts: &Options, streams: &mut IoStreams) -> BuiltinResult {
         for abbr in abbrs.list() {
             let mut name = abbr.name.clone();
             name.push('\n');
-            streams.out.append(name);
+            streams.out.append(&name);
         }
     });
 
@@ -205,7 +207,7 @@ fn abbr_rename(opts: &Options, streams: &mut IoStreams) -> BuiltinResult {
     let subcmd = L!("--rename");
 
     if opts.args.len() != 2 {
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             "%s %s: Requires exactly two arguments\n",
             CMD,
             subcmd
@@ -217,12 +219,12 @@ fn abbr_rename(opts: &Options, streams: &mut IoStreams) -> BuiltinResult {
     if old_name.is_empty() || new_name.is_empty() {
         streams
             .err
-            .append(wgettext_fmt!("%s %s: Name cannot be empty\n", CMD, subcmd));
+            .append(&wgettext_fmt!("%s %s: Name cannot be empty\n", CMD, subcmd));
         return Err(STATUS_INVALID_ARGS);
     }
 
     if contains_whitespace(new_name) {
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             "%s %s: Abbreviation '%s' cannot have spaces in the word\n",
             CMD,
             subcmd,
@@ -236,7 +238,7 @@ fn abbr_rename(opts: &Options, streams: &mut IoStreams) -> BuiltinResult {
             .iter()
             .any(|a| a.name == *old_name && a.commands == opts.commands)
         {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "%s %s: No abbreviation named %s with the specified command restrictions\n",
                 CMD,
                 subcmd,
@@ -250,7 +252,7 @@ fn abbr_rename(opts: &Options, streams: &mut IoStreams) -> BuiltinResult {
             .any(|a| a.name == *new_name && a.commands == opts.commands)
         {
             if opts.commands.is_empty() {
-                streams.err.append(wgettext_fmt!(
+                streams.err.append(&wgettext_fmt!(
                     "%s %s: Abbreviation %s already exists, cannot rename %s\n",
                     CMD,
                     subcmd,
@@ -267,7 +269,7 @@ fn abbr_rename(opts: &Options, streams: &mut IoStreams) -> BuiltinResult {
                     cmd_list.push_utfstr(&escape_string(cmd, style));
                 }
 
-                streams.err.append(wgettext_fmt!(
+                streams.err.append(&wgettext_fmt!(
                     "%s %s: Abbreviation %s already exists for commands %s, cannot rename %s\n",
                     CMD,
                     subcmd,
@@ -307,7 +309,7 @@ fn abbr_add(opts: &Options, streams: &mut IoStreams) -> BuiltinResult {
     let subcmd = L!("--add");
 
     if opts.args.len() < 2 && opts.function.is_none() {
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             "%s %s: Requires at least two arguments\n",
             CMD,
             subcmd
@@ -318,12 +320,12 @@ fn abbr_add(opts: &Options, streams: &mut IoStreams) -> BuiltinResult {
     if opts.args.is_empty() || opts.args[0].is_empty() {
         streams
             .err
-            .append(wgettext_fmt!("%s %s: Name cannot be empty\n", CMD, subcmd));
+            .append(&wgettext_fmt!("%s %s: Name cannot be empty\n", CMD, subcmd));
         return Err(STATUS_INVALID_ARGS);
     }
     let name = &opts.args[0];
     if name.chars().any(|c| c.is_whitespace()) {
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             "%s %s: Abbreviation '%s' cannot have spaces in the word\n",
             CMD,
             subcmd,
@@ -344,7 +346,7 @@ fn abbr_add(opts: &Options, streams: &mut IoStreams) -> BuiltinResult {
         let result = builder.build(to_boxed_chars(regex_pattern));
 
         if let Err(error) = result {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "%s: Regular expression compile error: %s\n",
                 CMD,
                 error.error_message(),
@@ -352,12 +354,12 @@ fn abbr_add(opts: &Options, streams: &mut IoStreams) -> BuiltinResult {
             if let Some(offset) = error.offset() {
                 streams
                     .err
-                    .append(sprintf!("%s: %s\n", CMD, regex_pattern.as_utfstr()));
+                    .append(&sprintf!("%s: %s\n", CMD, regex_pattern.as_utfstr()));
                 // TODO: This is misaligned if `regex_pattern` contains characters which are not
                 // exactly 1 terminal cell wide.
                 let mut marker = " ".repeat(offset.saturating_sub(1));
                 marker.push('^');
-                streams.err.append(sprintf!("%s: %s\n", CMD, marker));
+                streams.err.append(&sprintf!("%s: %s\n", CMD, marker));
             }
             return Err(STATUS_INVALID_ARGS);
         }
@@ -379,14 +381,14 @@ fn abbr_add(opts: &Options, streams: &mut IoStreams) -> BuiltinResult {
     if opts.function.is_some() && opts.args.len() > 1 {
         streams
             .err
-            .append(wgettext_fmt!(BUILTIN_ERR_TOO_MANY_ARGUMENTS, L!("abbr")));
+            .append(&wgettext_fmt!(BUILTIN_ERR_TOO_MANY_ARGUMENTS, L!("abbr")));
         return Err(STATUS_INVALID_ARGS);
     }
     let replacement = if let Some(ref function) = opts.function {
         // Abbreviation function names disallow spaces.
         // This is to prevent accidental usage of e.g. `--function 'string replace'`
         if !valid_func_name(function) || contains_whitespace(function) {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "%s: Invalid function name: %s\n",
                 CMD,
                 function.as_utfstr()
@@ -530,7 +532,7 @@ pub fn abbr(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
             'c' => opts.commands.push(w.woptarg.map(|x| x.to_owned()).unwrap()),
             'p' => {
                 if opts.position.is_some() {
-                    streams.err.append(wgettext_fmt!(
+                    streams.err.append(&wgettext_fmt!(
                         "%s: Cannot specify multiple positions\n",
                         CMD
                     ));
@@ -541,7 +543,7 @@ pub fn abbr(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
                 } else if w.woptarg == Some(L!("anywhere")) {
                     opts.position = Some(Position::Anywhere);
                 } else {
-                    streams.err.append(wgettext_fmt!(
+                    streams.err.append(&wgettext_fmt!(
                         "%s: Invalid position '%s'\n",
                         CMD,
                         w.woptarg.unwrap_or_default()
@@ -554,7 +556,7 @@ pub fn abbr(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
             }
             'r' => {
                 if opts.regex_pattern.is_some() {
-                    streams.err.append(wgettext_fmt!(
+                    streams.err.append(&wgettext_fmt!(
                         "%s: Cannot specify multiple regex patterns\n",
                         CMD
                     ));
@@ -564,7 +566,7 @@ pub fn abbr(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
             }
             SET_CURSOR_SHORT => {
                 if opts.set_cursor_marker.is_some() {
-                    streams.err.append(wgettext_fmt!(
+                    streams.err.append(&wgettext_fmt!(
                         "%s: Cannot specify multiple set-cursor options\n",
                         CMD
                     ));
@@ -587,7 +589,7 @@ pub fn abbr(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
 
             'U' => {
                 // Kept and made ineffective, so we warn.
-                streams.err.append(wgettext_fmt!(
+                streams.err.append(&wgettext_fmt!(
                     "%s: Warning: Option '%s' was removed and is now ignored",
                     cmd,
                     argv_read[w.wopt_index - 1]

--- a/src/builtins/argparse.rs
+++ b/src/builtins/argparse.rs
@@ -145,7 +145,7 @@ fn check_for_mutually_exclusive_flags(
                         if flag1 > flag2 {
                             std::mem::swap(&mut flag1, &mut flag2);
                         }
-                        streams.err.append(wgettext_fmt!(
+                        streams.err.append(&wgettext_fmt!(
                             "%s: %s %s: options cannot be used together\n",
                             opts.name,
                             flag1,
@@ -167,7 +167,7 @@ fn parse_exclusive_args(opts: &mut ArgParseCmdOpts, streams: &mut IoStreams) -> 
     for raw_xflags in &opts.raw_exclusive_flags {
         let xflags: Vec<_> = raw_xflags.split(',').collect();
         if xflags.len() < 2 {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "%s: exclusive flag string '%s' is not valid\n",
                 opts.name,
                 raw_xflags
@@ -185,7 +185,7 @@ fn parse_exclusive_args(opts: &mut ArgParseCmdOpts, streams: &mut IoStreams) -> 
                 // It's a long flag we store as its short flag equivalent.
                 exclusive_set.push(*short_equiv);
             } else {
-                streams.err.append(wgettext_fmt!(
+                streams.err.append(&wgettext_fmt!(
                     "%s: exclusive flag '%s' is not valid\n",
                     opts.name,
                     flag
@@ -214,7 +214,7 @@ fn parse_flag_modifiers<'args>(
         && s.char_at(0) != '!'
         && s.char_at(0) != '&'
     {
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             "%s: Implicit int short flag '%c' does not allow modifiers like '%c'\n",
             opts.name,
             opt_spec.short_flag,
@@ -249,7 +249,7 @@ fn parse_flag_modifiers<'args>(
 
     if s.char_at(0) == '!' {
         if opt_spec.arg_type == ArgType::NoArgument {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 BUILTIN_ERR_INVALID_OPT_SPEC,
                 opts.name,
                 option_spec,
@@ -261,7 +261,7 @@ fn parse_flag_modifiers<'args>(
         // Move cursor to the end so we don't expect a long flag.
         s = s.slice_from(s.char_count());
     } else if !s.is_empty() {
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             BUILTIN_ERR_INVALID_OPT_SPEC,
             opts.name,
             option_spec,
@@ -276,7 +276,7 @@ fn parse_flag_modifiers<'args>(
     }
 
     if opts.options.contains_key(&opt_spec.short_flag) {
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             "%s: Short flag '%c' already defined\n",
             opts.name,
             opt_spec.short_flag
@@ -308,7 +308,7 @@ fn parse_option_spec_sep<'args>(
             *counter += 1;
         }
         if opts.implicit_int_flag != '\0' {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "%s: Implicit int flag '%c' already defined\n",
                 opts.name,
                 opts.implicit_int_flag
@@ -327,7 +327,7 @@ fn parse_option_spec_sep<'args>(
             opt_spec.short_flag_valid = false;
             i += 1;
             if i == s.char_count() {
-                streams.err.append(wgettext_fmt!(
+                streams.err.append(&wgettext_fmt!(
                     BUILTIN_ERR_INVALID_OPT_SPEC,
                     opts.name,
                     option_spec,
@@ -339,7 +339,7 @@ fn parse_option_spec_sep<'args>(
         '/' => {
             i += 1; // the struct is initialized assuming short_flag_valid should be true
             if i == s.char_count() {
-                streams.err.append(wgettext_fmt!(
+                streams.err.append(&wgettext_fmt!(
                     BUILTIN_ERR_INVALID_OPT_SPEC,
                     opts.name,
                     option_spec,
@@ -350,7 +350,7 @@ fn parse_option_spec_sep<'args>(
         }
         '#' => {
             if opts.implicit_int_flag != '\0' {
-                streams.err.append(wgettext_fmt!(
+                streams.err.append(&wgettext_fmt!(
                     "%s: Implicit int flag '%c' already defined\n",
                     opts.name,
                     opts.implicit_int_flag
@@ -394,7 +394,7 @@ fn parse_option_spec<'args>(
     streams: &mut IoStreams,
 ) -> bool {
     if option_spec.is_empty() {
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             "%s: An option spec must have at least a short or a long flag\n",
             opts.name
         ));
@@ -404,7 +404,7 @@ fn parse_option_spec<'args>(
     let mut s = option_spec;
     if !fish_iswalnum(s.char_at(0)) && s.char_at(0) != '#' && !(s.char_at(0) == '/' && s.len() > 1)
     {
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             "%s: Short flag '%c' invalid, must be alphanum or '#'\n",
             opts.name,
             s.char_at(0)
@@ -431,7 +431,7 @@ fn parse_option_spec<'args>(
         if long_flag_char_count > 0 {
             opt_spec.long_flag = s.slice_to(long_flag_char_count);
             if opts.long_to_short_flag.contains_key(opt_spec.long_flag) {
-                streams.err.append(wgettext_fmt!(
+                streams.err.append(&wgettext_fmt!(
                     "%s: Long flag '%s' already defined\n",
                     opts.name,
                     opt_spec.long_flag
@@ -480,7 +480,7 @@ fn collect_option_specs<'args>(
         if *optind == argc {
             streams
                 .err
-                .append(wgettext_fmt!("%s: Missing -- separator\n", cmd));
+                .append(&wgettext_fmt!("%s: Missing -- separator\n", cmd));
             return Err(STATUS_INVALID_ARGS);
         }
 
@@ -502,7 +502,7 @@ fn collect_option_specs<'args>(
     if counter > counter_max {
         streams
             .err
-            .append(wgettext_fmt!("%s: Too many long-only options\n", cmd));
+            .append(&wgettext_fmt!("%s: Too many long-only options\n", cmd));
         return Err(STATUS_INVALID_ARGS);
     }
 
@@ -532,7 +532,7 @@ fn parse_cmd_opts<'args>(
             's' => opts.stop_nonopt = true,
             'i' | 'u' => {
                 if opts.unknown_handling != UnknownHandling::Error {
-                    streams.err.append(wgettext_fmt!(
+                    streams.err.append(&wgettext_fmt!(
                         BUILTIN_ERR_COMBO2_EXCLUSIVE,
                         cmd,
                         "--ignore-unknown",
@@ -556,7 +556,7 @@ fn parse_cmd_opts<'args>(
                 } else if kind == L!("none") {
                     ArgType::NoArgument
                 } else {
-                    streams.err.append(wgettext_fmt!(
+                    streams.err.append(&wgettext_fmt!(
                         "%s: Invalid --unknown-arguments value '%s'\n",
                         cmd,
                         kind
@@ -573,7 +573,7 @@ fn parse_cmd_opts<'args>(
                 opts.min_args = {
                     let x = fish_wcstol(w.woptarg.unwrap()).unwrap_or(-1);
                     if x < 0 {
-                        streams.err.append(wgettext_fmt!(
+                        streams.err.append(&wgettext_fmt!(
                             "%s: Invalid --min-args value '%s'\n",
                             cmd,
                             w.woptarg.unwrap()
@@ -587,7 +587,7 @@ fn parse_cmd_opts<'args>(
                 opts.max_args = {
                     let x = fish_wcstol(w.woptarg.unwrap()).unwrap_or(-1);
                     if x < 0 {
-                        streams.err.append(wgettext_fmt!(
+                        streams.err.append(&wgettext_fmt!(
                             "%s: Invalid --max-args value '%s'\n",
                             cmd,
                             w.woptarg.unwrap()
@@ -642,7 +642,7 @@ fn parse_cmd_opts<'args>(
         // The user didn't specify any option specs.
         streams
             .err
-            .append(wgettext_fmt!("%s: Missing -- separator\n", cmd));
+            .append(&wgettext_fmt!("%s: Missing -- separator\n", cmd));
         return Err(STATUS_INVALID_ARGS);
     }
 
@@ -730,7 +730,7 @@ fn validate_arg<'opts>(
     );
 
     for output in cmd_output {
-        streams.err.append(output);
+        streams.err.append(&output);
         streams.err.append_char('\n');
     }
     vars.pop();
@@ -947,7 +947,7 @@ fn argparse_parse_flags<'args>(
                         streams,
                     )?;
                 } else if opts.unknown_handling == UnknownHandling::Error {
-                    streams.err.append(wgettext_fmt!(
+                    streams.err.append(&wgettext_fmt!(
                         BUILTIN_ERR_UNKNOWN,
                         opts.name,
                         args_read[w.wopt_index - 1]
@@ -1002,7 +1002,7 @@ fn argparse_parse_flags<'args>(
                             Some(w.argv[w.wopt_index - 1])
                         } else {
                             // the option is at the end of argv, so it has no argument
-                            streams.err.append(wgettext_fmt!(
+                            streams.err.append(&wgettext_fmt!(
                                 BUILTIN_ERR_MISSING,
                                 opts.name,
                                 args_read[w.wopt_index - 1]
@@ -1018,7 +1018,7 @@ fn argparse_parse_flags<'args>(
                         && is_long_flag
                         && arg_contents.contains('=')
                     {
-                        streams.err.append(wgettext_fmt!(
+                        streams.err.append(&wgettext_fmt!(
                             BUILTIN_ERR_UNEXP_ARG,
                             opts.name,
                             args_read[w.wopt_index - 1]
@@ -1115,7 +1115,7 @@ fn check_min_max_args_constraints(
     let cmd = &opts.name;
 
     if opts.args.len() < opts.min_args {
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             BUILTIN_ERR_MIN_ARG_COUNT1,
             cmd,
             opts.min_args,
@@ -1125,7 +1125,7 @@ fn check_min_max_args_constraints(
     }
 
     if opts.max_args != usize::MAX && opts.args.len() > opts.max_args {
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             BUILTIN_ERR_MAX_ARG_COUNT1,
             cmd,
             opts.max_args,

--- a/src/builtins/bg.rs
+++ b/src/builtins/bg.rs
@@ -17,7 +17,7 @@ fn send_to_bg(
         let jobs = parser.jobs();
         if !jobs[job_pos].wants_job_control() {
             let job = &jobs[job_pos];
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "%s: Can't put job %s, '%s' to background because it is not under job control\n",
                 cmd,
                 job.job_id().to_wstring(),
@@ -27,7 +27,7 @@ fn send_to_bg(
         }
 
         let job = &jobs[job_pos];
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             "Send job %s '%s' to background\n",
             job.job_id().to_wstring(),
             job.command()
@@ -68,7 +68,7 @@ pub fn bg(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Built
         let Some(job_pos) = job_pos else {
             streams
                 .err
-                .append(wgettext_fmt!("%s: There are no suitable jobs\n", cmd));
+                .append(&wgettext_fmt!("%s: There are no suitable jobs\n", cmd));
             return Err(STATUS_CMD_ERROR);
         };
 
@@ -103,7 +103,7 @@ pub fn bg(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Built
         } else {
             streams
                 .err
-                .append(wgettext_fmt!("%s: Could not find job '%d'\n", cmd, pid));
+                .append(&wgettext_fmt!("%s: Could not find job '%d'\n", cmd, pid));
         }
     }
 

--- a/src/builtins/bind.rs
+++ b/src/builtins/bind.rs
@@ -157,9 +157,9 @@ impl BuiltinBind {
             let mut colors = Vec::new();
             highlight_shell(&out, &mut colors, &parser.context(), false, None);
             let colored = colorize(&out, &colors, parser.vars());
-            streams.out.append(bytes2wcstring(&colored));
+            streams.out.append(&bytes2wcstring(&colored));
         } else {
-            streams.out.append(out);
+            streams.out.append(&out);
         }
 
         true
@@ -251,7 +251,7 @@ impl BuiltinBind {
         match parse_keys(seq) {
             Ok(keys) => Some(keys),
             Err(err) => {
-                streams.err.append(sprintf!("bind: %s\n", err));
+                streams.err.append(&sprintf!("bind: %s\n", err));
                 None
             }
         }
@@ -306,7 +306,7 @@ impl BuiltinBind {
         } else {
             // Inserting both on the other hand makes no sense.
             if self.opts.have_preset && self.opts.have_user {
-                streams.err.append(wgettext_fmt!(
+                streams.err.append(&wgettext_fmt!(
                     BUILTIN_ERR_COMBO2_EXCLUSIVE,
                     cmd,
                     "--preset",
@@ -349,13 +349,13 @@ impl BuiltinBind {
                 );
                 if !self.opts.silent {
                     if seq.len() == 1 {
-                        streams.err.append(wgettext_fmt!(
+                        streams.err.append(&wgettext_fmt!(
                             "%s: No binding found for key '%s'\n",
                             cmd,
                             seq[0]
                         ));
                     } else {
-                        streams.err.append(wgettext_fmt!(
+                        streams.err.append(&wgettext_fmt!(
                             "%s: No binding found for key sequence '%s'\n",
                             cmd,
                             eseq
@@ -425,7 +425,7 @@ fn parse_cmd_opts(
 
     let mut check_mode_name = |mode_name: &wstr| -> Result<(), ErrorCode> {
         if !valid_var_name(mode_name) {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 BUILTIN_ERR_BIND_MODE,
                 cmd,
                 mode_name,
@@ -444,7 +444,7 @@ fn parse_cmd_opts(
             'f' => opts.mode = BIND_FUNCTION_NAMES,
             'h' => opts.print_help = true,
             'k' => {
-                streams.err.append(wgettext_fmt!(
+                streams.err.append(&wgettext_fmt!(
                     "%s: the -k/--key syntax is no longer supported. See `bind --help` and `bind --key-names`\n",
                     cmd,
                 ));
@@ -557,7 +557,7 @@ impl BuiltinBind {
             _ => {
                 streams
                     .err
-                    .append(wgettext_fmt!("%s: Invalid state\n", cmd));
+                    .append(&wgettext_fmt!("%s: Invalid state\n", cmd));
                 return Err(STATUS_CMD_ERROR);
             }
         }

--- a/src/builtins/block.rs
+++ b/src/builtins/block.rs
@@ -84,7 +84,7 @@ pub fn block(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Bu
 
     if opts.erase {
         if opts.scope != Scope::Unset {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "%s: Can not specify scope when removing block\n",
                 cmd
             ));
@@ -94,7 +94,7 @@ pub fn block(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Bu
         if parser.global_event_blocks.load(Ordering::Relaxed) == 0 {
             streams
                 .err
-                .append(wgettext_fmt!("%s: No blocks defined\n", cmd));
+                .append(&wgettext_fmt!("%s: No blocks defined\n", cmd));
             return Err(STATUS_CMD_ERROR);
         }
         parser.global_event_blocks.fetch_sub(1, Ordering::Relaxed);

--- a/src/builtins/breakpoint.rs
+++ b/src/builtins/breakpoint.rs
@@ -7,7 +7,7 @@ use libc::STDIN_FILENO;
 pub fn breakpoint(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> BuiltinResult {
     let cmd = argv[0];
     if argv.len() != 1 {
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             BUILTIN_ERR_ARG_COUNT1,
             cmd,
             0,
@@ -28,7 +28,7 @@ pub fn breakpoint(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) 
             .block_at_index(1)
             .is_none_or(|b| b.typ() == BlockType::breakpoint)
         {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "%s: Command not valid at an interactive prompt\n",
                 cmd,
             ));

--- a/src/builtins/builtin.rs
+++ b/src/builtins/builtin.rs
@@ -53,7 +53,7 @@ pub fn r#builtin(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
     }
 
     if opts.query && opts.list_names {
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             BUILTIN_ERR_COMBO2,
             cmd,
             wgettext!("--query and --names are mutually exclusive")

--- a/src/builtins/cd.rs
+++ b/src/builtins/cd.rs
@@ -39,7 +39,7 @@ pub fn cd(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Built
             None => {
                 streams
                     .err
-                    .append(wgettext_fmt!("%s: Could not find home directory\n", cmd));
+                    .append(&wgettext_fmt!("%s: Could not find home directory\n", cmd));
                 return Err(STATUS_CMD_ERROR);
             }
         }
@@ -47,13 +47,13 @@ pub fn cd(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Built
 
     // Stop `cd ""` from crashing
     if dir_in.is_empty() {
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             "%s: Empty directory '%s' does not exist\n",
             cmd,
             dir_in
         ));
         if !parser.is_interactive() {
-            streams.err.append(parser.current_line());
+            streams.err.append(&parser.current_line());
         };
         return Err(STATUS_CMD_ERROR);
     }
@@ -62,14 +62,14 @@ pub fn cd(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Built
 
     let dirs = path_apply_cdpath(dir_in, &pwd, vars);
     if dirs.is_empty() {
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             "%s: The directory '%s' does not exist\n",
             cmd,
             dir_in
         ));
 
         if !parser.is_interactive() {
-            streams.err.append(parser.current_line());
+            streams.err.append(&parser.current_line());
         }
 
         return Err(STATUS_CMD_ERROR);
@@ -134,22 +134,22 @@ pub fn cd(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Built
     if best_errno == ENOTDIR {
         streams
             .err
-            .append(wgettext_fmt!("%s: '%s' is not a directory\n", cmd, dir_in));
+            .append(&wgettext_fmt!("%s: '%s' is not a directory\n", cmd, dir_in));
     } else if !broken_symlink.is_empty() {
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             "%s: '%s' is a broken symbolic link to '%s'\n",
             cmd,
             broken_symlink,
             broken_symlink_target
         ));
     } else if best_errno == ELOOP {
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             "%s: Too many levels of symbolic links: '%s'\n",
             cmd,
             dir_in
         ));
     } else if best_errno == ENOENT {
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             "%s: The directory '%s' does not exist\n",
             cmd,
             dir_in
@@ -157,11 +157,11 @@ pub fn cd(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Built
     } else if best_errno == EACCES || best_errno == EPERM {
         streams
             .err
-            .append(wgettext_fmt!("%s: Permission denied: '%s'\n", cmd, dir_in));
+            .append(&wgettext_fmt!("%s: Permission denied: '%s'\n", cmd, dir_in));
     } else {
         errno::set_errno(Errno(best_errno));
         wperror(L!("cd"));
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             "%s: Unknown error trying to locate directory '%s'\n",
             cmd,
             dir_in
@@ -169,7 +169,7 @@ pub fn cd(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Built
     }
 
     if !parser.is_interactive() {
-        streams.err.append(parser.current_line());
+        streams.err.append(&parser.current_line());
     }
 
     Err(STATUS_CMD_ERROR)

--- a/src/builtins/commandline.rs
+++ b/src/builtins/commandline.rs
@@ -310,7 +310,7 @@ pub fn commandline(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr])
             'f' => function_mode = true,
             'x' | '\x02' | 'o' => {
                 if token_mode.is_some() {
-                    streams.err.append(wgettext_fmt!(
+                    streams.err.append(&wgettext_fmt!(
                         BUILTIN_ERR_COMBO2,
                         cmd,
                         wgettext!("--tokens options are mutually exclusive")
@@ -377,7 +377,7 @@ pub fn commandline(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr])
             || selection_start_mode
             || selection_end_mode
         {
-            streams.err.append(wgettext_fmt!(BUILTIN_ERR_COMBO, cmd));
+            streams.err.append(&wgettext_fmt!(BUILTIN_ERR_COMBO, cmd));
             builtin_print_error_trailer(parser, streams.err, cmd);
             return Err(STATUS_INVALID_ARGS);
         }
@@ -392,7 +392,7 @@ pub fn commandline(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr])
             let Some(cmd) = input_function_get_code(arg) else {
                 streams
                     .err
-                    .append(wgettext_fmt!("%s: Unknown input function '%s'", cmd, arg));
+                    .append(&wgettext_fmt!("%s: Unknown input function '%s'", cmd, arg));
                 builtin_print_error_trailer(parser, streams.err, cmd);
                 return Err(STATUS_INVALID_ARGS);
             };
@@ -422,7 +422,7 @@ pub fn commandline(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr])
     if (selection_start_mode || selection_end_mode) && positional_args != 0 {
         streams
             .err
-            .append(wgettext_fmt!(BUILTIN_ERR_TOO_MANY_ARGUMENTS, cmd));
+            .append(&wgettext_fmt!(BUILTIN_ERR_TOO_MANY_ARGUMENTS, cmd));
         builtin_print_error_trailer(parser, streams.err, cmd);
         return Err(STATUS_INVALID_ARGS);
     }
@@ -432,7 +432,7 @@ pub fn commandline(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr])
     {
         streams
             .err
-            .append(wgettext_fmt!(BUILTIN_ERR_TOO_MANY_ARGUMENTS, cmd));
+            .append(&wgettext_fmt!(BUILTIN_ERR_TOO_MANY_ARGUMENTS, cmd));
         builtin_print_error_trailer(parser, streams.err, cmd);
         return Err(STATUS_INVALID_ARGS);
     }
@@ -442,13 +442,13 @@ pub fn commandline(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr])
         // Special case - we allow to get/set cursor position relative to the process/job/token.
         && ((buffer_part.is_none() && !search_field_mode) || !cursor_mode)
     {
-        streams.err.append(wgettext_fmt!(BUILTIN_ERR_COMBO, cmd));
+        streams.err.append(&wgettext_fmt!(BUILTIN_ERR_COMBO, cmd));
         builtin_print_error_trailer(parser, streams.err, cmd);
         return Err(STATUS_INVALID_ARGS);
     }
 
     if (token_mode.is_some() || cut_at_cursor) && positional_args != 0 {
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             BUILTIN_ERR_COMBO2,
             cmd,
             "--cut-at-cursor and token options can not be used when setting the commandline"
@@ -458,7 +458,7 @@ pub fn commandline(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr])
     }
 
     if search_field_mode && (buffer_part.is_some() || token_mode.is_some()) {
-        streams.err.append(wgettext_fmt!(BUILTIN_ERR_COMBO, cmd));
+        streams.err.append(&wgettext_fmt!(BUILTIN_ERR_COMBO, cmd));
         builtin_print_error_trailer(parser, streams.err, cmd);
         return Err(STATUS_INVALID_ARGS);
     }
@@ -475,7 +475,7 @@ pub fn commandline(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr])
 
     if append_mode == AppendMode::InsertSmart {
         if search_field_mode {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 BUILTIN_ERR_COMBO2_EXCLUSIVE,
                 cmd,
                 "--insert-smart",
@@ -488,7 +488,7 @@ pub fn commandline(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr])
             TextScope::String | TextScope::Job | TextScope::Process => (),
             TextScope::Token => {
                 // To-do: we can support it in command position.
-                streams.err.append(wgettext_fmt!(
+                streams.err.append(&wgettext_fmt!(
                     BUILTIN_ERR_COMBO2_EXCLUSIVE,
                     cmd,
                     "--insert-smart",
@@ -507,7 +507,7 @@ pub fn commandline(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr])
                 Err(_) => {
                     streams
                         .err
-                        .append(wgettext_fmt!(BUILTIN_ERR_NOT_NUMBER, cmd, arg));
+                        .append(&wgettext_fmt!(BUILTIN_ERR_NOT_NUMBER, cmd, arg));
                     builtin_print_error_trailer(parser, streams.err, cmd);
                     0
                 }
@@ -516,7 +516,7 @@ pub fn commandline(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr])
             let Ok(new_coord) = usize::try_from(new_coord) else {
                 streams
                     .err
-                    .append(wgettext_fmt!("%s: line/column index starts at 1", cmd));
+                    .append(&wgettext_fmt!("%s: line/column index starts at 1", cmd));
                 builtin_print_error_trailer(parser, streams.err, cmd);
                 return Err(STATUS_INVALID_ARGS);
             };
@@ -528,7 +528,7 @@ pub fn commandline(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr])
                 ) else {
                     streams
                         .err
-                        .append(wgettext_fmt!("%s: there is no line %s\n", cmd, arg));
+                        .append(&wgettext_fmt!("%s: there is no line %s\n", cmd, arg));
                     builtin_print_error_trailer(parser, streams.err, cmd);
                     return Err(STATUS_INVALID_ARGS);
                 };
@@ -542,7 +542,7 @@ pub fn commandline(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr])
                     parse_util_get_offset_from_line(&rstate.text, line_index + 1)
                         .unwrap_or(rstate.text.len());
                 if line_offset + new_coord > next_line_offset {
-                    streams.err.append(wgettext_fmt!(
+                    streams.err.append(&wgettext_fmt!(
                         "%s: column %s exceeds line length\n",
                         cmd,
                         arg
@@ -554,7 +554,7 @@ pub fn commandline(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr])
             };
             commandline_set_buffer(parser, None, Some(new_pos));
         } else {
-            streams.out.append(sprintf!(
+            streams.out.append(&sprintf!(
                 "%d\n",
                 if line_mode {
                     parse_util_lineno(&rstate.text, rstate.cursor_pos)
@@ -600,7 +600,7 @@ pub fn commandline(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr])
         let Some(selection) = rstate.selection else {
             return Err(STATUS_CMD_ERROR);
         };
-        streams.out.append(sprintf!("%u\n", selection.start));
+        streams.out.append(&sprintf!("%u\n", selection.start));
         return Ok(SUCCESS);
     }
 
@@ -608,7 +608,7 @@ pub fn commandline(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr])
         let Some(selection) = rstate.selection else {
             return Err(STATUS_CMD_ERROR);
         };
-        streams.out.append(sprintf!("%u\n", selection.end));
+        streams.out.append(&sprintf!("%u\n", selection.end));
         return Ok(SUCCESS);
     }
 
@@ -631,7 +631,7 @@ pub fn commandline(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr])
         current_cursor_pos = current_buffer.len();
     } else if parser.libdata().transient_commandline.is_some() {
         if cursor_mode && positional_args != 0 {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "%s: setting cursor while evaluating 'complete --arguments' is not yet supported",
                 cmd
             ));
@@ -705,7 +705,7 @@ pub fn commandline(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr])
                 Err(_) => {
                     streams
                         .err
-                        .append(wgettext_fmt!(BUILTIN_ERR_NOT_NUMBER, cmd, arg));
+                        .append(&wgettext_fmt!(BUILTIN_ERR_NOT_NUMBER, cmd, arg));
                     builtin_print_error_trailer(parser, streams.err, cmd);
                     0
                 }
@@ -722,7 +722,7 @@ pub fn commandline(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr])
         } else {
             streams
                 .out
-                .append(sprintf!("%u\n", current_cursor_pos - range.start));
+                .append(&sprintf!("%u\n", current_cursor_pos - range.start));
         }
         return Ok(SUCCESS);
     }

--- a/src/builtins/complete.rs
+++ b/src/builtins/complete.rs
@@ -230,9 +230,9 @@ fn builtin_complete_print(cmd: &wstr, streams: &mut IoStreams, parser: &Parser) 
         highlight_shell(&repr, &mut colors, &parser.context(), false, None);
         streams
             .out
-            .append(bytes2wcstring(&colorize(&repr, &colors, parser.vars())));
+            .append(&bytes2wcstring(&colorize(&repr, &colors, parser.vars())));
     } else {
-        streams.out.append(repr);
+        streams.out.append(&repr);
     }
 }
 
@@ -318,7 +318,7 @@ pub fn complete(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) ->
                         cmd_to_complete.push(tmp);
                     }
                 } else {
-                    streams.err.append(wgettext_fmt!(
+                    streams.err.append(&wgettext_fmt!(
                         "%s: Invalid token '%s'\n",
                         cmd,
                         w.woptarg.unwrap()
@@ -341,7 +341,7 @@ pub fn complete(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) ->
                 if arg.is_empty() {
                     streams
                         .err
-                        .append(wgettext_fmt!("%s: -s requires a non-empty string\n", cmd,));
+                        .append(&wgettext_fmt!("%s: -s requires a non-empty string\n", cmd,));
                     return Err(STATUS_INVALID_ARGS);
                 }
             }
@@ -351,7 +351,7 @@ pub fn complete(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) ->
                 if arg.is_empty() {
                     streams
                         .err
-                        .append(wgettext_fmt!("%s: -l requires a non-empty string\n", cmd,));
+                        .append(&wgettext_fmt!("%s: -l requires a non-empty string\n", cmd,));
                     return Err(STATUS_INVALID_ARGS);
                 }
             }
@@ -361,7 +361,7 @@ pub fn complete(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) ->
                 if arg.is_empty() {
                     streams
                         .err
-                        .append(wgettext_fmt!("%s: -o requires a non-empty string\n", cmd,));
+                        .append(&wgettext_fmt!("%s: -o requires a non-empty string\n", cmd,));
                     return Err(STATUS_INVALID_ARGS);
                 }
             }
@@ -407,7 +407,7 @@ pub fn complete(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) ->
 
     if result_mode.no_files && result_mode.force_files {
         if !have_x {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 BUILTIN_ERR_COMBO2,
                 "complete",
                 "'--no-files' and '--force-files'"
@@ -415,7 +415,7 @@ pub fn complete(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) ->
         } else {
             // The reason for us not wanting files is `-x`,
             // which is short for `-rf`.
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 BUILTIN_ERR_COMBO2,
                 "complete",
                 "'--exclusive' and '--force-files'"
@@ -435,7 +435,7 @@ pub fn complete(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) ->
         } else {
             streams
                 .err
-                .append(wgettext_fmt!(BUILTIN_ERR_TOO_MANY_ARGUMENTS, cmd));
+                .append(&wgettext_fmt!(BUILTIN_ERR_TOO_MANY_ARGUMENTS, cmd));
             builtin_print_error_trailer(parser, streams.err, cmd);
             return Err(STATUS_INVALID_ARGS);
         }
@@ -446,7 +446,7 @@ pub fn complete(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) ->
         if parse_util_detect_errors(condition_string, Some(&mut errors), false).is_err() {
             for error in errors {
                 let prefix = cmd.to_owned() + L!(": -n '") + &condition_string[..] + L!("': ");
-                streams.err.append(error.describe_with_prefix(
+                streams.err.append(&error.describe_with_prefix(
                     condition_string,
                     &prefix,
                     parser.is_interactive(),
@@ -464,12 +464,12 @@ pub fn complete(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) ->
         prefix.push_str(": ");
 
         if let Err(err_text) = parse_util_detect_errors_in_argument_list(&comp, &prefix) {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "%s: %s: contains a syntax error\n",
                 cmd,
                 comp
             ));
-            streams.err.append(err_text);
+            streams.err.append(&err_text);
             streams.err.append_char('\n');
             return Err(STATUS_CMD_ERROR);
         }
@@ -563,7 +563,7 @@ pub fn complete(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) ->
                     faux_cmdline_with_completion.push_utfstr(&next.description);
                 }
                 faux_cmdline_with_completion.push('\n');
-                streams.out.append(faux_cmdline_with_completion);
+                streams.out.append(&faux_cmdline_with_completion);
             }
 
             parser.libdata_mut().builtin_complete_current_commandline = false;

--- a/src/builtins/contains.rs
+++ b/src/builtins/contains.rs
@@ -73,7 +73,7 @@ pub fn contains(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) ->
     } else {
         streams
             .err
-            .append(wgettext_fmt!("%s: Key not specified\n", cmd));
+            .append(&wgettext_fmt!("%s: Key not specified\n", cmd));
     }
 
     Err(STATUS_CMD_ERROR)

--- a/src/builtins/disown.rs
+++ b/src/builtins/disown.rs
@@ -23,7 +23,7 @@ fn disown_job(cmd: &wstr, streams: &mut IoStreams, j: &Job) {
                 libc::killpg(pgid.as_pid_t(), SIGCONT);
             }
         }
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             "%s: job %d ('%s') was stopped and has been signalled to continue.\n",
             cmd,
             j.job_id(),
@@ -68,7 +68,7 @@ pub fn disown(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
         } else {
             streams
                 .err
-                .append(wgettext_fmt!("%s: There are no suitable jobs\n", cmd));
+                .append(&wgettext_fmt!("%s: There are no suitable jobs\n", cmd));
             retval = Err(STATUS_CMD_ERROR);
         }
     } else {
@@ -91,7 +91,7 @@ pub fn disown(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
                     // Valid identifier but no such job
                     streams
                         .err
-                        .append(wgettext_fmt!("%s: Could not find job '%d'\n", cmd, pid));
+                        .append(&wgettext_fmt!("%s: Could not find job '%d'\n", cmd, pid));
                     None
                 })
             })

--- a/src/builtins/echo.rs
+++ b/src/builtins/echo.rs
@@ -218,7 +218,7 @@ pub fn echo(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Bui
     }
 
     if !out.is_empty() {
-        streams.out.append(out);
+        streams.out.append(&out);
     }
 
     Ok(SUCCESS)

--- a/src/builtins/emit.rs
+++ b/src/builtins/emit.rs
@@ -16,7 +16,7 @@ pub fn emit(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
     let Some(event_name) = argv.get(opts.optind) else {
         streams
             .err
-            .append(sprintf!(L!("%s: expected event name\n"), cmd));
+            .append(&sprintf!(L!("%s: expected event name\n"), cmd));
         return Err(STATUS_INVALID_ARGS);
     };
 

--- a/src/builtins/fg.rs
+++ b/src/builtins/fg.rs
@@ -37,7 +37,7 @@ pub fn fg(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Built
             None => {
                 streams
                     .err
-                    .append(wgettext_fmt!("%s: There are no suitable jobs\n", cmd));
+                    .append(&wgettext_fmt!("%s: There are no suitable jobs\n", cmd));
                 return Err(STATUS_INVALID_ARGS);
             }
             Some((pos, j)) => {
@@ -57,11 +57,11 @@ pub fn fg(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Built
         if found_job {
             streams
                 .err
-                .append(wgettext_fmt!("%s: Ambiguous job\n", cmd));
+                .append(&wgettext_fmt!("%s: Ambiguous job\n", cmd));
         } else {
             streams
                 .err
-                .append(wgettext_fmt!("%s: '%s' is not a job\n", cmd, argv[optind]));
+                .append(&wgettext_fmt!("%s: '%s' is not a job\n", cmd, argv[optind]));
         }
 
         builtin_print_error_trailer(parser, streams.err, cmd);
@@ -76,14 +76,14 @@ pub fn fg(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Built
                 {
                     streams
                         .err
-                        .append(wgettext_fmt!("%s: No suitable job: %d\n", cmd, pid));
+                        .append(&wgettext_fmt!("%s: No suitable job: %d\n", cmd, pid));
                     job_pos = None;
                     job = None
                 } else {
                     let (pos, j) = j.unwrap();
                     job_pos = Some(pos);
                     job = if !j.wants_job_control() {
-                        streams.err.append(wgettext_fmt!(
+                        streams.err.append(&wgettext_fmt!(
                                         "%s: Can't put job %d, '%s' to foreground because it is not under job control\n",
                                         cmd,
                                         pid,
@@ -111,7 +111,7 @@ pub fn fg(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Built
     if streams.err_is_redirected {
         streams
             .err
-            .append(wgettext_fmt!(FG_MSG, job.job_id(), job.command()));
+            .append(&wgettext_fmt!(FG_MSG, job.job_id(), job.command()));
     } else {
         // If we aren't redirecting, send output to real stderr, since stuff in sb_err won't get
         // printed until the command finishes.

--- a/src/builtins/fish_indent.rs
+++ b/src/builtins/fish_indent.rs
@@ -1008,7 +1008,7 @@ fn do_indent(streams: &mut IoStreams, args: Vec<WString>) -> BuiltinResult {
             '\x03' => output_type = OutputType::PygmentsCsv,
             'c' => output_type = OutputType::Check,
             ';' => {
-                streams.err.append(wgettext_fmt!(
+                streams.err.append(&wgettext_fmt!(
                     BUILTIN_ERR_UNEXP_ARG,
                     "fish_indent",
                     w.argv[w.wopt_index - 1]
@@ -1016,7 +1016,7 @@ fn do_indent(streams: &mut IoStreams, args: Vec<WString>) -> BuiltinResult {
                 return Err(STATUS_CMD_ERROR);
             }
             '?' => {
-                streams.err.append(wgettext_fmt!(
+                streams.err.append(&wgettext_fmt!(
                     BUILTIN_ERR_UNKNOWN,
                     "fish_indent",
                     w.argv[w.wopt_index - 1]
@@ -1078,7 +1078,7 @@ fn do_indent(streams: &mut IoStreams, args: Vec<WString>) -> BuiltinResult {
 
         if output_type == OutputType::PygmentsCsv {
             let output = make_pygments_csv(&src);
-            streams.out.append(bytes2wcstring(&output));
+            streams.out.append(&bytes2wcstring(&output));
             i += 1;
             continue;
         }
@@ -1176,7 +1176,7 @@ fn do_indent(streams: &mut IoStreams, args: Vec<WString>) -> BuiltinResult {
             }
         }
 
-        streams.out.append(bytes2wcstring(&colored_output));
+        streams.out.append(&bytes2wcstring(&colored_output));
         i += 1;
     }
     if retval == 0 {

--- a/src/builtins/fish_key_reader.rs
+++ b/src/builtins/fish_key_reader.rs
@@ -59,7 +59,7 @@ fn should_exit(
             {
                 return true;
             }
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "Press ctrl-%c again to exit\n",
                 char::from(modes.c_cc[evt] + 0x60)
             ));
@@ -107,7 +107,7 @@ fn process_input(
         if verbose {
             streams.out.append(L!("# decoded from: "));
             for (i, byte) in kevt.seq.chars().enumerate() {
-                streams.out.append(char_to_symbol(byte, i == 0));
+                streams.out.append(&char_to_symbol(byte, i == 0));
             }
             streams.out.append(L!("\n"));
         }
@@ -125,7 +125,7 @@ fn process_input(
             keys.push((base_layout_key, "physical key"));
         }
         for (key, explanation) in keys {
-            streams.out.append(sprintf!(
+            streams.out.append(&sprintf!(
                 "bind %s 'do something'%s%s\n",
                 key,
                 if explanation.is_empty() { "" } else { " # " },
@@ -208,7 +208,7 @@ fn parse_flags(
                 *verbose = true;
             }
             ';' => {
-                streams.err.append(wgettext_fmt!(
+                streams.err.append(&wgettext_fmt!(
                     BUILTIN_ERR_UNEXP_ARG,
                     "fish_key_reader",
                     w.argv[w.wopt_index - 1]
@@ -216,7 +216,7 @@ fn parse_flags(
                 return ControlFlow::Break(Err(STATUS_CMD_ERROR));
             }
             '?' => {
-                streams.err.append(wgettext_fmt!(
+                streams.err.append(&wgettext_fmt!(
                     BUILTIN_ERR_UNKNOWN,
                     "fish_key_reader",
                     w.argv[w.wopt_index - 1]

--- a/src/builtins/function.rs
+++ b/src/builtins/function.rs
@@ -94,7 +94,7 @@ fn parse_cmd_opts(
                 let woptarg = w.woptarg.unwrap().to_owned();
                 if handling_named_arguments {
                     if is_read_only(&woptarg) {
-                        streams.err.append(wgettext_fmt!(
+                        streams.err.append(&wgettext_fmt!(
                             "%s: variable '%s' is read-only\n",
                             cmd,
                             woptarg
@@ -103,7 +103,7 @@ fn parse_cmd_opts(
                     }
                     opts.named_arguments.push(woptarg);
                 } else {
-                    streams.err.append(wgettext_fmt!(
+                    streams.err.append(&wgettext_fmt!(
                         "%s: %s: unexpected positional argument",
                         cmd,
                         woptarg
@@ -116,7 +116,7 @@ fn parse_cmd_opts(
             }
             's' => {
                 let Some(signal) = Signal::parse(w.woptarg.unwrap()) else {
-                    streams.err.append(wgettext_fmt!(
+                    streams.err.append(&wgettext_fmt!(
                         "%s: Unknown signal '%s'",
                         cmd,
                         w.woptarg.unwrap()
@@ -128,7 +128,7 @@ fn parse_cmd_opts(
             'v' => {
                 let name = w.woptarg.unwrap().to_owned();
                 if !valid_var_name(&name) {
-                    streams.err.append(varname_error(cmd, &name));
+                    streams.err.append(&varname_error(cmd, &name));
                     return Err(STATUS_INVALID_ARGS);
                 }
                 opts.events.push(EventDescription::Variable { name });
@@ -147,7 +147,7 @@ fn parse_cmd_opts(
                         0
                     };
                     if caller_id == 0 {
-                        streams.err.append(wgettext_fmt!(
+                        streams.err.append(&wgettext_fmt!(
                             "%s: calling job for event handler not found",
                             cmd
                         ));
@@ -177,7 +177,7 @@ fn parse_cmd_opts(
             'a' => {
                 let name = w.woptarg.unwrap().to_owned();
                 if is_read_only(&name) {
-                    streams.err.append(wgettext_fmt!(
+                    streams.err.append(&wgettext_fmt!(
                         "%s: variable '%s' is read-only\n",
                         cmd,
                         name
@@ -196,7 +196,7 @@ fn parse_cmd_opts(
             'V' => {
                 let woptarg = w.woptarg.unwrap();
                 if !valid_var_name(woptarg) {
-                    streams.err.append(varname_error(cmd, woptarg));
+                    streams.err.append(&varname_error(cmd, woptarg));
                     return Err(STATUS_INVALID_ARGS);
                 }
                 opts.inherit_vars.push(woptarg.to_owned());
@@ -241,12 +241,12 @@ fn validate_function_name(
     if argv.len() < 2 {
         streams
             .err
-            .append(wgettext_fmt!("%s: function name required", cmd));
+            .append(&wgettext_fmt!("%s: function name required", cmd));
         return Err(STATUS_INVALID_ARGS);
     }
     *function_name = argv[1].to_owned();
     if !valid_func_name(function_name) {
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             "%s: %s: invalid function name",
             cmd,
             function_name,
@@ -254,7 +254,7 @@ fn validate_function_name(
         return Err(STATUS_INVALID_ARGS);
     }
     if parser_keywords_is_reserved(function_name) {
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             "%s: %s: cannot use reserved keyword as function name",
             cmd,
             function_name
@@ -300,13 +300,13 @@ pub fn function(
             // Remaining arguments are named arguments.
             for &arg in argv[optind..].iter() {
                 if !valid_var_name(arg) {
-                    streams.err.append(varname_error(cmd, arg));
+                    streams.err.append(&varname_error(cmd, arg));
                     return Err(STATUS_INVALID_ARGS);
                 }
                 opts.named_arguments.push(arg.to_owned());
             }
         } else {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "%s: %s: unexpected positional argument",
                 cmd,
                 argv[optind],
@@ -333,7 +333,7 @@ pub fn function(
 
     for named in &opts.named_arguments {
         if !valid_var_name(named) {
-            streams.err.append(varname_error(cmd, named));
+            streams.err.append(&varname_error(cmd, named));
             return Err(STATUS_INVALID_ARGS);
         }
     }

--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -132,13 +132,13 @@ pub fn functions(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -
         .count()
         > 1
     {
-        streams.err.append(wgettext_fmt!(BUILTIN_ERR_COMBO, cmd));
+        streams.err.append(&wgettext_fmt!(BUILTIN_ERR_COMBO, cmd));
         builtin_print_error_trailer(parser, streams.err, cmd);
         return Err(STATUS_INVALID_ARGS);
     }
 
     if opts.report_metadata && opts.no_metadata {
-        streams.err.append(wgettext_fmt!(BUILTIN_ERR_COMBO, cmd));
+        streams.err.append(&wgettext_fmt!(BUILTIN_ERR_COMBO, cmd));
         builtin_print_error_trailer(parser, streams.err, cmd);
         return Err(STATUS_INVALID_ARGS);
     }
@@ -153,7 +153,7 @@ pub fn functions(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -
 
     if let Some(desc) = opts.description {
         if args.len() != 1 {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "%s: Expected exactly one function name\n",
                 cmd
             ));
@@ -163,7 +163,7 @@ pub fn functions(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -
         let current_func = args[0];
 
         if !function::exists(current_func, parser) {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "%s: Function '%s' does not exist\n",
                 cmd,
                 current_func
@@ -178,7 +178,7 @@ pub fn functions(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -
 
     if opts.report_metadata {
         if args.len() != 1 {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 BUILTIN_ERR_ARG_COUNT2,
                 cmd,
                 // This error is
@@ -261,7 +261,7 @@ pub fn functions(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -
         if !opts.handlers_type.unwrap_or(L!("")).is_empty()
             && !event::EVENT_FILTER_NAMES.contains(&opts.handlers_type.unwrap())
         {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "%s: Expected generic | variable | signal | exit | job-id for --handlers-type\n",
                 cmd
             ));
@@ -290,7 +290,7 @@ pub fn functions(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -
             }
             streams
                 .out
-                .append(reformat_for_screen(&buff, &termsize_last()));
+                .append(&reformat_for_screen(&buff, &termsize_last()));
         } else {
             for name in names {
                 streams.out.appendln(name);
@@ -301,7 +301,7 @@ pub fn functions(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -
 
     if opts.copy {
         if args.len() != 2 {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "%s: Expected exactly two names (current function name, and new function name)\n",
                 cmd
             ));
@@ -312,7 +312,7 @@ pub fn functions(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -
         let new_func = args[1];
 
         if !function::exists(current_func, parser) {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "%s: Function '%s' does not exist\n",
                 cmd,
                 current_func
@@ -322,7 +322,7 @@ pub fn functions(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -
         }
 
         if !valid_func_name(new_func) || parser_keywords_is_reserved(new_func) {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "%s: Illegal function name '%s'\n",
                 cmd,
                 new_func
@@ -332,7 +332,7 @@ pub fn functions(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -
         }
 
         if function::exists(new_func, parser) {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "%s: Function '%s' already exists. Cannot create copy of '%s'\n",
                 cmd,
                 new_func,
@@ -419,9 +419,9 @@ pub fn functions(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -
             highlight_shell(&def, &mut colors, &parser.context(), false, None);
             streams
                 .out
-                .append(bytes2wcstring(&colorize(&def, &colors, parser.vars())));
+                .append(&bytes2wcstring(&colorize(&def, &colors, parser.vars())));
         } else {
-            streams.out.append(def);
+            streams.out.append(&def);
         }
         first = false;
     }

--- a/src/builtins/history.rs
+++ b/src/builtins/history.rs
@@ -92,7 +92,7 @@ fn set_hist_cmd(
     streams: &mut IoStreams,
 ) -> bool {
     if *hist_cmd != HistCmd::None {
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             BUILTIN_ERR_COMBO2_EXCLUSIVE,
             cmd,
             hist_cmd.to_wstr(),
@@ -112,7 +112,7 @@ fn check_for_unexpected_hist_args(
 ) -> bool {
     if opts.search_type.is_some() || opts.show_time_format.is_some() || opts.null_terminate {
         let subcmd_str = opts.hist_cmd.to_wstr();
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             "%s: %s: subcommand takes no options\n",
             cmd,
             subcmd_str
@@ -121,7 +121,7 @@ fn check_for_unexpected_hist_args(
     }
     if !args.is_empty() {
         let subcmd_str = opts.hist_cmd.to_wstr();
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             BUILTIN_ERR_ARG_COUNT2,
             cmd,
             subcmd_str,
@@ -193,7 +193,7 @@ fn parse_cmd_opts(
             'n' => match fish_wcstol(w.woptarg.unwrap()) {
                 Ok(x) => opts.max_items = Some(x as _), // todo!("historical behavior is to cast")
                 Err(_) => {
-                    streams.err.append(wgettext_fmt!(
+                    streams.err.append(&wgettext_fmt!(
                         BUILTIN_ERR_NOT_NUMBER,
                         cmd,
                         w.woptarg.unwrap()
@@ -334,7 +334,7 @@ pub fn history(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> 
             }
 
             if in_private_mode(parser.vars()) {
-                streams.err.append(wgettext_fmt!(
+                streams.err.append(&wgettext_fmt!(
                     "%s: can't merge history in private mode\n",
                     cmd
                 ));

--- a/src/builtins/jobs.rs
+++ b/src/builtins/jobs.rs
@@ -79,7 +79,7 @@ fn builtin_jobs_print(j: &Job, mode: JobsPrintMode, header: bool, streams: &mut 
             out += &cmd[..];
 
             out += "\n";
-            streams.out.append(out);
+            streams.out.append(&out);
         }
         JobsPrintMode::PrintGroup => {
             if header {
@@ -87,7 +87,7 @@ fn builtin_jobs_print(j: &Job, mode: JobsPrintMode, header: bool, streams: &mut 
                 out += wgettext!("Group\n");
             }
             out += &sprintf!("%s\n", pgid)[..];
-            streams.out.append(out);
+            streams.out.append(&out);
         }
         JobsPrintMode::PrintPid => {
             if header {
@@ -98,7 +98,7 @@ fn builtin_jobs_print(j: &Job, mode: JobsPrintMode, header: bool, streams: &mut 
             for p in j.external_procs() {
                 out += &sprintf!("%d\n", *p.pid.get().unwrap())[..];
             }
-            streams.out.append(out);
+            streams.out.append(&out);
         }
         JobsPrintMode::PrintCommand => {
             if header {
@@ -109,7 +109,7 @@ fn builtin_jobs_print(j: &Job, mode: JobsPrintMode, header: bool, streams: &mut 
             for p in j.processes() {
                 out += &sprintf!("%s\n", p.argv0().unwrap())[..];
             }
-            streams.out.append(out);
+            streams.out.append(&out);
         }
     };
 }
@@ -192,7 +192,7 @@ pub fn jobs(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
             if arg.char_at(0) == '%' {
                 match fish_wcstoi(&arg[1..]).ok().filter(|&job_id| job_id >= 0) {
                     None => {
-                        streams.err.append(wgettext_fmt!(
+                        streams.err.append(&wgettext_fmt!(
                             "%s: '%s' is not a valid job ID\n",
                             cmd,
                             arg
@@ -222,7 +222,7 @@ pub fn jobs(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
                 if mode != JobsPrintMode::PrintNothing {
                     streams
                         .err
-                        .append(wgettext_fmt!("%s: No suitable job: %s\n", cmd, arg));
+                        .append(&wgettext_fmt!("%s: No suitable job: %s\n", cmd, arg));
                 }
                 return Err(STATUS_CMD_ERROR);
             }
@@ -242,7 +242,7 @@ pub fn jobs(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
         if !streams.out_is_redirected && mode != JobsPrintMode::PrintNothing {
             streams
                 .out
-                .append(wgettext_fmt!("%s: There are no jobs\n", argv[0]));
+                .append(&wgettext_fmt!("%s: There are no jobs\n", argv[0]));
         }
         return Err(STATUS_CMD_ERROR);
     }

--- a/src/builtins/math.rs
+++ b/src/builtins/math.rs
@@ -69,7 +69,7 @@ fn parse_cmd_opts(
                     if scale < 0 || scale > 15 {
                         streams
                             .err
-                            .append(wgettext_fmt!("%s: %s: invalid scale\n", cmd, optarg));
+                            .append(&wgettext_fmt!("%s: %s: invalid scale\n", cmd, optarg));
                         return Err(STATUS_INVALID_ARGS);
                     }
                     // We know the value is in the range [0, 15]
@@ -89,7 +89,7 @@ fn parse_cmd_opts(
                 } else {
                     streams
                         .err
-                        .append(wgettext_fmt!("%s: %s: invalid mode\n", cmd, optarg));
+                        .append(&wgettext_fmt!("%s: %s: invalid mode\n", cmd, optarg));
                     return Err(STATUS_INVALID_ARGS);
                 }
             }
@@ -102,7 +102,7 @@ fn parse_cmd_opts(
                 } else {
                     let base = fish_wcstoi(optarg).unwrap_or(-1);
                     if base != 8 && base != 16 {
-                        streams.err.append(wgettext_fmt!(
+                        streams.err.append(&wgettext_fmt!(
                             "%s: %s: invalid base value\n",
                             cmd,
                             optarg
@@ -142,7 +142,7 @@ fn parse_cmd_opts(
     }
 
     if have_scale && opts.scale != 0 && opts.base != 10 {
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             BUILTIN_ERR_COMBO2,
             cmd,
             "non-zero scale value only valid
@@ -239,30 +239,30 @@ fn evaluate_expression(
                 let mut s = format_double(n, opts);
                 s.push('\n');
 
-                streams.out.append(s);
+                streams.out.append(&s);
                 return Ok(SUCCESS);
             };
 
             streams
                 .err
-                .append(sprintf!("%s: Error: %s\n", cmd, error_message));
-            streams.err.append(sprintf!("'%s'\n", expression));
+                .append(&sprintf!("%s: Error: %s\n", cmd, error_message));
+            streams.err.append(&sprintf!("'%s'\n", expression));
 
             Err(STATUS_CMD_ERROR)
         }
         Err(err) => {
-            streams.err.append(sprintf!(
+            streams.err.append(&sprintf!(
                 L!("%s: Error: %s\n"),
                 cmd,
                 err.kind.describe_wstr()
             ));
-            streams.err.append(sprintf!("'%s'\n", expression));
+            streams.err.append(&sprintf!("'%s'\n", expression));
             let padding = WString::from_chars(vec![' '; err.position + 1]);
             if err.len >= 2 {
                 let tildes = WString::from_chars(vec!['~'; err.len - 2]);
-                streams.err.append(sprintf!("%s^%s^\n", padding, tildes));
+                streams.err.append(&sprintf!("%s^%s^\n", padding, tildes));
             } else {
-                streams.err.append(sprintf!("%s^\n", padding));
+                streams.err.append(&sprintf!("%s^\n", padding));
             }
 
             Err(STATUS_CMD_ERROR)
@@ -295,7 +295,7 @@ pub fn math(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
     if expression.is_empty() {
         streams
             .err
-            .append(wgettext_fmt!(BUILTIN_ERR_MIN_ARG_COUNT1, cmd, 1, 0));
+            .append(&wgettext_fmt!(BUILTIN_ERR_MIN_ARG_COUNT1, cmd, 1, 0));
         return Err(STATUS_CMD_ERROR);
     }
 

--- a/src/builtins/path.rs
+++ b/src/builtins/path.rs
@@ -23,7 +23,7 @@ macro_rules! path_error {
     $(,)?
     ) => {
         $streams.err.append(L!("path "));
-        $streams.err.append(wgettext_fmt!($string, $($args),*));
+        $streams.err.append(&wgettext_fmt!($string, $($args),*));
     };
 }
 
@@ -171,7 +171,7 @@ fn path_out(streams: &mut IoStreams, opts: &Options<'_>, s: impl AsRef<wstr>) {
             let mut output = WString::with_capacity(s.len() + 1);
             output.push_utfstr(s);
             output.push('\0');
-            streams.out.append(output);
+            streams.out.append(&output);
         }
     }
 }
@@ -953,7 +953,7 @@ pub fn path(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Bui
     if argc <= 1 {
         streams
             .err
-            .append(wgettext_fmt!(BUILTIN_ERR_MISSING_SUBCMD, cmd));
+            .append(&wgettext_fmt!(BUILTIN_ERR_MISSING_SUBCMD, cmd));
         builtin_print_error_trailer(parser, streams.err, cmd);
         return Err(STATUS_INVALID_ARGS);
     }
@@ -979,7 +979,7 @@ pub fn path(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Bui
         _ => {
             streams
                 .err
-                .append(wgettext_fmt!(BUILTIN_ERR_INVALID_SUBCMD, cmd, subcmd_name));
+                .append(&wgettext_fmt!(BUILTIN_ERR_INVALID_SUBCMD, cmd, subcmd_name));
             builtin_print_error_trailer(parser, streams.err, cmd);
             return Err(STATUS_INVALID_ARGS);
         }

--- a/src/builtins/pwd.rs
+++ b/src/builtins/pwd.rs
@@ -40,7 +40,7 @@ pub fn pwd(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Buil
     if w.wopt_index != argc {
         streams
             .err
-            .append(wgettext_fmt!(BUILTIN_ERR_ARG_COUNT1, cmd, 0, argc - 1));
+            .append(&wgettext_fmt!(BUILTIN_ERR_ARG_COUNT1, cmd, 0, argc - 1));
         return Err(STATUS_INVALID_ARGS);
     }
 
@@ -52,7 +52,7 @@ pub fn pwd(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Buil
         if let Some(real_pwd) = wrealpath(&pwd) {
             pwd = real_pwd;
         } else {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "%s: realpath failed: %s\n",
                 cmd,
                 errno().to_string()

--- a/src/builtins/random.rs
+++ b/src/builtins/random.rs
@@ -59,7 +59,7 @@ pub fn random(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
         if arg_count == 1 {
             streams
                 .err
-                .append(wgettext_fmt!("%s: nothing to choose from\n", cmd));
+                .append(&wgettext_fmt!("%s: nothing to choose from\n", cmd));
             return Err(STATUS_INVALID_ARGS);
         }
 
@@ -72,7 +72,7 @@ pub fn random(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
         if res.is_err() {
             streams
                 .err
-                .append(wgettext_fmt!("%s: %s: invalid integer\n", cmd, num));
+                .append(&wgettext_fmt!("%s: %s: invalid integer\n", cmd, num));
         }
         res
     }
@@ -81,7 +81,7 @@ pub fn random(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
         if res.is_err() {
             streams
                 .err
-                .append(wgettext_fmt!("%s: %s: invalid integer\n", cmd, num));
+                .append(&wgettext_fmt!("%s: %s: invalid integer\n", cmd, num));
         }
         res
     }
@@ -127,7 +127,7 @@ pub fn random(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
                 Ok(0) => {
                     streams
                         .err
-                        .append(wgettext_fmt!("%s: STEP must be a positive integer\n", cmd,));
+                        .append(&wgettext_fmt!("%s: STEP must be a positive integer\n", cmd,));
                     return Err(STATUS_INVALID_ARGS);
                 }
                 Ok(x) => step = x,
@@ -141,7 +141,7 @@ pub fn random(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
         _ => {
             streams
                 .err
-                .append(wgettext_fmt!("%s: too many arguments\n", cmd,));
+                .append(&wgettext_fmt!("%s: too many arguments\n", cmd,));
             return Err(STATUS_CMD_ERROR);
         }
     }

--- a/src/builtins/read.rs
+++ b/src/builtins/read.rs
@@ -122,7 +122,7 @@ fn parse_cmd_opts(
                 opts.delimiter = Some(w.woptarg.unwrap().to_owned());
             }
             'i' => {
-                streams.err.append(wgettext_fmt!(
+                streams.err.append(&wgettext_fmt!(
                     "%s: usage of -i for --silent is deprecated. Please use -s or --silent instead.\n",
                     cmd
                 ));
@@ -147,7 +147,7 @@ fn parse_cmd_opts(
                 opts.nchars = match fish_wcstoi(w.woptarg.unwrap()) {
                     Ok(n) if n >= 0 => NonZeroUsize::new(n.try_into().unwrap()),
                     Err(wutil::Error::Overflow) => {
-                        streams.err.append(wgettext_fmt!(
+                        streams.err.append(&wgettext_fmt!(
                             "%s: Argument '%s' is out of range\n",
                             cmd,
                             w.woptarg.unwrap()
@@ -156,7 +156,7 @@ fn parse_cmd_opts(
                         return Err(STATUS_INVALID_ARGS);
                     }
                     _ => {
-                        streams.err.append(wgettext_fmt!(
+                        streams.err.append(&wgettext_fmt!(
                             BUILTIN_ERR_NOT_NUMBER,
                             cmd,
                             w.woptarg.unwrap()
@@ -189,7 +189,7 @@ fn parse_cmd_opts(
                 };
                 if let Some(old_mode) = opts.token_mode {
                     if old_mode != new_mode {
-                        streams.err.append(wgettext_fmt!(
+                        streams.err.append(&wgettext_fmt!(
                             BUILTIN_ERR_COMBO2,
                             cmd,
                             wgettext_fmt!(
@@ -448,7 +448,7 @@ fn validate_read_args(
     streams: &mut IoStreams,
 ) -> BuiltinResult {
     if opts.prompt.is_some() && opts.prompt_str.is_some() {
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             "%s: Options %s and %s cannot be used together\n",
             cmd,
             "-p",
@@ -459,7 +459,7 @@ fn validate_read_args(
     }
 
     if opts.delimiter.is_some() && opts.one_line {
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             "%s: Options %s and %s cannot be used together\n",
             cmd,
             "--delimiter",
@@ -468,7 +468,7 @@ fn validate_read_args(
         return Err(STATUS_INVALID_ARGS);
     }
     if opts.one_line && opts.split_null {
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             "%s: Options %s and %s cannot be used together\n",
             cmd,
             "-z",
@@ -484,7 +484,9 @@ fn validate_read_args(
     }
 
     if opts.place.contains(EnvMode::UNEXPORT) && opts.place.contains(EnvMode::EXPORT) {
-        streams.err.append(wgettext_fmt!(BUILTIN_ERR_EXPUNEXP, cmd));
+        streams
+            .err
+            .append(&wgettext_fmt!(BUILTIN_ERR_EXPUNEXP, cmd));
         builtin_print_error_trailer(parser, streams.err, cmd);
         return Err(STATUS_INVALID_ARGS);
     }
@@ -496,7 +498,7 @@ fn validate_read_args(
         .count()
         > 1
     {
-        streams.err.append(wgettext_fmt!(BUILTIN_ERR_GLOCAL, cmd));
+        streams.err.append(&wgettext_fmt!(BUILTIN_ERR_GLOCAL, cmd));
         builtin_print_error_trailer(parser, streams.err, cmd);
         return Err(STATUS_INVALID_ARGS);
     }
@@ -505,21 +507,21 @@ fn validate_read_args(
     if !opts.array && argc < 1 && !opts.to_stdout {
         streams
             .err
-            .append(wgettext_fmt!(BUILTIN_ERR_MIN_ARG_COUNT1, cmd, 1, argc));
+            .append(&wgettext_fmt!(BUILTIN_ERR_MIN_ARG_COUNT1, cmd, 1, argc));
         return Err(STATUS_INVALID_ARGS);
     }
 
     if opts.array && argc != 1 {
         streams
             .err
-            .append(wgettext_fmt!(BUILTIN_ERR_ARG_COUNT1, cmd, 1, argc));
+            .append(&wgettext_fmt!(BUILTIN_ERR_ARG_COUNT1, cmd, 1, argc));
         return Err(STATUS_INVALID_ARGS);
     }
 
     if opts.to_stdout && argc > 0 {
         streams
             .err
-            .append(wgettext_fmt!(BUILTIN_ERR_MAX_ARG_COUNT1, cmd, 0, argc));
+            .append(&wgettext_fmt!(BUILTIN_ERR_MAX_ARG_COUNT1, cmd, 0, argc));
         return Err(STATUS_INVALID_ARGS);
     }
 
@@ -533,7 +535,7 @@ fn validate_read_args(
 
     if let Some(token_mode) = opts.token_mode {
         if opts.delimiter.is_some() {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 BUILTIN_ERR_COMBO2_EXCLUSIVE,
                 cmd,
                 "--delimiter",
@@ -543,7 +545,7 @@ fn validate_read_args(
         }
 
         if opts.one_line {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 BUILTIN_ERR_COMBO2_EXCLUSIVE,
                 cmd,
                 "--line",
@@ -556,12 +558,12 @@ fn validate_read_args(
     // Verify all variable names.
     for arg in argv {
         if !valid_var_name(arg) {
-            streams.err.append(varname_error(cmd, arg));
+            streams.err.append(&varname_error(cmd, arg));
             builtin_print_error_trailer(parser, streams.err, cmd);
             return Err(STATUS_INVALID_ARGS);
         }
         if EnvVar::flags_for(arg).contains(EnvVarFlags::READ_ONLY) {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "%s: %s: cannot overwrite read-only variable",
                 cmd,
                 arg
@@ -603,7 +605,7 @@ pub fn read(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
     if streams.stdin_fd < 0 {
         streams
             .err
-            .append(wgettext_fmt!("%s: stdin is closed\n", cmd));
+            .append(&wgettext_fmt!("%s: stdin is closed\n", cmd));
         return Err(STATUS_CMD_ERROR);
     }
 
@@ -677,7 +679,7 @@ pub fn read(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
         }
 
         if opts.to_stdout {
-            streams.out.append(buff);
+            streams.out.append(&buff);
             return exit_res;
         }
 

--- a/src/builtins/realpath.rs
+++ b/src/builtins/realpath.rs
@@ -69,7 +69,7 @@ pub fn realpath(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) ->
 
     // TODO: allow arbitrary args. `realpath *` should print many paths
     if optind + 1 != args.len() {
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             BUILTIN_ERR_ARG_COUNT1,
             cmd,
             0,
@@ -83,13 +83,13 @@ pub fn realpath(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) ->
 
     if !opts.no_symlinks {
         if let Some(real_path) = wrealpath(arg) {
-            streams.out.append(real_path);
+            streams.out.append(&real_path);
         } else {
             let errno = errno();
             if errno.0 != 0 {
                 // realpath() just couldn't do it. Report the error and make it clear
                 // this is an error from our builtin, not the system's realpath.
-                streams.err.append(wgettext_fmt!(
+                streams.err.append(&wgettext_fmt!(
                     "builtin %s: %s: %s\n",
                     cmd,
                     arg,
@@ -99,7 +99,7 @@ pub fn realpath(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) ->
                 // Who knows. Probably a bug in our wrealpath() implementation.
                 streams
                     .err
-                    .append(wgettext_fmt!("builtin %s: Invalid arg: %s\n", cmd, arg));
+                    .append(&wgettext_fmt!("builtin %s: Invalid arg: %s\n", cmd, arg));
             }
 
             return Err(STATUS_CMD_ERROR);
@@ -114,9 +114,9 @@ pub fn realpath(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) ->
             } else {
                 path_apply_working_directory(arg, &realpwd)
             };
-            streams.out.append(normalize_path(&absolute_arg, false));
+            streams.out.append(&normalize_path(&absolute_arg, false));
         } else {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "builtin %s: realpath failed: %s\n",
                 cmd,
                 errno().to_string()

--- a/src/builtins/return.rs
+++ b/src/builtins/return.rs
@@ -99,7 +99,7 @@ pub fn parse_return_value(
     if optind + 1 < args.len() {
         streams
             .err
-            .append(wgettext_fmt!(BUILTIN_ERR_TOO_MANY_ARGUMENTS, cmd));
+            .append(&wgettext_fmt!(BUILTIN_ERR_TOO_MANY_ARGUMENTS, cmd));
         builtin_print_error_trailer(parser, streams.err, cmd);
         return ControlFlow::Break(Err(STATUS_INVALID_ARGS));
     }
@@ -111,7 +111,7 @@ pub fn parse_return_value(
             Err(_e) => {
                 streams
                     .err
-                    .append(wgettext_fmt!(BUILTIN_ERR_NOT_NUMBER, cmd, args[1]));
+                    .append(&wgettext_fmt!(BUILTIN_ERR_NOT_NUMBER, cmd, args[1]));
                 builtin_print_error_trailer(parser, streams.err, cmd);
                 ControlFlow::Break(Err(STATUS_INVALID_ARGS))
             }

--- a/src/builtins/set.rs
+++ b/src/builtins/set.rs
@@ -232,14 +232,14 @@ impl Options {
     ) -> Result<(), ErrorCode> {
         // Can't query and erase or list.
         if opts.query && (opts.erase || opts.list) {
-            streams.err.append(wgettext_fmt!(BUILTIN_ERR_COMBO, cmd));
+            streams.err.append(&wgettext_fmt!(BUILTIN_ERR_COMBO, cmd));
             builtin_print_error_trailer(parser, streams.err, cmd);
             return Err(STATUS_INVALID_ARGS);
         }
 
         // We can't both list and erase variables.
         if opts.erase && opts.list {
-            streams.err.append(wgettext_fmt!(BUILTIN_ERR_COMBO, cmd));
+            streams.err.append(&wgettext_fmt!(BUILTIN_ERR_COMBO, cmd));
             builtin_print_error_trailer(parser, streams.err, cmd);
             return Err(STATUS_INVALID_ARGS);
         }
@@ -253,14 +253,16 @@ impl Options {
             // ..unless we are erasing a variable, in which case we can erase from several in one go.
             && !opts.erase
         {
-            streams.err.append(wgettext_fmt!(BUILTIN_ERR_GLOCAL, cmd));
+            streams.err.append(&wgettext_fmt!(BUILTIN_ERR_GLOCAL, cmd));
             builtin_print_error_trailer(parser, streams.err, cmd);
             return Err(STATUS_INVALID_ARGS);
         }
 
         // Variables can only have one export status.
         if opts.exportv && opts.unexport {
-            streams.err.append(wgettext_fmt!(BUILTIN_ERR_EXPUNEXP, cmd));
+            streams
+                .err
+                .append(&wgettext_fmt!(BUILTIN_ERR_EXPUNEXP, cmd));
             builtin_print_error_trailer(parser, streams.err, cmd);
             return Err(STATUS_INVALID_ARGS);
         }
@@ -269,14 +271,14 @@ impl Options {
         if opts.pathvar && opts.unpathvar {
             streams
                 .err
-                .append(wgettext_fmt!(BUILTIN_ERR_PATHUNPATH, cmd));
+                .append(&wgettext_fmt!(BUILTIN_ERR_PATHUNPATH, cmd));
             builtin_print_error_trailer(parser, streams.err, cmd);
             return Err(STATUS_INVALID_ARGS);
         }
 
         // Trying to erase and (un)export at the same time doesn't make sense.
         if opts.erase && (opts.exportv || opts.unexport) {
-            streams.err.append(wgettext_fmt!(BUILTIN_ERR_COMBO, cmd));
+            streams.err.append(&wgettext_fmt!(BUILTIN_ERR_COMBO, cmd));
             builtin_print_error_trailer(parser, streams.err, cmd);
             return Err(STATUS_INVALID_ARGS);
         }
@@ -291,7 +293,7 @@ impl Options {
                 || opts.exportv
                 || opts.universal)
         {
-            streams.err.append(wgettext_fmt!(BUILTIN_ERR_COMBO, cmd));
+            streams.err.append(&wgettext_fmt!(BUILTIN_ERR_COMBO, cmd));
             builtin_print_error_trailer(parser, streams.err, cmd);
             return Err(STATUS_INVALID_ARGS);
         }
@@ -299,7 +301,7 @@ impl Options {
         if args.len() == optind && opts.erase {
             streams
                 .err
-                .append(wgettext_fmt!(BUILTIN_ERR_MISSING, cmd, L!("--erase")));
+                .append(&wgettext_fmt!(BUILTIN_ERR_MISSING, cmd, L!("--erase")));
             builtin_print_error_trailer(parser, streams.err, cmd);
             return Err(STATUS_INVALID_ARGS);
         }
@@ -321,7 +323,7 @@ fn warn_if_uvar_shadows_global(
         && parser.is_interactive()
         && parser.vars().getf(dest, EnvMode::GLOBAL).is_some()
     {
-        streams.err.append(wgettext_fmt!(UVAR_ERR, cmd, dest));
+        streams.err.append(&wgettext_fmt!(UVAR_ERR, cmd, dest));
     }
 }
 
@@ -329,28 +331,28 @@ fn handle_env_return(retval: EnvStackSetResult, cmd: &wstr, key: &wstr, streams:
     match retval {
         EnvStackSetResult::Ok => (),
         EnvStackSetResult::Perm => {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "%s: Tried to change the read-only variable '%s'\n",
                 cmd,
                 key
             ));
         }
         EnvStackSetResult::Scope => {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "%s: Tried to modify the special variable '%s' with the wrong scope\n",
                 cmd,
                 key
             ));
         }
         EnvStackSetResult::Invalid => {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "%s: Tried to modify the special variable '%s' to an invalid value\n",
                 cmd,
                 key
             ));
         }
         EnvStackSetResult::NotFound => {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "%s: The variable '%s' does not exist\n",
                 cmd,
                 key
@@ -430,7 +432,7 @@ fn split_var_and_indexes<'a>(
     match split_var_and_indexes_internal(arg, mode, vars) {
         Ok(split) => Some(split),
         Err(EnvArrayParseError::InvalidIndex(varname)) => {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "%s: Invalid index starting at '%s'\n",
                 "set",
                 &varname,
@@ -590,7 +592,7 @@ fn list(opts: &Options, parser: &Parser, streams: &mut IoStreams) -> BuiltinResu
         }
 
         out.push('\n');
-        streams.out.append(out);
+        streams.out.append(&out);
     }
 
     Ok(SUCCESS)
@@ -659,7 +661,7 @@ fn show_scope(var_name: &wstr, scope: EnvMode, streams: &mut IoStreams, vars: &d
         L!("")
     };
     let vals = var.as_list();
-    streams.out.append(wgettext_fmt!(
+    streams.out.append(&wgettext_fmt!(
         "$%s: set in %s scope, %s,%s with %d elements",
         var_name,
         scope_name,
@@ -697,7 +699,7 @@ fn show_scope(var_name: &wstr, scope: EnvMode, streams: &mut IoStreams, vars: &d
         );
         streams
             .out
-            .append(sprintf!("$%s[%d]: |%s|\n", var_name, i + 1, &escaped_val));
+            .append(&sprintf!("$%s[%d]: |%s|\n", var_name, i + 1, &escaped_val));
     }
 }
 
@@ -722,7 +724,7 @@ fn show(cmd: &wstr, parser: &Parser, streams: &mut IoStreams, args: &[&wstr]) ->
                     inherited,
                     EscapeStringStyle::Script(EscapeFlags::NO_PRINTABLES | EscapeFlags::NO_QUOTED),
                 );
-                streams.out.append(wgettext_fmt!(
+                streams.out.append(&wgettext_fmt!(
                     "$%s: originally inherited as |%s|\n",
                     name,
                     escaped_val
@@ -732,13 +734,13 @@ fn show(cmd: &wstr, parser: &Parser, streams: &mut IoStreams, args: &[&wstr]) ->
     } else {
         for arg in args.iter().copied() {
             if !valid_var_name(arg) {
-                streams.err.append(varname_error(cmd, arg));
+                streams.err.append(&varname_error(cmd, arg));
                 builtin_print_error_trailer(parser, streams.err, cmd);
                 return Err(STATUS_INVALID_ARGS);
             }
 
             if arg.contains('[') {
-                streams.err.append(wgettext_fmt!(
+                streams.err.append(&wgettext_fmt!(
                     "%s: `set --show` does not allow slices with the var names\n",
                     cmd
                 ));
@@ -754,7 +756,7 @@ fn show(cmd: &wstr, parser: &Parser, streams: &mut IoStreams, args: &[&wstr]) ->
                     inherited,
                     EscapeStringStyle::Script(EscapeFlags::NO_PRINTABLES | EscapeFlags::NO_QUOTED),
                 );
-                streams.out.append(wgettext_fmt!(
+                streams.out.append(&wgettext_fmt!(
                     "$%s: originally inherited as |%s|\n",
                     arg,
                     escaped_val
@@ -788,7 +790,7 @@ fn erase(
             };
 
             if !valid_var_name(split.varname) {
-                streams.err.append(varname_error(cmd, split.varname));
+                streams.err.append(&varname_error(cmd, split.varname));
                 builtin_print_error_trailer(parser, streams.err, cmd);
                 return Err(STATUS_INVALID_ARGS);
             }
@@ -909,7 +911,7 @@ fn set_internal(
     if argv.is_empty() {
         streams
             .err
-            .append(wgettext_fmt!(BUILTIN_ERR_MIN_ARG_COUNT1, cmd, 1));
+            .append(&wgettext_fmt!(BUILTIN_ERR_MIN_ARG_COUNT1, cmd, 1));
         builtin_print_error_trailer(parser, streams.err, cmd);
         return Err(STATUS_INVALID_ARGS);
     }
@@ -925,9 +927,9 @@ fn set_internal(
 
     // Is the variable valid?
     if !valid_var_name(split.varname) {
-        streams.err.append(varname_error(cmd, split.varname));
+        streams.err.append(&varname_error(cmd, split.varname));
         if let Some(pos) = split.varname.chars().position(|c| c == '=') {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "%s: Did you mean `set %s %s`?",
                 cmd,
                 &escape(&split.varname[..pos]),
@@ -945,14 +947,14 @@ fn set_internal(
             if *ind <= 0 {
                 streams
                     .err
-                    .append(wgettext_fmt!("%s: array index out of bounds\n", cmd));
+                    .append(&wgettext_fmt!("%s: array index out of bounds\n", cmd));
                 builtin_print_error_trailer(parser, streams.err, cmd);
                 return Err(STATUS_INVALID_ARGS);
             }
         }
         // Append and prepend are disallowed.
         if opts.append || opts.prepend {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "%s: Cannot use --append or --prepend when assigning to a slice",
                 cmd
             ));
@@ -962,7 +964,7 @@ fn set_internal(
 
         // Argument count and index count must agree.
         if split.indexes.len() != argv.len() {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 MISMATCHED_ARGS,
                 cmd,
                 split.indexes.len(),

--- a/src/builtins/set_color.rs
+++ b/src/builtins/set_color.rs
@@ -47,7 +47,7 @@ fn print_colors(
     } // conveniently, 'normal' is always the last color so we don't need to reset here
 
     let contents = outp.contents();
-    streams.out.append(bytes2wcstring(contents));
+    streams.out.append(&bytes2wcstring(contents));
 }
 
 /// set_color builtin.
@@ -99,11 +99,11 @@ pub fn set_color(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
             Err(UnknownColor(arg)) => {
                 streams
                     .err
-                    .append(wgettext_fmt!("%s: Unknown color '%s'\n", argv[0], arg));
+                    .append(&wgettext_fmt!("%s: Unknown color '%s'\n", argv[0], arg));
                 return Err(STATUS_INVALID_ARGS);
             }
             Err(UnknownUnderlineStyle(arg)) => {
-                streams.err.append(wgettext_fmt!(
+                streams.err.append(&wgettext_fmt!(
                     "%s: invalid underline style: %s\n",
                     argv[0],
                     arg
@@ -147,7 +147,7 @@ pub fn set_color(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -
 
     // Output the collected string.
     let contents = outp.contents();
-    streams.out.append(bytes2wcstring(contents));
+    streams.out.append(&bytes2wcstring(contents));
 
     Ok(SUCCESS)
 }

--- a/src/builtins/shared.rs
+++ b/src/builtins/shared.rs
@@ -633,7 +633,7 @@ pub fn builtin_print_help(parser: &Parser, streams: &mut IoStreams, cmd: &wstr) 
     if res.status.normal_exited() && res.status.exit_code() == 2 {
         streams
             .err
-            .append(wgettext_fmt!(BUILTIN_ERR_MISSING_HELP, name_esc, name_esc));
+            .append(&wgettext_fmt!(BUILTIN_ERR_MISSING_HELP, name_esc, name_esc));
     }
 }
 
@@ -647,7 +647,7 @@ pub fn builtin_unknown_option(
 ) {
     streams
         .err
-        .append(wgettext_fmt!(BUILTIN_ERR_UNKNOWN, cmd, opt));
+        .append(&wgettext_fmt!(BUILTIN_ERR_UNKNOWN, cmd, opt));
     if print_hints {
         builtin_print_error_trailer(parser, streams.err, cmd);
     }
@@ -664,7 +664,7 @@ pub fn builtin_missing_argument(
     if opt.char_at(0) == '-' && opt.char_at(1) != '-' {
         // if c in -qc '-qc' is missing the argument, now opt is just 'c'
         opt = &opt[opt.len() - 1..];
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             BUILTIN_ERR_MISSING,
             cmd,
             L!("-").to_owned() + opt
@@ -672,7 +672,7 @@ pub fn builtin_missing_argument(
     } else {
         streams
             .err
-            .append(wgettext_fmt!(BUILTIN_ERR_MISSING, cmd, opt));
+            .append(&wgettext_fmt!(BUILTIN_ERR_MISSING, cmd, opt));
     }
     if print_hints {
         builtin_print_error_trailer(parser, streams.err, cmd);
@@ -689,7 +689,7 @@ pub fn builtin_unexpected_argument(
 ) {
     streams
         .err
-        .append(wgettext_fmt!(BUILTIN_ERR_UNEXP_ARG, cmd, opt));
+        .append(&wgettext_fmt!(BUILTIN_ERR_UNEXP_ARG, cmd, opt));
     if print_hints {
         builtin_print_error_trailer(parser, streams.err, cmd);
     }
@@ -701,10 +701,10 @@ pub fn builtin_print_error_trailer(parser: &Parser, b: &mut OutputStream, cmd: &
     let stacktrace = parser.current_line();
     // Don't print two empty lines if we don't have a stacktrace.
     if !stacktrace.is_empty() {
-        b.append(stacktrace);
+        b.append(&stacktrace);
         b.append_char('\n');
     }
-    b.append(wgettext_fmt!(
+    b.append(&wgettext_fmt!(
         "(Type 'help %s' for related documentation)\n",
         cmd
     ));
@@ -718,7 +718,7 @@ pub fn builtin_wperror(program_name: &wstr, streams: &mut IoStreams) {
     streams.err.append(L!(": "));
     if err.0 != 0 {
         let werr = WString::from_str(&err.to_string());
-        streams.err.append(werr);
+        streams.err.append(&werr);
         streams.err.append_char('\n');
     }
 }
@@ -966,7 +966,7 @@ fn parsed_pid(
     match pid {
         Ok(pid @ 1..) => Ok(Pid::new(pid)),
         _ => {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "%s: '%s' is not a valid process ID\n",
                 cmd,
                 arg
@@ -1017,7 +1017,7 @@ pub fn builtin_break_continue(
     if argc != 1 {
         streams
             .err
-            .append(wgettext_fmt!(BUILTIN_ERR_UNKNOWN, argv[0], argv[1]));
+            .append(&wgettext_fmt!(BUILTIN_ERR_UNKNOWN, argv[0], argv[1]));
         return Err(STATUS_INVALID_ARGS);
     }
 
@@ -1036,7 +1036,7 @@ pub fn builtin_break_continue(
     if !has_loop {
         streams
             .err
-            .append(wgettext_fmt!("%s: Not inside of loop\n", argv[0]));
+            .append(&wgettext_fmt!("%s: Not inside of loop\n", argv[0]));
         return Err(STATUS_CMD_ERROR);
     }
 

--- a/src/builtins/source.rs
+++ b/src/builtins/source.rs
@@ -39,13 +39,13 @@ pub fn source(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
         if streams.stdin_fd < 0 {
             streams
                 .err
-                .append(wgettext_fmt!("%s: stdin is closed\n", cmd));
+                .append(&wgettext_fmt!("%s: stdin is closed\n", cmd));
             return Err(STATUS_CMD_ERROR);
         }
         // Either a bare `source` which means to implicitly read from stdin or an explicit `-`.
         if argc == optind && isatty(streams.stdin_fd) {
             // Don't implicitly read from the terminal.
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "%s: missing filename argument or input redirection\n",
                 cmd
             ));
@@ -60,7 +60,7 @@ pub fn source(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
             }
             Err(_) => {
                 let esc = escape(args[optind]);
-                streams.err.append(wgettext_fmt!(
+                streams.err.append(&wgettext_fmt!(
                     "%s: Error encountered while sourcing file '%s':\n",
                     cmd,
                     &esc
@@ -97,7 +97,7 @@ pub fn source(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
         Ok(_) => BuiltinResult::from_dynamic(parser.get_last_status()),
         Err(err) => {
             let esc = escape(&func_filename);
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "%s: Error while reading file '%s'\n",
                 cmd,
                 if esc == "-" { L!("<stdin>") } else { &esc }

--- a/src/builtins/status.rs
+++ b/src/builtins/status.rs
@@ -105,7 +105,7 @@ impl StatusCmdOpts {
     fn try_set_status_cmd(&mut self, subcmd: StatusCmd, streams: &mut IoStreams) -> bool {
         match self.status_cmd.replace(subcmd) {
             Some(existing) => {
-                streams.err.append(wgettext_fmt!(
+                streams.err.append(&wgettext_fmt!(
                     BUILTIN_ERR_COMBO2_EXCLUSIVE,
                     "status",
                     existing.to_wstr(),
@@ -183,7 +183,7 @@ fn print_features(streams: &mut IoStreams) {
         } else {
             L!("off")
         };
-        streams.out.append(sprintf!(
+        streams.out.append(&sprintf!(
             "%-*s%-3s %s %s\n",
             max_len + 1,
             md.name,
@@ -215,7 +215,7 @@ fn parse_cmd_opts(
                     match fish_wcstoi(arg) {
                         Ok(level) if level >= 0 => level,
                         Err(Error::Overflow) | Ok(_) => {
-                            streams.err.append(wgettext_fmt!(
+                            streams.err.append(&wgettext_fmt!(
                                 "%s: Invalid level value '%s'\n",
                                 cmd,
                                 arg
@@ -225,7 +225,7 @@ fn parse_cmd_opts(
                         _ => {
                             streams
                                 .err
-                                .append(wgettext_fmt!(BUILTIN_ERR_NOT_NUMBER, cmd, arg));
+                                .append(&wgettext_fmt!(BUILTIN_ERR_NOT_NUMBER, cmd, arg));
                             return Err(STATUS_INVALID_ARGS);
                         }
                     }
@@ -251,7 +251,7 @@ fn parse_cmd_opts(
                     return Err(STATUS_CMD_ERROR);
                 }
                 let Ok(job_mode) = w.woptarg.unwrap().try_into() else {
-                    streams.err.append(wgettext_fmt!(
+                    streams.err.append(&wgettext_fmt!(
                         "%s: Invalid job control mode '%s'\n",
                         cmd,
                         w.woptarg.unwrap()
@@ -373,7 +373,7 @@ pub fn status(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
             None => {
                 streams
                     .err
-                    .append(wgettext_fmt!(BUILTIN_ERR_INVALID_SUBCMD, cmd, args[1]));
+                    .append(&wgettext_fmt!(BUILTIN_ERR_INVALID_SUBCMD, cmd, args[1]));
                 return Err(STATUS_INVALID_ARGS);
             }
         }
@@ -396,8 +396,8 @@ pub fn status(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
         };
         streams
             .out
-            .append(wgettext_fmt!("Job control: %s\n", job_control_mode));
-        streams.out.append(parser.stack_trace());
+            .append(&wgettext_fmt!("Job control: %s\n", job_control_mode));
+        streams.out.append(&parser.stack_trace());
 
         return Ok(SUCCESS);
     };
@@ -408,7 +408,7 @@ pub fn status(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
                 Some(j) => {
                     // Flag form used
                     if !args.is_empty() {
-                        streams.err.append(wgettext_fmt!(
+                        streams.err.append(&wgettext_fmt!(
                             BUILTIN_ERR_ARG_COUNT2,
                             cmd,
                             c.to_wstr(),
@@ -421,7 +421,7 @@ pub fn status(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
                 }
                 None => {
                     if args.len() != 1 {
-                        streams.err.append(wgettext_fmt!(
+                        streams.err.append(&wgettext_fmt!(
                             BUILTIN_ERR_ARG_COUNT2,
                             cmd,
                             c.to_wstr(),
@@ -431,7 +431,7 @@ pub fn status(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
                         return Err(STATUS_INVALID_ARGS);
                     }
                     let Ok(new_mode) = args[0].try_into() else {
-                        streams.err.append(wgettext_fmt!(
+                        streams.err.append(&wgettext_fmt!(
                             "%s: Invalid job control mode '%s'\n",
                             cmd,
                             args[0]
@@ -446,7 +446,7 @@ pub fn status(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
         STATUS_FEATURES => print_features(streams),
         c @ STATUS_TEST_FEATURE => {
             if args.len() != 1 {
-                streams.err.append(wgettext_fmt!(
+                streams.err.append(&wgettext_fmt!(
                     BUILTIN_ERR_ARG_COUNT2,
                     cmd,
                     c.to_wstr(),
@@ -468,7 +468,7 @@ pub fn status(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
         }
         c @ STATUS_GET_FILE => {
             if args.len() != 1 {
-                streams.err.append(wgettext_fmt!(
+                streams.err.append(&wgettext_fmt!(
                     BUILTIN_ERR_ARG_COUNT2,
                     cmd,
                     c.to_wstr(),
@@ -486,7 +486,7 @@ pub fn status(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
                 return Err(STATUS_CMD_ERROR);
             };
             let src = bytes2wcstring(&emfile.data);
-            streams.out.append(src);
+            streams.out.append(&src);
             return Ok(SUCCESS);
         }
         STATUS_LANGUAGE => {
@@ -496,12 +496,12 @@ pub fn status(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
                     return Err(STATUS_CMD_ERROR);
                 } else {
                     if args.is_empty() {
-                        streams.out.append(crate::localization::status_language());
+                        streams.out.append(&crate::localization::status_language());
                         return Ok(SUCCESS);
                     }
                     match args[0].to_string().as_str() {
                         "list-available" => {
-                            streams.out.append(crate::localization::list_available_languages());
+                            streams.out.append(&crate::localization::list_available_languages());
                             return Ok(SUCCESS);
                         },
                         "set" => {
@@ -523,7 +523,7 @@ pub fn status(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
                         invalid => {
                             streams
                                 .err
-                                .append(wgettext_fmt!(BUILTIN_ERR_INVALID_SUBSUBCMD, cmd, subcmd.to_wstr(), invalid));
+                                .append(&wgettext_fmt!(BUILTIN_ERR_INVALID_SUBSUBCMD, cmd, subcmd.to_wstr(), invalid));
                             return Err(STATUS_INVALID_ARGS);
                         }
                     }
@@ -566,7 +566,7 @@ pub fn status(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
         }
         c @ STATUS_TEST_TERMINAL_FEATURE => {
             if args.len() != 1 {
-                streams.err.append(wgettext_fmt!(
+                streams.err.append(&wgettext_fmt!(
                     BUILTIN_ERR_ARG_COUNT2,
                     cmd,
                     c.to_wstr(),
@@ -593,7 +593,7 @@ pub fn status(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
 
         ref s => {
             if !args.is_empty() {
-                streams.err.append(wgettext_fmt!(
+                streams.err.append(&wgettext_fmt!(
                     BUILTIN_ERR_ARG_COUNT2,
                     cmd,
                     s.to_wstr(),
@@ -728,7 +728,7 @@ pub fn status(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
                     }
                 }
                 STATUS_STACK_TRACE => {
-                    streams.out.append(parser.stack_trace());
+                    streams.out.append(&parser.stack_trace());
                 }
                 STATUS_CURRENT_CMD => {
                     let command = &parser.libdata().status_vars.command;

--- a/src/builtins/string.rs
+++ b/src/builtins/string.rs
@@ -28,7 +28,7 @@ macro_rules! string_error {
     $(,)?
     ) => {
         $streams.err.append(L!("string "));
-        $streams.err.append(wgettext_fmt!($string, $($args),*));
+        $streams.err.append(&wgettext_fmt!($string, $($args),*));
     };
 }
 use string_error;
@@ -194,7 +194,7 @@ impl RegexError {
                 string_error!(streams, "%s: %s\n", cmd, marker);
             }
             InvalidCaptureGroupName(name) => {
-                streams.err.append(wgettext_fmt!(
+                streams.err.append(&wgettext_fmt!(
                     "Modification of read-only variable \"%s\" is not allowed\n",
                     name
                 ));
@@ -319,7 +319,7 @@ pub fn string(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
     if argc <= 1 {
         streams
             .err
-            .append(wgettext_fmt!(BUILTIN_ERR_MISSING_SUBCMD, cmd));
+            .append(&wgettext_fmt!(BUILTIN_ERR_MISSING_SUBCMD, cmd));
         builtin_print_error_trailer(parser, streams.err, cmd);
         return Err(STATUS_INVALID_ARGS);
     }
@@ -368,7 +368,7 @@ pub fn string(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
         _ => {
             streams
                 .err
-                .append(wgettext_fmt!(BUILTIN_ERR_INVALID_SUBCMD, cmd, args[0]));
+                .append(&wgettext_fmt!(BUILTIN_ERR_INVALID_SUBCMD, cmd, args[0]));
             builtin_print_error_trailer(parser, streams.err, cmd);
             Err(STATUS_INVALID_ARGS)
         }

--- a/src/builtins/string/escape.rs
+++ b/src/builtins/string/escape.rs
@@ -52,7 +52,7 @@ impl StringSubCommand<'_> for Escape {
                 escaped.push('\n');
             }
 
-            streams.out.append(escaped);
+            streams.out.append(&escaped);
             escaped_any = true;
         }
 

--- a/src/builtins/string/join.rs
+++ b/src/builtins/string/join.rs
@@ -61,7 +61,7 @@ impl<'args> StringSubCommand<'args> for Join<'args> {
         optind: &mut usize,
         args: &[&wstr],
     ) -> Result<(), ErrorCode> {
-        let sep = &self.sep;
+        let sep = self.sep;
         let mut nargs = 0usize;
         let mut print_trailing_newline = true;
         for InputValue { arg, want_newline } in arguments(args, optind, streams) {
@@ -74,7 +74,7 @@ impl<'args> StringSubCommand<'args> for Join<'args> {
                     streams.out.append(sep);
                 }
 
-                streams.out.append(arg);
+                streams.out.append(&arg);
             } else if nargs > 1 {
                 return Ok(());
             }

--- a/src/builtins/string/match.rs
+++ b/src/builtins/string/match.rs
@@ -93,7 +93,7 @@ impl<'args> StringSubCommand<'args> for Match<'args> {
         let cmd = args[0];
 
         if self.entire && self.index {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 BUILTIN_ERR_COMBO2,
                 cmd,
                 wgettext!("--entire and --index are mutually exclusive")
@@ -102,7 +102,7 @@ impl<'args> StringSubCommand<'args> for Match<'args> {
         }
 
         if self.invert_match && self.groups_only {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 BUILTIN_ERR_COMBO2,
                 cmd,
                 wgettext!("--invert and --groups-only are mutually exclusive")
@@ -111,7 +111,7 @@ impl<'args> StringSubCommand<'args> for Match<'args> {
         }
 
         if self.entire && self.groups_only {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 BUILTIN_ERR_COMBO2,
                 cmd,
                 wgettext!("--entire and --groups-only are mutually exclusive")
@@ -324,7 +324,7 @@ impl<'opts, 'args> RegexMatcher<'opts, 'args> {
         let Some(cg) = cg else {
             if self.opts.invert_match && !self.opts.quiet {
                 if self.opts.index {
-                    streams.out.append(sprintf!("1 %u\n", arg.len()));
+                    streams.out.append(&sprintf!("1 %u\n", arg.len()));
                 } else {
                     streams.out.appendln(arg);
                 }
@@ -353,7 +353,7 @@ impl<'opts, 'args> RegexMatcher<'opts, 'args> {
             if self.opts.index {
                 streams
                     .out
-                    .append(sprintf!("%u %u\n", m.start() + 1, m.end() - m.start()));
+                    .append(&sprintf!("%u %u\n", m.start() + 1, m.end() - m.start()));
             } else {
                 streams.out.appendln(&arg[m.start()..m.end()]);
             }
@@ -401,7 +401,7 @@ impl<'opts, 'args> WildCardMatcher<'opts, 'args> {
             self.total_matched += 1;
             if !self.opts.quiet {
                 if self.opts.index {
-                    streams.out.append(sprintf!("1 %u\n", arg.len()));
+                    streams.out.append(&sprintf!("1 %u\n", arg.len()));
                 } else {
                     streams.out.appendln(arg);
                 }

--- a/src/builtins/string/pad.rs
+++ b/src/builtins/string/pad.rs
@@ -105,7 +105,7 @@ impl StringSubCommand<'_> for Pad {
                 padded.push('\n');
             }
 
-            streams.out.append(padded);
+            streams.out.append(&padded);
         }
 
         Ok(())

--- a/src/builtins/string/replace.rs
+++ b/src/builtins/string/replace.rs
@@ -114,7 +114,7 @@ impl<'args> StringSubCommand<'args> for Replace<'args> {
             replace_count += replaced as usize;
 
             if !self.quiet && (!self.filter || replaced) {
-                streams.out.append(result);
+                streams.out.append(&result);
                 if want_newline {
                     streams.out.append_char('\n');
                 }

--- a/src/builtins/string/shorten.rs
+++ b/src/builtins/string/shorten.rs
@@ -230,7 +230,7 @@ impl<'args> StringSubCommand<'args> for Shorten<'args> {
             newl.truncate(pos);
             newl.push_utfstr(ell);
             newl.push('\n');
-            streams.out.append(newl);
+            streams.out.append(&newl);
         }
 
         // Return true if we have shortened something and false otherwise.

--- a/src/builtins/string/split.rs
+++ b/src/builtins/string/split.rs
@@ -165,7 +165,7 @@ impl<'args> StringSubCommand<'args> for Split<'args> {
         args: &[&'args wstr],
     ) -> Result<(), ErrorCode> {
         if self.fields.is_empty() && self.allow_empty {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 BUILTIN_ERR_COMBO2,
                 args[0],
                 wgettext!("--allow-empty is only valid with --fields")

--- a/src/builtins/string/sub.rs
+++ b/src/builtins/string/sub.rs
@@ -57,7 +57,7 @@ impl StringSubCommand<'_> for Sub {
     ) -> Result<(), ErrorCode> {
         let cmd = args[0];
         if self.length.is_some() && self.end.is_some() {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 BUILTIN_ERR_COMBO2,
                 cmd,
                 wgettext!("--end and --length are mutually exclusive")

--- a/src/builtins/string/transform.rs
+++ b/src/builtins/string/transform.rs
@@ -31,7 +31,7 @@ impl StringSubCommand<'_> for Transform {
                 n_transformed += 1;
             }
             if !self.quiet {
-                streams.out.append(transformed);
+                streams.out.append(&transformed);
                 if want_newline {
                     streams.out.append_char('\n');
                 }

--- a/src/builtins/string/unescape.rs
+++ b/src/builtins/string/unescape.rs
@@ -40,7 +40,7 @@ impl StringSubCommand<'_> for Unescape {
         let mut nesc = 0;
         for InputValue { arg, want_newline } in arguments(args, optind, streams) {
             if let Some(res) = unescape_string(&arg, self.style) {
-                streams.out.append(res);
+                streams.out.append(&res);
                 if want_newline {
                     streams.out.append_char('\n');
                 }

--- a/src/builtins/test.rs
+++ b/src/builtins/test.rs
@@ -1040,7 +1040,7 @@ pub fn test(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
                 "%s: called with no arguments. This will be an error in future.",
                 program_name
             ));
-            streams.err.append(parser.current_line());
+            streams.err.append(&parser.current_line());
         }
         return Err(STATUS_INVALID_ARGS); // Per 1003.1, exit false.
     } else if argc == 1 {
@@ -1049,7 +1049,7 @@ pub fn test(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
                 "%s: called with one argument. This will return false in future.",
                 program_name
             ));
-            streams.err.append(parser.current_line());
+            streams.err.append(&parser.current_line());
         }
         // Per 1003.1, exit true if the arg is non-empty.
         return if args[0].is_empty() {
@@ -1063,8 +1063,8 @@ pub fn test(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
     let mut err = WString::new();
     let expr = test_expressions::TestParser::parse_args(args, &mut err, program_name);
     let Some(expr) = expr else {
-        streams.err.append(err);
-        streams.err.append(parser.current_line());
+        streams.err.append(&err);
+        streams.err.append(&parser.current_line());
         return Err(STATUS_CMD_ERROR);
     };
 
@@ -1076,7 +1076,7 @@ pub fn test(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
         }
         // Add a backtrace but not the "see help" message
         // because this isn't about passing the wrong options.
-        streams.err.append(parser.current_line());
+        streams.err.append(&parser.current_line());
         return Err(STATUS_INVALID_ARGS);
     }
 

--- a/src/builtins/type.rs
+++ b/src/builtins/type.rs
@@ -75,7 +75,7 @@ pub fn r#type(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
     }
 
     if opts.query as i64 + opts.path as i64 + opts.get_type as i64 + opts.force_path as i64 > 1 {
-        streams.err.append(wgettext_fmt!(BUILTIN_ERR_COMBO, cmd));
+        streams.err.append(&wgettext_fmt!(BUILTIN_ERR_COMBO, cmd));
         return Err(STATUS_INVALID_ARGS);
     }
 
@@ -131,7 +131,7 @@ pub fn r#type(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
                             streams.out.appendln(path);
                         }
                     } else if !opts.short_output {
-                        streams.out.append(wgettext_fmt!("%s is a function", arg));
+                        streams.out.append(&wgettext_fmt!("%s is a function", arg));
                         streams.out.appendln(wgettext!(" with definition"));
                         let mut def = WString::new();
                         def.push_utfstr(&sprintf!(
@@ -153,13 +153,13 @@ pub fn r#type(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
                                 /*cursor=*/ None,
                             );
                             let col = bytes2wcstring(&colorize(&def, &color, parser.vars()));
-                            streams.out.append(col);
+                            streams.out.append(&col);
                         } else {
-                            streams.out.append(def);
+                            streams.out.append(&def);
                         }
                     } else {
-                        streams.out.append(wgettext_fmt!("%s is a function", arg));
-                        streams.out.append(wgettext_fmt!(" (%s)\n", comment));
+                        streams.out.append(&wgettext_fmt!("%s is a function", arg));
+                        streams.out.append(&wgettext_fmt!(" (%s)\n", comment));
                     }
                 } else if opts.get_type {
                     streams.out.appendln(L!("function"));
@@ -177,7 +177,7 @@ pub fn r#type(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
                 return Ok(SUCCESS);
             }
             if !opts.get_type {
-                streams.out.append(wgettext_fmt!("%s is a builtin\n", arg));
+                streams.out.append(&wgettext_fmt!("%s is a builtin\n", arg));
             } else if opts.get_type {
                 streams.out.append(L!("builtin\n"));
             }
@@ -205,7 +205,7 @@ pub fn r#type(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
                 if opts.path || opts.force_path {
                     streams.out.appendln(path);
                 } else {
-                    streams.out.append(wgettext_fmt!("%s is %s\n", arg, path));
+                    streams.out.append(&wgettext_fmt!("%s is %s\n", arg, path));
                 }
             } else if opts.get_type {
                 streams.out.appendln(L!("file"));
@@ -223,7 +223,7 @@ pub fn r#type(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
         if found == 0 && !opts.query && !opts.path {
             streams
                 .err
-                .append(wgettext_fmt!("%s: Could not find '%s'\n", L!("type"), arg));
+                .append(&wgettext_fmt!("%s: Could not find '%s'\n", L!("type"), arg));
         }
     }
 

--- a/src/builtins/ulimit.rs
+++ b/src/builtins/ulimit.rs
@@ -117,7 +117,7 @@ fn print(resource: c_uint, hard: bool, streams: &mut IoStreams) {
     } else {
         streams
             .out
-            .append(wgettext_fmt!("%u\n", l / get_multiplier(resource)));
+            .append(&wgettext_fmt!("%u\n", l / get_multiplier(resource)));
     }
 }
 
@@ -141,7 +141,7 @@ fn print_all(hard: bool, streams: &mut IoStreams) {
         } else {
             "(kB, "
         };
-        streams.out.append(sprintf!(
+        streams.out.append(&sprintf!(
             "%-*s %10s-%c) ",
             w,
             resource.desc,
@@ -152,9 +152,10 @@ fn print_all(hard: bool, streams: &mut IoStreams) {
         if l == RLIM_INFINITY {
             streams.out.append(wgettext!("unlimited\n"));
         } else {
-            streams
-                .out
-                .append(wgettext_fmt!("%u\n", l / get_multiplier(resource.resource)));
+            streams.out.append(&wgettext_fmt!(
+                "%u\n",
+                l / get_multiplier(resource.resource)
+            ));
         }
     }
 }
@@ -195,7 +196,7 @@ fn set_limit(
 
     if let Err(errno) = setrlimit(resource, rlim_cur, rlim_max) {
         if errno == Errno::EPERM {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "ulimit: Permission denied when changing resource of type '%s'\n",
                 get_desc(resource)
             ));
@@ -332,7 +333,7 @@ pub fn ulimit(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
     }
 
     if opts.what == -1 {
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             "%s: Resource limit not available on this operating system\n",
             cmd
         ));
@@ -351,7 +352,7 @@ pub fn ulimit(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
     } else if arg_count != 1 {
         streams
             .err
-            .append(wgettext_fmt!(BUILTIN_ERR_TOO_MANY_ARGUMENTS, cmd));
+            .append(&wgettext_fmt!(BUILTIN_ERR_TOO_MANY_ARGUMENTS, cmd));
 
         builtin_print_error_trailer(parser, streams.err, cmd);
         return Err(STATUS_INVALID_ARGS);
@@ -366,7 +367,7 @@ pub fn ulimit(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
     }
 
     let new_limit: rlim_t = if w.wopt_index == argc {
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             "%s: New limit cannot be an empty string\n",
             cmd
         ));
@@ -386,7 +387,7 @@ pub fn ulimit(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
         }
     } else if let Ok(limit) = fish_wcstol(w.argv[w.wopt_index]) {
         let Some(x) = get_multiplier(what).checked_mul(limit as rlim_t) else {
-            streams.err.append(wgettext_fmt!(
+            streams.err.append(&wgettext_fmt!(
                 "%s: Invalid limit '%s'\n",
                 cmd,
                 w.argv[w.wopt_index]
@@ -396,7 +397,7 @@ pub fn ulimit(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> B
         };
         x
     } else {
-        streams.err.append(wgettext_fmt!(
+        streams.err.append(&wgettext_fmt!(
             "%s: Invalid limit '%s'\n",
             cmd,
             w.argv[w.wopt_index]

--- a/src/builtins/wait.rs
+++ b/src/builtins/wait.rs
@@ -199,7 +199,7 @@ pub fn wait(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
                 continue;
             };
             if !find_wait_handles(WaitHandleQuery::Pid(pid), parser, &mut wait_handles) {
-                streams.err.append(wgettext_fmt!(
+                streams.err.append(&wgettext_fmt!(
                     "%s: Could not find a job with process ID '%d'\n",
                     cmd,
                     pid,
@@ -208,7 +208,7 @@ pub fn wait(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> Bui
         } else {
             // argument is process name
             if !find_wait_handles(WaitHandleQuery::ProcName(item), parser, &mut wait_handles) {
-                streams.err.append(wgettext_fmt!(
+                streams.err.append(&wgettext_fmt!(
                     "%s: Could not find child processes with the name '%s'\n",
                     cmd,
                     item,

--- a/src/common.rs
+++ b/src/common.rs
@@ -1151,11 +1151,7 @@ pub(crate) fn charptr2wcstring(input: *const libc::c_char) -> WString {
 ///
 /// This function decodes illegal character sequences in a reversible way using the private use
 /// area.
-pub fn wcs2bytes(input: &wstr) -> Vec<u8> {
-    if input.is_empty() {
-        return vec![];
-    }
-
+pub fn wcs2bytes(input: impl IntoCharIter) -> Vec<u8> {
     let mut result = vec![];
     wcs2bytes_appending(&mut result, input);
     result
@@ -1199,8 +1195,7 @@ pub fn wcs2zstring(input: &wstr) -> CString {
 }
 
 /// Like [`wcs2bytes`], but appends to `output` instead of returning a new string.
-pub fn wcs2bytes_appending(output: &mut Vec<u8>, input: &wstr) {
-    output.reserve(input.len());
+pub fn wcs2bytes_appending(output: &mut Vec<u8>, input: impl IntoCharIter) {
     str2bytes_callback(input, |buff| {
         output.extend_from_slice(buff);
         true

--- a/src/event.rs
+++ b/src/event.rs
@@ -630,7 +630,7 @@ pub fn print(streams: &mut IoStreams, type_filter: &wstr) {
             }
 
             last_type = std::mem::discriminant(&evt.desc);
-            streams.out.append(sprintf!("Event %s\n", evt.desc.name()));
+            streams.out.append(&sprintf!("Event %s\n", evt.desc.name()));
         }
 
         match &evt.desc {
@@ -638,18 +638,18 @@ pub fn print(streams: &mut IoStreams, type_filter: &wstr) {
                 let name: WString = signal.name().into();
                 streams
                     .out
-                    .append(sprintf!("%s %s\n", name, evt.function_name));
+                    .append(&sprintf!("%s %s\n", name, evt.function_name));
             }
             EventDescription::ProcessExit { .. } | EventDescription::JobExit { .. } => {}
             EventDescription::CallerExit { .. } => {
                 streams
                     .out
-                    .append(sprintf!("caller-exit %s\n", evt.function_name));
+                    .append(&sprintf!("caller-exit %s\n", evt.function_name));
             }
             EventDescription::Variable { name: param } | EventDescription::Generic { param } => {
                 streams
                     .out
-                    .append(sprintf!("%s %s\n", param, evt.function_name));
+                    .append(&sprintf!("%s %s\n", param, evt.function_name));
             }
             EventDescription::Any => unreachable!(),
         }

--- a/src/flog.rs
+++ b/src/flog.rs
@@ -168,7 +168,7 @@ impl FloggableDisplay for WString {
 
 impl FloggableDisplay for &wstr {
     fn to_flog_str(&self) -> Vec<u8> {
-        wcs2bytes(self)
+        wcs2bytes(*self)
     }
 }
 

--- a/src/history/history.rs
+++ b/src/history/history.rs
@@ -1382,7 +1382,7 @@ impl History {
                 collected.push(formatted_record);
             } else {
                 // We can output this immediately.
-                if !streams.out.append(formatted_record) {
+                if !streams.out.append(&formatted_record) {
                     // This can happen if the user hit Ctrl-C to abort (maybe after the first page?).
                     output_error = true;
                     return ControlFlow::Break(());
@@ -1427,7 +1427,7 @@ impl History {
                 break;
             }
 
-            if !streams.out.append(item) {
+            if !streams.out.append(&item) {
                 // Don't force an error if output was aborted (typically via Ctrl-C/SIGINT); just don't
                 // try writing any more.
                 output_error = true;


### PR DESCRIPTION
Change the input of some functions to take `impl IntoCharIter`, allowing them to accept more input. Implementing this efficiently means that no owned types should be passed into these functions, because their `IntoCharIter` implementation would require unnecessary allocations. Instead, convert the uses which previously passed `WString` by prefixing an `&`, so the borrowed `&WString` is passed instead.

To allow for wider use of the modified functions, `IntoCharIter` implementations are added for `&String`, `&Cow<str>`, and `&Cow<wstr>`.

Some of the changes in this commit were taken from @krobelus's changes on top of the Fluent PR. I realized that `ToChars` essentially duplicates the functionality of `IntoCharIter`, while being a worse interface, so the new code no longer uses `ToChars`. Not sure if the `TODO optimize` comment in `src/io.rs` is still relevant.