### PR TITLE
Add strikethrough TextStyling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,10 @@ New or improved bindings
 - Vi mode key bindings now support counts for movement and deletion commands (e.g. `d3w` or `3l`), via a new operator mode (:issue:`2192`).
 - New ``catpuccin-*`` color themes.
 
+Improved terminal support
+-------------------------
+- Support strikethrough (``--strikethrough`` or ``-s``) modifier on `set_color`.
+
 For distributors and developers
 -------------------------------
 - The CMake option ``WITH_GETTEXT`` has been renamed to ``WITH_MESSAGE_LOCALIZATION``, to reflect that it toggles localization independently of the backend used in the implementation.

--- a/doc_src/cmds/set_color.rst
+++ b/doc_src/cmds/set_color.rst
@@ -54,6 +54,9 @@ The following options are available:
 **-r** or **--reverse**
     Sets reverse mode.
 
+**-s** or **--strikethrough**
+    Sets strikethrough mode.
+
 **-u** or **--underline**, or **-uSTYLE** or **--underline=STYLE**
     Set the underline mode; supported styles are **single** (default), **double**, **curly**, **dotted** and **dashed**.
 

--- a/doc_src/interactive.rst
+++ b/doc_src/interactive.rst
@@ -110,6 +110,7 @@ Options accepted by ``set_color`` like
 ``--dim``,
 ``--italics``,
 ``--reverse``,
+``--strikethrough``,
 ``--underline`` and
 ``--underline-color=``
 are also accepted.

