### PR TITLE
string: accept --char alias for pad and shorten

### DIFF
--- a/src/builtins/string/pad.rs
+++ b/src/builtins/string/pad.rs
@@ -23,7 +23,8 @@ impl Default for Pad {
 
 impl StringSubCommand<'_> for Pad {
     const LONG_OPTIONS: &'static [WOption<'static>] = &[
-        // FIXME docs say `--char`, there was no long_opt with `--char` in C++
+        // Support both spellings: docs use --char, older fish accepted --chars.
+        wopt(L!("char"), RequiredArgument, 'c'),
         wopt(L!("chars"), RequiredArgument, 'c'),
         wopt(L!("right"), NoArgument, 'r'),
         wopt(L!("center"), NoArgument, 'C'),

--- a/src/builtins/string/shorten.rs
+++ b/src/builtins/string/shorten.rs
@@ -25,7 +25,8 @@ impl Default for Shorten<'_> {
 
 impl<'args> StringSubCommand<'args> for Shorten<'args> {
     const LONG_OPTIONS: &'static [WOption<'static>] = &[
-        // FIXME: documentation says it's --char
+        // Support both spellings: docs use --char, older fish accepted --chars.
+        wopt(L!("char"), RequiredArgument, 'c'),
         wopt(L!("chars"), RequiredArgument, 'c'),
         wopt(L!("max"), RequiredArgument, 'm'),
         wopt(L!("no-newline"), NoArgument, 'N'),

--- a/tests/checks/string.fish
+++ b/tests/checks/string.fish
@@ -47,7 +47,7 @@ string pad foo
 string pad -C foo
 # CHECK: foo
 
-string pad -r -w 7 --chars - foo
+string pad -r -w 7 --char - foo
 # CHECK: foo----
 string pad -r -w 7 --chars - --center foo
 # CHECK: --foo--
@@ -1003,7 +1003,7 @@ string shorten --max 4 -c /// foobar
 string shorten --max 4 -c /// foobarnana
 # CHECK: f///
 
-string shorten --max 2 --chars "" foo
+string shorten --max 2 --char "" foo
 # CHECK: fo
 
 string shorten foo foobar


### PR DESCRIPTION
## Summary

`string pad` and `string shorten` documentation advertise `--char`, but implementation only accepted `--chars`.

This change adds `--char` as an alias for both subcommands while keeping `--chars` for backwards compatibility.

Updated files:
- `src/builtins/string/pad.rs`
- `src/builtins/string/shorten.rs`
- `tests/checks/string.fish`

## Testing

- `cargo build`
- `tests/test_driver.py target/debug tests/checks/string.fish` (passes)

checks:
- `target/debug/fish -c 'string pad -r -w 7 --char - foo'` -> `foo----`
- `target/debug/fish -c 'string shorten --max 2 --char "" foo'` -> `fo`

## TODOs:
<!-- Check off what what has been done so far. -->
- [ ] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>` (not addressing a specific issue)
- [x] Changes to fish usage are reflected in user documentation/manpages. (docs already used `--char`; implementation now matches)
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
