### PR TITLE
resource usage: print KiB, not kb

### DIFF
--- a/src/bin/fish.rs
+++ b/src/bin/fish.rs
@@ -117,7 +117,8 @@ fn print_rusage_self() {
     // `getrusage` should never fail with this usage.
     // If it does, it suggests a non-POSIX-compliant OS.
     let usage = getrusage(UsageWho::RUSAGE_SELF).unwrap();
-    let rss_kb = if cfg!(apple) {
+    #[allow(non_snake_case)]
+    let rss_KiB = if cfg!(apple) {
         // Macs use bytes,
         // Source: commit b6555a0dc462f669e1b5a370c3efae0f5948a1ef
         // The docs at https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/getrusage.2.html say otherwise.
@@ -134,7 +135,7 @@ fn print_rusage_self() {
     eprintf!("      user time: %s ms\n", sys_time.to_string());
     eprintf!("       sys time: %s ms\n", user_time.to_string());
     eprintf!("     total time: %s ms\n", total_time.to_string());
-    eprintf!("        max rss: %s kb\n", rss_kb.to_string());
+    eprintf!("        max rss: %s KiB\n", rss_KiB.to_string());
     eprintf!("        signals: %s\n", signals.to_string());
 }
 


### PR DESCRIPTION
The value shown is in KiB (2^{10} bytes), according to `man 2 getrusage`, not kb (10^3 bits), so reflect this in the variable name and output.
