### PR TITLE
fish_indent: Keep braces on same line in if/while conditions

### DIFF
--- a/src/builtins/fish_indent.rs
+++ b/src/builtins/fish_indent.rs
@@ -756,6 +756,10 @@ impl<'source, 'ast> PrettyPrinterState<'source, 'ast> {
         };
 
         conj.decorator.is_some()
+            || matches!(
+                self.traversal.parent(conj.as_node()).kind(),
+                Kind::IfClause(_) | Kind::WhileHeader(_)
+            )
     }
 
     fn visit_left_brace(&mut self, node: &dyn ast::Token) {

--- a/tests/checks/indent.fish
+++ b/tests/checks/indent.fish
@@ -513,6 +513,28 @@ echo 'time {
 # CHECK: {{^    }}echo hi
 # CHECK: {{^}}{{[}]}}
 
+echo 'if {
+    true
+}
+    echo ok
+end' | $fish_indent
+# CHECK: if {
+# CHECK: {{^        }}true
+# CHECK: {{^    }}{{[}]}}
+# CHECK: {{^    }}echo ok
+# CHECK: {{^}}end
+
+echo 'while {
+    true
+}
+    echo ok
+end' | $fish_indent
+# CHECK: while {
+# CHECK: {{^        }}true
+# CHECK: {{^    }}{{[}]}}
+# CHECK: {{^    }}echo ok
+# CHECK: {{^}}end
+
 echo 'echo x{a,
   b}y' | $fish_indent
 # CHECK: echo x{a,


### PR DESCRIPTION
Fixes #11984

## Description

Extends the brace continuation fix to handle if and while conditions. fish_indent was placing braces on a new line after if/while keywords, which breaks the syntax.

Fixes issue #11984