### PR TITLE
Fix vi key bindings: use -M insert instead of $argv for ctrl-right

### DIFF
--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -349,7 +349,7 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
     bind -s --preset ] history-token-search-forward
     bind -s --preset -m insert / history-pager repaint-mode
 
-    __fish_per_os_bind --preset $argv ctrl-right forward-token forward-word-vi
+    __fish_per_os_bind --preset -M insert ctrl-right forward-token forward-word-vi
     # ctrl-left is same as emacs mode
 
     bind -s --preset -M insert ctrl-n accept-autosuggestion


### PR DESCRIPTION
This fixes a regression introduced in bbb2f0de8d where calling `fish_vi_key_bindings` with a mode argument causes the error:
```
bind: cannot parse key 'default'
```

## Problem

Commit bbb2f0de8d added a ctrl-right binding to override the shared binding with `forward-word-vi` for vi-compliance. However, it incorrectly used `$argv` instead of `-M insert`.

When users call `fish_vi_key_bindings "default"` (e.g., in a `fish_prompt` event handler), the `$argv` variable contains the user's mode argument (e.g., "default"), which gets passed to `bind` as a key name instead of a mode, causing the parse error.

## Solution

Replace `$argv` with `-M insert` to explicitly specify that this binding overrides the shared ctrl-right binding for insert mode only, changing it from `forward-word` to the vi-compliant `forward-word-vi`.

## Reproduction

```fish
function my_vi_mode_setup --on-event fish_prompt
    fish_vi_key_bindings "default"
end
```

**Before:** Produces error: `bind: cannot parse key 'default'`  
**After:** No error

Fixes regression from bbb2f0de8d (feat(vi-mode): make word movements vi-compliant)