### PR TITLE
bind: nextd-or-forward-word/prevd-or-backward-word don't emit nextd/prevd

### DIFF
--- a/src/reader/reader.rs
+++ b/src/reader/reader.rs
@@ -3566,8 +3566,8 @@ impl<'a> Reader<'a> {
             | rl::KillWordEmacs
             | rl::KillBigwordEmacs
             | rl::NextdOrForwardWordEmacs => {
-                if c == rl::PrevdOrBackwardWord && self.command_line.is_empty() {
-                    self.eval_bind_cmd(L!("prevd"));
+                if c == rl::NextdOrForwardWordEmacs && self.command_line.is_empty() {
+                    self.eval_bind_cmd(L!("nextd"));
                     self.schedule_prompt_repaint();
                     return;
                 }
@@ -3752,6 +3752,11 @@ impl<'a> Reader<'a> {
             | rl::BackwardBigword
             | rl::BackwardBigwordEnd
             | rl::PrevdOrBackwardWord => {
+                if c == rl::PrevdOrBackwardWord && self.command_line.is_empty() {
+                    self.eval_bind_cmd(L!("prevd"));
+                    self.schedule_prompt_repaint();
+                    return;
+                }
                 let to_word_end = matches!(c, rl::BackwardWordEnd | rl::BackwardBigwordEnd);
 
                 let style = match c {


### PR DESCRIPTION
Regression of bbb2f0de8d5
