### PR TITLE
history: fix highlighting for inline timestamps

### DIFF
--- a/src/history/history.rs
+++ b/src/history/history.rs
@@ -1114,6 +1114,8 @@ fn format_history_record(
     item: &HistoryItem,
     show_time_format: Option<&str>,
     null_terminate: bool,
+    parser: &Parser,
+    color_enabled: bool,
 ) -> WString {
     let mut result = WString::new();
     let seconds = time_to_seconds(item.timestamp());
@@ -1139,7 +1141,16 @@ fn format_history_record(
         }
     }
 
-    result.push_utfstr(item.str());
+    let mut command = WString::from(item.str());
+    if color_enabled {
+        command = bytes2wcstring(&highlight_and_colorize(
+            &command,
+            &parser.context(),
+            parser.vars(),
+        ));
+    }
+
+    result.push_utfstr(&command);
     result.push(if null_terminate { '\0' } else { '\n' });
     result
 }
@@ -1366,16 +1377,13 @@ impl History {
                 return ControlFlow::Break(());
             }
             remaining -= 1;
-            let mut formatted_record =
-                format_history_record(item, show_time_format, null_terminate);
-
-            if color_enabled {
-                formatted_record = bytes2wcstring(&highlight_and_colorize(
-                    &formatted_record,
-                    &parser.context(),
-                    parser.vars(),
-                ));
-            }
+            let formatted_record = format_history_record(
+                item,
+                show_time_format,
+                null_terminate,
+                parser,
+                color_enabled,
+            );
 
             if reverse {
                 // We need to collect this for later.


### PR DESCRIPTION
Highlighting the entire record caused custom prefixes to be parsed as command syntax. For example, using:
`history --show-time="[%Y-%m-%d %H:%M:%S] "`
resulted in the timestamp being colorized as shell code.

Move highlighting inside format_history_record to process the command string before the timestamp is prepended.
