### PR TITLE
completion/rfkill: add completions for toggle command

### DIFF
--- a/share/completions/rfkill.fish
+++ b/share/completions/rfkill.fish
@@ -1,5 +1,5 @@
 complete -c rfkill -xa 'block unblock list event help' -n 'not __fish_seen_subcommand_from block unblock list event help'
-complete -c rfkill -n '__fish_seen_subcommand_from block unblock list' -d 'device group' -xa "all wifi wlan bluetooth uwb ultrawideband wimax wwan gps fm (rfkill list | string replace : \t)"
+complete -c rfkill -n '__fish_seen_subcommand_from block unblock toggle list' -d 'device group' -xa "all wifi wlan bluetooth uwb ultrawideband wimax wwan gps fm (rfkill list | string replace : \t)"
 complete -c rfkill -s V -l version -d 'Print version'
 complete -c rfkill -s h -l help -d 'Print help'
 complete -c rfkill -s J -l json -d 'JSON output'


### PR DESCRIPTION
Minor completion improvement for rfkill.
The "toggle" command was not considered in the completions, it uses the same logic to complete as block and unblock.

Best regards and thanks for fish

## TODOs:
- [x] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
