### PR TITLE
bind: show all modes by default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Scripting improvements
 
 Interactive improvements
 ------------------------
+- The `bind` builtin lists mappings from all modes if `--mode` is not provided (:issue:`12214`).
 
 New or improved bindings
 ------------------------

--- a/doc_src/cmds/bind.rst
+++ b/doc_src/cmds/bind.rst
@@ -19,8 +19,8 @@ Description
 ``bind`` manages key bindings.
 
 If both ``KEYS`` and ``COMMAND`` are given, ``bind`` adds (or replaces) a binding in ``MODE``.
-If only ``KEYS`` is given, any existing binding for those keys in the given ``MODE`` will be printed.
-If no ``KEYS`` argument is provided, all bindings (in the given ``MODE``) are printed.
+If only ``KEYS`` is given, ``bind`` lists any existing bindings for those keys in ``MODE`` or in all modes.
+If no ``KEYS`` argument is provided, ``bind`` lists all bindings in ``MODE`` or in all modes.
 
 ``KEYS`` is a comma-separated list of key names.
 Modifier keys can be specified by prefixing a key name with a combination of ``ctrl-``, ``alt-``, ``shift-`` and ``super-`` (i.e. the "windows" or "command" key).

--- a/src/input.rs
+++ b/src/input.rs
@@ -44,11 +44,11 @@ pub struct InputMapping {
     /// We wish to preserve the user-specified order. This is just an incrementing value.
     specification_order: u32,
     /// Mode in which this command should be evaluated.
-    mode: WString,
+    pub mode: WString,
     /// New mode that should be switched to after command evaluation, or None to leave the mode unchanged.
-    sets_mode: Option<WString>,
+    pub sets_mode: Option<WString>,
     /// Perhaps this binding was created using a raw escape sequence.
-    key_name_style: KeyNameStyle,
+    pub key_name_style: KeyNameStyle,
 }
 
 impl InputMapping {
@@ -922,31 +922,37 @@ impl InputMappingSet {
         result
     }
 
-    /// Gets the command bound to the specified key sequence in the specified mode. Returns true if
-    /// it exists, false if not.
+    /// Returns the command bound to the specified bind mode.
+    ///
+    /// If bind_mode is None, then binds from all modes are returned.
     pub fn get<'a>(
         &'a self,
         sequence: &[Key],
-        mode: &wstr,
-        out_cmds: &mut &'a [WString],
+        bind_mode: Option<&wstr>,
         user: bool,
-        out_sets_mode: &mut Option<&'a wstr>,
-        out_key_name_style: &mut KeyNameStyle,
-    ) -> bool {
+    ) -> Vec<&'a InputMapping> {
         let ml = if user {
             &self.mapping_list
         } else {
             &self.preset_mapping_list
         };
-        for m in ml {
-            if m.seq == sequence && m.mode == mode {
-                *out_cmds = &m.commands;
-                *out_sets_mode = m.sets_mode.as_deref();
-                *out_key_name_style = m.key_name_style.clone();
-                return true;
-            }
-        }
-        false
+
+        let mut results: Vec<&'a InputMapping> = if let Some(mode) = bind_mode {
+            // if a mode is set, return the specific mapping for the mode
+            return ml
+                .iter()
+                .filter(|mapping| mapping.seq == sequence && mapping.mode == mode)
+                .collect();
+        } else {
+            // otherwise, return all mappings for this sequence
+            ml.iter()
+                .filter(|mapping| mapping.seq == sequence)
+                .collect()
+        };
+
+        // sort by specification_order to ensure consistent output
+        results.sort_unstable_by_key(|mapping| mapping.specification_order);
+        results
     }
 }
 

--- a/tests/checks/bind.fish
+++ b/tests/checks/bind.fish
@@ -178,4 +178,17 @@ bind ctrl-shift-a
 bind ctrl-shift-ä
 # CHECKERR: bind: No binding found for key 'ctrl-shift-ä'
 
+# Verify binds from all modes are returned when querying a sequence
+fish_vi_key_bindings
+bind --preset ctrl-q 'echo preset'
+bind ctrl-q 'echo default'
+bind ctrl-q --mode insert 'echo insert'
+bind ctrl-q --mode replace 'echo replace'
+bind ctrl-q
+# CHECK: bind --preset ctrl-q 'echo preset'
+# CHECK: bind ctrl-q 'echo default'
+# CHECK: bind -M insert ctrl-q 'echo insert'
+# CHECK: bind -M replace ctrl-q 'echo replace'
+fish_default_key_bindings
+
 exit 0


### PR DESCRIPTION
## Description

Lists binds for all modes for `bind` builtin. The `bind` currently only lists binds for the current mode when provided a sequence. This PR changes that by listing all binds regardless of mode unless `--mode` is used.

### Notable Changes

- The `get` function in `src/input.rs` now takes an optional bind mode and returns a list of input mappings (binds).
- The `list_one` function in `src/builtins/bind.rs` lists binds in the results returned by `get`. Assuming there can only be one bind per mode, if a mode is specified then only one bind will be listed.
- Creating the output string for a bind has been extracted to its own function: `BuiltinBind::generate_output_string`.

Fixes #12214 

## TODOs:
<!-- Just check off what what we know been done so far. We can help you with this stuff. -->
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst <!-- Don't document changes for completions inside CHANGELOG.rst, there are lot of such edits -->
