### PR TITLE
check: allow overriding default Rust toolchain

### DIFF
--- a/build_tools/check.sh
+++ b/build_tools/check.sh
@@ -33,8 +33,13 @@ fi
 cargo() {
     subcmd=$1
     shift
-    # shellcheck disable=2086
-    command cargo "$subcmd" $cargo_args "$@"
+    if [ -n "$FISH_CHECK_RUST_TOOLCHAIN" ]; then
+        # shellcheck disable=2086
+        command cargo "+$FISH_CHECK_RUST_TOOLCHAIN" "$subcmd" $cargo_args "$@"
+    else
+        # shellcheck disable=2086
+        command cargo "$subcmd" $cargo_args "$@"
+    fi
 }
 
 cleanup () {


### PR DESCRIPTION
This is useful for running the checks with a toolchain which is different from the default toolchain, for example to check if everything works with our MSRV, or on beta/nightly toolchains. Additionally, providing a way to run using the nightly toolchain allows writing wrappers around `check.sh` which make use of nightly-only features.

The toolchain could be changed using `rustup toolchain default`, but if the toolchain should only be used for a specific run, this is inconvenient, and it does not allow for concurrent builds using different toolchains.