### PR TITLE
Make the behavior regarding function descriptions of the functions(1) completion more consistent with the type(1) completion

### DIFF
--- a/share/completions/functions.fish
+++ b/share/completions/functions.fish
@@ -8,7 +8,7 @@ function __fish_maybe_list_all_functions
 end
 
 complete -c functions -s e -l erase -d "Erase function" -x -a "(__fish_maybe_list_all_functions)"
-complete -c functions -xa "(functions -na)"
+complete -c functions -a "(__fish_complete_command)" -x
 complete -c functions -s a -l all -d "Show hidden functions"
 complete -c functions -s h -l help -d "Display help and exit"
 complete -c functions -s d -l description -d "Set function description" -x


### PR DESCRIPTION
The current completion just adds "Function" as the description for every function. This is really useless, and should be replaced with the actual descriptions of the functions, as it's being done in the type(1) completion using `__fish_complete_command`.

I will probably add fixes for other cases of inconsistency between functions(1) and type(1), hence marking the PR as a draft.