### PR TITLE
Update phf from 0.12 to 0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "pcre2",
- "phf_codegen 0.12.1",
+ "phf_codegen 0.13.1",
  "portable-atomic",
  "rand 0.9.2",
  "rsconf",
@@ -232,7 +232,7 @@ version = "0.0.0"
 dependencies = [
  "fish-gettext-maps",
  "once_cell",
- "phf 0.12.1",
+ "phf 0.13.1",
 ]
 
 [[package]]
@@ -250,8 +250,8 @@ version = "0.0.0"
 dependencies = [
  "fish-build-helper",
  "fish-gettext-mo-file-parser",
- "phf 0.12.1",
- "phf_codegen 0.12.1",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
  "rsconf",
 ]
 
@@ -539,11 +539,11 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_shared 0.12.1",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -558,12 +558,12 @@ dependencies = [
 
 [[package]]
 name = "phf_codegen"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbdcb6f01d193b17f0b9c3360fa7e0e620991b193ff08702f78b3ce365d7e61"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
- "phf_generator 0.12.1",
- "phf_shared 0.12.1",
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -578,12 +578,12 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cbb1126afed61dd6368748dae63b1ee7dc480191c6262a3b4ff1e29d86a6c5b"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared 0.12.1",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -597,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,8 @@ once_cell = "1.19.0"
 pcre2 = { git = "https://github.com/fish-shell/rust-pcre2", tag = "0.2.9-utf32", default-features = false, features = [
     "utf32",
 ] }
-phf = { version = "0.12", default-features = false }
-phf_codegen = { version = "0.12" }
+phf = { version = "0.13", default-features = false }
+phf_codegen = { version = "0.13" }
 portable-atomic = { version = "1", default-features = false, features = [
     "fallback",
 ] }


### PR DESCRIPTION
## Description

The phf 0.13 release notes aren’t very clear about what caused the SemVer break: https://github.com/rust-phf/rust-phf/releases/tag/v0.13.0

The full source diff is https://github.com/rust-phf/rust-phf/compare/v0.12.1...v0.13.1.

I tried `cargo test` and `tests/test_driver.py target/debug` and did not observe any regressions.

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages. **N/A**
- [x] Tests have been added for regressions fixed **N/A**
- [x] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->  **N/A**
