### PR TITLE
common: remove unused constant

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1061,10 +1061,6 @@ pub fn has_working_tty_timestamps() -> bool {
     }
 }
 
-/// A global, empty string. This is useful for functions which wish to return a reference to an
-/// empty string.
-pub static EMPTY_STRING: WString = WString::new();
-
 /// A function type to check for cancellation.
 /// Return true if execution should cancel.
 /// todo!("Maybe remove the box? It is only needed for get_bg_context.")

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,5 +1,5 @@
 use crate::builtins::shared::{STATUS_CMD_ERROR, STATUS_CMD_OK, STATUS_READ_TOO_MUCH};
-use crate::common::{EMPTY_STRING, bytes2wcstring, wcs2bytes};
+use crate::common::{bytes2wcstring, wcs2bytes};
 use crate::fd_monitor::{Callback, FdMonitor, FdMonitorItemId};
 use crate::fds::{
     BorrowedFdFile, PIPE_ERROR, make_autoclose_pipes, make_fd_nonblocking, wopen_cloexec,
@@ -667,7 +667,7 @@ impl OutputStream {
     pub fn contents(&self) -> &wstr {
         match self {
             OutputStream::String(stream) => stream.contents(),
-            OutputStream::Null | OutputStream::Fd(_) | OutputStream::Buffered(_) => &EMPTY_STRING,
+            OutputStream::Null | OutputStream::Fd(_) | OutputStream::Buffered(_) => L!(""),
         }
     }
 


### PR DESCRIPTION
There was only a single usage of `EMPTY_STRING`, and there it was immediately dereferenced, so use an empty static `&wstr` instead and remove the `WString` constant.
