### PR TITLE
Revert ALT-backspace to original behaviour

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 fish ?.?.? (released ???)
 =========================
 
+New or improved bindings
+------------------------
+- On non-macOS systems, :kbd:`alt-backspace` operates again on punctuation-delimited words. (:issue:`12122`).
+
 Notable improvements and fixes
 ------------------------------
 - New Spanish translations (:issue:`12489`).

--- a/share/functions/fish_default_key_bindings.fish
+++ b/share/functions/fish_default_key_bindings.fish
@@ -50,7 +50,7 @@ function fish_default_key_bindings -d "emacs-like key binds"
     bind --preset $argv alt-u upcase-word
 
     bind --preset $argv alt-c capitalize-word
-    __fish_per_os_bind --preset $argv alt-backspace backward-kill-word backward-kill-token
+    bind --preset $argv alt-backspace backward-kill-word
     __fish_per_os_bind --preset $argv ctrl-alt-h backward-kill-word backward-kill-token
     __fish_per_os_bind --preset $argv ctrl-backspace backward-kill-token backward-kill-word
     __fish_per_os_bind --preset $argv alt-delete kill-word kill-token


### PR DESCRIPTION
As described in the issue, other alternatives are highly uncomfortable, so it would be amazing if we could have same good ol' behaviour.

Partly reverts 6af96a81a8c6 ("Default bindings for token movement commands")

Closes #12122
