### PR TITLE
Fix fish_mode_prompt formatting error

### DIFF
--- a/doc_src/cmds/fish_mode_prompt.rst
+++ b/doc_src/cmds/fish_mode_prompt.rst
@@ -20,7 +20,7 @@ Description
 
 The ``fish_mode_prompt`` function outputs the mode indicator for use in vi mode.
 
-The default ``fish_mode_prompt`` function will output indicators about the current vi editor mode displayed to the left of the regular prompt. Define your own function to customize the appearance of the mode indicator. The ``$fish_bind_mode variable`` can be used to determine the current mode. It will be one of ``default``, ``insert``, ``replace_one``, ``replace``, ``visual``, or ``operator``.
+The default ``fish_mode_prompt`` function will output indicators about the current vi editor mode displayed to the left of the regular prompt. Define your own function to customize the appearance of the mode indicator. The ``$fish_bind_mode`` variable can be used to determine the current mode. It will be one of ``default``, ``insert``, ``replace_one``, ``replace``, ``visual``, or ``operator``.
 
 You can also define an empty ``fish_mode_prompt`` function to remove the vi mode indicators::
 


### PR DESCRIPTION
"variable" was in the formatted portion of the text when it should not have been.
