### PR TITLE
completions: add completions for `ijq`

### DIFF
--- a/share/completions/ijq.fish
+++ b/share/completions/ijq.fish
@@ -1,0 +1,19 @@
+# Completion for https://codeberg.org/gpanders/ijq
+# also at https://github.com/gpanders/ijq
+
+complete ijq -o h -l help -o help -d 'print help'
+complete ijq -o V -d 'output version'
+
+complete ijq -o C -d 'color output'
+complete ijq -o M -d 'no color, monochrome'
+complete ijq -o R -d 'input raw string, not JSON'
+complete ijq -o r -d 'output raw string unescaped'
+complete ijq -o S -d 'sort keys in output'
+complete ijq -o c -d 'no pretty-printing, compact'
+complete ijq -o n -d 'use `null` as input'
+complete ijq -o s -d 'turn all inputs into one array input'
+complete ijq -o hide-input-pane -d 'hide input pane'
+
+complete ijq -ro jqbin -d 'path to `jq` binary'
+complete ijq -ro f -d 'read initial filter from file'
+complete ijq -ro H -d 'history file'


### PR DESCRIPTION
https://codeberg.org/gpanders/ijq
https://github.com/gpanders/ijq

For comparison purposes, here's the output of `ijq --help` as of ijq 1.2.0:

```
ijq - interactive jq

Usage: ijq [-cnsrRMSV] [-f file] [filter] [files ...]

Options:
  -C	force colorized JSON, even if writing to a pipe or file
  -H string
    	set path to history file. Set to '' to disable history. (default "/Users/ilyagr/Library/Application Support/ijq/history")
  -M	monochrome (don't colorize JSON)
  -R	read raw strings, not JSON texts
  -S	sort keys of objects on output
  -V	print version and exit
  -c	compact instead of pretty-printed output
  -f filename
    	read initial filter from filename
  -hide-input-pane
    	hide input (left) viewing pane
  -jqbin string
    	name of or path to jq binary to use (default "jq")
  -n	use `null` as the single input value
  -r	output raw strings, not JSON texts
  -s	read (slurp) all inputs into an array; apply filter to it
```