### PR TITLE
set_color: use only on/off for boolean options

### DIFF
--- a/doc_src/cmds/set_color.rst
+++ b/doc_src/cmds/set_color.rst
@@ -55,13 +55,13 @@ The following options are available:
     Sets dim mode.
 
 **-i** or **--italics**, or **-iSTATE** or **--italics=STATE**
-    Sets italics mode. The state can be **on** / **true** (default), or **off** / **false**
+    Sets italics mode. The state can be **on** (default), or **off**.
 
 **-r** or **--reverse**, or **-iSTATE** or **--reverse=STATE**
-    Sets reverse mode. The state can be **on** / **true** (default), or **off** / **false**
+    Sets reverse mode. The state can be **on** (default), or **off**.
 
 **-s** or **--strikethrough**, or **-sSTATE** or **--strikethrough=STATE**
-    Sets strikethrough mode. The state can be **on** / **true** (default), or **off** / **false**
+    Sets strikethrough mode. The state can be **on** (default), or **off**.
 
 **-u** or **--underline**, or **-uSTYLE** or **--underline=STYLE**
     Set the underline mode; supported styles are **single** (default), **double**, **curly**, **dotted**, **dashed** and **off**.

--- a/src/text_face.rs
+++ b/src/text_face.rs
@@ -247,9 +247,9 @@ fn parse_resettable_style<'a>(w: &WGetopter<'_, 'a, '_>) -> Result<ResettableSty
     let Some(arg) = w.woptarg else {
         return Ok(ResettableStyle::On(()));
     };
-    if (arg == "off") || (arg == "false") {
+    if arg == "off" {
         Ok(ResettableStyle::Off)
-    } else if (arg == "on") || (arg == "true") {
+    } else if arg == "on" {
         Ok(ResettableStyle::On(()))
     } else {
         Err(arg)

--- a/tests/checks/set_color.fish
+++ b/tests/checks/set_color.fish
@@ -64,11 +64,7 @@ string escape (set_color --italics)
 # CHECK: \e\[3m
 string escape (set_color --italics=on)
 # CHECK: \e\[3m
-string escape (set_color --italics=true)
-# CHECK: \e\[3m
 string escape (set_color --italics=off)
-# CHECK: \e\[23m
-string escape (set_color --italics=false)
 # CHECK: \e\[23m
 string escape (set_color --italics=foo)
 # CHECKERR: set_color: --italics: invalid option argument: foo
@@ -76,11 +72,7 @@ string escape (set_color -i)
 # CHECK: \e\[3m
 string escape (set_color -ion)
 # CHECK: \e\[3m
-string escape (set_color -itrue)
-# CHECK: \e\[3m
 string escape (set_color -ioff)
-# CHECK: \e\[23m
-string escape (set_color -ifalse)
 # CHECK: \e\[23m
 string escape (set_color -ifoo)
 # CHECKERR: set_color: --italics: invalid option argument: foo
@@ -89,11 +81,7 @@ string escape (set_color --reverse)
 # CHECK: \e\[7m
 string escape (set_color --reverse=on)
 # CHECK: \e\[7m
-string escape (set_color --reverse=true)
-# CHECK: \e\[7m
 string escape (set_color --reverse=off)
-# CHECK: \e\[27m
-string escape (set_color --reverse=false)
 # CHECK: \e\[27m
 string escape (set_color --reverse=foo)
 # CHECKERR: set_color: --reverse: invalid option argument: foo
@@ -101,11 +89,7 @@ string escape (set_color -r)
 # CHECK: \e\[7m
 string escape (set_color -ron)
 # CHECK: \e\[7m
-string escape (set_color -rtrue)
-# CHECK: \e\[7m
 string escape (set_color -roff)
-# CHECK: \e\[27m
-string escape (set_color -rfalse)
 # CHECK: \e\[27m
 string escape (set_color -rfoo)
 # CHECKERR: set_color: --reverse: invalid option argument: foo
@@ -114,11 +98,7 @@ string escape (set_color --strikethrough)
 # CHECK: \e\[9m
 string escape (set_color --strikethrough=on)
 # CHECK: \e\[9m
-string escape (set_color --strikethrough=true)
-# CHECK: \e\[9m
 string escape (set_color --strikethrough=off)
-# CHECK: \e\[29m
-string escape (set_color --strikethrough=false)
 # CHECK: \e\[29m
 string escape (set_color --strikethrough=foo)
 # CHECKERR: set_color: --strikethrough: invalid option argument: foo
@@ -126,11 +106,7 @@ string escape (set_color -s)
 # CHECK: \e\[9m
 string escape (set_color -son)
 # CHECK: \e\[9m
-string escape (set_color -strue)
-# CHECK: \e\[9m
 string escape (set_color -soff)
-# CHECK: \e\[29m
-string escape (set_color -sfalse)
 # CHECK: \e\[29m
 string escape (set_color -sfoo)
 # CHECKERR: set_color: --strikethrough: invalid option argument: foo


### PR DESCRIPTION
This is done partly for consistency `underline` where we still need `off` but where true/false doesn't make sense, and partly to simplify user choices and the code.

See #12507
