### PR TITLE
l10n: localize colon followed by content

### DIFF
--- a/localization/po/de.po
+++ b/localization/po/de.po
@@ -100,12 +100,12 @@ msgid "%s %s: unrecognized feature '%s'"
 msgstr ""
 
 #, c-format
-msgid "%s (line %d):"
-msgstr "%s (Zeile %d):"
+msgid "%s (line %d)"
+msgstr "%s (Zeile %d)"
 
 #, c-format
-msgid "%s (line %u):"
-msgstr "%s (Zeile %u):"
+msgid "%s (line %u)"
+msgstr "%s (Zeile %u)"
 
 #, c-format
 msgid "%s and %s are mutually exclusive"
@@ -141,7 +141,7 @@ msgstr ""
 
 #, c-format
 msgid "%s: %s"
-msgstr ""
+msgstr "%s: %s"
 
 #, c-format
 msgid "%s: %s %s: options cannot be used together"
@@ -1460,12 +1460,12 @@ msgid "Standard input"
 msgstr "Standardeingabe"
 
 #, c-format
-msgid "Standard input (line %d):"
+msgid "Standard input (line %d)"
 msgstr ""
 
 #, c-format
-msgid "Startup (line %d):"
-msgstr "Start (Zeile %d):"
+msgid "Startup (line %d)"
+msgstr "Start (Zeile %d)"
 
 msgid "State"
 msgstr "Status"

--- a/localization/po/en.po
+++ b/localization/po/en.po
@@ -100,12 +100,12 @@ msgid "%s %s: unrecognized feature '%s'"
 msgstr ""
 
 #, c-format
-msgid "%s (line %d):"
-msgstr "%s (line %d):"
+msgid "%s (line %d)"
+msgstr "%s (line %d)"
 
 #, c-format
-msgid "%s (line %u):"
-msgstr "%s (line %u):"
+msgid "%s (line %u)"
+msgstr "%s (line %u)"
 
 #, c-format
 msgid "%s and %s are mutually exclusive"
@@ -1460,11 +1460,11 @@ msgid "Standard input"
 msgstr "Standard input"
 
 #, c-format
-msgid "Standard input (line %d):"
+msgid "Standard input (line %d)"
 msgstr ""
 
 #, c-format
-msgid "Startup (line %d):"
+msgid "Startup (line %d)"
 msgstr ""
 
 msgid "State"

--- a/localization/po/fr.po
+++ b/localization/po/fr.po
@@ -229,12 +229,12 @@ msgid "%s %s: unrecognized feature '%s'"
 msgstr "%s %s : fonctionnalité non reconnue « %s »"
 
 #, c-format
-msgid "%s (line %d):"
-msgstr "%s (ligne %d) :"
+msgid "%s (line %d)"
+msgstr "%s (ligne %d)"
 
 #, c-format
-msgid "%s (line %u):"
-msgstr "%s (ligne %u) :"
+msgid "%s (line %u)"
+msgstr "%s (ligne %u)"
 
 #, c-format
 msgid "%s and %s are mutually exclusive"
@@ -1589,11 +1589,11 @@ msgid "Standard input"
 msgstr "Entrée standard"
 
 #, c-format
-msgid "Standard input (line %d):"
+msgid "Standard input (line %d)"
 msgstr ""
 
 #, c-format
-msgid "Startup (line %d):"
+msgid "Startup (line %d)"
 msgstr ""
 
 msgid "State"

--- a/localization/po/pl.po
+++ b/localization/po/pl.po
@@ -96,12 +96,12 @@ msgid "%s %s: unrecognized feature '%s'"
 msgstr ""
 
 #, c-format
-msgid "%s (line %d):"
-msgstr "%s (linia %d):"
+msgid "%s (line %d)"
+msgstr "%s (linia %d)"
 
 #, c-format
-msgid "%s (line %u):"
-msgstr "%s (linia %u):"
+msgid "%s (line %u)"
+msgstr "%s (linia %u)"
 
 #, c-format
 msgid "%s and %s are mutually exclusive"
@@ -1456,11 +1456,11 @@ msgid "Standard input"
 msgstr "Standardowe wejście"
 
 #, c-format
-msgid "Standard input (line %d):"
+msgid "Standard input (line %d)"
 msgstr ""
 
 #, c-format
