### PR TITLE
Fix Ctrl-L interference with history search

### DIFF
--- a/src/reader/reader.rs
+++ b/src/reader/reader.rs
@@ -6268,6 +6268,8 @@ fn command_ends_history_search(c: ReadlineCmd) -> bool {
             | rl::HistoryPagerDelete
             | rl::BeginningOfHistory
             | rl::EndOfHistory
+            | rl::ScrollbackPush
+            | rl::ClearScreenAndRepaint
             | rl::Repaint
             | rl::ForceRepaint
     )

--- a/tests/pexpects/history.py
+++ b/tests/pexpects/history.py
@@ -154,6 +154,20 @@ expect_prompt()
 send("\x1b[A")
 expect_re("echo TERM")  # not ephemeral!
 
+# Verify that ctrl-l preserves an active up-arrow history search
+sendline("echo __ctrl_l_history_a")
+expect_prompt("__ctrl_l_history_a")
+sendline("echo __ctrl_l_history_b")
+expect_prompt("__ctrl_l_history_b")
+send("__ctrl_l_history")
+send("\x1b[A")
+expect_re("echo __ctrl_l_history_b")
+send("\f")
+send("\x1b[A")
+expect_re("echo __ctrl_l_history_a")
+sendline("")
+expect_prompt("__ctrl_l_history_a")
+
 # Verify that clear-session works as expected
 # Note: This test depends on that history merge resets the session from history clear-sessions point of view.
 sendline("builtin history clear")


### PR DESCRIPTION
I've noticed that pressing Ctrl-L interrupts an active history search. I run into this quite frequently and it seems like a bug.

## TODOs:
<!-- Check off what what has been done so far. -->
- [ ] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
