### PR TITLE
clippy: fix stable_sort_primitive lint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,6 +179,7 @@ dependencies = [
  "fish-wgetopt",
  "fish-widecharwidth",
  "fish-widestring",
+ "itertools",
  "libc",
  "lru",
  "macro_rules_attribute",
@@ -392,6 +399,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ fish-wcstringutil = { path = "crates/wcstringutil" }
 fish-widecharwidth = { path = "crates/widecharwidth" }
 fish-widestring = { path = "crates/widestring" }
 fish-wgetopt = { path = "crates/wgetopt" }
+itertools = "0.14.0"
 libc = "0.2.177"
 # lru pulls in hashbrown by default, which uses a faster (though less DoS resistant) hashing algo.
 # disabling default features uses the stdlib instead, but it doubles the time to rewrite the history
@@ -106,9 +107,10 @@ fish-printf.workspace = true
 fish-tempfile.workspace = true
 fish-util.workspace = true
 fish-wcstringutil.workspace = true
+fish-wgetopt.workspace = true
 fish-widecharwidth.workspace = true
 fish-widestring.workspace = true
-fish-wgetopt.workspace = true
+itertools.workspace = true
 libc.workspace = true
 lru.workspace = true
 macro_rules_attribute = "0.2.2"

--- a/src/localization/settings.rs
+++ b/src/localization/settings.rs
@@ -1,6 +1,7 @@
 use super::{localizable_consts, localizable_string, wgettext, wgettext_fmt};
 use crate::env::{EnvStack, Environment};
 use fish_widestring::{L, WString, wstr};
+use itertools::Itertools;
 use std::collections::{HashMap, HashSet};
 use std::sync::{LazyLock, Mutex};
 
@@ -392,22 +393,9 @@ pub fn status_language() -> WString {
 }
 
 pub fn list_available_languages() -> WString {
-    let mut language_set = HashSet::new();
-    fn add_languages<'a, 'b: 'a, LocalizationLanguage: 'a>(
-        language_set: &mut HashSet<&'b str>,
-        get_available_languages: fn() -> &'a HashMap<&'b str, LocalizationLanguage>,
-    ) {
-        for &lang in get_available_languages().keys() {
-            language_set.insert(lang);
-        }
-    }
-    add_languages(&mut language_set, fish_gettext::get_available_languages);
-    let mut language_list = Vec::from_iter(language_set);
-    language_list.sort_unstable();
-    let mut languages = WString::new();
-    for lang in language_list {
-        languages.push_str(lang);
-        languages.push('\n');
-    }
-    languages
+    fish_gettext::get_available_languages()
+        .keys()
+        .sorted_unstable()
+        .flat_map(|lang| [lang, "\n"])
+        .collect()
 }


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/index.html#stable_sort_primitive

cc: @danielrainer