### PR TITLE
cmake: use variable for sphinx output dir

### DIFF
--- a/cmake/Docs.cmake
+++ b/cmake/Docs.cmake
@@ -7,9 +7,9 @@ find_program(SPHINX_EXECUTABLE NAMES sphinx-build
 include(FeatureSummary)
 
 set(SPHINX_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/doc_src")
-set(SPHINX_ROOT_DIR "${CMAKE_CURRENT_BINARY_DIR}/user_doc")
-set(SPHINX_HTML_DIR "${SPHINX_ROOT_DIR}/html")
-set(SPHINX_MANPAGE_DIR "${SPHINX_ROOT_DIR}/man")
+set(SPHINX_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/user_doc")
+set(SPHINX_HTML_DIR "${SPHINX_OUTPUT_DIR}/html")
+set(SPHINX_MANPAGE_DIR "${SPHINX_OUTPUT_DIR}/man")
 
 set(FISH_INDENT_FOR_BUILDING_DOCS "" CACHE FILEPATH "Path to fish_indent executable for building HTML docs")
 
@@ -29,7 +29,7 @@ add_custom_target(sphinx-docs
         -j auto
         -q -b html
         -c "${SPHINX_SRC_DIR}"
-        -d "${SPHINX_ROOT_DIR}/.doctrees-html"
+        -d "${SPHINX_OUTPUT_DIR}/.doctrees-html"
         "${SPHINX_SRC_DIR}"
         "${SPHINX_HTML_DIR}"
     DEPENDS
@@ -42,7 +42,7 @@ add_custom_target(sphinx-manpages
         -j auto
         -q -b man
         -c "${SPHINX_SRC_DIR}"
-        -d "${SPHINX_ROOT_DIR}/.doctrees-man"
+        -d "${SPHINX_OUTPUT_DIR}/.doctrees-man"
         "${SPHINX_SRC_DIR}"
         "${SPHINX_MANPAGE_DIR}/man1"
     COMMENT "Building man pages with Sphinx")

--- a/cmake/Install.cmake
+++ b/cmake/Install.cmake
@@ -28,18 +28,18 @@ set(extra_confdir
 
 
 # These are the man pages that go in system manpath; all manpages go in the fish-specific manpath.
-set(MANUALS ${CMAKE_CURRENT_BINARY_DIR}/user_doc/man/man1/fish.1
-            ${CMAKE_CURRENT_BINARY_DIR}/user_doc/man/man1/fish_indent.1
-            ${CMAKE_CURRENT_BINARY_DIR}/user_doc/man/man1/fish_key_reader.1
-            ${CMAKE_CURRENT_BINARY_DIR}/user_doc/man/man1/fish-doc.1
-            ${CMAKE_CURRENT_BINARY_DIR}/user_doc/man/man1/fish-tutorial.1
-            ${CMAKE_CURRENT_BINARY_DIR}/user_doc/man/man1/fish-language.1
-            ${CMAKE_CURRENT_BINARY_DIR}/user_doc/man/man1/fish-interactive.1
-            ${CMAKE_CURRENT_BINARY_DIR}/user_doc/man/man1/fish-terminal-compatibility.1
-            ${CMAKE_CURRENT_BINARY_DIR}/user_doc/man/man1/fish-completions.1
-            ${CMAKE_CURRENT_BINARY_DIR}/user_doc/man/man1/fish-prompt-tutorial.1
-            ${CMAKE_CURRENT_BINARY_DIR}/user_doc/man/man1/fish-for-bash-users.1
-            ${CMAKE_CURRENT_BINARY_DIR}/user_doc/man/man1/fish-faq.1
+set(MANUALS ${SPHINX_OUTPUT_DIR}/man/man1/fish.1
+            ${SPHINX_OUTPUT_DIR}/man/man1/fish_indent.1
+            ${SPHINX_OUTPUT_DIR}/man/man1/fish_key_reader.1
+            ${SPHINX_OUTPUT_DIR}/man/man1/fish-doc.1
+            ${SPHINX_OUTPUT_DIR}/man/man1/fish-tutorial.1
+            ${SPHINX_OUTPUT_DIR}/man/man1/fish-language.1
+            ${SPHINX_OUTPUT_DIR}/man/man1/fish-interactive.1
+            ${SPHINX_OUTPUT_DIR}/man/man1/fish-terminal-compatibility.1
+            ${SPHINX_OUTPUT_DIR}/man/man1/fish-completions.1
+            ${SPHINX_OUTPUT_DIR}/man/man1/fish-prompt-tutorial.1
+            ${SPHINX_OUTPUT_DIR}/man/man1/fish-for-bash-users.1
+            ${SPHINX_OUTPUT_DIR}/man/man1/fish-faq.1
 )
 
 # Determine which man page we don't want to install.
@@ -141,7 +141,7 @@ install(DIRECTORY share/themes/
 
 # CONDEMNED_PAGE is managed by the conditional above
 # Building the man pages is optional: if sphinx isn't installed, they're not built
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/user_doc/man/man1/
+install(DIRECTORY ${SPHINX_OUTPUT_DIR}/man/man1/
         DESTINATION ${rel_datadir}/fish/man/man1
         FILES_MATCHING
         PATTERN "*.1"
@@ -161,7 +161,7 @@ install(DIRECTORY share/tools/web_config
 
 # Building the man pages is optional: if Sphinx isn't installed, they're not built
 install(FILES ${MANUALS} DESTINATION ${mandir}/man1/ OPTIONAL)
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/user_doc/html/ # Trailing slash is important!
+install(DIRECTORY ${SPHINX_OUTPUT_DIR}/html/ # Trailing slash is important!
         DESTINATION ${docdir} OPTIONAL)
 install(FILES CHANGELOG.rst DESTINATION ${docdir})
 


### PR DESCRIPTION
This clarifies the usage of the directory, simplifies usages, and makes it easier to move the directory.