-msgid "Startup (line %d):"
+msgid "Startup (line %d)"
 msgstr ""
 
 msgid "State"

--- a/localization/po/pt_BR.po
+++ b/localization/po/pt_BR.po
@@ -101,12 +101,12 @@ msgid "%s %s: unrecognized feature '%s'"
 msgstr ""
 
 #, c-format
-msgid "%s (line %d):"
-msgstr "%s (linha %d):"
+msgid "%s (line %d)"
+msgstr "%s (linha %d)"
 
 #, c-format
-msgid "%s (line %u):"
-msgstr "%s (linha %u):"
+msgid "%s (line %u)"
+msgstr "%s (linha %u)"
 
 #, c-format
 msgid "%s and %s are mutually exclusive"
@@ -1461,11 +1461,11 @@ msgid "Standard input"
 msgstr "Entrada padrão"
 
 #, c-format
-msgid "Standard input (line %d):"
+msgid "Standard input (line %d)"
 msgstr ""
 
 #, c-format
-msgid "Startup (line %d):"
+msgid "Startup (line %d)"
 msgstr ""
 
 msgid "State"

--- a/localization/po/sv.po
+++ b/localization/po/sv.po
@@ -97,11 +97,11 @@ msgid "%s %s: unrecognized feature '%s'"
 msgstr ""
 
 #, c-format
-msgid "%s (line %d):"
-msgstr "%s (rad %d):"
+msgid "%s (line %d)"
+msgstr "%s (rad %d)"
 
 #, c-format
-msgid "%s (line %u):"
+msgid "%s (line %u)"
 msgstr ""
 
 #, c-format
@@ -1457,11 +1457,11 @@ msgid "Standard input"
 msgstr "Standard in"
 
 #, c-format
-msgid "Standard input (line %d):"
+msgid "Standard input (line %d)"
 msgstr ""
 
 #, c-format
-msgid "Startup (line %d):"
+msgid "Startup (line %d)"
 msgstr ""
 
 msgid "State"

--- a/localization/po/zh_CN.po
+++ b/localization/po/zh_CN.po
@@ -121,12 +121,12 @@ msgid "%s %s: unrecognized feature '%s'"
 msgstr "%s %s: 未识别的特性 '%s'"
 
 #, c-format
-msgid "%s (line %d):"
-msgstr "%s (行 %d):"
+msgid "%s (line %d)"
+msgstr "%s (行 %d)"
 
 #, c-format
-msgid "%s (line %u):"
-msgstr "%s (行 %u):"
+msgid "%s (line %u)"
+msgstr "%s (行 %u)"
 
 #, c-format
 msgid "%s and %s are mutually exclusive"
@@ -1481,12 +1481,12 @@ msgid "Standard input"
 msgstr "标准输入"
 
 #, c-format
-msgid "Standard input (line %d):"
-msgstr "标准输入 (行 %d)："
+msgid "Standard input (line %d)"
+msgstr "标准输入 (行 %d)"
 
 #, c-format
-msgid "Startup (line %d):"
-msgstr "启动 (行 %d)："
+msgid "Startup (line %d)"
+msgstr "启动 (行 %d)"
 
 msgid "State"
 msgstr "状态"

--- a/localization/po/zh_TW.po
+++ b/localization/po/zh_TW.po
@@ -94,12 +94,12 @@ msgid "%s %s: unrecognized feature '%s'"
 msgstr "%s %s：不認識的功能「%s」"
 
 #, c-format
-msgid "%s (line %d):"
-msgstr "%s（第 %d 行）："
+msgid "%s (line %d)"
+msgstr "%s（第 %d 行）"
 
 #, c-format
-msgid "%s (line %u):"
-msgstr "%s（第 %u 行）："
+msgid "%s (line %u)"
+msgstr "%s（第 %u 行）"
 
 #, c-format
 msgid "%s and %s are mutually exclusive"
@@ -1456,12 +1456,12 @@ msgid "Standard input"
 msgstr "標準輸入流"
 
 #, c-format
-msgid "Standard input (line %d):"
-msgstr "標準輸入流（第 %d 行）："
+msgid "Standard input (line %d)"
+msgstr "標準輸入流（第 %d 行）"
 
 #, c-format
