### PR TITLE
docs(changelog): fix typo for Catppuccin color themes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -54,7 +54,7 @@ New or improved bindings
 - Vi mode word movements (``w``, ``W``, ``e``, and ``E``) are now largely in line with Vim. The only exception is that underscores are treated as word separators (:issue:`12269`).
 - New special input functions to support these movements: ``forward-word-vi``, ``kill-word-vi``, ``forward-bigword-vi``, ``kill-bigword-vi``, ``forward-word-end``, ``backward-word-end``, ``forward-bigword-end``, ``backward-bigword-end``, ``kill-a-word``, ``kill-inner-word``, ``kill-a-bigword``, and ``kill-inner-bigword``.
 - Vi mode key bindings now support counts for movement and deletion commands (e.g. `d3w` or `3l`), via a new operator mode (:issue:`2192`).
-- New ``catpuccin-*`` color themes.
+- New ``catppuccin-*`` color themes.
 
 Improved terminal support
 -------------------------


### PR DESCRIPTION

## TODOs:
<!-- Check off what what has been done so far. -->
- [ ] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->

---

This PR aims to fix a typo in the [4.4.0 release notes](https://fishshell.com/docs/current/relnotes.html#fish-4-4-0-released-february-03-2026) for the Catppuccin color themes. In the release notes, the Catppuccin themes are spelled `catpuccin-*`, when the correct name should be `catppuccin-*`.