### PR TITLE
Feat: Implement Tab Completion Preview Feature

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Notable improvements and fixes
 ------------------------------
 - New Spanish translations (:issue:`12489`).
 - New Japanese translations (:issue:`12499`).
+- A new "Tab Completion Preview" feature visually underlines the "guaranteed" portion of an autosuggestion (the longest common prefix across all completions) (:issue:`11250`).
 
 Deprecations and removed features
 ---------------------------------

--- a/doc_src/interactive.rst
+++ b/doc_src/interactive.rst
@@ -27,6 +27,8 @@ To accept the autosuggestion (replacing the command line contents), press :kbd:`
 
 Autosuggestions are a powerful way to quickly summon frequently entered commands, by typing the first few characters. They are also an efficient technique for navigating through directory hierarchies.
 
+To provide immediate feedback on the result of a completion, fish includes a **Tab Completion Preview** feature. The "guaranteed" portion of an autosuggestion (the longest common prefix shared by all possible completions at that point) is visually underlined. This tells you exactly what part of the suggestion will be inserted if you press :kbd:`tab`.
+
 If you don't like autosuggestions, you can disable them by setting ``$fish_autosuggestion_enabled`` to 0::
 
   set -g fish_autosuggestion_enabled 0

--- a/src/reader/reader.rs
+++ b/src/reader/reader.rs
@@ -1899,12 +1899,11 @@ impl<'a> Reader<'a> {
             ],
         );
 
-        // Apply force_underline for the guaranteed prefix.
+        // Apply force_underline for the guaranteed prefix of the suggestion.
         if self.is_at_line_with_autosuggestion() {
-            let guaranteed_end = self.autosuggestion.search_string_range.start
-                + self.autosuggestion.common_prefix_len;
-            let end = colors.len().min(guaranteed_end);
-            for color in &mut colors[..end] {
+            let start = autosuggested_range.start;
+            let end = (start + self.autosuggestion.common_prefix_len).min(colors.len());
+            for color in &mut colors[start..end] {
                 color.force_underline = true;
             }
         }
@@ -5499,13 +5498,15 @@ fn get_autosuggestion_performer(
                         break;
                     }
                 }
-                common_prefix_len = lcp.len();
+                let cursor_pos_in_token = line_range.end - token_range.start;
+                common_prefix_len = lcp.len().saturating_sub(cursor_pos_in_token);
             }
 
             let comp = &completions[0];
 
-            // Use the token range for the coordinate fix.
-            search_string_range.start = token_range.start;
+            // Do NOT use the token range for the start of search_string_range yet,
+            // as it breaks the suggestion positioning in paint_layout.
+            search_string_range.start = line_range.start;
 
             // Prefer icase history over smartcase/icase completions.
             if let (Some(result), CaseSensitivity::Smart | CaseSensitivity::Insensitive) =
@@ -7610,30 +7611,27 @@ mod tests {
     fn test_autosuggestion_common_prefix() {
         use super::AutosuggestionResult;
 
-        let parser = TestParser::new();
-        let _vars = parser.vars();
-
         // Test with a multi-token command: "echo d"
-        // Completions for "d" could be "documents" and "downloads"
-        // LCP is 2 ("do")
-        // Token range is 5..6 ("d")
-        
+        // Token "d" starts at 5. Cursor is at 6.
+        // Completions could be "documents" and "downloads" (LCP "do")
+        // Shared prefix *after* the cursor is "o" (len 1).
+
         let command_line = L!("echo d");
-        let suggestion = L!("echo documents");
-        let common_prefix_len = 2; // "do"
-        let token_start = 5;
+        let suggestion = L!("ocuments"); // Suffix starting from index 6
+        let common_prefix_len = 1; // "o" is guaranteed after "d"
+        let cursor_pos = 6;
 
         let result = AutosuggestionResult::new(
             command_line.to_owned(),
-            token_start..6,
+            cursor_pos..cursor_pos,
             suggestion.to_owned(),
             None,
             false,
             common_prefix_len,
         );
 
-        assert_eq!(result.search_string_range, 5..6);
-        assert_eq!(result.common_prefix_len, 2);
-        assert_eq!(result.autosuggestion.text, L!("echo documents"));
+        assert_eq!(result.search_string_range, 6..6);
+        assert_eq!(result.common_prefix_len, 1);
+        assert_eq!(result.autosuggestion.text, L!("ocuments"));
     }
 }

--- a/src/reader/reader.rs
+++ b/src/reader/reader.rs
@@ -1899,6 +1899,16 @@ impl<'a> Reader<'a> {
             ],
         );
 
+        // Apply force_underline for the guaranteed prefix.
+        if self.is_at_line_with_autosuggestion() {
+            let guaranteed_end = self.autosuggestion.search_string_range.start
+                + self.autosuggestion.common_prefix_len;
+            let end = colors.len().min(guaranteed_end);
+            for color in &mut colors[..end] {
+                color.force_underline = true;
+            }
+        }
+
         // Compute the indentation.
         let indents = compute_indents(&full_line);
 
@@ -5225,12 +5235,16 @@ pub(super) struct Autosuggestion {
 
     /// Whether the autosuggestion is a whole match from history.
     is_whole_item_from_history: bool,
+
+    /// The length of the longest common prefix across all completions of the same rank.
+    common_prefix_len: usize,
 }
 
 impl Autosuggestion {
     // Clear our contents.
     fn clear(&mut self) {
         self.text.clear();
+        self.common_prefix_len = 0;
     }
 
     // Return whether we have empty text.
@@ -5266,6 +5280,7 @@ impl AutosuggestionResult {
         text: WString,
         icase_matched_codepoints: Option<usize>,
         is_whole_item_from_history: bool,
+        common_prefix_len: usize,
     ) -> Self {
         Self {
             autosuggestion: Autosuggestion {
@@ -5273,6 +5288,7 @@ impl AutosuggestionResult {
                 search_string_range,
                 icase_matched_codepoints,
                 is_whole_item_from_history,
+                common_prefix_len,
             },
             command_line,
             needs_load: vec![],
@@ -5408,6 +5424,7 @@ fn get_autosuggestion_performer(
                         full[suggested_range].into(),
                         icase.then(|| searcher.canon_term().char_count()),
                         is_whole,
+                        0, // common_prefix_len: history matches don't calculate LCP yet
                     );
                     if icase {
                         icase_history_result = Some(result);
@@ -5448,6 +5465,10 @@ fn get_autosuggestion_performer(
         let (mut completions, needs_load) =
             complete(&command_line[..would_be_cursor], complete_flags, &ctx);
 
+        let mut common_prefix_len = 0;
+        let (token_range, _) = get_token_extent(&command_line, line_range.end);
+        let mut search_string_range = line_range.clone();
+
         let suggestion = if completions.is_empty() {
             // If there are no completions to suggest, fall back to icase history.
             if let Some(result) = icase_history_result {
@@ -5456,7 +5477,35 @@ fn get_autosuggestion_performer(
             WString::new()
         } else {
             sort_and_prioritize(&mut completions, complete_flags);
+
+            // Calculate LCP across completions of the same rank, skipping suppressed ones.
+            let mut completions_iter = completions
+                .iter()
+                .filter(|c| !c.flags.contains(CompleteFlags::SUPPRESS_PAGER_PREFIX));
+            if let Some(first) = completions_iter.next() {
+                let mut lcp: Vec<char> = first.completion.chars().collect();
+                for next in completions_iter {
+                    let next_chars: Vec<char> = next.completion.chars().collect();
+                    let mut new_len = 0;
+                    for (c1, c2) in lcp.iter().zip(next_chars.iter()) {
+                        if c1 == c2 {
+                            new_len += 1;
+                        } else {
+                            break;
+                        }
+                    }
+                    lcp.truncate(new_len);
+                    if lcp.is_empty() {
+                        break;
+                    }
+                }
+                common_prefix_len = lcp.len();
+            }
+
             let comp = &completions[0];
+
+            // Use the token range for the coordinate fix.
+            search_string_range.start = token_range.start;
 
             // Prefer icase history over smartcase/icase completions.
             if let (Some(result), CaseSensitivity::Smart | CaseSensitivity::Insensitive) =
@@ -5479,10 +5528,11 @@ fn get_autosuggestion_performer(
         let lowercase_char_count = lowercase(command_line[line_range.clone()].chars()).count();
         let mut result = AutosuggestionResult::new(
             command_line,
-            line_range,
+            search_string_range,
             suggestion,
             Some(lowercase_char_count), // normal completions are case-insensitive
             /*is_whole_item_from_history=*/ false,
+            common_prefix_len,
         );
         result.needs_load = needs_load;
         result
@@ -7454,6 +7504,7 @@ mod tests {
                 search_string_range: 0..4,
                 icase_matched_codepoints: None,
                 is_whole_item_from_history: true,
+                common_prefix_len: 0,
             },
             "echo",
             Edit::new(4..4, L!(" ").to_owned()),
@@ -7462,6 +7513,7 @@ mod tests {
                 search_string_range: 0..5,
                 icase_matched_codepoints: None,
                 is_whole_item_from_history: true,
+                common_prefix_len: 0,
             })
         );
 
@@ -7472,10 +7524,31 @@ mod tests {
                 search_string_range: 0..4,
                 icase_matched_codepoints: None,
                 is_whole_item_from_history: true,
+                common_prefix_len: 0,
             },
             "echo",
             Edit::new(4..4, L!("f").to_owned()),
             None,
+        );
+
+        validate!(
+            "Matching edit prefix",
+            Autosuggestion {
+                text: L!("echo hest").to_owned(),
+                search_string_range: 0..4,
+                icase_matched_codepoints: None,
+                is_whole_item_from_history: true,
+                common_prefix_len: 7,
+            },
+            "echo",
+            Edit::new(4..4, L!(" ").to_owned()),
+            Some(Autosuggestion {
+                text: L!("echo hest").to_owned(),
+                search_string_range: 0..5,
+                icase_matched_codepoints: None,
+                is_whole_item_from_history: true,
+                common_prefix_len: 7,
+            })
         );
 
         validate!(
@@ -7485,6 +7558,7 @@ mod tests {
                 search_string_range: 0..4,
                 icase_matched_codepoints: Some(4),
                 is_whole_item_from_history: true,
+                common_prefix_len: 0,
             },
             "echo",
             Edit::new(4..4, L!(" H").to_owned()),
@@ -7493,6 +7567,7 @@ mod tests {
                 search_string_range: 0..6,
                 icase_matched_codepoints: Some(6),
                 is_whole_item_from_history: true,
+                common_prefix_len: 0,
             })
         );
 
@@ -7503,6 +7578,7 @@ mod tests {
                 search_string_range: 0..4,
                 icase_matched_codepoints: Some(4),
                 is_whole_item_from_history: true,
+                common_prefix_len: 0,
             },
             "echo",
             Edit::new(3..4, L!("").to_owned()),
@@ -7511,6 +7587,7 @@ mod tests {
                 search_string_range: 0..3,
                 icase_matched_codepoints: Some(3),
                 is_whole_item_from_history: true,
+                common_prefix_len: 0,
             })
         );
 
@@ -7521,10 +7598,42 @@ mod tests {
                 search_string_range: 0..6,
                 icase_matched_codepoints: Some(6),
                 is_whole_item_from_history: true,
+                common_prefix_len: 0,
             },
             "echo i",
             Edit::new(6..6, L!("n").to_owned()),
             None,
         );
+    }
+
+    #[test]
+    fn test_autosuggestion_common_prefix() {
+        use super::AutosuggestionResult;
+
+        let parser = TestParser::new();
+        let _vars = parser.vars();
+
+        // Test with a multi-token command: "echo d"
+        // Completions for "d" could be "documents" and "downloads"
+        // LCP is 2 ("do")
+        // Token range is 5..6 ("d")
+        
+        let command_line = L!("echo d");
+        let suggestion = L!("echo documents");
+        let common_prefix_len = 2; // "do"
+        let token_start = 5;
+
+        let result = AutosuggestionResult::new(
+            command_line.to_owned(),
+            token_start..6,
+            suggestion.to_owned(),
+            None,
+            false,
+            common_prefix_len,
+        );
+
+        assert_eq!(result.search_string_range, 5..6);
+        assert_eq!(result.common_prefix_len, 2);
+        assert_eq!(result.autosuggestion.text, L!("echo documents"));
     }
 }


### PR DESCRIPTION

- [x] Fixes issue #12390 
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst

This PR introduces a Tab Completion Preview feature that visually distinguishes the "guaranteed" part of an autosuggestion. The guaranteed portion of the grey autosuggestion text is now underlined.

@krobelus , please review this PR , this solves the earlier issue.
<img width="784" height="154" alt="image" src="https://github.com/user-attachments/assets/c149da73-531d-4cd8-8680-feba45ccaea8" />
It was due to a coordinate system mismatch: I was applying the common prefix length relative to the start of the line, but for file completions, it should be relative to the start of the token. 
And I did the necessary changes 