### PR TITLE
gettext: use `wgettext_fmt` for formatting

### DIFF
--- a/localization/po/de.po
+++ b/localization/po/de.po
@@ -572,6 +572,14 @@ msgid "%s: Not inside of loop\n"
 msgstr "%s: Nicht innerhalb einer Schleife\n"
 
 #, c-format
+msgid "%s: Number out of range"
+msgstr ""
+
+#, c-format
+msgid "%s: Number was empty"
+msgstr "%s: Zahl war leer"
+
+#, c-format
 msgid "%s: Options %s and %s cannot be used together\n"
 msgstr ""
 
@@ -1334,9 +1342,6 @@ msgstr ""
 
 msgid "Number out of range"
 msgstr ""
-
-msgid "Number was empty"
-msgstr "Zahl war leer"
 
 msgid "Only on interactive jobs"
 msgstr ""

--- a/localization/po/en.po
+++ b/localization/po/en.po
@@ -570,6 +570,14 @@ msgid "%s: Not inside of loop\n"
 msgstr "%s: Not inside of loop\n"
 
 #, c-format
+msgid "%s: Number out of range"
+msgstr ""
+
+#, c-format
+msgid "%s: Number was empty"
+msgstr ""
+
+#, c-format
 msgid "%s: Options %s and %s cannot be used together\n"
 msgstr ""
 
@@ -1331,9 +1339,6 @@ msgid "Number is too large"
 msgstr ""
 
 msgid "Number out of range"
-msgstr ""
-
-msgid "Number was empty"
 msgstr ""
 
 msgid "Only on interactive jobs"

--- a/localization/po/fr.po
+++ b/localization/po/fr.po
@@ -701,6 +701,14 @@ msgid "%s: Not inside of loop\n"
 msgstr "%s : À l’extérieur de toute boucle\n"
 
 #, c-format
+msgid "%s: Number out of range"
+msgstr "%s : Nombre hors limites"
+
+#, c-format
+msgid "%s: Number was empty"
+msgstr ""
+
+#, c-format
 msgid "%s: Options %s and %s cannot be used together\n"
 msgstr ""
 
@@ -1463,9 +1471,6 @@ msgstr ""
 
 msgid "Number out of range"
 msgstr "Nombre hors limites"
-
-msgid "Number was empty"
-msgstr ""
 
 msgid "Only on interactive jobs"
 msgstr "Seulement sur les tâches interactives"

--- a/localization/po/pl.po
+++ b/localization/po/pl.po
@@ -566,6 +566,14 @@ msgid "%s: Not inside of loop\n"
 msgstr ""
 
 #, c-format
+msgid "%s: Number out of range"
+msgstr ""
+
+#, c-format
+msgid "%s: Number was empty"
+msgstr ""
+
+#, c-format
 msgid "%s: Options %s and %s cannot be used together\n"
 msgstr ""
 
@@ -1327,9 +1335,6 @@ msgid "Number is too large"
 msgstr ""
 
 msgid "Number out of range"
-msgstr ""
-
-msgid "Number was empty"
 msgstr ""
 
 msgid "Only on interactive jobs"

--- a/localization/po/pt_BR.po
+++ b/localization/po/pt_BR.po
@@ -571,6 +571,14 @@ msgid "%s: Not inside of loop\n"
 msgstr "%s: Não está dentro de laço\n"
 
 #, c-format
+msgid "%s: Number out of range"
+msgstr ""
+
+#, c-format
+msgid "%s: Number was empty"
+msgstr ""
+
+#, c-format
 msgid "%s: Options %s and %s cannot be used together\n"
 msgstr ""
 
@@ -1332,9 +1340,6 @@ msgid "Number is too large"
 msgstr ""
 
 msgid "Number out of range"
-msgstr ""
-
-msgid "Number was empty"
 msgstr ""
 
 msgid "Only on interactive jobs"

--- a/localization/po/sv.po
+++ b/localization/po/sv.po
@@ -567,6 +567,14 @@ msgid "%s: Not inside of loop\n"
 msgstr "%s: Inte i en loop\n"
 
 #, c-format
+msgid "%s: Number out of range"
+msgstr ""
+
+#, c-format
+msgid "%s: Number was empty"
+msgstr ""
+
+#, c-format
 msgid "%s: Options %s and %s cannot be used together\n"
 msgstr ""
 
@@ -1328,9 +1336,6 @@ msgid "Number is too large"
 msgstr ""
 
 msgid "Number out of range"
-msgstr ""
-
-msgid "Number was empty"
 msgstr ""
 
 msgid "Only on interactive jobs"

--- a/localization/po/zh_CN.po
+++ b/localization/po/zh_CN.po
@@ -593,6 +593,14 @@ msgid "%s: Not inside of loop\n"
 msgstr "%s: 不在循环体内部\n"
 
 #, c-format
+msgid "%s: Number out of range"
+msgstr "%s：数字超出范围"
+
+#, c-format
+msgid "%s: Number was empty"
+msgstr "%s：数字为空"
+
+#, c-format
 msgid "%s: Options %s and %s cannot be used together\n"
 msgstr "%s: 选项 %s 和 %s 无法一起使用\n"
 
@@ -1358,9 +1366,6 @@ msgstr "数字过大"
 
 msgid "Number out of range"
 msgstr "数字超出范围"
-
-msgid "Number was empty"
-msgstr "数字为空"
 
 msgid "Only on interactive jobs"
 msgstr "只在不活跃的作业上"

--- a/localization/po/zh_TW.po
+++ b/localization/po/zh_TW.po
@@ -566,6 +566,14 @@ msgid "%s: Not inside of loop\n"
 msgstr "%s：不在迴圈裡面\n"
 
 #, c-format
+msgid "%s: Number out of range"
+msgstr "%s：數字超出範圍"
+
+#, c-format
+msgid "%s: Number was empty"
+msgstr "%s：數字空白"
+
+#, c-format
 msgid "%s: Options %s and %s cannot be used together\n"
 msgstr "%s：選項 %s 和 %s 不能同時使用\n"
 
@@ -1332,9 +1340,6 @@ msgstr "數字太大"
 
 msgid "Number out of range"
 msgstr "數字超出範圍"
-
-msgid "Number was empty"
-msgstr "數字空白"
 
 msgid "Only on interactive jobs"
 msgstr "僅限互動式作業"

--- a/src/builtins/printf.rs
+++ b/src/builtins/printf.rs
@@ -208,10 +208,10 @@ impl<'a, 'b> builtin_printf_state_t<'a, 'b> {
         if errcode != None && errcode != Some(Error::InvalidChar) && errcode != Some(Error::Empty) {
             match errcode.unwrap() {
                 Error::Overflow => {
-                    self.fatal_error(sprintf!("%s: %s", s, wgettext!("Number out of range")));
+                    self.fatal_error(wgettext_fmt!("%s: Number out of range", s));
                 }
                 Error::Empty => {
-                    self.fatal_error(sprintf!("%s: %s", s, wgettext!("Number was empty")));
+                    self.fatal_error(wgettext_fmt!("%s: Number was empty", s));
                 }
                 Error::InvalidChar => {
                     panic!("Unreachable");


### PR DESCRIPTION
Using `wgettext_fmt` instead of `wgettext` + `sprintf` in these cases allows for proper localization of the colons.
