### PR TITLE
dnf: support subcommand aliases in completions

### DIFF
--- a/share/completions/dnf.fish
+++ b/share/completions/dnf.fish
@@ -137,7 +137,6 @@ complete -c dnf -n __fish_use_subcommand -xa "$__dnf_info_cmds" -d "Describes th
 complete -c dnf -n "__fish_seen_subcommand_from $__dnf_info_cmds; and not __fish_seen_subcommand_from history" \
     -k -xa "(__dnf_list_available_packages)"
 
-
 # Install
 complete -c dnf -n __fish_use_subcommand -xa "$__dnf_install_cmds" -d "Install package"
 complete -c dnf -n "__fish_seen_subcommand_from $__dnf_install_cmds" \


### PR DESCRIPTION
DNF provides short aliases for commonly used subcommands, such as
`in`, `rm`, `rei`, and `if`. Fish completions currently only recognize
the full subcommand names, so argument and package completions do not
work when using these aliases.

This change groups the aliases with their corresponding subcommands and
treats them equivalently for completion purposes. As a result, completions
work consistently whether the full subcommand or its alias is used.

Tested in a Fedora container with dnf; completions work for both full
subcommands and their aliases.

Fixes #11613  


