### PR TITLE
Deprecation of --self-contained and its replacement

### DIFF
--- a/share/completions/pandoc.fish
+++ b/share/completions/pandoc.fish
@@ -22,7 +22,9 @@ complete -c pandoc -s s -l standalone
 complete -c pandoc -l strip-comments
 complete -c pandoc -l toc -l table-of-contents
 complete -c pandoc -l no-highlight
-complete -c pandoc -l self-contained
+complete -c pandoc -l self-contained # deprecated: replaced by the following two options
+complete -c pandoc -l standalone
+complete -c pandoc -l embed-resources
 complete -c pandoc -l html-q-tags
 complete -c pandoc -l ascii
 complete -c pandoc -l reference-links


### PR DESCRIPTION
Pandoc has deprecated the command-line option `--self-contained ` replacing it by the pair `--standalone` and `--embed-resources`. I decided to keep `--self-contained` nonetheless to be compatible with all versions.