### PR TITLE
cmake: rename `WITH_GETTEXT` to `LOCALIZE_MESSAGES`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -80,6 +80,7 @@ For distributors and developers
 - Tarballs no longer contain prebuilt documentation,
   so building and installing documentation requires Sphinx.
   To avoid users accidentally losing docs, the ``BUILD_DOCS`` and ``INSTALL_DOCS`` configuration options have been replaced with a new ``WITH_DOCS`` option.
+- The CMake option ``WITH_GETTEXT`` has been renamed to ``WITH_MESSAGE_LOCALIZATION``, to reflect that it toggles localization independently of the backend used in the implementation.
 - ``fish_key_reader`` and ``fish_indent`` are now installed as hardlinks to ``fish``, to save some space.
 
 Regression fixes:

--- a/README.rst
+++ b/README.rst
@@ -164,7 +164,7 @@ In addition to the normal CMake build options (like ``CMAKE_INSTALL_PREFIX``), f
   If that's not runnable on the compile host,
   you can build a native one with ``cargo build --bin fish_indent`` and set this to ``$PWD/target/debug/fish_indent``.
 - FISH_USE_SYSTEM_PCRE2=ON|OFF - whether to use an installed pcre2. This is normally autodetected.
-- WITH_GETTEXT=ON|OFF - whether to include translations.
+- WITH_MESSAGE_LOCALIZATION=ON|OFF - whether to include translations.
 - extra_functionsdir, extra_completionsdir and extra_confdir - to compile in an additional directory to be searched for functions, completions and configuration snippets
 
 Building fish with Cargo

--- a/cmake/Rust.cmake
+++ b/cmake/Rust.cmake
@@ -1,3 +1,4 @@
+include(FeatureSummary)
 include(FindRust)
 find_package(Rust REQUIRED)
 
@@ -20,10 +21,17 @@ endif()
 
 set(rust_profile $<IF:$<CONFIG:Debug>,debug,$<IF:$<CONFIG:RelWithDebInfo>,release-with-debug,release>>)
 
-option(WITH_GETTEXT "Build with gettext localization support. Requires `msgfmt` to work." ON)
+if (NOT DEFINED WITH_MESSAGE_LOCALIZATION) # Don't check for legacy options if the new one is defined, to help bisecting.
+    if(DEFINED WITH_GETTEXT)
+        message(FATAL_ERROR "the WITH_GETTEXT option is no longer supported, use -DWITH_MESSAGE_LOCALIZATION=ON|OFF")
+    endif()
+endif()
+option(WITH_MESSAGE_LOCALIZATION "Build with localization support. Requires `msgfmt` to work." ON)
 # Enable gettext feature unless explicitly disabled.
-if(NOT DEFINED WITH_GETTEXT OR "${WITH_GETTEXT}")
+if(NOT DEFINED WITH_MESSAGE_LOCALIZATION OR "${WITH_MESSAGE_LOCALIZATION}")
     list(APPEND FISH_CARGO_FEATURES_LIST "localize-messages")
 endif()
+
+add_feature_info(Translation WITH_MESSAGE_LOCALIZATION "message localization (requires gettext)")
 
 list(JOIN FISH_CARGO_FEATURES_LIST , FISH_CARGO_FEATURES)


### PR DESCRIPTION
This change is made to make the option name appropriate for Fluent localization.

## TODOs:
- [x] User-visible changes noted in CHANGELOG.rst
