### PR TITLE
cmake: remove unnecessary dir nesting

### DIFF
--- a/cmake/Rust.cmake
+++ b/cmake/Rust.cmake
@@ -2,7 +2,7 @@ include(FeatureSummary)
 include(FindRust)
 find_package(Rust REQUIRED)
 
-set(FISH_RUST_BUILD_DIR "${CMAKE_BINARY_DIR}/cargo/build")
+set(FISH_RUST_BUILD_DIR "${CMAKE_BINARY_DIR}/cargo")
 
 if(DEFINED ASAN)
     list(APPEND CARGO_FLAGS "-Z" "build-std")


### PR DESCRIPTION
The `cargo` directory in the CMake build directory is only used to store Cargo's build output, as would be done by `target` when building without CMake. But instead of putting the build output directly into the `cargo` directory, a nested `build` directory was used. There is no point in this nesting, so remove it.
