### PR TITLE
Switch back alt/ctrl-left/right/backspace/del behaviour on non-macOS systems (Fixes issue #12122)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Notable improvements and fixes
 - ``set_color`` is able to turn off italics, reverse mode, strikethrough and underline individually (e.g. ``--italics=off``).
 - ``set_color`` learned the foreground (``--foreground`` or ``-f``) and reset (``--reset``) modifiers.
 - ``fish_indent`` now preserves comments and newlines immediately preceding a brace block (``{ }``) (:issue:`12505`).
+- On non-macOS platforms, :kbd:`alt-backspace`, :kbd:`alt-left` and :kbd:`alt-right` operate on words again instead of tokens (:issue:`12122`) eliminating cross-platform differences in input handling.
 
 For distributors and developers
 -------------------------------

--- a/doc_src/interactive.rst
+++ b/doc_src/interactive.rst
@@ -326,11 +326,11 @@ Some bindings are common across Emacs and vi mode, because they aren't text edit
 
 - :kbd:`alt-enter` inserts a newline at the cursor position. This is useful to add a line to a commandline that's already complete.
 
-- :kbd:`alt-left` (``←``) and :kbd:`alt-right` (``→``) move the cursor left or right by one argument (or one word on macOS).
+- :kbd:`alt-left` (``←``) and :kbd:`alt-right` (``→``) move the cursor left or right by one word.
   If the command line is empty, they move forward/backward in the directory history.
-  If the cursor is already at the end of the line, and an autosuggestion is available, :kbd:`alt-right` (``→``) (or :kbd:`alt-f`) accepts the first argument (or word on macOS) in the suggestion.
+  If the cursor is already at the end of the line, and an autosuggestion is available, :kbd:`alt-right` (``→``) (or :kbd:`alt-f`) accepts the first word in the suggestion.
 
-- :kbd:`ctrl-left` (``←``) and :kbd:`ctrl-right` (``→``) move the cursor left or right by one word. These accept one word of the autosuggestion - the part they'd move over.
+- :kbd:`ctrl-left` (``←``) and :kbd:`ctrl-right` (``→``) move the cursor left or right by one token. These accept one token of the autosuggestion - the part they'd move over.
 
 - :kbd:`shift-left` (``←``) and :kbd:`shift-right` (``→``) move the cursor one word left or right, without stopping on punctuation. These accept one big word of the autosuggestion.
 
@@ -400,8 +400,7 @@ To enable emacs mode, use :doc:`fish_default_key_bindings <cmds/fish_default_key
 
 - :kbd:`delete` or :kbd:`backspace` or :kbd:`ctrl-h` removes one character forwards or backwards respectively.
 
-- :kbd:`ctrl-backspace` removes one word backwards and :kbd:`alt-backspace` removes one argument backwards.
-  On macOS, it's the other way round.
+- :kbd:`alt-backspace` removes one word backwards and :kbd:`ctrl-backspace` removes one argument backwards.
 
 - :kbd:`alt-<` moves to the beginning of the commandline, :kbd:`alt->` moves to the end.
 

--- a/share/functions/__fish_shared_key_bindings.fish
+++ b/share/functions/__fish_shared_key_bindings.fish
@@ -19,8 +19,8 @@ function __fish_shared_key_bindings -d "Bindings shared between emacs and vi mod
     bind --preset $argv left backward-char
 
     # Ctrl-left/right - these also work in vim.
-    __fish_per_os_bind --preset $argv ctrl-right forward-token forward-word
-    __fish_per_os_bind --preset $argv ctrl-left backward-token backward-word
+    bind --preset $argv ctrl-right forward-token
+    bind --preset $argv ctrl-left backward-token
 
     bind --preset $argv pageup beginning-of-history
     bind --preset $argv pagedown end-of-history
@@ -48,12 +48,10 @@ function __fish_shared_key_bindings -d "Bindings shared between emacs and vi mod
     bind --preset $argv alt-f nextd-or-forward-word
 
     for alt_right in alt-right \e\[1\;9C # TODO(terminal-workaround) iTerm2 < 3.5.12
-        __fish_per_os_bind --preset $argv $alt_right \
-            nextd-or-forward-word nextd-or-forward-token
+        bind --preset $argv $alt_right nextd-or-forward-word
     end
     for alt_left in alt-left \e\[1\;9D # TODO(terminal-workaround) iTerm2 < 3.5.12
-        __fish_per_os_bind --preset $argv $alt_left \
-            prevd-or-backward-word prevd-or-backward-token
+        bind --preset $argv $alt_left prevd-or-backward-word
     end
 
     bind --preset $argv alt-up history-token-search-backward

--- a/share/functions/fish_default_key_bindings.fish
+++ b/share/functions/fish_default_key_bindings.fish
@@ -50,11 +50,11 @@ function fish_default_key_bindings -d "emacs-like key binds"
     bind --preset $argv alt-u upcase-word
 
     bind --preset $argv alt-c capitalize-word
-    __fish_per_os_bind --preset $argv alt-backspace backward-kill-word backward-kill-token
-    __fish_per_os_bind --preset $argv ctrl-alt-h backward-kill-word backward-kill-token
-    __fish_per_os_bind --preset $argv ctrl-backspace backward-kill-token backward-kill-word
-    __fish_per_os_bind --preset $argv alt-delete kill-word kill-token
-    __fish_per_os_bind --preset $argv ctrl-delete kill-token kill-word
+    bind --preset $argv alt-backspace backward-kill-word
+    bind --preset $argv ctrl-alt-h backward-kill-word
+    bind --preset $argv ctrl-backspace backward-kill-token
+    bind --preset $argv alt-delete kill-word
+    bind --preset $argv ctrl-delete kill-token
 
     bind --preset $argv alt-\< beginning-of-buffer
     bind --preset $argv alt-\> end-of-buffer


### PR DESCRIPTION
This PR addresses issue #12122. In order to not splinter the discussion, I have posted my rationale there. I think it would be best to keep general discussion about this change over there, and keep this PR for discussion of technical details of the changes.

I have not added tests as I wasn't sure how this would be tested. If there is a mechanism for testing interactive use, I will be happy to add tests as well.

Note that I have not removed the (now unused) underlying `__fish_per_os_bind` function in anticipation of a future platform-native binding set, but I don't have strong feelings about this either way, so I can amend the changes to remove it as well if desired.

## TODOs:
<!-- Check off what what has been done so far. -->
- [x] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
