### PR TITLE
Update file names of the Catppuccin theme for fetching in build scripts

### DIFF
--- a/build_tools/update-dependencies.sh
+++ b/build_tools/update-dependencies.sh
@@ -50,18 +50,9 @@ from_gh() {
 
 from_gh ridiculousfish/widecharwidth widechar_width.rs crates/widecharwidth/src/widechar_width.rs
 from_gh ridiculousfish/littlecheck littlecheck/littlecheck.py tests/littlecheck.py
-
-from_gh_ctp() {
-    ctp_flavor=$1
-    ctp_file_destination=$2
-    ctp_commit="bc201afe737fa0c8884ffcef206217f8aac88866"
-    ctp_contents=$(curl -fsS https://raw.githubusercontent.com/catppuccin/fish/"${ctp_commit}"/themes/"${ctp_flavor}".theme)
-    printf '%s\n' "$ctp_contents" >"$ctp_file_destination"
-}
-
-from_gh_ctp 'Catppuccin%20Frappe' share/themes/catppuccin-frappe.theme
-from_gh_ctp 'Catppuccin%20Macchiato' share/themes/catppuccin-macchiato.theme
-from_gh_ctp 'Catppuccin%20Mocha' share/themes/catppuccin-mocha.theme
+from_gh catppuccin/fish themes/catppuccin-frappe.theme share/themes/catppuccin-frappe.theme
+from_gh catppuccin/fish themes/catppuccin-macchiato.theme share/themes/catppuccin-macchiato.theme
+from_gh catppuccin/fish themes/catppuccin-mocha.theme share/themes/catppuccin-mocha.theme
 
 # Update Cargo.lock
 cargo update


### PR DESCRIPTION

## TODOs:
<!-- Check off what what has been done so far. -->
- [ ] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
---

This PR aims to update the `update-dependencies` build script to pin a specific commit from the [Catppuccin theme's repository for fish](https://github.com/catppuccin/fish) when being fetched by the script to create Catppuccin color theme files for upstream fish.

This change was made to ensure any possible future changes to the theme file names in Catppuccin's own repo, such as my PR to rename the files to match fish's built-in ones (https://github.com/catppuccin/fish/pull/41), will not break the building of Catppuccin themes for the fish upstream.