### PR TITLE
Regroup bindings by files when using bind and hiding files starting with "__"

### DIFF
--- a/share/functions/__fish_per_os_bind.fish
+++ b/share/functions/__fish_per_os_bind.fish
@@ -1,12 +1,19 @@
 # localization: skip(private)
 function __fish_per_os_bind
-    set -l macos $argv[-2]
-    set -l non_macos $argv[-1]
-    set -e argv[-2..-1]
-    for varname in macos non_macos
-        if contains -- $$varname (bind --function-names)
-            set $varname 'commandline -f '$$varname
-        end
-    end
-    bind $argv "if fish_in_macos_terminal; $macos; else $non_macos; end"
+    echo -e '
+        set -l macos $argv[-2] \n
+        set -l non_macos $argv[-1] \n
+        set -e argv[-2..-1] \n
+        for varname in macos non_macos \n
+            if contains -- $$varname (bind --function-names) \n
+                set $varname \'commandline -f \'$$varname \n
+            end \n
+        end \n
+
+        if fish_in_macos_terminal \n
+            bind $argv $macos \n
+        else \n
+            bind $argv $non_macos \n
+        end \n
+            '
 end

--- a/share/functions/__fish_shared_key_bindings.fish
+++ b/share/functions/__fish_shared_key_bindings.fish
@@ -3,130 +3,127 @@ function __fish_shared_key_bindings -d "Bindings shared between emacs and vi mod
     # These are some bindings that are supposed to be shared between vi mode and default mode.
     # They are supposed to be unrelated to text-editing (or movement).
     # This takes $argv so the vi-bindings can pass the mode they are valid in.
+    echo -e '
+        if contains -- -h $argv \n
+            or contains -- --help $argv \n
+            echo "Sorry but this function doesn\'t support -h or --help" >&2 \n
+            return 1 \n
+        end \n
 
-    if contains -- -h $argv
-        or contains -- --help $argv
-        echo "Sorry but this function doesn't support -h or --help" >&2
-        return 1
-    end
+        bind --preset $argv ctrl-y yank \n
+        or return  # protect against invalid $argv \n
+        bind --preset $argv alt-y yank-pop \n
 
-    bind --preset $argv ctrl-y yank
-    or return # protect against invalid $argv
-    bind --preset $argv alt-y yank-pop
+         # Left/Right arrow \n
+        bind --preset $argv right forward-char \n
+        bind --preset $argv left backward-char \n
 
-    # Left/Right arrow
-    bind --preset $argv right forward-char
-    bind --preset $argv left backward-char
+         # Ctrl-left/right - these also work in vim. \n
+        per_os_bind --preset $argv ctrl-right forward-token forward-word \n
+        per_os_bind --preset $argv ctrl-left backward-token backward-word \n
 
-    # Ctrl-left/right - these also work in vim.
-    __fish_per_os_bind --preset $argv ctrl-right forward-token forward-word
-    __fish_per_os_bind --preset $argv ctrl-left backward-token backward-word
+        bind --preset $argv pageup beginning-of-history \n
+        bind --preset $argv pagedown end-of-history \n
 
-    bind --preset $argv pageup beginning-of-history
-    bind --preset $argv pagedown end-of-history
+         # Interaction with the system clipboard. \n
+        bind --preset $argv ctrl-x fish_clipboard_copy \n
+        bind --preset $argv ctrl-v fish_clipboard_paste \n
 
