### PR TITLE
ci: update before `apt install`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,12 @@ jobs:
         include_sphinx: false
     - name: Install g++-multilib
       run: |
+        # GitHub does not consistently provide images with up-to-date package lists, causing
+        # `apt install` failures.
+        # Work around this by updating the package list.
+        # https://github.com/actions/runner-images/issues/13636
+        # https://github.com/actions/runner-images/issues/12599
+        sudo apt-get update
         sudo apt install g++-multilib
     - name: cmake
       env:


### PR DESCRIPTION
GitHub does not consistently provide images with up-to-date package lists, causing `apt install` failures.
Work around this by updating the package list.
https://github.com/actions/runner-images/issues/13636
https://github.com/actions/runner-images/issues/12599



## TODOs:
- [ ] For now, this only adds a single `apt-get update` before the `apt install` which currently fails. We probably want to update before all `apt install` invocations. This leaves the question of what to do about the comment. Do we omit it and only have it in the commit messages? Or do we prefer replicating it to all relevant sites?
