### PR TITLE
xtasks: make `files_with_extension` more accessible

### DIFF
--- a/crates/xtask/src/format.rs
+++ b/crates/xtask/src/format.rs
@@ -2,10 +2,11 @@ use anstyle::{AnsiColor, Style};
 use clap::Args;
 use std::{
     io::{ErrorKind, Write},
-    path::{Path, PathBuf},
+    path::PathBuf,
     process::{Command, Stdio},
 };
-use walkdir::WalkDir;
+
+use crate::files_with_extension;
 
 const GREEN: Style = AnsiColor::Green.on_default();
 const YELLOW: Style = AnsiColor::Yellow.on_default();
@@ -65,32 +66,6 @@ pub fn format(args: FormatArgs) {
     format_fish(&args);
     format_python(&args);
     format_rust(&args);
-}
-
-fn get_matching_files<P: AsRef<Path>, I: IntoIterator<Item = P>, M: Fn(&Path) -> bool>(
-    all_paths: I,
-    matcher: M,
-) -> Vec<PathBuf> {
-    all_paths
-        .into_iter()
-        .flat_map(WalkDir::new)
-        .filter_map(|res| {
-            let entry = res.unwrap();
-            let path = entry.path();
-            if entry.file_type().is_file() && matcher(path) {
-                Some(path.to_owned())
-            } else {
-                None
-            }
-        })
-        .collect()
-}
-fn files_with_extension<P: AsRef<Path>, I: IntoIterator<Item = P>>(
-    all_paths: I,
-    extension: &str,
-) -> Vec<PathBuf> {
-    let matcher = |p: &Path| p.extension().is_some_and(|e| e == extension);
-    get_matching_files(all_paths, matcher)
 }
 
 fn run_formatter(formatter: &mut Command, name: &str) {

--- a/crates/xtask/src/lib.rs
+++ b/crates/xtask/src/lib.rs
@@ -1,4 +1,10 @@
-use std::{ffi::OsStr, process::Command};
+use std::{
+    ffi::OsStr,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use walkdir::WalkDir;
 
 pub mod format;
 
@@ -27,4 +33,31 @@ where
     S: AsRef<OsStr>,
 {
     Command::new(env!("CARGO")).args(cargo_args).run_or_panic();
+}
+
+fn get_matching_files<P: AsRef<Path>, I: IntoIterator<Item = P>, M: Fn(&Path) -> bool>(
+    all_paths: I,
+    matcher: M,
+) -> Vec<PathBuf> {
+    all_paths
+        .into_iter()
+        .flat_map(WalkDir::new)
+        .filter_map(|res| {
+            let entry = res.unwrap();
+            let path = entry.path();
+            if entry.file_type().is_file() && matcher(path) {
+                Some(path.to_owned())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn files_with_extension<P: AsRef<Path>, I: IntoIterator<Item = P>>(
+    all_paths: I,
+    extension: &str,
+) -> Vec<PathBuf> {
+    let matcher = |p: &Path| p.extension().is_some_and(|e| e == extension);
+    get_matching_files(all_paths, matcher)
 }


### PR DESCRIPTION
This function is useful beyond the formatting module, so put it into the top level of the library.
