### PR TITLE
rust: use const_locks feature

### DIFF
--- a/crates/gettext/src/lib.rs
+++ b/crates/gettext/src/lib.rs
@@ -6,8 +6,7 @@ use std::{
 
 type Catalog = &'static phf::Map<&'static str, &'static str>;
 
-static LANGUAGE_PRECEDENCE: LazyLock<Mutex<Vec<(&'static str, Catalog)>>> =
-    LazyLock::new(|| Mutex::new(vec![]));
+static LANGUAGE_PRECEDENCE: Mutex<Vec<(&'static str, Catalog)>> = Mutex::new(Vec::new());
 
 pub fn gettext(message_str: &'static str) -> Option<&'static str> {
     let language_precedence = LANGUAGE_PRECEDENCE.lock().unwrap();

--- a/src/input.rs
+++ b/src/input.rs
@@ -13,7 +13,7 @@ use crate::threads::assert_is_main_thread;
 use fish_common::assert_sorted_by_name;
 use std::mem;
 use std::sync::{
-    LazyLock, Mutex, MutexGuard,
+    Mutex, MutexGuard,
     atomic::{AtomicU32, Ordering},
 };
 
@@ -239,10 +239,18 @@ pub struct InputMappingSet {
     preset_mapping_list: Vec<InputMapping>,
 }
 
+impl InputMappingSet {
+    const fn new() -> Self {
+        Self {
+            mapping_list: Vec::new(),
+            preset_mapping_list: Vec::new(),
+        }
+    }
+}
+
 /// Access the singleton input mapping set.
 pub fn input_mappings() -> MutexGuard<'static, InputMappingSet> {
-    static INPUT_MAPPINGS: LazyLock<Mutex<InputMappingSet>> =
-        LazyLock::new(|| Mutex::new(InputMappingSet::default()));
+    static INPUT_MAPPINGS: Mutex<InputMappingSet> = Mutex::new(InputMappingSet::new());
     INPUT_MAPPINGS.lock().unwrap()
 }
 

--- a/src/kill.rs
+++ b/src/kill.rs
@@ -4,17 +4,17 @@
 //! previous cuts.
 
 use std::collections::VecDeque;
-use std::sync::{LazyLock, Mutex};
+use std::sync::Mutex;
 
 use crate::prelude::*;
 
 struct KillRing(VecDeque<WString>);
 
-static KILL_RING: LazyLock<Mutex<KillRing>> = LazyLock::new(|| Mutex::new(KillRing::new()));
+static KILL_RING: Mutex<KillRing> = Mutex::new(KillRing::new());
 
 impl KillRing {
     /// Create a new killring.
-    fn new() -> Self {
+    const fn new() -> Self {
         Self(VecDeque::new())
     }
 

--- a/src/localization/settings.rs
+++ b/src/localization/settings.rs
@@ -3,7 +3,7 @@ use crate::env::{EnvStack, Environment};
 use fish_widestring::{L, WString, wstr};
 use itertools::Itertools;
 use std::collections::{HashMap, HashSet};
-use std::sync::{LazyLock, Mutex};
+use std::sync::Mutex;
 
 #[derive(PartialEq, Eq, Clone, Copy)]
 enum LanguagePrecedenceOrigin {
@@ -138,7 +138,7 @@ struct LocalizationState {
 }
 
 impl LocalizationState {
-    fn new() -> Self {
+    const fn new() -> Self {
         Self {
             precedence_origin: LanguagePrecedenceOrigin::Default,
         }
@@ -322,8 +322,7 @@ impl LocalizationState {
 ///
 /// This struct should be updated when the relevant variables change or `status language` is used
 /// to modify the localization state.
-static LOCALIZATION_STATE: LazyLock<Mutex<LocalizationState>> =
-    LazyLock::new(|| Mutex::new(LocalizationState::new()));
+static LOCALIZATION_STATE: Mutex<LocalizationState> = Mutex::new(LocalizationState::new());
 
 /// Call this when one of `LANGUAGE`, `LC_ALL`, `LC_MESSAGES`, `LANG` changes.
 /// Updates internal state such that the correct localizations will be used in subsequent


### PR DESCRIPTION
`Mutex::new` is now const so `LazyLock`is no longer needed