-msgid "Startup (line %d):"
-msgstr "啟動命令稿（第 %d 行）："
+msgid "Startup (line %d)"
+msgstr "啟動命令稿（第 %d 行）"
 
 msgid "State"
 msgstr "狀態"

--- a/src/builtins/complete.rs
+++ b/src/builtins/complete.rs
@@ -462,7 +462,7 @@ pub fn complete(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) ->
         let mut errors = ParseErrorList::new();
         if detect_parse_errors(condition_string, Some(&mut errors), false).is_err() {
             for error in errors {
-                let prefix = cmd.to_owned() + L!(": -n '") + &condition_string[..] + L!("': ");
+                let prefix = cmd.to_owned() + L!(": -n '") + &condition_string[..] + L!("'");
                 streams.err.appendln(&error.describe_with_prefix(
                     condition_string,
                     &prefix,
@@ -475,11 +475,7 @@ pub fn complete(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) ->
     }
 
     if !comp.is_empty() {
-        let mut prefix = WString::new();
-        prefix.push_utfstr(cmd);
-        prefix.push_str(": ");
-
-        if let Err(err_text) = detect_errors_in_argument_list(&comp, &prefix) {
+        if let Err(err_text) = detect_errors_in_argument_list(&comp, cmd) {
             streams
                 .err
                 .appendln(&wgettext_fmt!("%s: %s: contains a syntax error", cmd, comp));

--- a/src/parse_constants.rs
+++ b/src/parse_constants.rs
@@ -295,11 +295,19 @@ impl ParseError {
         is_interactive: bool,
         skip_caret: bool,
     ) -> WString {
-        let mut result = prefix.to_owned();
         if skip_caret && self.text.is_empty() {
             return L!("").to_owned();
         }
-        result.push_utfstr(&self.text);
+
+        let mut result = if prefix.is_empty() {
+            self.text.clone()
+        } else {
+            wgettext_fmt!("%s: %s", prefix, &self.text)
+        };
+
+        if skip_caret {
+            return result;
+        }
 
         let mut start = self.source_start;
         let mut len = self.source_length;
@@ -311,10 +319,6 @@ impl ParseError {
 
         if start + len > src.len() {
             len = src.len() - self.source_start;
-        }
-
-        if skip_caret {
-            return result;
         }
 
         // Locate the beginning of this line of source.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -791,16 +791,15 @@ impl Parser {
         if !self.is_interactive() || self.is_function() {
             if let Some(file) = file {
                 prefix.push_utfstr(&wgettext_fmt!(
-                    "%s (line %d):",
+                    "%s (line %d)",
                     &user_presentable_path(&file, self.vars()),
                     lineno
                 ));
             } else if self.libdata().within_fish_init {
-                prefix.push_utfstr(&wgettext_fmt!("Startup (line %d):", lineno));
+                prefix.push_utfstr(&wgettext_fmt!("Startup (line %d)", lineno));
             } else {
-                prefix.push_utfstr(&wgettext_fmt!("Standard input (line %d):", lineno));
+                prefix.push_utfstr(&wgettext_fmt!("Standard input (line %d)", lineno));
             }
-            prefix.push(' ');
         }
 
         let skip_caret = self.is_interactive() && !self.is_function();
@@ -1191,18 +1190,16 @@ impl Parser {
 
         let prefix = if let Some(filename) = self.current_filename() {
             if which_line > 0 {
-                let mut prefix = wgettext_fmt!(
-                    "%s (line %u):",
+                wgettext_fmt!(
+                    "%s (line %u)",
                     user_presentable_path(&filename, self.vars()),
                     which_line
-                );
-                prefix.push(' ');
-                prefix
+                )
             } else {
-                sprintf!("%s: ", user_presentable_path(&filename, self.vars()))
+                user_presentable_path(&filename, self.vars())
             }
         } else {
-            L!("fish: ").to_owned()
+            L!("fish").to_owned()
         };
 
         let mut output = err.describe_with_prefix(src, &prefix, self.is_interactive(), skip_caret);


### PR DESCRIPTION
Some languages have different conventions regarding colons. In order to
handle this better in cases with non-constant strings, as is the case in
`describe_with_prefix`, use localization to figure out how colons should
be localized.

This approach fixes the extra whitespace inserted after Chinese colons.
See #12405.