### PR TITLE
style.fish: canonicalize workspace root

### DIFF
--- a/build_tools/style.fish
+++ b/build_tools/style.fish
@@ -24,7 +24,7 @@ if set -l -q _flag_all
     end
 end
 
-set -l workspace_root (status dirname)/..
+set -l workspace_root (realpath (status dirname)/..)
 
 if test $all = yes
     if not set -l -q _flag_force; and not set -l -q _flag_check


### PR DESCRIPTION
Use a canonicalized absolute path for the workspace root to make errors containing paths easier to read.
