### PR TITLE
functions/history: honor explicitly specified --color=

### DIFF
--- a/share/functions/history.fish
+++ b/share/functions/history.fish
@@ -90,7 +90,11 @@ function history --description "display or manipulate interactive command histor
                 not set -qx LV # ask the pager lv not to strip colors
                 and set -fx LV -c
 
-                builtin history search --color=always $search_mode $show_time $max_count $_flag_case_sensitive $_flag_reverse $_flag_null -- $argv | $pager
+                if contains -- "$color_opt" '' '--color=auto'
+                    set color_opt --color=always
+                end
+
+                builtin history search $color_opt $search_mode $show_time $max_count $_flag_case_sensitive $_flag_reverse $_flag_null -- $argv | $pager
             else
                 builtin history search $color_opt $search_mode $show_time $max_count $_flag_case_sensitive $_flag_reverse $_flag_null -- $argv
             end


### PR DESCRIPTION
This partially reverts 324223ddfffa4c1012256470ee3bb365c5ad4a9b.

The offending commit broke the ability to set color mode via option completely in interactive sessions.



## TODOs:
<!-- Check off what what has been done so far. -->
- [ ] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
