### PR TITLE
clippy: fix format_push_string lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,6 +193,7 @@ rustdoc.private_intra_doc_links = "allow"
 [workspace.lints.clippy]
 assigning_clones = "warn"
 cloned_instead_of_copied = "warn"
+format_push_string = "warn"
 implicit_clone = "warn"
 len_without_is_empty = "allow"    # we're not a library crate
 let_and_return = "allow"

--- a/src/builtins/fish_indent.rs
+++ b/src/builtins/fish_indent.rs
@@ -32,6 +32,7 @@ use crate::topic_monitor::topic_monitor_init;
 use crate::wutil::fish_iswalnum;
 use fish_wcstringutil::count_preceding_backslashes;
 use fish_wgetopt::{ArgType, WGetopter, WOption, wopt};
+use std::fmt::Write as _;
 
 /// Note: this got somewhat more complicated after introducing the new AST, because that AST no
 /// longer encodes detailed lexical information (e.g. every newline). This feels more complex
@@ -1286,14 +1287,16 @@ fn make_pygments_csv(src: &wstr) -> Vec<u8> {
     }
 
     // Now render these to a string.
-    let mut result = String::new();
+    let mut result = String::with_capacity(token_ranges.len() * 32);
     for range in token_ranges {
-        result += &format!(
-            "{},{},{}\n",
+        writeln!(
+            result,
+            "{},{},{}",
             range.start,
             range.end,
             highlight_role_to_string(range.role)
-        );
+        )
+        .unwrap();
     }
     result.into_bytes()
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -1385,6 +1385,7 @@ mod tests {
     use fish_util::get_seeded_rng;
     use fish_widestring::{ENCODE_DIRECT_BASE, L, WString, wstr};
     use rand::{Rng, RngCore};
+    use std::fmt::Write as _;
 
     #[test]
     fn test_escape_string() {
@@ -1525,9 +1526,9 @@ mod tests {
 
     /// Helper to convert a narrow string to a sequence of hex digits.
     fn bytes2hex(input: &[u8]) -> String {
-        let mut output = "".to_string();
+        let mut output = String::with_capacity(input.len() * 5);
         for byte in input {
-            output += &format!("0x{:2X} ", *byte);
+            write!(output, "0x{:2X} ", *byte).unwrap();
         }
         output
     }


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/index.html#format_push_string
