### PR TITLE
check: add `sanitize` option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,14 +77,6 @@ jobs:
 
   ubuntu-asan:
     runs-on: ubuntu-latest
-    env:
-        # Rust has two different memory sanitizers of interest; they can't be used at the same time:
-        # * AddressSanitizer detects out-of-bound access, use-after-free, use-after-return,
-        #   use-after-scope, double-free, invalid-free, and memory leaks.
-        # * MemorySanitizer detects uninitialized reads.
-        #
-        RUSTFLAGS: "-Zsanitizer=address"
-        # RUSTFLAGS: "-Zsanitizer=memory -Zsanitizer-memory-track-origins"
     steps:
     - uses: actions/checkout@v6
     # All -Z options require running nightly
@@ -110,21 +102,13 @@ jobs:
         cmake .. -DASAN=1 -DRust_CARGO_TARGET=x86_64-unknown-linux-gnu -DCMAKE_BUILD_TYPE=Debug
     - name: make
       run: |
+        . "$PWD/build_tools/set_asan_vars.sh"
         make -C build VERBOSE=1
     - name: make fish_run_tests
-      env:
-          FISH_CI_SAN: 1
-          ASAN_OPTIONS: check_initialization_order=1:detect_stack_use_after_return=1:detect_leaks=1:fast_unwind_on_malloc=0
-          # use_tls=0 is a workaround for LSAN crashing with "Tracer caught signal 11" (SIGSEGV),
-          # which seems to be an issue with TLS support in newer glibc versions under virtualized
-          # environments. Follow https://github.com/google/sanitizers/issues/1342 and
-          # https://github.com/google/sanitizers/issues/1409 to track this issue.
-          # UPDATE: this can cause spurious leak reports for __cxa_thread_atexit_impl() under glibc.
-          LSAN_OPTIONS: verbosity=0:log_threads=0:use_tls=1:print_suppressions=0
       run: |
         set -x
+        . "$PWD/build_tools/set_asan_vars.sh"
         export ASAN_SYMBOLIZER_PATH=$(command -v /usr/bin/llvm-symbolizer* | sort -n | head -1)
-        export LSAN_OPTIONS="$LSAN_OPTIONS:suppressions=$PWD/build_tools/lsan_suppressions.txt"
         make -C build VERBOSE=1 fish_run_tests
 
   macos:

--- a/build_tools/set_asan_vars.sh
+++ b/build_tools/set_asan_vars.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+workspace_root="$(realpath "$(dirname "$0")/..")"
+
+# Variables used at build time
+
+export RUSTFLAGS="-Zsanitizer=address $RUSTFLAGS"
+export RUSTDOCFLAGS="-Zsanitizer=address $RUSTDOCFLAGS"
+
+# Variables used at runtime
+
+export ASAN_OPTIONS=check_initialization_order=1:detect_stack_use_after_return=1:detect_leaks=1:fast_unwind_on_malloc=0
+export LSAN_OPTIONS=verbosity=0:log_threads=0:print_suppressions=0:suppressions="$workspace_root"/build_tools/lsan_suppressions.txt
+export FISH_CI_SAN=1

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -17,7 +17,10 @@ struct Cli {
 #[derive(Subcommand)]
 enum Task {
     /// Run various checks on the repo.
-    Check,
+    Check {
+        #[arg(long)]
+        sanitize: bool,
+    },
     /// Build HTML docs
     HtmlDocs {
         /// Path to a fish_indent executable. If none is specified, fish_indent will be built.
@@ -31,16 +34,17 @@ enum Task {
 fn main() {
     let cli = Cli::parse();
     match cli.task {
-        Task::Check => run_checks(),
+        Task::Check { sanitize } => run_checks(sanitize),
         Task::HtmlDocs { fish_indent } => build_html_docs(fish_indent),
         Task::ManPages => cargo(["build", "--package", "fish-build-man-pages"]),
     }
 }
 
-fn run_checks() {
+fn run_checks(sanitize: bool) {
     let repo_root_dir = fish_build_helper::workspace_root();
     let check_script = repo_root_dir.join("build_tools").join("check.sh");
-    Command::new(check_script).run_or_panic();
+    let args = if sanitize { vec!["--sanitize"] } else { vec![] };
+    Command::new(check_script).args(args).run_or_panic();
 }
 
 fn build_html_docs(fish_indent: Option<PathBuf>) {


### PR DESCRIPTION
When invoked with the `--sanitize` option, the `check.sh` script will
run the checks with address and leak sanitation enabled. We already run
similar checks in CI, so it's desirable to have them available locally
as well. The `check` xtask also supports the `--sanitize` flag.

The code is assembled from the deleted `jammy-asan.Dockerfile` and the
`ubuntu-asan` job in `.github/workflows/test.yml`. The configuration in
these two sources is not entirely consistent, so we should take care to
find out which options we want to use. They should be the same locally
and in CI.

While we could resurrect a Dockerfile for running these checks, it adds
significant overhead, while not providing much value, so I think
integrating it into `check.sh` makes more sense.

# TODO

- [ ] Document the existence of the new script somewhere?