### PR TITLE
bind: forward-word cannot goto end of line

### DIFF
--- a/src/reader/reader.rs
+++ b/src/reader/reader.rs
@@ -3608,7 +3608,7 @@ impl<'a> Reader<'a> {
                     );
                     if !is_kill {
                         let (_elt, el) = self.active_edit_line_mut();
-                        if el.position() + 1 < el.len() {
+                        if el.position() + 1 <= el.len() {
                             el.set_position(el.position() + 1);
                         }
                     }


### PR DESCRIPTION
regression of bbb2f0de8d58610e7f9d4f1b00903562753ec199

emacs forward-word can goto end of line
