### PR TITLE
xtask: don't panic on failure

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 fish ?.?.? (released ???)
 =========================
 
+Interactive improvements
+------------------------
+- xtasks no longer panic for expected failures
+
 Regression fixes:
 -----------------
 - (from 4.5.0) Intermediate ``⏎`` artifact when redrawing prompt (:issue:`12476`).

--- a/crates/xtask/src/format.rs
+++ b/crates/xtask/src/format.rs
@@ -57,7 +57,7 @@ pub fn format(args: FormatArgs) {
                         "{YELLOW}warning: Did not find git, will proceed without checking for unstaged changes.{YELLOW:#}"
                     )
                 } else {
-                    panic!("Failed to run git status:\n{e}")
+                    fail!("Failed to run git status:\n{e}")
                 }
             }
         }
@@ -98,7 +98,7 @@ fn run_formatter(formatter: &mut Command, name: &str) {
     match formatter.status() {
         Ok(exit_status) => {
             if !exit_status.success() {
-                panic!("{name:?}: Files are not formatted correctly.");
+                fail!("{name:?}: Files are not formatted correctly.");
             }
         }
         Err(e) => {
@@ -107,7 +107,7 @@ fn run_formatter(formatter: &mut Command, name: &str) {
                     "{YELLOW}Formatter not found: {name:?}. Skipping associated files.{YELLOW:#}"
                 );
             } else {
-                panic!("Error occurred while running {name:?}:\n{e}")
+                fail!("Error occurred while running {name:?}:\n{e}")
             }
         }
     }

--- a/crates/xtask/src/lib.rs
+++ b/crates/xtask/src/lib.rs
@@ -1,21 +1,28 @@
 use std::{ffi::OsStr, process::Command};
 
+macro_rules! fail {
+    ($($arg:tt)+) => {{
+        eprintln!($($arg)+);
+        std::process::exit(1);
+    }}
+}
+
 pub mod format;
 
 pub trait CommandExt {
-    fn run_or_panic(&mut self);
+    fn run_or_fail(&mut self);
 }
 
 impl CommandExt for Command {
-    fn run_or_panic(&mut self) {
+    fn run_or_fail(&mut self) {
         match self.status() {
             Ok(exit_status) => {
                 if !exit_status.success() {
-                    panic!("Command did not run successfully: {:?}", self.get_program())
+                    fail!("Command did not run successfully: {:?}", self.get_program())
                 }
             }
             Err(err) => {
-                panic!("Failed to run command: {err}");
+                fail!("Failed to run command: {err}")
             }
         }
     }
@@ -26,5 +33,5 @@ where
     I: IntoIterator<Item = S>,
     S: AsRef<OsStr>,
 {
-    Command::new(env!("CARGO")).args(cargo_args).run_or_panic();
+    Command::new(env!("CARGO")).args(cargo_args).run_or_fail();
 }

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -43,7 +43,7 @@ fn main() {
 fn run_checks() {
     let repo_root_dir = fish_build_helper::workspace_root();
     let check_script = repo_root_dir.join("build_tools").join("check.sh");
-    Command::new(check_script).run_or_panic();
+    Command::new(check_script).run_or_fail();
 }
 
 fn build_html_docs(fish_indent: Option<PathBuf>) {
@@ -94,5 +94,5 @@ fn build_html_docs(fish_indent: Option<PathBuf>) {
     Command::new(option_env!("FISH_SPHINX").unwrap_or("sphinx-build"))
         .env("PATH", new_path)
         .args(args)
-        .run_or_panic();
+        .run_or_fail();
 }


### PR DESCRIPTION
Panicking suggests that an assumption of our code was violated. The current use of panics in xtasks is for expected failures, so it's better to avoid panicking and instead just print the error message to stderr and exit 1.

## TODOs:
- [x] User-visible changes noted in CHANGELOG.rst
