### PR TITLE
__fish_complete_suffix: Remove –foo= from token

### DIFF
--- a/share/functions/__fish_complete_suffix.fish
+++ b/share/functions/__fish_complete_suffix.fish
@@ -11,7 +11,8 @@
 # is preserved.
 function __fish_complete_suffix -d "Complete using files"
     set -l _flag_prefix ""
-    set -l _flag_complete (commandline -ct)
+    # We need to remove '--name=' from the completion. See __fish_complete_directories
+    set -l _flag_complete (commandline -ct | string replace -r -- '^-[^=]*=' '')
 
     argparse 'prefix=' 'description=' 'complete=' -- $argv
 


### PR DESCRIPTION
Otherwise we get --foo=--foo= suggested.

Fixes #12374. Related to #9538.

I didn't add tests because there are currently none for `__fish_complete_suffix`, but I could add some tests for it if needed.

I also wasn't sure if this change should be listed in the changelog or not, so I skipped it for now.

## TODOs:
<!-- Check off what what has been done so far. -->
- [X] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
