### PR TITLE
Fix the link to GitHub repo

### DIFF
--- a/build_tools/osx_package_resources/welcome.html
+++ b/build_tools/osx_package_resources/welcome.html
@@ -23,6 +23,6 @@
     <p>
     <code>chsh -s /usr/local/bin/fish</code>
     </p>
-    <p>Enjoy! Bugs can be reported on <a href="https://github.org/fish-shell/fish-shell/">GitHub</a>.</p>
+    <p>Enjoy! Bugs can be reported on <a href="https://github.com/fish-shell/fish-shell/">GitHub</a>.</p>
     </body>
 </html>


### PR DESCRIPTION
Old/current GitHub link: https://github.org/fish-shell/fish-shell/ - this link shows SSL error, if visited.
Proposed GitHub link: https://github.com/fish-shell/fish-shell/