### PR TITLE
Add complete-prefix command for prefix-only tab completion

### DIFF
--- a/src/complete.rs
+++ b/src/complete.rs
@@ -224,6 +224,15 @@ impl CompletionRequestOptions {
             fuzzy_match: true,
         }
     }
+
+    /// Options for prefix-only completion (no fuzzy/subsequence matching).
+    pub fn prefix_only() -> Self {
+        Self {
+            autosuggestion: false,
+            descriptions: true,
+            fuzzy_match: false,
+        }
+    }
 }
 
 /// A completion receiver accepts completions. It is essentially a wrapper around `Vec` with

--- a/src/input/binding.rs
+++ b/src/input/binding.rs
@@ -211,6 +211,7 @@ define_readline_cmds! {
     ("clear-screen", ClearScreenAndRepaint),
     ("complete", Complete),
     ("complete-and-search", CompleteAndSearch),
+    ("complete-prefix", CompletePrefix),
     ("delete-char", DeleteChar),
     ("delete-or-exit", DeleteOrExit),
     ("down-line", DownLine),

--- a/src/reader/reader.rs
+++ b/src/reader/reader.rs
@@ -3140,7 +3140,7 @@ impl<'a> Reader<'a> {
                 if self.rls().completion_action == Some(CompletionAction::InsertedUnique)
                     && matches!(
                         self.rls().last_cmd,
-                        Some(rl::Complete | rl::CompleteAndSearch)
+                        Some(rl::Complete | rl::CompleteAndSearch | rl::CompletePrefix)
                     )
                 {
                     let (elt, _el) = self.active_edit_line();
@@ -3181,13 +3181,13 @@ impl<'a> Reader<'a> {
                 self.force_exec_prompt_and_repaint = false;
                 self.parser.libdata_mut().is_repaint = false;
             }
-            rl::Complete | rl::CompleteAndSearch => {
+            rl::Complete | rl::CompleteAndSearch | rl::CompletePrefix => {
                 if !self.conf.complete_ok {
                     return;
                 }
                 if self.is_navigating_pager_contents()
                     || (self.rls().completion_action == Some(CompletionAction::ShownAmbiguous)
-                        && self.rls().last_cmd == Some(rl::Complete))
+                        && matches!(self.rls().last_cmd, Some(rl::Complete | rl::CompletePrefix)))
                 {
                     // The user typed complete more than once in a row. If we are not yet fully
                     // disclosed, then become so; otherwise cycle through our available completions.
@@ -3195,7 +3195,7 @@ impl<'a> Reader<'a> {
                         self.pager.set_fully_disclosed();
                     } else {
                         self.select_completion_in_direction(
-                            if c == rl::Complete {
+                            if c == rl::Complete || c == rl::CompletePrefix {
                                 SelectionMotion::Next
                             } else {
                                 SelectionMotion::Prev
@@ -6207,6 +6207,7 @@ fn command_ends_paging(c: ReadlineCmd, focused_on_search_field: bool) -> bool {
         }
         rl::Complete
         | rl::CompleteAndSearch
+        | rl::CompletePrefix
         | rl::HistoryPager
         | rl::BackwardChar
         | rl::BackwardCharPassive
@@ -6899,7 +6900,10 @@ fn reader_can_replace(s: &wstr, flags: CompleteFlags) -> bool {
 impl<'a> Reader<'a> {
     /// Compute completions and update the pager and/or commandline as needed.
     fn compute_and_apply_completions(&mut self, c: ReadlineCmd) {
-        assert_matches!(c, ReadlineCmd::Complete | ReadlineCmd::CompleteAndSearch);
+        assert_matches!(
+            c,
+            ReadlineCmd::Complete | ReadlineCmd::CompleteAndSearch | ReadlineCmd::CompletePrefix
+        );
         assert!(
             !get_tty_protocols_active(),
             "should not be called with TTY protocols active"
@@ -6969,11 +6973,12 @@ impl<'a> Reader<'a> {
 
         let (mut comp, _needs_load) = {
             let cmdsub = &self.data.command_line.text()[cmdsub_range.start..token_range.end];
-            complete(
-                cmdsub,
-                CompletionRequestOptions::normal(),
-                &mut self.parser.context(),
-            )
+            let options = if c == ReadlineCmd::CompletePrefix {
+                CompletionRequestOptions::prefix_only()
+            } else {
+                CompletionRequestOptions::normal()
+            };
+            complete(cmdsub, options, &mut self.parser.context())
         };
 
         let el = &self.command_line;


### PR DESCRIPTION
The `complete-prefix` readline command only matches completions by prefix, disabling fuzzy/subsequence matching.

This allows users who find subsequence matching annoying (e.g., "car" completing to "blkdiscard" when "cargo" isn't in PATH) to bind Tab to prefix-only completion while keeping fuzzy matching available on another key.

Usage:
  bind tab complete-prefix
  bind shift-tab complete  # keeps fuzzy behavior

See: https://github.com/fish-shell/fish-shell/discussions/11670

---

For now, I'm asking for feedback. I haven't even looked at how to write docs or tests. Before that, I need to ask: does this approach look good?


## TODOs:
<!-- Check off what what has been done so far. -->
- [x] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
