### PR TITLE
CI: rebase MSYS2 dll

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,10 +164,17 @@ jobs:
       with:
         update: true
         msystem: MSYS
+      id: msys2
     - name: Install deps
       # Not using setup-msys2 `install` option to make it easier to copy/paste
       run: |
         pacman --noconfirm -S --needed git rust
+    - name: rebase
+      env:
+        MSYS2_LOCATION: ${{ steps.msys2.outputs.msys2-location }}
+      shell: cmd
+      run: |
+        "%MSYS2_LOCATION%\usr\bin\dash" /usr/bin/rebaseall -p -v
     - name: cargo build
       run: |
         cargo build


### PR DESCRIPTION
This fixes, or should make it less likely, spurious CI failures because of:
`child_info_fork::abort: address space needed by <DLL> is already occupied`

The issue is that Unix `fork()`, given how it works, preserves libraries' addresses. Windows does not have such a function, so Cygwin needs emulate it by moving the libraries in a child process to match the addresses in its parent. This leads to conflicts if Windows already loaded something there.

As a workaround, Cygwin has a `rebase` application to assign specific addresses to each DLL and forcing Windows to use those. This generally fixes the issue (until a DLL is updated that is, but that's not a concern for CI since everything is rebuilt from scratch every time).

In the case of #12515 though, the failing DLL is a temporary one built during the compilation. So a rebase of MSYS2 packages will not quite fix the problem. However, by moving other DLLs at specific locations, it reduce the risk of collision to only be between the temporary ones.

Fixes #12515
