### PR TITLE
docs: fix doc dir computation

### DIFF
--- a/crates/build-helper/src/lib.rs
+++ b/crates/build-helper/src/lib.rs
@@ -35,7 +35,7 @@ pub fn fish_build_dir() -> Cow<'static, Path> {
 }
 
 pub fn fish_doc_dir() -> Cow<'static, Path> {
-    fish_build_dir().join("fish-docs").into()
+    cargo_target_dir().join("fish-docs").into()
 }
 
 // TODO Move this to rsconf


### PR DESCRIPTION
`FISH_CMAKE_BINARY_DIR` is the top-level CMake output directory, not its subdirectory used as the target directory by Cargo. So far, this has not caused issues because CMake builds explicitly call `sphinx-build` to build the man pages, instead of using the Rust crate for embedding them.