--- a/doc_src/terminal-compatibility.rst
+++ b/doc_src/terminal-compatibility.rst
@@ -92,7 +92,7 @@ Optional Commands
 
    * - ``\e[m``
      - sgr0
-     - Turn off bold/dim/italic/underline/reverse attribute modes and select default colors.
+     - Turn off bold/dim/italic/underline/strikethrough/reverse attribute modes and select default colors.
    * - ``\e[1m``
      - bold
      - Enter bold mode.
@@ -120,12 +120,18 @@ Optional Commands
    * - ``\e[7m``
      - rev
      - Enter reverse video mode (swap foreground and background colors).
+   * - ``\e[9m``
+     - smxx
+     - Enter strikethrough mode
    * - ``\e[23m``
      - ritm
      - Exit italic mode.
    * - ``\e[24m``
      - rmul
      - Exit underline mode.
+   * - ``\e[29m``
+     - rmxx
+     - Exit strikethrough mode.
    * - ``\e[38;5; Ps m``
      - setaf
      - Select foreground color Ps from the 256-color-palette.

--- a/share/completions/set.fish
+++ b/share/completions/set.fish
@@ -139,6 +139,7 @@ complete -c set -n '__fish_set_is_color false true' -a '--underline-color=(set_c
 complete -c set -n '__fish_set_is_color true false' -a --bold -x
 complete -c set -n '__fish_set_is_color true false' -a --dim -x
 complete -c set -n '__fish_set_is_color true false' -a --italics -x
+complete -c set -n '__fish_set_is_color true false' -a --strikethrough -x
 complete -c set -n '__fish_set_is_color true true' -a --reverse -x
 complete -c set -n '__fish_set_is_color true false' -a --underline -x
 complete -c set -n '__fish_set_is_color true false' -a--underline={double,curly,dotted,dashed} -x

--- a/share/completions/set_color.fish
+++ b/share/completions/set_color.fish
@@ -3,6 +3,7 @@ complete -c set_color -s b -l background -x -a '(set_color --print-colors)' -d "
 complete -c set_color -s b -l underline-color -x -a '(set_color --print-colors)' -d "Change underline color"
 complete -c set_color -s o -l bold -d 'Make font bold'
 complete -c set_color -s i -l italics -d Italicise
+complete -c set_color -s s -l strikethrough -d Strikethrough
 complete -c set_color -s d -l dim -d 'Dim text'
 complete -c set_color -s r -l reverse -d 'Reverse color text'
 complete -c set_color -s u -l underline -d 'Underline style' -a 'single double curly dotted dashed'

--- a/share/tools/web_config/webconfig.py
+++ b/share/tools/web_config/webconfig.py
@@ -233,6 +233,7 @@ def parse_color(comps):
     bold = False
     underline = None
     italics = False
+    strikethrough = False
     dim = False
     reverse = False
     i = 0
@@ -256,6 +257,8 @@ def parse_color(comps):
             dim = True
         elif comp == "--reverse" or comp == "-r":
             reverse = True
+        elif comp == "--strikethrough" or comp == "-s":
+            strikethrough = True
         elif comp.startswith("--theme="):
             pass  # Not yet supported here.
         else:
@@ -310,6 +313,7 @@ def parse_color(comps):
         "italics": italics,
         "dim": dim,
         "reverse": reverse,
+        "strikethrough": strikethrough,
     }
 
 
@@ -330,6 +334,8 @@ def unparse_color(col):
         ret += " --dim"
     if col["reverse"]:
         ret += " --reverse"
+    if col["strikethrough"]:
+        ret += " --strikethrough"
     if col["background"]:
         ret += " --background=" + col["background"]
     if col["underline-color"]:
@@ -659,7 +665,7 @@ def append_html_for_ansi_escape(full_val, result, span_open):
         close_span()
         return False
 
-    # TODO We don't handle bold, underline, italics, dim, or reverse yet
+    # TODO We don't handle bold, underline, italics, dim, strikethrough, or reverse yet
 
     # Do nothing on failure
     return span_open

--- a/src/text_face.rs
+++ b/src/text_face.rs
@@ -37,6 +37,7 @@ pub(crate) struct TextStyling {
     pub(crate) italics: bool,
     pub(crate) dim: bool,
     pub(crate) reverse: bool,
+    pub(crate) strikethrough: bool,
 }
 
 impl TextStyling {
@@ -47,6 +48,7 @@ impl TextStyling {
             italics: false,
             dim: false,
             reverse: false,
+            strikethrough: false,
         }
     }
     pub(crate) fn is_empty(&self) -> bool {
@@ -61,6 +63,7 @@ impl TextStyling {
             italics: self.is_italics() || other.is_italics(),
             dim: self.is_dim() || other.is_dim(),
             reverse: self.is_reverse() || other.is_reverse(),
+            strikethrough: self.is_strikethrough() || other.is_strikethrough(),
         }
     }
     pub(crate) fn difference_prefer_empty(self, other: Self) -> Self {
@@ -72,6 +75,7 @@ impl TextStyling {
             italics: self.is_italics() && !other.is_italics(),
             dim: self.is_dim() && !other.is_dim(),
             reverse: self.is_reverse() && !other.is_reverse(),
+            strikethrough: self.is_strikethrough() && !other.is_strikethrough(),
         }
     }
 
@@ -103,6 +107,11 @@ impl TextStyling {
     /// Returns whether the text face has reverse foreground/background colors.
     pub const fn is_reverse(self) -> bool {
         self.reverse
+    }
+
+    /// Returns whether the text face is strikethrough.
+    pub const fn is_strikethrough(self) -> bool {
+        self.strikethrough
     }
 }
 
@@ -197,6 +206,7 @@ pub(crate) fn parse_text_face_and_options<'argarray, 'args>(
         wopt(L!("underline"), ArgType::OptionalArgument, 'u'),
         wopt(L!("italics"), ArgType::NoArgument, 'i'),
         wopt(L!("dim"), ArgType::NoArgument, 'd'),
+        wopt(L!("strikethrough"), ArgType::NoArgument, 's'),
         wopt(L!("reverse"), ArgType::NoArgument, 'r'),
         wopt(L!("theme"), ArgType::RequiredArgument, '\x01'),
         wopt(L!("help"), ArgType::NoArgument, 'h'),
@@ -248,6 +258,7 @@ pub(crate) fn parse_text_face_and_options<'argarray, 'args>(
             'i' => init_style(&mut style).italics = true,
             'd' => init_style(&mut style).dim = true,
             'r' => init_style(&mut style).reverse = true,
+            's' => init_style(&mut style).strikethrough = true,
             'u' => {
                 let arg = w.woptarg.unwrap_or(L!("single"));
                 init_style(&mut style).underline_style = Some(if arg == "single" {

--- a/tests/checks/set_color.fish
+++ b/tests/checks/set_color.fish
@@ -22,6 +22,11 @@ string escape (set_color --bold=red)
 #CHECKERR: called on line {{\d+}} of file {{.*}}checks/set_color.fish
 #CHECKERR: (Type 'help set_color' for related documentation)
 
+string escape (set_color --strikethrough red --background=normal)
+# CHECK: \e\[31m\e\[49m\e\[9m
+string escape (set_color --strikethrough red --background=blue)
+# CHECK: \e\[31m\e\[44m\e\[9m
+
 string escape (set_color --bold red --background=normal)
 # CHECK: \e\[31m\e\[49m\e\[1m
 string escape (set_color --bold red --background=blue)


### PR DESCRIPTION
## Description
This commit adds a strikethrough styling option (`--strikethrough` or `-s`). Many, but not all, terminals support this, https://github.com/matterhorn-chat/matterhorn/issues/671 .
This is my first PR here, so any feedback is appreciated.

Screenshot using kitty with IBM Plex Mono with the default config.
<img width="2364" height="492" alt="image" src="https://github.com/user-attachments/assets/cb2941e5-f473-48cb-a665-3c64bc24c68e" />




## Note
This uses the `smxx` and `rmxx` terminfo capability codes. The `get_str_cap` documentation claims that using a non two-letter code will panic, but `terminfo::Database.raw` mentions no such restriction, and it did not crash in my testing.

## TODOs:
<!-- Check off what what has been done so far. -->
- [ n/a] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [n/a] n/a Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->

