### PR TITLE
feat: add catpuccin themes

### DIFF
--- a/share/themes/catppuccin-frappe.theme
+++ b/share/themes/catppuccin-frappe.theme
@@ -1,0 +1,61 @@
+# name: 'Catppuccin Frappé'
+# url: 'https://github.com/catppuccin/fish'
+
+[light]
+# preferred_background: eff1f5
+fish_color_normal 4c4f69
+fish_color_command 1e66f5
+fish_color_param dd7878
+fish_color_keyword 8839ef
+fish_color_quote 40a02b
+fish_color_redirection ea76cb
+fish_color_end fe640b
+fish_color_comment 8c8fa1
+fish_color_error d20f39
+fish_color_gray 9ca0b0
+fish_color_selection --background=ccd0da
+fish_color_search_match --background=ccd0da
+fish_color_option 40a02b
+fish_color_operator ea76cb
+fish_color_escape e64553
+fish_color_autosuggestion 9ca0b0
+fish_color_cancel d20f39
+fish_color_cwd df8e1d
+fish_color_user 179299
+fish_color_host 1e66f5
+fish_color_host_remote 40a02b
+fish_color_status d20f39
+fish_pager_color_progress 9ca0b0
+fish_pager_color_prefix ea76cb
+fish_pager_color_completion 4c4f69
+fish_pager_color_description 9ca0b0
+
+[dark]
+# preferred_background: 303446
+fish_color_normal c6d0f5
+fish_color_command 8caaee
+fish_color_param eebebe
+fish_color_keyword ca9ee6
+fish_color_quote a6d189
+fish_color_redirection f4b8e4
+fish_color_end ef9f76
+fish_color_comment 838ba7
+fish_color_error e78284
+fish_color_gray 737994
+fish_color_selection --background=414559
+fish_color_search_match --background=414559
+fish_color_option a6d189
+fish_color_operator f4b8e4
+fish_color_escape ea999c
+fish_color_autosuggestion 737994
+fish_color_cancel e78284
+fish_color_cwd e5c890
+fish_color_user 81c8be
+fish_color_host 8caaee
+fish_color_host_remote a6d189
+fish_color_status e78284
+fish_pager_color_progress 737994
+fish_pager_color_prefix f4b8e4
+fish_pager_color_completion c6d0f5
+fish_pager_color_description 737994
+

--- a/share/themes/catppuccin-macchiato.theme
+++ b/share/themes/catppuccin-macchiato.theme
@@ -1,0 +1,61 @@
+# name: 'Catppuccin Macchiato'
+# url: 'https://github.com/catppuccin/fish'
+
+[light]
+# preferred_background: eff1f5
+fish_color_normal 4c4f69
+fish_color_command 1e66f5
+fish_color_param dd7878
+fish_color_keyword 8839ef
+fish_color_quote 40a02b
+fish_color_redirection ea76cb
+fish_color_end fe640b
+fish_color_comment 8c8fa1
+fish_color_error d20f39
+fish_color_gray 9ca0b0
+fish_color_selection --background=ccd0da
+fish_color_search_match --background=ccd0da
+fish_color_option 40a02b
+fish_color_operator ea76cb
+fish_color_escape e64553
+fish_color_autosuggestion 9ca0b0
+fish_color_cancel d20f39
+fish_color_cwd df8e1d
+fish_color_user 179299
+fish_color_host 1e66f5
+fish_color_host_remote 40a02b
+fish_color_status d20f39
+fish_pager_color_progress 9ca0b0
+fish_pager_color_prefix ea76cb
+fish_pager_color_completion 4c4f69
+fish_pager_color_description 9ca0b0
+
+[dark]
+# preferred_background: 24273a
+fish_color_normal cad3f5
+fish_color_command 8aadf4
+fish_color_param f0c6c6
+fish_color_keyword c6a0f6
+fish_color_quote a6da95
+fish_color_redirection f5bde6
+fish_color_end f5a97f
+fish_color_comment 8087a2
+fish_color_error ed8796
+fish_color_gray 6e738d
+fish_color_selection --background=363a4f
+fish_color_search_match --background=363a4f
+fish_color_option a6da95
+fish_color_operator f5bde6
+fish_color_escape ee99a0
+fish_color_autosuggestion 6e738d
+fish_color_cancel ed8796
+fish_color_cwd eed49f
+fish_color_user 8bd5ca
+fish_color_host 8aadf4
+fish_color_host_remote a6da95
+fish_color_status ed8796
+fish_pager_color_progress 6e738d
+fish_pager_color_prefix f5bde6
+fish_pager_color_completion cad3f5
+fish_pager_color_description 6e738d
+

--- a/share/themes/catppuccin-mocha.theme
+++ b/share/themes/catppuccin-mocha.theme
@@ -1,0 +1,61 @@
+# name: 'Catppuccin Mocha'
+# url: 'https://github.com/catppuccin/fish'
+
+[light]
+# preferred_background: eff1f5
+fish_color_normal 4c4f69
+fish_color_command 1e66f5
+fish_color_param dd7878
+fish_color_keyword 8839ef
+fish_color_quote 40a02b
+fish_color_redirection ea76cb
+fish_color_end fe640b
+fish_color_comment 8c8fa1
+fish_color_error d20f39
+fish_color_gray 9ca0b0
+fish_color_selection --background=ccd0da
+fish_color_search_match --background=ccd0da
+fish_color_option 40a02b
+fish_color_operator ea76cb
+fish_color_escape e64553
+fish_color_autosuggestion 9ca0b0
+fish_color_cancel d20f39
+fish_color_cwd df8e1d
+fish_color_user 179299
+fish_color_host 1e66f5
+fish_color_host_remote 40a02b
+fish_color_status d20f39
+fish_pager_color_progress 9ca0b0
+fish_pager_color_prefix ea76cb
+fish_pager_color_completion 4c4f69
+fish_pager_color_description 9ca0b0
+
+[dark]
+# preferred_background: 1e1e2e
+fish_color_normal cdd6f4
+fish_color_command 89b4fa
+fish_color_param f2cdcd
+fish_color_keyword cba6f7
+fish_color_quote a6e3a1
+fish_color_redirection f5c2e7
+fish_color_end fab387
+fish_color_comment 7f849c
+fish_color_error f38ba8
+fish_color_gray 6c7086
+fish_color_selection --background=313244
+fish_color_search_match --background=313244
+fish_color_option a6e3a1
+fish_color_operator f5c2e7
+fish_color_escape eba0ac
+fish_color_autosuggestion 6c7086
+fish_color_cancel f38ba8
+fish_color_cwd f9e2af
+fish_color_user 94e2d5
+fish_color_host 89b4fa
+fish_color_host_remote a6e3a1
+fish_color_status f38ba8
+fish_pager_color_progress 6c7086
+fish_pager_color_prefix f5c2e7
+fish_pager_color_completion cdd6f4
+fish_pager_color_description 6c7086
+


### PR DESCRIPTION
Apologies about the unsolicited PR. I hope this helps. I hope this is not a nuissance.

Adding Catppuccin themes from: https://github.com/catppuccin/fish

They note:

Q: Where's the Latte theme?
A: All three themes contain Latte as the light variant. Install any of them, and then set your system or terminal theme to light mode.

## TODOs:
<!-- Check off what what has been done so far. -->
- [ ] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst 
<!-- Usually skipped for changes to completions -->
