### PR TITLE
unicode: fix history search cursor positioning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ fish ?.?.? (released ???)
 Interactive improvements
 ------------------------
 - :kbd:`ctrl-l` no longer cancels history search (:issue:`12436`).
+- History search cursor positioning now works correctly with characters of arbitrary width.
 
 Deprecations and removed features
 ---------------------------------

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,6 +296,7 @@ dependencies = [
  "rsconf",
  "rust-embed",
  "serial_test",
+ "unicode-width",
  "unix_path",
  "xterm-color",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,7 @@ num-traits.workspace = true
 once_cell.workspace = true
 pcre2.workspace = true
 rand.workspace = true
+unicode-width.workspace = true
 xterm-color.workspace = true
 
 [target.'cfg(not(target_has_atomic = "64"))'.dependencies]

--- a/src/pager.rs
+++ b/src/pager.rs
@@ -15,6 +15,7 @@ use crate::prelude::*;
 use crate::screen::{CharOffset, Line, ScreenData, wcswidth_rendered, wcwidth_rendered};
 use crate::termsize::Termsize;
 use fish_wcstringutil::string_fuzzy_match_string;
+use unicode_width::UnicodeWidthStr;
 
 /// Represents rendering from the pager.
 #[derive(Default)]
@@ -1043,8 +1044,13 @@ impl Pager {
 
     // Position of the cursor.
     pub fn cursor_position(&self) -> usize {
-        let mut result =
-            wgettext!(SEARCH_FIELD_PROMPT).len() + 1 + self.search_field_line.position();
+        let mut result = sprintf!(
+            "%s %s",
+            wgettext!(SEARCH_FIELD_PROMPT),
+            self.search_field_line.text()
+        )
+        .to_string()
+        .width();
         // Clamp it to the right edge.
         if self.available_term_width > 0 && result + 1 > self.available_term_width {
             result = self.available_term_width - 1;


### PR DESCRIPTION
The cursor position calculation did not correctly account for the width of Unicode text, resulting in the cursor being placed to far left in scenarios with characters taking up 2 cells, such as in Chinese text.

Fix this by combining the entire line into a string and computing the length of the resulting string using the `unicode-width` crate.

This is the first code in the main crate making use of `unicode-width`. Eventually, we'll probably want to use it in more places, to get better and consistent results.

Fixes #12444



## TODOs:
- [x] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
