### PR TITLE
asan: remove redundant handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,7 +183,6 @@ localize-messages = ["dep:fish-gettext"]
 gettext-extract = ["dep:fish-gettext-extraction"]
 
 # The following features are auto-detected by the build-script and should not be enabled manually.
-asan = []
 tsan = []
 
 [workspace.lints]

--- a/build_tools/lsan_suppressions.txt
+++ b/build_tools/lsan_suppressions.txt
@@ -1,3 +1,0 @@
-# LSAN can detect leaks tracing back to __asan::AsanThread::ThreadStart (probably caused by our
-# threads not exiting before their TLS dtors are called). Just ignore it.
-leak:AsanThread

--- a/cmake/Rust.cmake
+++ b/cmake/Rust.cmake
@@ -6,7 +6,6 @@ set(FISH_RUST_BUILD_DIR "${CMAKE_BINARY_DIR}/cargo")
 
 if(DEFINED ASAN)
     list(APPEND CARGO_FLAGS "-Z" "build-std")
-    list(APPEND FISH_CARGO_FEATURES_LIST "asan")
 endif()
 if(DEFINED TSAN)
     list(APPEND CARGO_FLAGS "-Z" "build-std")

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -12,7 +12,7 @@ use libc::STDIN_FILENO;
 use crate::{
     common::{get_program_name, read_blocked},
     nix::isatty,
-    threads::{asan_maybe_exit, is_main_thread},
+    threads::is_main_thread,
 };
 
 pub static AT_EXIT: OnceLock<Box<dyn Fn() + Send + Sync>> = OnceLock::new();
@@ -59,6 +59,5 @@ pub fn panic_handler(main: impl FnOnce() -> i32 + UnwindSafe) -> ! {
     if let Some(at_exit) = AT_EXIT.get() {
         (at_exit)();
     }
-    asan_maybe_exit(exit_status);
     std::process::exit(exit_status)
 }

--- a/src/threads/threads.rs
+++ b/src/threads/threads.rs
@@ -178,18 +178,6 @@ pub fn spawn<F: FnOnce() + Send + 'static>(callback: F) -> bool {
     result
 }
 
-/// Exits calling onexit handlers if running under ASAN, otherwise does nothing.
-///
-/// This function is always defined but is a no-op if not running under ASAN. This is to make it
-/// more ergonomic to call it in general and also makes it possible to call it via ffi at all.
-pub fn asan_maybe_exit(code: i32) {
-    if cfg!(feature = "asan") {
-        unsafe {
-            libc::exit(code);
-        }
-    }
-}
-
 /// Data shared between the thread pool [`ThreadPool`] and worker threads [`WorkerThread`].
 #[derive(Default)]
 struct ThreadPoolProtected {


### PR DESCRIPTION
The special exit handling when running with address sanitization no longer seems necessary. Our tests all pass without it.

Similarly, the leak sanitizer suppression is no longer needed, since we don't get any warnings when running our checks without it.

Because our Rust code no longer has any ASAN-specific behavior, we don't need the `asan` feature anymore.
