### PR TITLE
completions/docker: don't load if docker is not started

### DIFF
--- a/share/completions/docker.fish
+++ b/share/completions/docker.fish
@@ -1,1 +1,4 @@
-docker completion fish 2>/dev/null | source
+# In WSL, when the docker app is not yet started, "docker" is a script printing
+# some error message on stdout instead of a sourceable script
+set -l docker_completion "$(docker completion fish 2>/dev/null)"
+and eval "$docker_completion"


### PR DESCRIPTION
In WSL, if Docker is not started, the `docker` command is a script that prints an error message to stdout instead of a valid script.

This was causing `tests/checks/check-completions.fish` to fail when running the tests in WSL with docker stopped.