### PR TITLE
cmake: don't build fish_test_helper

### DIFF
--- a/cmake/Tests.cmake
+++ b/cmake/Tests.cmake
@@ -1,5 +1,3 @@
-add_executable(fish_test_helper tests/fish_test_helper.c)
-
 FILE(GLOB FISH_CHECKS CONFIGURE_DEPENDS ${CMAKE_SOURCE_DIR}/tests/checks/*.fish)
 foreach(CHECK ${FISH_CHECKS})
   get_filename_component(CHECK_NAME ${CHECK} NAME)
@@ -8,7 +6,7 @@ foreach(CHECK ${FISH_CHECKS})
     COMMAND ${CMAKE_SOURCE_DIR}/tests/test_driver.py ${CMAKE_CURRENT_BINARY_DIR}
                 checks/${CHECK_NAME}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests
-    DEPENDS fish fish_indent fish_key_reader fish_test_helper
+    DEPENDS fish fish_indent fish_key_reader
     USES_TERMINAL
   )
 endforeach(CHECK)
@@ -21,7 +19,7 @@ foreach(PEXPECT ${PEXPECTS})
     COMMAND ${CMAKE_SOURCE_DIR}/tests/test_driver.py ${CMAKE_CURRENT_BINARY_DIR}
                 pexpects/${PEXPECT}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests
-    DEPENDS fish fish_indent fish_key_reader fish_test_helper
+    DEPENDS fish fish_indent fish_key_reader
     USES_TERMINAL
   )
 endforeach(PEXPECT)
@@ -67,6 +65,6 @@ add_custom_target(fish_run_tests
             --target-dir ${rust_target_dir}
             ${cargo_test_flags}
   WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-  DEPENDS fish fish_indent fish_key_reader fish_test_helper
+  DEPENDS fish fish_indent fish_key_reader
   USES_TERMINAL
 )


### PR DESCRIPTION
Our test driver (`tests/test_driver.py`) already builds this unconditionally on each run, so there is no point in having CMake build the binary as well. If we want to reduce the effort of rebuilding the test helper on each invocation of the test driver, we could consider some other caching approach, but it should work for non-CMake builds as well. I consider this a low priority, since building the executable only takes a few 10s of milliseconds on relatively modern hardware.