### PR TITLE
doc: add link to `not` command from `if` command

### DIFF
--- a/doc_src/cmds/if.rst
+++ b/doc_src/cmds/if.rst
@@ -16,7 +16,7 @@ Description
 
 ``if`` will execute the command ``CONDITION``. If the condition's exit status is 0, the commands ``COMMANDS_TRUE`` will execute.  If the exit status is not 0 and :doc:`else <else>` is given, ``COMMANDS_FALSE`` will be executed.
 
-You can use :doc:`and <and>` or :doc:`or <or>` in the condition. See the second example below.
+You can use :doc:`not <not>`, :doc:`and <and>` or :doc:`or <or>` in the condition. See the second example below.
 
 The exit status of the last foreground command to exit can always be accessed using the :ref:`$status <variables-status>` variable.
 


### PR DESCRIPTION
Hi

It's very common to want to express negation in a `if` command. Therefore a quick way to learn about the `not` command is handy.

Thanks

## TODOs:
<!-- Check off what what has been done so far. -->
- [ ] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