-    # Interaction with the system clipboard.
-    bind --preset $argv ctrl-x fish_clipboard_copy
-    bind --preset $argv ctrl-v fish_clipboard_paste
+        bind --preset $argv escape cancel \n
+        bind --preset $argv ctrl-\[ cancel \n
+        bind --preset $argv tab complete \n
+        bind --preset $argv ctrl-i complete \n
+        bind --preset $argv ctrl-s pager-toggle-search \n
+         # shift-tab does a tab complete followed by a search. \n
+        bind --preset $argv shift-tab complete-and-search \n
+        bind --preset $argv shift-delete history-delete or backward-delete-char \n
 
-    bind --preset $argv escape cancel
-    bind --preset $argv ctrl-\[ cancel
-    bind --preset $argv tab complete
-    bind --preset $argv ctrl-i complete
-    bind --preset $argv ctrl-s pager-toggle-search
-    # shift-tab does a tab complete followed by a search.
-    bind --preset $argv shift-tab complete-and-search
-    bind --preset $argv shift-delete history-delete or backward-delete-char
+        bind --preset $argv down down-or-search \n
+        bind --preset $argv up up-or-search \n
 
-    bind --preset $argv down down-or-search
-    bind --preset $argv up up-or-search
+        bind --preset $argv shift-right forward-bigword \n
+        bind --preset $argv shift-left backward-bigword \n
 
-    bind --preset $argv shift-right forward-bigword
-    bind --preset $argv shift-left backward-bigword
+        bind --preset $argv alt-b prevd-or-backward-word \n
+        bind --preset $argv alt-f nextd-or-forward-word \n
 
-    bind --preset $argv alt-b prevd-or-backward-word
-    bind --preset $argv alt-f nextd-or-forward-word
+        for alt_right in alt-right \\e\[1\;9C  # TODO(terminal-workaround) iTerm2 < 3.5.12 \n
+            per_os_bind --preset $argv $alt_right nextd-or-forward-word nextd-or-forward-token \n
+        end \n
+        for alt_left in alt-left \\e\[1\;9D  # TODO(terminal-workaround) iTerm2 < 3.5.12 \n
+            per_os_bind --preset $argv $alt_left prevd-or-backward-word prevd-or-backward-token \n
+        end \n
 
-    for alt_right in alt-right \e\[1\;9C # TODO(terminal-workaround) iTerm2 < 3.5.12
-        __fish_per_os_bind --preset $argv $alt_right \
-            nextd-or-forward-word nextd-or-forward-token
-    end
-    for alt_left in alt-left \e\[1\;9D # TODO(terminal-workaround) iTerm2 < 3.5.12
-        __fish_per_os_bind --preset $argv $alt_left \
-            prevd-or-backward-word prevd-or-backward-token
-    end
+        bind --preset $argv alt-up history-token-search-backward \n
+        bind --preset $argv alt-down history-token-search-forward \n
+         # TODO(terminal-workaround) \n
+        bind --preset $argv \e\[1\;9A history-token-search-backward  # iTerm2 < 3.5.12 \n
+        bind --preset $argv \e\[1\;9B history-token-search-forward  # iTerm2 < 3.5.12 \n
+         # Bash compatibility \n
+         # https://github.com/fish-shell/fish-shell/issues/89 \n
+        bind --preset $argv alt-. history-token-search-backward \n
 
-    bind --preset $argv alt-up history-token-search-backward
-    bind --preset $argv alt-down history-token-search-forward
-    # TODO(terminal-workaround)
-    bind --preset $argv \e\[1\;9A history-token-search-backward # iTerm2 < 3.5.12
-    bind --preset $argv \e\[1\;9B history-token-search-forward # iTerm2 < 3.5.12
-    # Bash compatibility
-    # https://github.com/fish-shell/fish-shell/issues/89
-    bind --preset $argv alt-. history-token-search-backward
+        bind --preset $argv alt-l __fish_list_current_token \n
+        bind --preset $argv alt-o __fish_preview_current_file \n
+        bind --preset $argv alt-w __fish_whatis_current_token \n
+        bind --preset $argv ctrl-l \'status test-terminal-feature scroll-content-up && commandline -f scrollback-push\' clear-screen \n
+        bind --preset $argv ctrl-c clear-commandline \n
+        bind --preset $argv ctrl-u backward-kill-line \n
+        bind --preset $argv ctrl-k kill-line \n
+        bind --preset $argv ctrl-w backward-kill-path-component \n
+        bind --preset $argv end end-of-line \n
+        bind --preset $argv home beginning-of-line \n
 
-    bind --preset $argv alt-l __fish_list_current_token
-    bind --preset $argv alt-o __fish_preview_current_file
-    bind --preset $argv alt-w __fish_whatis_current_token
-    bind --preset $argv ctrl-l \
-        'status test-terminal-feature scroll-content-up && commandline -f scrollback-push' \
-        clear-screen
-    bind --preset $argv ctrl-c clear-commandline
-    bind --preset $argv ctrl-u backward-kill-line
-    bind --preset $argv ctrl-k kill-line
-    bind --preset $argv ctrl-w backward-kill-path-component
-    bind --preset $argv end end-of-line
-    bind --preset $argv home beginning-of-line
+        bind --preset $argv alt-d \'if test "$(commandline; printf .)" = "\\n."; __fish_echo dirh; else; commandline -f kill-word; end\' \n
+        bind --preset $argv ctrl-d delete-or-exit \n
 
-    bind --preset $argv alt-d 'if test "$(commandline; printf .)" = \n.; __fish_echo dirh; else; commandline -f kill-word; end'
-    bind --preset $argv ctrl-d delete-or-exit
+        bind --preset $argv alt-s \'for cmd in sudo doas please run0; if command -q $cmd; fish_commandline_prepend $cmd; break; end; end\' \n
 
-    bind --preset $argv alt-s 'for cmd in sudo doas please run0; if command -q $cmd; fish_commandline_prepend $cmd; break; end; end'
+         # Allow reading manpages by pressing f1 (many GUI applications) or Alt+h (like in zsh). \n
+        bind --preset $argv f1 __fish_man_page \n
+        bind --preset $argv alt-h __fish_man_page \n
 
-    # Allow reading manpages by pressing f1 (many GUI applications) or Alt+h (like in zsh).
-    bind --preset $argv f1 __fish_man_page
-    bind --preset $argv alt-h __fish_man_page
+         # This will make sure the output of the current command is paged using the default pager when \n
+         # you press Meta-p. \n
+         # If none is set, less will be used. \n
+        bind --preset $argv alt-p __fish_paginate \n
 
-    # This will make sure the output of the current command is paged using the default pager when
-    # you press Meta-p.
-    # If none is set, less will be used.
-    bind --preset $argv alt-p __fish_paginate
+         # Make it easy to turn an unexecuted command into a comment in the shell history. Also, \n
+         # remove the commenting chars so the command can be further edited then executed. \n
+        bind --preset $argv alt-# __fish_toggle_comment_commandline \n
 
-    # Make it easy to turn an unexecuted command into a comment in the shell history. Also,
-    # remove the commenting chars so the command can be further edited then executed.
-    bind --preset $argv alt-# __fish_toggle_comment_commandline
+         # These keystrokes invoke an external editor on the command buffer. \n
+        bind --preset $argv alt-e edit_command_buffer \n
+        bind --preset $argv alt-v edit_command_buffer \n
 
-    # These keystrokes invoke an external editor on the command buffer.
-    bind --preset $argv alt-e edit_command_buffer
-    bind --preset $argv alt-v edit_command_buffer
+         # Bindings that are shared in text-insertion modes. \n
+        if not set -l index (contains --index -- -M $argv) \n
+        or test $argv[(math $index + 1)] = insert \n
 
-    # Bindings that are shared in text-insertion modes.
-    if not set -l index (contains --index -- -M $argv)
-        or test $argv[(math $index + 1)] = insert
+             # This is the default binding, i.e. the one used if no other binding matches \n
+            bind --preset $argv "" self-insert \n
+            or exit  # protect against invalid $argv \n
 
-        # This is the default binding, i.e. the one used if no other binding matches
-        bind --preset $argv "" self-insert
-        or exit # protect against invalid $argv
+             # Space and other command terminators expands abbrs _and_ inserts itself. \n
+            bind --preset $argv space self-insert expand-abbr \n
+            bind --preset $argv ";" self-insert expand-abbr \n
+            bind --preset $argv "|" self-insert expand-abbr \n
+            bind --preset $argv "&" self-insert expand-abbr \n
+            bind --preset $argv ">" self-insert expand-abbr \n
+            bind --preset $argv "<" self-insert expand-abbr \n
+            set -l maybe_search_field \'(commandline --search-field >/dev/null && echo --search-field)\' \n
+            bind --preset $argv shift-enter \'commandline -i "\\n" $maybe_search_field\'  expand-abbr \n
+            bind --preset $argv alt-enter \'commandline -i "\\n" $maybe_search_field\' expand-abbr \n
+            bind --preset $argv ")" self-insert expand-abbr  # Closing a command substitution. \n
+            bind --preset $argv ctrl-space \'test -n "$(commandline)" && commandline -i " " \'$maybe_search_field \n
+             # Shift-space behaves like space because it\'s easy to mistype. \n
+            bind --preset $argv shift-space \'commandline -i " " \'$maybe_search_field expand-abbr \n
 
-        # Space and other command terminators expands abbrs _and_ inserts itself.
-        bind --preset $argv space self-insert expand-abbr
-        bind --preset $argv ";" self-insert expand-abbr
-        bind --preset $argv "|" self-insert expand-abbr
-        bind --preset $argv "&" self-insert expand-abbr
-        bind --preset $argv ">" self-insert expand-abbr
-        bind --preset $argv "<" self-insert expand-abbr
-        set -l maybe_search_field '(commandline --search-field >/dev/null && echo --search-field)'
-        bind --preset $argv shift-enter "commandline -i \n $maybe_search_field" expand-abbr
-        bind --preset $argv alt-enter "commandline -i \n $maybe_search_field" expand-abbr
-        bind --preset $argv ")" self-insert expand-abbr # Closing a command substitution.
-        bind --preset $argv ctrl-space 'test -n "$(commandline)" && commandline -i " " '$maybe_search_field
-        # Shift-space behaves like space because it's easy to mistype.
-        bind --preset $argv shift-space 'commandline -i " " '$maybe_search_field expand-abbr
-
-        bind --preset $argv enter execute
-        bind --preset $argv ctrl-j execute
-        bind --preset $argv ctrl-m execute
-        # Make Control+Return behave like Return because it's easy to mistype after accepting an autosuggestion.
-        bind --preset $argv ctrl-enter execute
-    end
+            bind --preset $argv enter execute \n
+            bind --preset $argv ctrl-j execute \n
+            bind --preset $argv ctrl-m execute \n
+             # Make Control+Return behave like Return because it\'s easy to mistype after accepting an autosuggestion. \n
+            bind --preset $argv ctrl-enter execute \n
+        end
+        '
 end

--- a/share/functions/fish_default_key_bindings.fish
+++ b/share/functions/fish_default_key_bindings.fish
@@ -13,13 +13,12 @@ function fish_default_key_bindings -d "emacs-like key binds"
         end
     end
 
-    # Silence warnings about unavailable keys. See #4431, 4188
-    if not contains -- -s $argv
-        set argv -s $argv
+    function per_os_bind
+        eval "$(__fish_per_os_bind)"
     end
 
     # These are shell-specific bindings that we share with vi mode.
-    __fish_shared_key_bindings $argv
+    eval "$(__fish_shared_key_bindings)" $argv
     or return # protect against invalid $argv
 
     bind --preset $argv right forward-char
@@ -50,11 +49,12 @@ function fish_default_key_bindings -d "emacs-like key binds"
     bind --preset $argv alt-u upcase-word
 
     bind --preset $argv alt-c capitalize-word
-    __fish_per_os_bind --preset $argv alt-backspace backward-kill-word backward-kill-token
-    __fish_per_os_bind --preset $argv ctrl-alt-h backward-kill-word backward-kill-token
-    __fish_per_os_bind --preset $argv ctrl-backspace backward-kill-token backward-kill-word
-    __fish_per_os_bind --preset $argv alt-delete kill-word kill-token
-    __fish_per_os_bind --preset $argv ctrl-delete kill-token kill-word
+
+    per_os_bind --preset $argv alt-backspace backward-kill-word backward-kill-token
+    per_os_bind --preset $argv ctrl-alt-h backward-kill-word backward-kill-token
+    per_os_bind --preset $argv ctrl-backspace backward-kill-token backward-kill-word
+    per_os_bind --preset $argv alt-delete kill-word kill-token
+    per_os_bind --preset $argv ctrl-delete kill-token kill-word
 
     bind --preset $argv alt-\< beginning-of-buffer
     bind --preset $argv alt-\> end-of-buffer

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -323,12 +323,21 @@ function fish_vi_key_bindings --description 'vi-like key bindings for fish'
         echo "Unknown argument $argv" >&2
     end
 
+    function per_os_bind
+        eval "$(__fish_per_os_bind)"
+    end
+
+    function shared_key_bindings
+        eval "$(__fish_shared_key_bindings)"
+    end
+
     # Inherit shared key bindings.
     # Do this first so vi-bindings win over default.
     for mode in insert default visual
-        __fish_shared_key_bindings -M $mode
-        __fish_per_os_bind --preset -M $mode ctrl-right forward-token forward-word-vi
+        per_os_bind --preset -M $mode ctrl-right forward-token forward-word-vi
         # ctrl-left is same as emacs mode
+
+        shared_key_bindings -M $mode
     end
 
     # Add a way to switch from insert to normal (command) mode.

--- a/src/builtins/bind.rs
+++ b/src/builtins/bind.rs
@@ -3,9 +3,9 @@
 use super::prelude::*;
 use crate::{
     builtins::error::Error,
-    common::{EscapeFlags, EscapeStringStyle, FilenameRef, bytes2wcstring, escape, escape_string, valid_var_name},
+    common::valid_var_name,
     err_fmt, err_raw, err_str,
-    highlight::highlight_and_colorize,
+    highlight::{colorize, highlight_and_colorize, highlight_shell},
     input::{
         InputMapping, InputMappingSet, KeyNameStyle, input_function_get_names, input_mappings,
     },
@@ -210,11 +210,30 @@ impl BuiltinBind {
         streams: &mut IoStreams,
     ) {
         let lst = self.input_mappings.get_names(user);
-        for binding in lst {
-            if bind_mode.is_some_and(|m| m != binding.mode) {
-                continue;
-            }
+        let mut cur_file = &Default::default();
 
+        for binding in lst {
+            let mut out = WString::new();
+            let definition_file =
+                &self.input_mappings.get(&binding.seq, bind_mode, user)[0].definition_file;
+
+            if let Some(def_file) = definition_file {
+                if def_file != cur_file {
+                    out.push_utfstr(&L!("# Defined in "));
+                    out.push_utfstr(&**def_file);
+                    out.push_utfstr(&L!(":\n"));
+                    let mut colors = Vec::new();
+                    highlight_shell(&out, &mut colors, &mut parser.context(), false, None);
+                    let colored = colorize(&out, &colors, parser.vars());
+                    streams.out.append(&bytes2wcstring(&colored));
+
+                    cur_file = def_file;
+                }
+
+                if bind_mode.is_some_and(|m| m != binding.mode) {
+                    continue;
+                }
+            }
             self.list_one(&binding.seq, Some(&binding.mode), user, parser, streams);
         }
     }
@@ -422,11 +441,11 @@ impl BuiltinBind {
 }
 
 fn parse_cmd_opts(
+    parser: &Parser,
+    streams: &mut IoStreams,
     opts: &mut Options,
     optind: &mut usize,
     argv: &mut [&wstr],
-    parser: &mut Parser,
-    streams: &mut IoStreams,
 ) -> BuiltinResult {
     let cmd = argv[0];
     let short_options = L!("aehkKfM:Lm:s");
@@ -533,7 +552,7 @@ impl BuiltinBind {
     ) -> BuiltinResult {
         let cmd = argv[0];
         let mut optind = 0;
-        parse_cmd_opts(&mut self.opts, &mut optind, argv, parser, streams)?;
+        parse_cmd_opts(parser, streams, &mut self.opts, &mut optind, argv)?;
 
         if self.opts.list_modes {
             self.list_modes(streams);

--- a/src/builtins/bind.rs
+++ b/src/builtins/bind.rs
@@ -266,8 +266,15 @@ impl BuiltinBind {
             KeyNameStyle::Plain
         };
         let definition_file = parser.current_filename();
-        self.input_mappings
-            .add(key_seq, key_name_style, cmds, mode, sets_mode, user, definition_file);
+        self.input_mappings.add(
+            key_seq,
+            key_name_style,
+            cmds,
+            mode,
+            sets_mode,
+            user,
+            definition_file,
+        );
         false
     }
 

--- a/src/builtins/bind.rs
+++ b/src/builtins/bind.rs
@@ -3,7 +3,7 @@
 use super::prelude::*;
 use crate::{
     builtins::error::Error,
-    common::valid_var_name,
+    common::{EscapeFlags, EscapeStringStyle, FilenameRef, bytes2wcstring, escape, escape_string, valid_var_name},
     err_fmt, err_raw, err_str,
     highlight::highlight_and_colorize,
     input::{
@@ -137,6 +137,7 @@ impl BuiltinBind {
             out.push(' ');
             out.push_utfstr(&escape(ecmd));
         }
+
         out.push('\n');
 
         out
@@ -243,6 +244,7 @@ impl BuiltinBind {
     }
 
     /// Add specified key binding.
+    #[allow(clippy::too_many_arguments)]
     fn add(
         &mut self,
         seq: &wstr,
@@ -250,6 +252,7 @@ impl BuiltinBind {
         mode: WString,
         sets_mode: Option<WString>,
         user: bool,
+        parser: &Parser,
         streams: &mut IoStreams,
     ) -> bool {
         let cmds = cmds.iter().map(|&s| s.to_owned()).collect();
@@ -262,8 +265,9 @@ impl BuiltinBind {
         } else {
             KeyNameStyle::Plain
         };
+        let definition_file = parser.current_filename();
         self.input_mappings
-            .add(key_seq, key_name_style, cmds, mode, sets_mode, user);
+            .add(key_seq, key_name_style, cmds, mode, sets_mode, user, definition_file);
         false
     }
 
@@ -383,6 +387,7 @@ impl BuiltinBind {
                     .unwrap_or(DEFAULT_BIND_MODE.to_owned()),
                 self.opts.sets_bind_mode.clone(),
                 self.opts.user,
+                parser,
                 streams,
             ) {
                 return true;

--- a/src/input.rs
+++ b/src/input.rs
@@ -323,7 +323,14 @@ impl InputMappingSet {
         }
 
         // Add a new mapping, using the next order.
-        let new_mapping = InputMapping::new(sequence, commands, mode, sets_mode, key_name_style, definition_file);
+        let new_mapping = InputMapping::new(
+            sequence,
+            commands,
+            mode,
+            sets_mode,
+            key_name_style,
+            definition_file,
+        );
         input_mapping_insert_sorted(ml, new_mapping);
     }
 
@@ -369,7 +376,15 @@ pub fn init_input() {
         let mut add = |key: Vec<Key>, cmd: &str| {
             let mode = DEFAULT_BIND_MODE.to_owned();
             let sets_mode = Some(DEFAULT_BIND_MODE.to_owned());
-            input_mapping.add1(key, KeyNameStyle::Plain, cmd.into(), mode, sets_mode, false, None);
+            input_mapping.add1(
+                key,
+                KeyNameStyle::Plain,
+                cmd.into(),
+                mode,
+                sets_mode,
+                false,
+                None,
+            );
         };
 
         add(vec![], "self-insert");

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,6 +1,4 @@
-<<<<<<< HEAD
 use crate::{
-    common::{FilenameRef, Named, escape, get_by_sorted_name},
     env::Environment,
     flog::flog,
     global_safety::RelaxedAtomicBool,
@@ -13,7 +11,7 @@ use crate::{
     reader::{Reader, reader_reset_interrupted},
     threads::assert_is_main_thread,
 };
-use fish_common::{Named, assert_sorted_by_name, escape, get_by_sorted_name};
+use fish_common::{FilenameRef, Named, assert_sorted_by_name, escape, get_by_sorted_name};
 use std::{
     mem,
     sync::{

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,4 +1,6 @@
+<<<<<<< HEAD
 use crate::{
+    common::{FilenameRef, Named, escape, get_by_sorted_name},
     env::Environment,
     flog::flog,
     global_safety::RelaxedAtomicBool,
@@ -53,6 +55,8 @@ pub struct InputMapping {
     pub sets_mode: Option<WString>,
     /// Perhaps this binding was created using a raw escape sequence.
     pub key_name_style: KeyNameStyle,
+    /// The file from which the binding was created, or None if not from a file.
+    pub definition_file: Option<FilenameRef>,
 }
 
 impl InputMapping {
@@ -63,6 +67,7 @@ impl InputMapping {
         mode: WString,
         sets_mode: Option<WString>,
         key_name_style: KeyNameStyle,
+        definition_file: Option<FilenameRef>,
     ) -> InputMapping {
         static LAST_INPUT_MAP_SPEC_ORDER: AtomicU32 = AtomicU32::new(0);
         let specification_order = 1 + LAST_INPUT_MAP_SPEC_ORDER.fetch_add(1, Ordering::Relaxed);
@@ -77,6 +82,7 @@ impl InputMapping {
             mode,
             sets_mode,
             key_name_style,
+            definition_file,
         }
     }
 
@@ -289,6 +295,7 @@ fn input_mapping_insert_sorted(ml: &mut Vec<InputMapping>, new_mapping: InputMap
 
 impl InputMappingSet {
     /// Adds an input mapping.
+    #[allow(clippy::too_many_arguments)]
     pub fn add(
         &mut self,
         sequence: Vec<Key>,
@@ -297,6 +304,7 @@ impl InputMappingSet {
         mode: WString,
         sets_mode: Option<WString>,
         user: bool,
+        definition_file: Option<FilenameRef>,
     ) {
         // Update any existing mapping with this sequence.
         // FIXME: this makes adding multiple bindings quadratic.
@@ -309,16 +317,18 @@ impl InputMappingSet {
             if m.seq == sequence && m.mode == mode {
                 m.commands = commands;
                 m.sets_mode = sets_mode;
+                m.definition_file = definition_file;
                 return;
             }
         }
 
         // Add a new mapping, using the next order.
-        let new_mapping = InputMapping::new(sequence, commands, mode, sets_mode, key_name_style);
+        let new_mapping = InputMapping::new(sequence, commands, mode, sets_mode, key_name_style, definition_file);
         input_mapping_insert_sorted(ml, new_mapping);
     }
 
     // Like add(), but takes a single command.
+    #[allow(clippy::too_many_arguments)]
     pub fn add1(
         &mut self,
         sequence: Vec<Key>,
@@ -327,6 +337,7 @@ impl InputMappingSet {
         mode: WString,
         sets_mode: Option<WString>,
         user: bool,
+        definition_file: Option<FilenameRef>,
     ) {
         self.add(
             sequence,
@@ -335,6 +346,7 @@ impl InputMappingSet {
             mode,
             sets_mode,
             user,
+            definition_file,
         );
     }
 }
@@ -357,7 +369,7 @@ pub fn init_input() {
         let mut add = |key: Vec<Key>, cmd: &str| {
             let mode = DEFAULT_BIND_MODE.to_owned();
             let sets_mode = Some(DEFAULT_BIND_MODE.to_owned());
-            input_mapping.add1(key, KeyNameStyle::Plain, cmd.into(), mode, sets_mode, false);
+            input_mapping.add1(key, KeyNameStyle::Plain, cmd.into(), mode, sets_mode, false, None);
         };
 
         add(vec![], "self-insert");
@@ -390,6 +402,7 @@ pub fn init_input() {
                 mode,
                 sets_mode,
                 false,
+                None,
             );
         };
         add_raw("\x1B[A", "up-line");
@@ -1044,6 +1057,7 @@ mod tests {
             bind_mode(),
             None,
             true,
+            None,
         );
         input_mappings.add1(
             desired_binding.clone(),
@@ -1052,6 +1066,7 @@ mod tests {
             bind_mode(),
             None,
             true,
+            None,
         );
 
         // Push the desired binding to the queue.

--- a/tests/checks/bind.fish
+++ b/tests/checks/bind.fish
@@ -9,10 +9,11 @@ for bindings in true fish_default_key_bindings fish_vi_key_bindings
         $bindings
         or echo >&2 error setting bindings: status=\$status
         bind > $tmpdir/old
+        bind | string replace -r ' # defined in .*' '' > $tmpdir/old
         bind --erase --all --preset
         bind --erase --all
         source $tmpdir/old
-        bind >$tmpdir/new
+        bind | string replace -r ' # defined in .*' '' >$tmpdir/new
         diff -u $tmpdir/{old,new}
     "
 end
@@ -35,8 +36,8 @@ bind -M bind-mode \cX true
 bind -M bind_mode \cX true
 
 # Listing bindings
-bind | string match -v '*\e\\[*' # Hide raw bindings.
-bind --user --preset | string match -v '*\e\\[*'
+bind | string match -v '*\e\\[*' | string replace -r ' # defined in .*' '' # Hide raw bindings.
+bind --user --preset | string match -v '*\e\\[*' | string replace -r ' # defined in .*' ''
 # CHECK: bind --preset '' self-insert
 # CHECK: bind --preset enter execute
 # CHECK: bind --preset tab complete
@@ -75,7 +76,7 @@ bind --user --preset | string match -v '*\e\\[*'
 # CHECK: bind -M bind_mode ctrl-x true
 
 # Preset only
-bind --preset | string match -v '*\e\\[*'
+bind --preset | string match -v '*\e\\[*' | string replace -r ' # defined in .*' ''
 # CHECK: bind --preset '' self-insert
 # CHECK: bind --preset enter execute
 # CHECK: bind --preset tab complete
@@ -95,12 +96,12 @@ bind --preset | string match -v '*\e\\[*'
 # CHECK: bind --preset ctrl-f forward-char
 
 # User only
-bind --user | string match -v '*\e\\[*'
+bind --user | string match -v '*\e\\[*' | string replace -r ' # defined in .*' ''
 # CHECK: bind -M bind_mode ctrl-x true
 
 # Adding bindings
 bind tab 'echo banana'
-bind | string match -v '*\e\\[*'
+bind | string match -v '*\e\\[*' | string replace -r ' # defined in .*' ''
 # CHECK: bind --preset '' self-insert
 # CHECK: bind --preset enter execute
 # CHECK: bind --preset tab complete

--- a/tests/checks/bind.fish
+++ b/tests/checks/bind.fish
@@ -133,15 +133,15 @@ bind super-alt-\~
 
 # Legacy
 bind \cx\cax 'echo foo'
-bind \cx\cax
+bind \cx\cax | string replace -r ' # defined in .*' ''
 # CHECK: bind ctrl-x,ctrl-a,x 'echo foo'
 bind \ef forward-word
-bind \ef
+bind \ef | string replace -r ' # defined in .*' ''
 # CHECK: bind alt-f forward-word
 
 # Erasing bindings
 bind --erase tab
-bind tab
+bind tab | string replace -r ' # defined in .*' ''
 bind tab 'echo wurst'
 # CHECK: bind --preset tab complete
 bind --erase --user --preset tab
@@ -155,7 +155,7 @@ bind -k nul 'echo foo'
 # CHECKERR: bind: the -k/--key syntax is no longer supported. See `bind --help` and `bind --key-names`
 
 # Either Return or ctrl-m.
-bind \r
+bind \r | string replace -r ' # defined in .*' ''
 # CHECK: bind --preset enter execute
 # Never Return, probably always ctrl-j.
 bind \n 2>&1

--- a/tests/checks/bind.fish
+++ b/tests/checks/bind.fish
@@ -9,11 +9,11 @@ for bindings in true fish_default_key_bindings fish_vi_key_bindings
         $bindings
         or echo >&2 error setting bindings: status=\$status
         bind > $tmpdir/old
-        bind | string replace -r ' # defined in .*' '' > $tmpdir/old
+        bind | string match -r -v '# Defined in *' > $tmpdir/old
         bind --erase --all --preset
         bind --erase --all
         source $tmpdir/old
-        bind | string replace -r ' # defined in .*' '' >$tmpdir/new
+        bind | string match -r -v '# Defined in *' >$tmpdir/new
         diff -u $tmpdir/{old,new}
     "
 end
@@ -36,8 +36,8 @@ bind -M bind-mode \cX true
 bind -M bind_mode \cX true
 
 # Listing bindings
-bind | string match -v '*\e\\[*' | string replace -r ' # defined in .*' '' # Hide raw bindings.
-bind --user --preset | string match -v '*\e\\[*' | string replace -r ' # defined in .*' ''
+bind | string match -v '*\e\\[*' | string match -r -v '# Defined in *' # Hide raw bindings.
+bind --user --preset | string match -v '*\e\\[*' | string match -r -v '# Defined in *'
 # CHECK: bind --preset '' self-insert
 # CHECK: bind --preset enter execute
 # CHECK: bind --preset tab complete
@@ -76,7 +76,7 @@ bind --user --preset | string match -v '*\e\\[*' | string replace -r ' # defined
 # CHECK: bind -M bind_mode ctrl-x true
 
 # Preset only
-bind --preset | string match -v '*\e\\[*' | string replace -r ' # defined in .*' ''
+bind --preset | string match -v '*\e\\[*' | string match -r -v '# Defined in *'
 # CHECK: bind --preset '' self-insert
 # CHECK: bind --preset enter execute
 # CHECK: bind --preset tab complete
@@ -96,12 +96,12 @@ bind --preset | string match -v '*\e\\[*' | string replace -r ' # defined in .*'
 # CHECK: bind --preset ctrl-f forward-char
 
 # User only
-bind --user | string match -v '*\e\\[*' | string replace -r ' # defined in .*' ''
+bind --user | string match -v '*\e\\[*' | string match -r -v '# Defined in *'
 # CHECK: bind -M bind_mode ctrl-x true
 
 # Adding bindings
 bind tab 'echo banana'
-bind | string match -v '*\e\\[*' | string replace -r ' # defined in .*' ''
+bind | string match -v '*\e\\[*' | string match -r -v '# Defined in *'
 # CHECK: bind --preset '' self-insert
 # CHECK: bind --preset enter execute
 # CHECK: bind --preset tab complete
@@ -133,15 +133,15 @@ bind super-alt-\~
 
 # Legacy
 bind \cx\cax 'echo foo'
-bind \cx\cax | string replace -r ' # defined in .*' ''
+bind \cx\cax | string match -r -v '# Defined in *'
 # CHECK: bind ctrl-x,ctrl-a,x 'echo foo'
 bind \ef forward-word
-bind \ef | string replace -r ' # defined in .*' ''
+bind \ef | string match -r -v '# Defined in *'
 # CHECK: bind alt-f forward-word
 
 # Erasing bindings
 bind --erase tab
-bind tab | string replace -r ' # defined in .*' ''
+bind tab | string match -r -v '# Defined in *'
 bind tab 'echo wurst'
 # CHECK: bind --preset tab complete
 bind --erase --user --preset tab
@@ -155,7 +155,7 @@ bind -k nul 'echo foo'
 # CHECKERR: bind: the -k/--key syntax is no longer supported. See `bind --help` and `bind --key-names`
 
 # Either Return or ctrl-m.
-bind \r | string replace -r ' # defined in .*' ''
+bind \r | string match -r -v '# Defined in *'
 # CHECK: bind --preset enter execute
 # Never Return, probably always ctrl-j.
 bind \n 2>&1
@@ -196,6 +196,7 @@ bind ctrl-q
 
 bind --user --preset ctrl-q 'echo preset'
 # CHECKERR: bind: --preset --user: options cannot be used together
+
 
 fish_default_key_bindings
 


### PR DESCRIPTION
# Description

This PR is based on this [PR](https://github.com/fish-shell/fish-shell/pull/12221) and aims at making things more readable by regrouping together bindings defined by the same file and not have to append ` # defined in ...` at each line.

For example : 
```
# Defined in embedded:functions/fish_default_key_bindings.fish:
bind --preset right forward-char
bind --preset left backward-char
bind --preset end end-of-line
bind --preset home beginning-of-line
bind --preset delete delete-char
bind --preset backspace backward-delete-char
bind --preset shift-backspace backward-delete-char
bind --preset ctrl-a beginning-of-line
bind --preset ctrl-e end-of-line
bind --preset ctrl-h backward-delete-char
bind --preset ctrl-p up-or-search
bind --preset ctrl-n down-or-search
bind --preset ctrl-f forward-char
bind --preset ctrl-b backward-char
bind --preset ctrl-t transpose-chars
bind --preset ctrl-g cancel
...
```

It also hides bindings defined in private implementation files such as `functions/__fish_shared_key_bindings.fish`.

It adresses the issue #12215 .

# TODO
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst 
