### PR TITLE
Show file location when querying bindings with bind

### DIFF
--- a/src/builtins/bind.rs
+++ b/src/builtins/bind.rs
@@ -2,7 +2,7 @@
 
 use super::prelude::*;
 use crate::common::{
-    EscapeFlags, EscapeStringStyle, bytes2wcstring, escape, escape_string, valid_var_name,
+    EscapeFlags, EscapeStringStyle, FilenameRef, bytes2wcstring, escape, escape_string, valid_var_name,
 };
 use crate::highlight::{colorize, highlight_shell};
 use crate::input::{InputMappingSet, KeyNameStyle, input_function_get_names, input_mappings};
@@ -82,6 +82,7 @@ impl BuiltinBind {
         let mut ecmds: &[_] = &[];
         let mut sets_mode = None;
         let mut key_name_style = KeyNameStyle::Plain;
+        let mut definition_file: Option<&FilenameRef> = None;
         let mut out = WString::new();
         if !self.input_mappings.get(
             seq,
@@ -90,6 +91,7 @@ impl BuiltinBind {
             user,
             &mut sets_mode,
             &mut key_name_style,
+            &mut definition_file,
         ) {
             return false;
         }
@@ -151,6 +153,13 @@ impl BuiltinBind {
             out.push(' ');
             out.push_utfstr(&escape(ecmd));
         }
+
+        // Show where the binding was defined
+        if let Some(def_file) = definition_file {
+            out.push_str(" # defined in ");
+            out.push_utfstr(&escape(def_file));
+        }
+
         out.push('\n');
 
         if !streams.out_is_redirected && isatty(libc::STDOUT_FILENO) {
@@ -230,6 +239,7 @@ impl BuiltinBind {
         mode: WString,
         sets_mode: Option<WString>,
         user: bool,
+        parser: &Parser,
         streams: &mut IoStreams,
     ) -> bool {
         let cmds = cmds.iter().map(|&s| s.to_owned()).collect();
@@ -242,8 +252,9 @@ impl BuiltinBind {
         } else {
             KeyNameStyle::Plain
         };
+        let definition_file = parser.current_filename();
         self.input_mappings
-            .add(key_seq, key_name_style, cmds, mode, sets_mode, user);
+            .add(key_seq, key_name_style, cmds, mode, sets_mode, user, definition_file);
         false
     }
 
@@ -373,6 +384,7 @@ impl BuiltinBind {
                 self.opts.bind_mode.to_owned(),
                 self.opts.sets_bind_mode.to_owned(),
                 self.opts.user,
+                parser,
                 streams,
             ) {
                 return true;

--- a/src/builtins/bind.rs
+++ b/src/builtins/bind.rs
@@ -2,7 +2,8 @@
 
 use super::prelude::*;
 use crate::common::{
-    EscapeFlags, EscapeStringStyle, FilenameRef, bytes2wcstring, escape, escape_string, valid_var_name,
+    EscapeFlags, EscapeStringStyle, FilenameRef, bytes2wcstring, escape, escape_string,
+    valid_var_name,
 };
 use crate::highlight::{colorize, highlight_shell};
 use crate::input::{InputMappingSet, KeyNameStyle, input_function_get_names, input_mappings};
@@ -254,8 +255,15 @@ impl BuiltinBind {
             KeyNameStyle::Plain
         };
         let definition_file = parser.current_filename();
-        self.input_mappings
-            .add(key_seq, key_name_style, cmds, mode, sets_mode, user, definition_file);
+        self.input_mappings.add(
+            key_seq,
+            key_name_style,
+            cmds,
+            mode,
+            sets_mode,
+            user,
+            definition_file,
+        );
         false
     }
 

--- a/src/builtins/bind.rs
+++ b/src/builtins/bind.rs
@@ -232,6 +232,7 @@ impl BuiltinBind {
     }
 
     /// Add specified key binding.
+    #[allow(clippy::too_many_arguments)]
     fn add(
         &mut self,
         seq: &wstr,

--- a/src/input.rs
+++ b/src/input.rs
@@ -269,6 +269,7 @@ fn input_mapping_insert_sorted(ml: &mut Vec<InputMapping>, new_mapping: InputMap
 
 impl InputMappingSet {
     /// Adds an input mapping.
+    #[allow(clippy::too_many_arguments)]
     pub fn add(
         &mut self,
         sequence: Vec<Key>,
@@ -301,6 +302,7 @@ impl InputMappingSet {
     }
 
     // Like add(), but takes a single command.
+    #[allow(clippy::too_many_arguments)]
     pub fn add1(
         &mut self,
         sequence: Vec<Key>,
@@ -1022,6 +1024,7 @@ mod tests {
             default_mode(),
             None,
             true,
+            None,
         );
         input_mappings.add1(
             desired_binding.clone(),
@@ -1030,6 +1033,7 @@ mod tests {
             default_mode(),
             None,
             true,
+            None,
         );
 
         // Push the desired binding to the queue.

--- a/src/input.rs
+++ b/src/input.rs
@@ -297,7 +297,14 @@ impl InputMappingSet {
         }
 
         // Add a new mapping, using the next order.
-        let new_mapping = InputMapping::new(sequence, commands, mode, sets_mode, key_name_style, definition_file);
+        let new_mapping = InputMapping::new(
+            sequence,
+            commands,
+            mode,
+            sets_mode,
+            key_name_style,
+            definition_file,
+        );
         input_mapping_insert_sorted(ml, new_mapping);
     }
 
@@ -343,7 +350,15 @@ pub fn init_input() {
         let mut add = |key: Vec<Key>, cmd: &str| {
             let mode = DEFAULT_BIND_MODE.to_owned();
             let sets_mode = Some(DEFAULT_BIND_MODE.to_owned());
-            input_mapping.add1(key, KeyNameStyle::Plain, cmd.into(), mode, sets_mode, false, None);
+            input_mapping.add1(
+                key,
+                KeyNameStyle::Plain,
+                cmd.into(),
+                mode,
+                sets_mode,
+                false,
+                None,
+            );
         };
 
         add(vec![], "self-insert");

--- a/tests/checks/bind.fish
+++ b/tests/checks/bind.fish
@@ -7,11 +7,11 @@ set -l tmpdir (mktemp -d)
 for bindings in true fish_default_key_bindings fish_vi_key_bindings
     $fish -c "
         $bindings
-        bind > $tmpdir/old
+        bind | string replace -r ' # defined in .*' '' > $tmpdir/old
         bind --erase --all --preset
         bind --erase --all
         source $tmpdir/old
-        bind >$tmpdir/new
+        bind | string replace -r ' # defined in .*' '' >$tmpdir/new
         diff -u $tmpdir/{old,new}
     "
 end
@@ -34,8 +34,8 @@ bind -M bind-mode \cX true
 bind -M bind_mode \cX true
 
 # Listing bindings
-bind | string match -v '*\e\\[*' # Hide raw bindings.
-bind --user --preset | string match -v '*\e\\[*'
+bind | string match -v '*\e\\[*' | string replace -r ' # defined in .*' '' # Hide raw bindings.
+bind --user --preset | string match -v '*\e\\[*' | string replace -r ' # defined in .*' ''
 # CHECK: bind --preset '' self-insert
 # CHECK: bind --preset enter execute
 # CHECK: bind --preset tab complete
@@ -74,7 +74,7 @@ bind --user --preset | string match -v '*\e\\[*'
 # CHECK: bind -M bind_mode ctrl-x true
 
 # Preset only
-bind --preset | string match -v '*\e\\[*'
+bind --preset | string match -v '*\e\\[*' | string replace -r ' # defined in .*' ''
 # CHECK: bind --preset '' self-insert
 # CHECK: bind --preset enter execute
 # CHECK: bind --preset tab complete
@@ -94,12 +94,12 @@ bind --preset | string match -v '*\e\\[*'
 # CHECK: bind --preset ctrl-f forward-char
 
 # User only
-bind --user | string match -v '*\e\\[*'
+bind --user | string match -v '*\e\\[*' | string replace -r ' # defined in .*' ''
 # CHECK: bind -M bind_mode ctrl-x true
 
 # Adding bindings
 bind tab 'echo banana'
-bind | string match -v '*\e\\[*'
+bind | string match -v '*\e\\[*' | string replace -r ' # defined in .*' ''
 # CHECK: bind --preset '' self-insert
 # CHECK: bind --preset enter execute
 # CHECK: bind --preset tab complete

--- a/tests/checks/bind.fish
+++ b/tests/checks/bind.fish
@@ -131,16 +131,16 @@ bind super-alt-\~
 
 # Legacy
 bind \cx\cax 'echo foo'
-bind \cx\cax
+bind \cx\cax | string replace -r ' # defined in .*' ''
 # CHECK: bind ctrl-x,ctrl-a,x 'echo foo'
 bind \ef forward-word
-bind \ef
+bind \ef | string replace -r ' # defined in .*' ''
 # CHECK: bind alt-f forward-word
 
 
 # Erasing bindings
 bind --erase tab
-bind tab
+bind tab | string replace -r ' # defined in .*' ''
 bind tab 'echo wurst'
 # CHECK: bind --preset tab complete
 bind --erase --user --preset tab
@@ -154,7 +154,7 @@ bind -k nul 'echo foo'
 # CHECKERR: bind: the -k/--key syntax is no longer supported. See `bind --help` and `bind --key-names`
 
 # Either Return or ctrl-m.
-bind \r
+bind \r | string replace -r ' # defined in .*' ''
 # CHECK: bind --preset enter execute
 # Never Return, probably always ctrl-j.
 bind \n 2>&1


### PR DESCRIPTION
## Description

This PR enhances the `bind` builtin to display the file in which a key binding was defined when querying existing bindings, similar to how `functions -q` and `type` show the definition location. 

- Adds a `definition_file` field to the `InputMapping` struct to track the source file for each binding.
- Updates the `bind` output to append `# defined in <filename>` when a binding was created from a file.
- Bindings created interactively or from stdin do not show a file location.

Fixes issue #12215

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->