### PR TITLE
cmake: remove obsolete doc setup

### DIFF
--- a/cmake/Docs.cmake
+++ b/cmake/Docs.cmake
@@ -8,7 +8,6 @@ include(FeatureSummary)
 
 set(SPHINX_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/doc_src")
 set(SPHINX_ROOT_DIR "${CMAKE_CURRENT_BINARY_DIR}/user_doc")
-set(SPHINX_BUILD_DIR "${SPHINX_ROOT_DIR}/build")
 set(SPHINX_HTML_DIR "${SPHINX_ROOT_DIR}/html")
 set(SPHINX_MANPAGE_DIR "${SPHINX_ROOT_DIR}/man")
 
@@ -74,7 +73,6 @@ endif()
 add_feature_info(Documentation WITH_DOCS "user manual and documentation")
 
 if(WITH_DOCS)
-    configure_file("${SPHINX_SRC_DIR}/conf.py" "${SPHINX_BUILD_DIR}/conf.py" @ONLY)
     add_custom_target(doc ALL
                       DEPENDS sphinx-docs sphinx-manpages)
     # Group docs targets into a DocsTargets folder


### PR DESCRIPTION
The `conf.py` file that was copied is not used for building. It seems that it was used as a mechanism for triggering rebuilds on changes to the original file, but in the current setup, `sphinx-build` is called unconditionally when the relevant targets are built, so there is no point in keeping on copying the `conf.py` file.
