### PR TITLE
refactor: create `fish-future-feature-flags` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,6 +272,7 @@ dependencies = [
  "fish-color",
  "fish-common",
  "fish-fallback",
+ "fish-feature-flags",
  "fish-gettext",
  "fish-gettext-extraction",
  "fish-gettext-mo-file-parser",
@@ -346,6 +347,13 @@ dependencies = [
  "libc",
  "rsconf",
  "widestring",
+]
+
+[[package]]
+name = "fish-feature-flags"
+version = "0.0.0"
+dependencies = [
+ "fish-widestring",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ fish-build-man-pages = { path = "crates/build-man-pages" }
 fish-color = { path = "crates/color" }
 fish-common = { path = "crates/common" }
 fish-fallback = { path = "crates/fallback" }
+fish-feature-flags = { path = "crates/feature-flags" }
 fish-gettext = { path = "crates/gettext" }
 fish-gettext-extraction = { path = "crates/gettext-extraction" }
 fish-gettext-maps = { path = "crates/gettext-maps" }
@@ -108,6 +109,7 @@ fish-build-man-pages = { workspace = true, optional = true }
 fish-color.workspace = true
 fish-common.workspace = true
 fish-fallback.workspace = true
+fish-feature-flags.workspace = true
 fish-gettext = { workspace = true, optional = true }
 fish-gettext-extraction = { workspace = true, optional = true }
 fish-printf.workspace = true

--- a/crates/feature-flags/Cargo.toml
+++ b/crates/feature-flags/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "fish-feature-flags"
+edition.workspace = true
+rust-version.workspace = true
+version = "0.0.0"
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+fish-widestring.workspace = true
+
+[lints]
+workspace = true

--- a/crates/feature-flags/src/lib.rs
+++ b/crates/feature-flags/src/lib.rs
@@ -1,9 +1,10 @@
 //! Flags to enable upcoming features
 
 use fish_widestring::{L, WExt as _, wstr};
-#[cfg(test)]
-use std::cell::RefCell;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::{
+    cell::RefCell,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 /// The list of flags.
 #[repr(u8)]
@@ -154,7 +155,6 @@ pub const METADATA: &[FeatureMetadata] = &[
 ];
 
 thread_local!(
-    #[cfg(test)]
     static LOCAL_OVERRIDE_STACK: RefCell<Vec<(FeatureFlag, bool)>> =
         const { RefCell::new(Vec::new()) };
 );
@@ -164,7 +164,6 @@ static FEATURES: Features = Features::new();
 
 /// Perform a feature test on the global set of features.
 pub fn feature_test(flag: FeatureFlag) -> bool {
-    #[cfg(test)]
     if let Some(value) = LOCAL_OVERRIDE_STACK.with(|stack| {
         for &(overridden_feature, value) in stack.borrow().iter().rev() {
             if flag == overridden_feature {
@@ -254,7 +253,6 @@ impl Features {
 
 /// Run code with a feature overridden.
 /// This should only be used in tests.
-#[cfg(test)]
 pub fn with_overridden_feature(flag: FeatureFlag, value: bool, test_fn: impl FnOnce()) {
     LOCAL_OVERRIDE_STACK.with(|stack| {
         stack.borrow_mut().push((flag, value));

--- a/src/bin/fish.rs
+++ b/src/bin/fish.rs
@@ -38,7 +38,7 @@ use fish::{
     eprintf,
     event::{self, Event},
     flog::{self, activate_flog_categories_by_pattern, flog, flogf, set_flog_file_fd},
-    fprintf, function, future_feature_flags as features,
+    fprintf, function,
     history::{self, start_private_mode},
     io::IoChain,
     locale::set_libc_locales,
@@ -482,10 +482,10 @@ fn throwing_main() -> i32 {
     // command line takes precedence).
     if let Some(features_var) = EnvStack::globals().get(L!("fish_features")) {
         for s in features_var.as_list() {
-            features::set_from_string(s.as_utfstr());
+            fish_feature_flags::set_from_string(s.as_utfstr());
         }
     }
-    features::set_from_string(opts.features.as_utfstr());
+    fish_feature_flags::set_from_string(opts.features.as_utfstr());
     proc_init();
     reader_init(true);
 

--- a/src/builtins/fish_indent.rs
+++ b/src/builtins/fish_indent.rs
@@ -20,7 +20,6 @@ use crate::env::EnvStack;
 use crate::env::env_init;
 use crate::env::environment::Environment as _;
 use crate::expand::INTERNAL_SEPARATOR;
-use crate::future_feature_flags;
 use crate::global_safety::RelaxedAtomicBool;
 use crate::highlight::{HighlightRole, HighlightSpec, colorize, highlight_shell};
 use crate::operation_context::OperationContext;
@@ -945,7 +944,7 @@ fn throwing_main() -> i32 {
     // Only set these here so you can't set them via the builtin.
     if let Some(features_var) = EnvStack::globals().get(L!("fish_features")) {
         for s in features_var.as_list() {
-            future_feature_flags::set_from_string(s.as_utfstr());
+            fish_feature_flags::set_from_string(s.as_utfstr());
         }
     }
 

--- a/src/builtins/fish_key_reader.rs
+++ b/src/builtins/fish_key_reader.rs
@@ -15,7 +15,6 @@ use crate::{
     builtins::shared::BUILTIN_ERR_UNKNOWN,
     common::{PROGRAM_NAME, get_program_name, osstr2wcstring, shell_modes},
     env::{EnvStack, Environment as _, env_init},
-    future_feature_flags,
     input_common::{
         CharEvent, ImplicitEvent, InputEventQueue, InputEventQueuer as _, KeyEvent,
         QueryResultEvent, match_key_event_to_key,
@@ -295,7 +294,7 @@ fn throwing_main() -> i32 {
     reader_init(false);
     if let Some(features_var) = EnvStack::globals().get(L!("fish_features")) {
         for s in features_var.as_list() {
-            future_feature_flags::set_from_string(s.as_utfstr());
+            fish_feature_flags::set_from_string(s.as_utfstr());
         }
     }
 

--- a/src/builtins/status.rs
+++ b/src/builtins/status.rs
@@ -1,7 +1,6 @@
 use super::prelude::*;
 use crate::common::{bytes2wcstring, get_program_name, osstr2wcstring, str2wcstring};
 use crate::env::config_paths::get_fish_path;
-use crate::future_feature_flags::{self as features, feature_test};
 use crate::proc::{
     JobControl, get_job_control_mode, get_login, is_interactive_session, set_job_control_mode,
 };
@@ -9,6 +8,7 @@ use crate::reader::reader_in_interactive_read;
 use crate::tty_handoff::{TERMINAL_OS_NAME, get_scroll_content_up_capability, xtversion};
 use crate::wutil::{Error, waccess, wbasename, wdirname, wrealpath};
 use cfg_if::cfg_if;
+use fish_feature_flags::{self as features, feature_test};
 use fish_util::wcsfilecmp_glob;
 use fish_wcstringutil::wcs2bytes;
 use nix::unistd::AccessFlags;

--- a/src/builtins/string/match.rs
+++ b/src/builtins/string/match.rs
@@ -414,9 +414,9 @@ impl<'opts, 'args> WildCardMatcher<'opts, 'args> {
 #[cfg(test)]
 mod tests {
     use crate::builtins::shared::{STATUS_CMD_ERROR, STATUS_CMD_OK, STATUS_INVALID_ARGS};
-    use crate::future_feature_flags::{FeatureFlag, with_overridden_feature};
     use crate::tests::prelude::*;
     use crate::validate;
+    use fish_feature_flags::{FeatureFlag, with_overridden_feature};
 
     #[test]
     #[serial]

--- a/src/builtins/string/replace.rs
+++ b/src/builtins/string/replace.rs
@@ -3,7 +3,7 @@ use std::num::NonZeroUsize;
 use pcre2::utf32::{Regex, RegexBuilder};
 
 use super::*;
-use crate::future_feature_flags::{FeatureFlag, feature_test};
+use fish_feature_flags::{FeatureFlag, feature_test};
 
 #[derive(Default)]
 pub struct Replace<'args> {

--- a/src/builtins/test.rs
+++ b/src/builtins/test.rs
@@ -1,6 +1,6 @@
 use super::prelude::*;
-use crate::future_feature_flags::{FeatureFlag, feature_test};
 use crate::should_flog;
+use fish_feature_flags::{FeatureFlag, feature_test};
 
 mod test_expressions {
     use nix::unistd::{AccessFlags, Gid, Uid};

--- a/src/common.rs
+++ b/src/common.rs
@@ -4,7 +4,6 @@ use crate::expand::{
     BRACE_BEGIN, BRACE_END, BRACE_SEP, BRACE_SPACE, HOME_DIRECTORY, INTERNAL_SEPARATOR,
     PROCESS_EXPAND_SELF, PROCESS_EXPAND_SELF_STR, VARIABLE_EXPAND, VARIABLE_EXPAND_SINGLE,
 };
-use crate::future_feature_flags::{FeatureFlag, feature_test};
 use crate::global_safety::AtomicRef;
 use crate::global_safety::RelaxedAtomicBool;
 use crate::key;
@@ -15,6 +14,7 @@ use crate::termsize::Termsize;
 use crate::wildcard::{ANY_CHAR, ANY_STRING, ANY_STRING_RECURSIVE};
 use crate::wutil::fish_iswalnum;
 use fish_fallback::fish_wcwidth;
+use fish_feature_flags::{FeatureFlag, feature_test};
 use fish_wcstringutil::wcs2bytes;
 use fish_widestring::{
     ENCODE_DIRECT_END, decode_byte_from_char, encode_byte_to_char, subslice_position,

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -14,7 +14,6 @@ use crate::common::{
 use crate::complete::{CompleteFlags, Completion, CompletionList, CompletionReceiver};
 use crate::env::{EnvVar, Environment};
 use crate::exec::exec_subshell_for_expand;
-use crate::future_feature_flags::{FeatureFlag, feature_test};
 use crate::history::{History, history_session_id};
 use crate::operation_context::OperationContext;
 use crate::parse_constants::{ParseError, ParseErrorCode, ParseErrorList, SOURCE_LOCATION_UNKNOWN};
@@ -26,6 +25,7 @@ use crate::wildcard::{wildcard_expand_string, wildcard_has_internal};
 use crate::wutil::{Options, normalize_path, wcstoi_partial};
 use bitflags::bitflags;
 use fish_common::{EXPAND_RESERVED_BASE, EXPAND_RESERVED_END};
+use fish_feature_flags::{FeatureFlag, feature_test};
 use fish_util::wcsfilecmp_glob;
 use fish_wcstringutil::{join_strings, trim};
 use fish_widestring::char_offset;

--- a/src/highlight/highlight.rs
+++ b/src/highlight/highlight.rs
@@ -12,7 +12,6 @@ use crate::expand::{
     ExpandFlags, ExpandResultCode, PROCESS_EXPAND_SELF_STR, expand_one, expand_to_command_and_args,
 };
 use crate::function;
-use crate::future_feature_flags::{FeatureFlag, feature_test};
 use crate::highlight::file_tester::FileTester;
 use crate::history::all_paths_are_valid;
 use crate::operation_context::OperationContext;
@@ -31,6 +30,7 @@ use crate::threads::assert_is_background_thread;
 use crate::tokenizer::{PipeOrRedir, variable_assignment_equals_pos};
 use fish_color::Color;
 use fish_common::{ASCII_MAX, EXPAND_RESERVED_BASE, EXPAND_RESERVED_END};
+use fish_feature_flags::{FeatureFlag, feature_test};
 use fish_wcstringutil::string_prefixes_string;
 use fish_widestring::{L, WExt as _, WString, wstr};
 use std::collections::HashMap;
@@ -1314,12 +1314,12 @@ mod tests {
     use super::{HighlightColorResolver, HighlightRole, HighlightSpec, highlight_shell};
     use crate::common::ScopeGuard;
     use crate::env::{EnvMode, EnvSetMode, EnvVar, EnvVarFlags, Environment as _};
-    use crate::future_feature_flags::{FeatureFlag, with_overridden_feature};
     use crate::highlight::parse_text_face_for_highlight;
     use crate::operation_context::{EXPANSION_LIMIT_BACKGROUND, OperationContext};
     use crate::prelude::*;
     use crate::tests::prelude::*;
     use crate::text_face::{ResettableStyle, UnderlineStyle};
+    use fish_feature_flags::{FeatureFlag, with_overridden_feature};
     use libc::PATH_MAX;
 
     // Helper to return a string whose length greatly exceeds PATH_MAX.

--- a/src/input_common.rs
+++ b/src/input_common.rs
@@ -5,7 +5,6 @@ use crate::common::{
 use crate::env::{EnvStack, Environment as _};
 use crate::fd_readable_set::{FdReadableSet, Timeout};
 use crate::flog::{FloggableDebug, FloggableDisplay, flog};
-use crate::future_feature_flags::{FeatureFlag, feature_test};
 use crate::key::{
     self, Key, Modifiers, ViewportPosition, alt, canonicalize_control_char,
     canonicalize_keyed_control_char, char_to_symbol, function_key, shift,
@@ -18,6 +17,7 @@ use crate::tty_handoff::{
 };
 use crate::universal_notifier::default_notifier;
 use crate::wutil::{fish_is_pua, fish_wcstol};
+use fish_feature_flags::{FeatureFlag, feature_test};
 use fish_widestring::encode_byte_to_char;
 use nix::sys::{select::FdSet, signal::SigSet, time::TimeSpec};
 use std::cell::{RefCell, RefMut};

--- a/src/key.rs
+++ b/src/key.rs
@@ -3,12 +3,12 @@ use libc::VERASE;
 use crate::{
     common::{EscapeFlags, EscapeStringStyle, escape_string},
     flog::FloggableDebug,
-    future_feature_flags::{FeatureFlag, feature_test},
     prelude::*,
     reader::safe_get_terminal_mode_on_startup,
     wutil::fish_wcstoul,
 };
 use fish_fallback::fish_wcwidth;
+use fish_feature_flags::{FeatureFlag, feature_test};
 use fish_widestring::decode_byte_from_char;
 
 pub(crate) const Backspace: char = '\u{F500}'; // below ENCODE_DIRECT_BASE

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,6 @@ pub mod flog;
 pub mod fork_exec;
 pub mod fs;
 pub mod function;
-pub mod future_feature_flags;
 pub mod global_safety;
 pub mod highlight;
 pub mod history;

--- a/src/parse_util.rs
+++ b/src/parse_util.rs
@@ -13,7 +13,6 @@ use crate::expand::{
     VARIABLE_EXPAND, VARIABLE_EXPAND_EMPTY, VARIABLE_EXPAND_SINGLE, expand_one,
     expand_to_command_and_args,
 };
-use crate::future_feature_flags::{FeatureFlag, feature_test};
 use crate::operation_context::OperationContext;
 use crate::parse_constants::{
     ERROR_BAD_VAR_CHAR1, ERROR_BRACKETED_VARIABLE_QUOTED1, ERROR_BRACKETED_VARIABLE1,
@@ -30,6 +29,7 @@ use crate::tokenizer::{
 };
 use crate::wildcard::{ANY_CHAR, ANY_STRING, ANY_STRING_RECURSIVE};
 use fish_common::help_section;
+use fish_feature_flags::{FeatureFlag, feature_test};
 use fish_wcstringutil::{count_newlines, truncate};
 use std::ops::Range;
 use std::{iter, ops};

--- a/src/reader/reader.rs
+++ b/src/reader/reader.rs
@@ -46,7 +46,6 @@ use crate::expand::{ExpandFlags, ExpandResultCode, expand_string, expand_tilde};
 use crate::fd_readable_set::poll_fd_readable;
 use crate::fds::{make_fd_blocking, wopen_cloexec};
 use crate::flog::{flog, flogf};
-use crate::future_feature_flags::{self, FeatureFlag};
 use crate::global_safety::RelaxedAtomicBool;
 use crate::highlight::{
     HighlightRole, HighlightSpec, autosuggest_validate_from_history, highlight_shell,
@@ -121,6 +120,7 @@ use errno::{Errno, errno};
 use fish_common::{UTF8_BOM_WCHAR, help_section};
 use fish_fallback::fish_wcwidth;
 use fish_fallback::lowercase;
+use fish_feature_flags::FeatureFlag;
 use fish_util::{perror, write_to_fd};
 use fish_wcstringutil::{
     CaseSensitivity, IsPrefix, StringFuzzyMatch, count_preceding_backslashes, is_prefix,
@@ -239,7 +239,7 @@ fn redirect_tty_after_sighup() {
 }
 
 fn querying_allowed(vars: &dyn Environment) -> bool {
-    future_feature_flags::feature_test(FeatureFlag::QueryTerm)
+    fish_feature_flags::feature_test(FeatureFlag::QueryTerm)
         && !is_dumb()
         && {
             // TODO(term-workaround)

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -1,12 +1,12 @@
 // Generic output functions.
 use crate::common::{self, EscapeStringStyle, escape_string};
-use crate::future_feature_flags::{self, FeatureFlag};
 use crate::prelude::*;
 use crate::screen::{is_dumb, only_grayscale};
 use crate::text_face::{ResettableStyle, TextFace, TextStyling, UnderlineStyle};
 use crate::threads::MainThread;
 use bitflags::bitflags;
 use fish_color::{Color, Color24};
+use fish_feature_flags::FeatureFlag;
 use fish_wcstringutil::{wcs2bytes, wcs2bytes_appending};
 use std::cell::{RefCell, RefMut};
 use std::ops::{Deref, DerefMut};
@@ -181,7 +181,7 @@ fn osc_0_or_1_terminal_title(out: &mut Outputter, is_1: bool, title: &[WString])
 }
 
 fn osc_133_prompt_start(out: &mut Outputter) -> bool {
-    if !future_feature_flags::feature_test(FeatureFlag::MarkPrompt) {
+    if !fish_feature_flags::feature_test(FeatureFlag::MarkPrompt) {
         return false;
     }
     static TEST_BALLOON: OnceLock<()> = OnceLock::new();
@@ -194,7 +194,7 @@ fn osc_133_prompt_start(out: &mut Outputter) -> bool {
 }
 
 fn osc_133_prompt_end(out: &mut Outputter) -> bool {
-    if !future_feature_flags::feature_test(FeatureFlag::MarkPrompt) {
+    if !fish_feature_flags::feature_test(FeatureFlag::MarkPrompt) {
         return false;
     }
     write_to_output!(out, "\x1b]133;B\x07");
@@ -202,7 +202,7 @@ fn osc_133_prompt_end(out: &mut Outputter) -> bool {
 }
 
 fn osc_133_command_start(out: &mut Outputter, command: &wstr) -> bool {
-    if !future_feature_flags::feature_test(FeatureFlag::MarkPrompt) {
+    if !fish_feature_flags::feature_test(FeatureFlag::MarkPrompt) {
         return false;
     }
     write_to_output!(
@@ -214,7 +214,7 @@ fn osc_133_command_start(out: &mut Outputter, command: &wstr) -> bool {
 }
 
 fn osc_133_command_finished(out: &mut Outputter, exit_status: libc::c_int) -> bool {
-    if !future_feature_flags::feature_test(FeatureFlag::MarkPrompt) {
+    if !fish_feature_flags::feature_test(FeatureFlag::MarkPrompt) {
         return false;
     }
     write_to_output!(out, "\x1b]133;D;{}\x07", exit_status);

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -3,11 +3,11 @@
 
 use crate::ast::unescape_keyword;
 use crate::common::valid_var_name_char;
-use crate::future_feature_flags::{FeatureFlag, feature_test};
 use crate::parse_constants::SOURCE_OFFSET_INVALID;
 use crate::parser_keywords::parser_keywords_is_subcommand;
 use crate::prelude::*;
 use crate::redirection::RedirectionMode;
+use fish_feature_flags::{FeatureFlag, feature_test};
 use libc::{STDIN_FILENO, STDOUT_FILENO};
 use nix::fcntl::OFlag;
 use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, Not, Range};

--- a/src/wildcard.rs
+++ b/src/wildcard.rs
@@ -13,12 +13,11 @@ use crate::common::{
 };
 use crate::complete::{CompleteFlags, Completion, CompletionReceiver, PROG_COMPLETE_SEP};
 use crate::expand::ExpandFlags;
-use crate::future_feature_flags::FeatureFlag;
-use crate::future_feature_flags::feature_test;
 use crate::prelude::*;
 use crate::wutil::dir_iter::DirEntryType;
 use crate::wutil::{dir_iter::DirEntry, lwstat, waccess};
 use fish_fallback::wcscasecmp;
+use fish_feature_flags::{FeatureFlag, feature_test};
 use fish_wcstringutil::{
     CaseSensitivity, string_fuzzy_match_string, string_suffixes_string_case_insensitive,
     strip_executable_suffix,
@@ -1231,7 +1230,7 @@ pub fn wildcard_has(s: impl AsRef<wstr>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::future_feature_flags::with_overridden_feature;
+    use fish_feature_flags::with_overridden_feature;
 
     #[test]
     fn test_wildcards() {


### PR DESCRIPTION
Another step in splitting up the main library crate.

At the moment, this breaks tests outside of the new crate, since the
crate changes behavior depending on whether the `test` config is active,
but tests outside the crate get the version with `test` disabled.

I tried to extract this because some other code I want to extract depends on it. However, in the current state it does not work. I haven't looked much into the semantics of the code, but the core problem is that `#[cfg(test)]` does not work across crate boundaries. Maybe we can resolve this by removing the behavioral difference in this case. Otherwise it might be possible to hack around it via some feature setting via `build.rs`, but that does not seem very robust.

Putting it out there in case someone has an idea of how to deal with this problem.

Stacked on #12493, but only to reduce merge conflicts.