### PR TITLE
fix: version test on shallow, dirty git repo

### DIFF
--- a/tests/checks/version.fish
+++ b/tests/checks/version.fish
@@ -6,10 +6,11 @@
 # 1.2.3-42-gdeadbeef
 # Git version when no tags are present. Distros should probably not package it like this.
 # 1.2.3-gdeadbeef
+# If the git commit hash is part of the version identifier, it may have a `-dirty` suffix.
 
 $fish -v
-# CHECK: fish, version {{\d+\.\d+\.\d+(-\d+-g[0-9a-f]{7,}(-dirty)?|-g[0-9a-f]{7,})?$}}
+# CHECK: fish, version {{\d+\.\d+\.\d+((-\d+)?-g[0-9a-f]{7,}(-dirty)?)?$}}
 
 set -l workspace_root (status dirname)/../..
 $workspace_root/build_tools/git_version_gen.sh
-# CHECK: {{\d+\.\d+\.\d+(-\d+-g[0-9a-f]{7,}(-dirty)?|-g[0-9a-f]{7,})?$}}
+# CHECK: {{\d+\.\d+\.\d+((-\d+)?-g[0-9a-f]{7,}(-dirty)?)?$}}


### PR DESCRIPTION
In shallow, dirty git repo, the version identifier will look something like `fish, version 4.5.0-g971e0b7-dirty`, with no commit counter indicating the commits since the last version. Our regex did not handle this case.

Make the commit counter optional, which also allows removing the second alternative in the regex, since it's now subsumed by the first.

Fixes #12497