### PR TITLE
color: prefer `set_color --reset` over `set_color normal`

### DIFF
--- a/doc_src/cmds/fish_breakpoint_prompt.rst
+++ b/doc_src/cmds/fish_breakpoint_prompt.rst
@@ -34,6 +34,6 @@ A simple prompt that is a simplified version of the default debugging prompt::
         set -l function (status current-function)
         set -l line (status current-line-number)
         set -l prompt "$function:$line >"
-        echo -ns (set_color $fish_color_status) "BP $prompt" (set_color normal) ' '
+        echo -ns (set_color $fish_color_status) "BP $prompt" (set_color --reset) ' '
     end
 

--- a/doc_src/cmds/fish_config.rst
+++ b/doc_src/cmds/fish_config.rst
@@ -85,10 +85,10 @@ The format looks like this:
     fish_color_command 5c5cff
 
     [unknown]
-    fish_color_normal normal
+    fish_color_normal --reset
     fish_color_autosuggestion brblack
     fish_color_cancel -r
-    fish_color_command normal
+    fish_color_command --reset
 
 The comments provide name and background color to the web config tool.
 

--- a/doc_src/cmds/fish_greeting.rst
+++ b/doc_src/cmds/fish_greeting.rst
@@ -39,5 +39,5 @@ A simple greeting:
 
   function fish_greeting
       echo Hello friend!
-      echo The time is (set_color yellow)(date +%T)(set_color normal) and this machine is called $hostname
+      echo The time is (set_color yellow)(date +%T)(set_color --reset) and this machine is called $hostname
   end

--- a/doc_src/cmds/fish_mode_prompt.rst
+++ b/doc_src/cmds/fish_mode_prompt.rst
@@ -62,7 +62,7 @@ Example
           set_color --bold red
           echo '?'
       end
-      set_color normal
+      set_color --reset
     end
 
 

--- a/doc_src/cmds/fish_prompt.rst
+++ b/doc_src/cmds/fish_prompt.rst
@@ -41,7 +41,7 @@ A simple prompt:
         # $USER and $hostname are set by fish, so you can just use them
         # instead of using `whoami` and `hostname`
         printf '%s@%s %s%s%s > ' $USER $hostname \
-            (set_color $fish_color_cwd) (prompt_pwd) (set_color normal)
+            (set_color $fish_color_cwd) (prompt_pwd) (set_color --reset)
     end
 
 

--- a/doc_src/cmds/read.rst
+++ b/doc_src/cmds/read.rst
@@ -62,7 +62,7 @@ The following options control the interactive mode:
     Masks characters written to the terminal, replacing them with asterisks. This is useful for reading things like passwords or other sensitive information.
 
 **-p** or **--prompt** *PROMPT_CMD*
-    Uses the output of the shell command *PROMPT_CMD* as the prompt for the interactive mode. The default prompt command is ``set_color green; echo -n read; set_color normal; echo -n "> "``
+    Uses the output of the shell command *PROMPT_CMD* as the prompt for the interactive mode. The default prompt command is ``set_color green; echo -n read; set_color --reset; echo -n "> "``
 
 **-P** or **--prompt-str** *PROMPT_STR*
     Uses the literal *PROMPT_STR* as the prompt for the interactive mode.

--- a/doc_src/cmds/set_color.rst
+++ b/doc_src/cmds/set_color.rst
@@ -11,7 +11,10 @@ Synopsis
 Description
 -----------
 
-``set_color`` is used to control the color and styling of text in the terminal. *VALUE* describes that styling. *VALUE* can be a reserved color name like **red** or an RGB color value given as 3 or 6 hexadecimal digits ("F27" or "FF2277"). A special keyword **normal** resets text formatting to terminal defaults.
+``set_color`` is used to control the color and styling of text in the terminal.
+*VALUE* describes that styling.
+*VALUE* can be a reserved color name like **red** or an RGB color value given as 3 or 6 hexadecimal digits ("F27" or "FF2277").
+A special keyword **normal** resets text formatting to terminal defaults, however it is not recommended and the **--reset** option is preferred as it is less confusing and more future-proof.
 
 Valid colors include:
 
@@ -87,9 +90,10 @@ Notes
 
 1. Using ``set_color normal`` will reset all colors and modes to the terminal's default.
 2. In contrast, ``set_color --foreground normal`` will only reset the foreground color and leave all the other colors and modes unchanged.
-3. Setting the background color only affects subsequently written characters. Fish provides no way to set the background color for the entire terminal window. Configuring the window background color (and other attributes such as its opacity) has to be done using whatever mechanisms the terminal provides. Look for a config option.
-4. Some terminals use the ``--bold`` escape sequence to switch to a brighter color set rather than increasing the weight of text.
-5. ``set_color`` works by printing sequences of characters to standard output. If used in command substitution or a pipe, these characters will also be captured. This may or may not be desirable. Checking the exit status of ``isatty stdout`` before using ``set_color`` can be useful to decide not to colorize output in a script.
+3. Because of the risk of confusion, ``set_color --reset`` is recommended over ``set_color normal``.
+4. Setting the background color only affects subsequently written characters. Fish provides no way to set the background color for the entire terminal window. Configuring the window background color (and other attributes such as its opacity) has to be done using whatever mechanisms the terminal provides. Look for a config option.
+5. Some terminals use the ``--bold`` escape sequence to switch to a brighter color set rather than increasing the weight of text.
+6. ``set_color`` works by printing sequences of characters to standard output. If used in command substitution or a pipe, these characters will also be captured. This may or may not be desirable. Checking the exit status of ``isatty stdout`` before using ``set_color`` can be useful to decide not to colorize output in a script.
 
 Examples
 --------

--- a/doc_src/faq.rst
+++ b/doc_src/faq.rst
@@ -91,7 +91,7 @@ The prompt is the output of the ``fish_prompt`` function. Put it in ``~/.config/
     function fish_prompt
         set_color $fish_color_cwd
         echo -n (prompt_pwd)
-        set_color normal
+        set_color --reset
         echo -n ' > '
     end
 

--- a/doc_src/fish_for_bash_users.rst
+++ b/doc_src/fish_for_bash_users.rst
@@ -318,7 +318,7 @@ and a rough fish equivalent::
 
       echo -s (prompt_hostname) \
       (set_color blue) (prompt_pwd) \
-      (set_color yellow) $prompt_symbol (set_color normal)
+      (set_color yellow) $prompt_symbol (set_color --reset)
   end
 
 This shows a few differences:

--- a/doc_src/interactive.rst
+++ b/doc_src/interactive.rst
@@ -105,6 +105,7 @@ Syntax highlighting variables
 
 The colors used by fish for syntax highlighting can be configured by changing the values of various variables. The value of these variables can be one of the colors accepted by the :doc:`set_color <cmds/set_color>` command.
 Options accepted by ``set_color`` like
+``--foreground=``,
 ``--background=``,
 ``--bold``,
 ``--dim``,

--- a/doc_src/prompt.rst
+++ b/doc_src/prompt.rst
@@ -67,10 +67,10 @@ Fortunately, fish offers the :doc:`set_color <cmds/set_color>` command, so you c
 So, taking our previous prompt and adding some color::
 
   function fish_prompt
-      string join '' -- (set_color green) $PWD (set_color normal) '>'
+      string join '' -- (set_color green) $PWD (set_color --reset) '>'
   end
 
-A "normal" color tells the terminal to go back to its normal formatting options.
+"--reset" tells the terminal to go back to its default formatting options.
 
 ``set_color`` works by producing an escape sequence, which is a special piece of text that terminals
 interpret as instructions - for example, to change color. So ``set_color red`` produces the same
@@ -86,13 +86,13 @@ Shortening the working directory
 This is fine, but our :envvar:`PWD` can be a bit long, and we are typically only interested in the last few directories. We can shorten this with the :doc:`prompt_pwd <cmds/prompt_pwd>` helper that will give us a shortened working directory::
 
   function fish_prompt
-      string join '' -- (set_color green) (prompt_pwd) (set_color normal) '>'
+      string join '' -- (set_color green) (prompt_pwd) (set_color --reset) '>'
   end
 
 ``prompt_pwd`` takes options to control how much to shorten. For instance, if we want to display the last two directories, we'd use ``prompt_pwd --full-length-dirs 2``::
 
   function fish_prompt
-      string join '' -- (set_color green) (prompt_pwd --full-length-dirs 2) (set_color normal) '>'
+      string join '' -- (set_color green) (prompt_pwd --full-length-dirs 2) (set_color --reset) '>'
   end
 
 With a current directory of "/home/tutorial/Music/Lena Raine/Oneknowing", this would print
@@ -119,12 +119,12 @@ And after that, you can set a string if it is not zero::
   # Prompt status only if it's not 0
   set -l stat
   if test $last_status -ne 0
-      set stat (set_color red)"[$last_status]"(set_color normal)
+      set stat (set_color red)"[$last_status]"(set_color --reset)
   end
 
 And to print it, we add it to our ``string join``::
 
-  string join '' -- (set_color green) (prompt_pwd) (set_color normal) $stat '>'
+  string join '' -- (set_color green) (prompt_pwd) (set_color --reset) $stat '>'
 
 If ``$last_status`` was 0, ``$stat`` is empty, and so it will simply disappear.
 
@@ -135,10 +135,10 @@ So our entire prompt is now::
       # Prompt status only if it's not 0
       set -l stat
       if test $last_status -ne 0
-          set stat (set_color red)"[$last_status]"(set_color normal)
+          set stat (set_color red)"[$last_status]"(set_color --reset)
       end
 
-      string join '' -- (set_color green) (prompt_pwd) (set_color normal) $stat '>'
+      string join '' -- (set_color green) (prompt_pwd) (set_color --reset) $stat '>'
   end
 
 And it looks like:
@@ -176,11 +176,11 @@ So you can use it to declutter your old prompts. For example if you want to see 
           set pwd (prompt_pwd)
           # Prompt status only if it's not 0
           if test $last_status -ne 0
-              set stat (set_color red)"[$last_status]"(set_color normal)
+              set stat (set_color red)"[$last_status]"(set_color --reset)
           end
       end
 
-      string join '' -- (set_color green) $pwd (set_color normal) $stat '>'
+      string join '' -- (set_color green) $pwd (set_color --reset) $stat '>'
   end
 
 Now running two commands in the same directory could result in this screen:

--- a/doc_src/tutorial.rst
+++ b/doc_src/tutorial.rst
@@ -633,7 +633,7 @@ Multiple lines are OK. Colors can be set via :doc:`set_color <cmds/set_color>` b
         set_color purple
         date "+%m/%d/%y"
         set_color FF0000
-        echo (pwd) '>' (set_color normal)
+        echo (pwd) '>' (set_color --reset)
     end
 
 

--- a/share/functions/__fish_migrate.fish
+++ b/share/functions/__fish_migrate.fish
@@ -43,7 +43,7 @@ end" >$__fish_config_dir/config.fish
             __fish_theme_freeze __fish_migrate $theme_data
             set msg_suffix " by default."\n"  Migrated them to global variables set in $(set_color --underline)$(
                     __fish_unexpand_tilde $__fish_config_dir/conf.d/fish_frozen_theme.fish
-                )$(set_color normal)"
+                )$(set_color --reset)"
         end
         set -a msg "* Color variables are no longer set in universal scope$msg_suffix"
         set -a msg '  To restore syntax highlighting in other fish sessions, please restart them.'
@@ -78,12 +78,12 @@ set --erase --universal fish_key_bindings"
         set -a msg '* The fish_key_bindings variable is no longer set in universal scope by default.'
         set -a msg (echo -s "  Migrated it to a global variable set in  " \
             "$(set_color --underline)$(__fish_unexpand_tilde $filename)" \
-            (set_color normal))
+            (set_color --reset))
         source $__fish_config_dir/$relative_filename
     end
     $mark_migration_done
     if $removing_uvars
-        echo -s (set_color --bold) 'fish:' (set_color normal) " upgraded to version 4.3:"
+        echo -s (set_color --bold) 'fish:' (set_color --reset) " upgraded to version 4.3:"
         string join \n -- $msg
         echo 'See also the release notes (type `help relnotes`).'
         set -Ue fish_key_bindings $theme_uvars
@@ -96,7 +96,7 @@ function __fish_config_theme_matches --no-scope-shadowing
     set -l varname $argv[1]
     set -l possible_values $argv[2..]
     if not set -q possible_values[1]
-        set possible_values normal ""
+        set possible_values normal "" --reset
     end
     set -a checked_varnames $varname
     not set -q $varname
@@ -109,7 +109,7 @@ function __fish_config_theme_uvars_subset_of_historical_default
     and $matches fish_color_option "$fish_color_param"
     and $matches fish_color_autosuggestion brblack
     and $matches fish_color_cancel -r
-    and $matches fish_color_command normal blue
+    and $matches fish_color_command normal blue --reset
     and $matches fish_color_comment red
     and $matches fish_color_cwd green
     and $matches fish_color_cwd_root red
@@ -137,7 +137,7 @@ function __fish_config_theme_uvars_subset_of_historical_default
     and $matches fish_pager_color_background
     and $matches fish_pager_color_completion
     and $matches fish_pager_color_description "yellow -i" "yellow --italics"
-    and $matches fish_pager_color_prefix "normal --bold --underline"
+    and $matches fish_pager_color_prefix "normal --bold --underline" "--bold --underline"
     and $matches fish_pager_color_progress \
         "brwhite --background=cyan" \
         "brwhite --background=cyan --bold"

--- a/share/functions/__fish_print_pipestatus.fish
+++ b/share/functions/__fish_print_pipestatus.fish
@@ -29,7 +29,7 @@ function __fish_print_pipestatus --description "Print pipestatus for prompt"
         if test "$last_status" -ne "$argv[-1]"
             set last_status_string " "$status_color$last_status
         end
-        set -l normal (set_color normal)
+        set -l normal (set_color --reset)
         # The "normal"s are to reset modifiers like bold - see #7771.
         printf "%s" $normal $brace_sep_color $left_brace \
             $status_color $last_pipestatus_string \

--- a/share/functions/cdh.fish
+++ b/share/functions/cdh.fish
@@ -46,10 +46,10 @@ function cdh --description "Menu based cd command"
     # we count down rather than up.
     for i in (seq $dirc -1 1)
         set -l dir $uniq_dirs[$i]
-        set -l label_color normal
+        set -l label_color --reset
         set -q fish_color_cwd
         and set label_color $fish_color_cwd
-        set -l dir_color_reset (set_color normal)
+        set -l dir_color_reset (set_color --reset)
         set -l dir_color
         if test "$dir" = "$PWD"
             set dir_color (set_color $fish_color_history_current)
@@ -59,7 +59,7 @@ function cdh --description "Menu based cd command"
         if set -q home_dir[2]
             set dir "~$home_dir[2]"
         end
-        printf '%s %s %2d) %s %s%s%s\n' (set_color $label_color) $letters[$i] $i (set_color normal) $dir_color $dir $dir_color_reset
+        printf '%s %s %2d) %s %s%s%s\n' (set_color $label_color) $letters[$i] $i (set_color --reset) $dir_color $dir $dir_color_reset
     end
 
     # Ask the user which directory from their history they want to cd to.

--- a/share/functions/dirh.fish
+++ b/share/functions/dirh.fish
@@ -19,7 +19,7 @@ function dirh --description "Print the current directory history (the prev and n
         end
     end
 
-    echo (set_color $fish_color_history_current)'   ' $PWD(set_color normal)
+    echo (set_color $fish_color_history_current)'   ' $PWD(set_color --reset)
 
     set -l dirc (count $dirnext)
     if test $dirc -gt 0

--- a/share/functions/fish_breakpoint_prompt.fish
+++ b/share/functions/fish_breakpoint_prompt.fish
@@ -19,5 +19,5 @@ function fish_breakpoint_prompt --description "A right prompt to be used when `b
         set prompt ...(string sub -s -(math $max_len - 3) -- $prompt)
     end
 
-    echo -ns (set_color $fish_color_status) "BP $prompt" (set_color normal) ' '
+    echo -ns (set_color $fish_color_status) "BP $prompt" (set_color --reset) ' '
 end

--- a/share/functions/fish_config.fish
+++ b/share/functions/fish_config.fish
@@ -55,14 +55,14 @@ function fish_config --description "Launch fish's web based configuration"
             end
 
         else
-            echo (set_color $fish_color_error)Cannot launch the web configuration tool:(set_color normal)
-            echo (set_color -o)"fish_config browse"(set_color normal) requires Python.
+            echo (set_color $fish_color_error)Cannot launch the web configuration tool:(set_color --reset)
+            echo (set_color -o)"fish_config browse"(set_color --reset) requires Python.
             echo Installing python will fix this, and also enable completions to be
             echo automatically generated from man pages.\n
-            echo To change your prompt, use (set_color -o)"fish_config prompt"(set_color normal) or create a (set_color -o)"fish_prompt"(set_color normal) function.
-            echo To list the samples use (set_color -o)"fish_config prompt show"(set_color normal).\n
+            echo To change your prompt, use (set_color -o)"fish_config prompt"(set_color --reset) or create a (set_color -o)"fish_prompt"(set_color --reset) function.
+            echo To list the samples use (set_color -o)"fish_config prompt show"(set_color --reset).\n
 
-            echo You can tweak your colors by setting the (set_color $fish_color_search_match)\$fish_color_\*(set_color normal) variables.
+            echo You can tweak your colors by setting the (set_color $fish_color_search_match)\$fish_color_\*(set_color --reset) variables.
         end
         return 0
     end
@@ -88,13 +88,13 @@ function fish_config --description "Launch fish's web based configuration"
                     set -l fish (status fish-path)
                     for p in (__fish_config_list_prompts $argv)
                         set -l promptname (string replace -r '.*/([^/]*).fish$' '$1' $p)
-                        echo -s (set_color --underline) $promptname (set_color normal)
+                        echo -s (set_color --underline) $promptname (set_color --reset)
                         $fish -c '
                             functions -e fish_right_prompt
                             __fish_config_with_file $argv[1] source
                             false
                             fish_prompt
-                            echo (set_color normal)
+                            echo (set_color --reset)
                             if functions -q fish_right_prompt
                                 echo right prompt: (false; fish_right_prompt)
                             end' $p
@@ -178,30 +178,30 @@ function fish_config --description "Launch fish's web based configuration"
                     return
                 case demo
                     echo -ns (set_color $fish_color_command || set_color $fish_color_normal) /bright/vixens
-                    echo -ns (set_color normal) ' '
+                    echo -ns (set_color --reset) ' '
                     echo -ns (set_color $fish_color_param || set_color $fish_color_normal) jump
-                    echo -ns (set_color normal) ' '
+                    echo -ns (set_color --reset) ' '
                     echo -ns (set_color $fish_color_redirection || set_color $fish_color_normal) '|'
-                    echo -ns (set_color normal) ' '
+                    echo -ns (set_color --reset) ' '
                     echo -ns (set_color $fish_color_quote || set_color $fish_color_normal) '"fowl"'
-                    echo -ns (set_color normal) ' '
+                    echo -ns (set_color --reset) ' '
                     echo -ns (set_color $fish_color_redirection || set_color $fish_color_normal) '> quack'
-                    echo -ns (set_color normal) ' '
+                    echo -ns (set_color --reset) ' '
                     echo -ns (set_color $fish_color_end || set_color $fish_color_normal) '&'
-                    set_color normal
+                    set_color --reset
                     echo -s (set_color $fish_color_comment || set_color $fish_color_normal) ' # This is a comment'
-                    set_color normal
+                    set_color --reset
                     echo -ns (set_color $fish_color_command || set_color $fish_color_normal) echo
-                    echo -ns (set_color normal) ' '
+                    echo -ns (set_color --reset) ' '
                     echo -s (set_color $fish_color_error || set_color $fish_color_normal) "'" (set_color $fish_color_quote || set_color $fish_color_normal) "Errors are the portal to discovery"
-                    set_color normal
+                    set_color --reset
                     echo -ns (set_color $fish_color_command || set_color $fish_color_normal) Th
-                    set_color normal
+                    set_color --reset
                     set_color $fish_color_autosuggestion || set_color $fish_color_normal
                     echo is an autosuggestion
                     echo
                 case show
-                    echo -s (set_color normal; set_color --underline) Current (set_color normal)
+                    echo -s (set_color --reset; set_color --underline) Current (set_color --reset)
                     fish_config theme demo
                     __fish_theme_for_each __fish_config_theme_demo $argv
                 case choose save
@@ -436,8 +436,8 @@ function __fish_config_theme_demo
     $fish --no-config -c '
         set -l name $argv[1]
         for color_theme in $argv[2..]
-            echo -s (set_color normal; set_color --underline) "$name" \
-                " ($color_theme color theme)" (set_color normal)
+            echo -s (set_color --reset; set_color --underline) "$name" \
+                " ($color_theme color theme)" (set_color --reset)
             fish_config theme choose $name --color-theme=$color_theme
             fish_config theme demo
         end

--- a/share/functions/fish_default_mode_prompt.fish
+++ b/share/functions/fish_default_mode_prompt.fish
@@ -22,7 +22,7 @@ function fish_default_mode_prompt --description "Display vi prompt mode"
                 set_color --bold cyan
                 echo '[N]'
         end
-        set_color normal
+        set_color --reset
         echo -n ' '
     end
 end

--- a/share/functions/fish_delta.fish
+++ b/share/functions/fish_delta.fish
@@ -69,7 +69,7 @@ function fish_delta
     set -l have_diff 0
 
     if isatty stdout
-        set -f colors "$(set_color normal)" "$(set_color brblue)" "$(set_color bryellow)" "$(set_color green)" "$(set_color red)"
+        set -f colors "$(set_color --reset)" "$(set_color brblue)" "$(set_color bryellow)" "$(set_color green)" "$(set_color red)"
         set -f pager (__fish_anypager)
         or set pager cat
 

--- a/share/functions/fish_fossil_prompt.fish
+++ b/share/functions/fish_fossil_prompt.fish
@@ -49,7 +49,7 @@ function fish_fossil_prompt --description 'Write out the fossil prompt'
     echo -n ' ('
     set_color magenta
     echo -n "$branch"
-    set_color normal
+    set_color --reset
     echo -n '|'
     #set -l repo_status (fossil changes --differ 2>/dev/null | string match -rv '\w:|^\s' | string split " " -f1 | sort -u)
     set -l repo_status (fossil changes --differ 2>/dev/null | string match -rv '\w:|^\s' | string split " " -f1 | path sort -u)
@@ -92,7 +92,7 @@ function fish_fossil_prompt --description 'Write out the fossil prompt'
         end
 
         echo -n '⚡'
-        set_color normal
+        set_color --reset
 
         # Sort status symbols
         for i in $fish_prompt_fossil_status_order
@@ -106,6 +106,6 @@ function fish_fossil_prompt --description 'Write out the fossil prompt'
         end
     end
 
-    set_color normal
+    set_color --reset
     echo -n ')'
 end

--- a/share/functions/fish_git_prompt.fish
+++ b/share/functions/fish_git_prompt.fish
@@ -603,9 +603,9 @@ function __fish_git_prompt_set_color
         case 1 # No defaults given, use prompt color
             set default $___fish_git_prompt_color
             set default_done $___fish_git_prompt_color_done
-        case 2 # One default given, use normal for done
+        case 2 # One default given, use "--reset" for done
             set default "$argv[2]"
-            set default_done (set_color normal)
+            set default_done (set_color --reset)
         case 3 # Both defaults given
             set default "$argv[2]"
             set default_done "$argv[3]"
@@ -617,7 +617,7 @@ function __fish_git_prompt_set_color
     if not set -q $variable
         if test -n "$$user_variable_name"
             set -g $variable (set_color $$user_variable_name)
-            set -g $variable_done (set_color normal)
+            set -g $variable_done (set_color --reset)
         else
             set -g $variable $default
             set -g $variable_done $default_done

--- a/share/functions/fish_greeting.fish
+++ b/share/functions/fish_greeting.fish
@@ -1,7 +1,7 @@
 function fish_greeting
     if not set -q fish_greeting
         set -l line1 (_ 'Welcome to fish, the friendly interactive shell')
-        set -l line2 \n(printf (_ 'Type %shelp%s for instructions on how to use fish') (set_color green) (set_color normal))
+        set -l line2 \n(printf (_ 'Type %shelp%s for instructions on how to use fish') (set_color green) (set_color --reset))
         set -g fish_greeting "$line1$line2"
     end
 

--- a/share/functions/fish_hg_prompt.fish
+++ b/share/functions/fish_hg_prompt.fish
@@ -37,7 +37,7 @@ function fish_hg_prompt --description 'Write out the hg prompt'
     end
 
     if not set -q fish_prompt_hg_show_informative_status
-        set_color normal
+        set_color --reset
         echo -n " ($branch)"
         return
     end
@@ -51,7 +51,7 @@ function fish_hg_prompt --description 'Write out the hg prompt'
     if test -z "$repo_status"
         set_color $fish_color_hg_clean
         echo -n "($branch)"'✓'
-        set_color normal
+        set_color --reset
 
         # Handle modified or dirty (unknown state)
     else
@@ -98,7 +98,7 @@ function fish_hg_prompt --description 'Write out the hg prompt'
             end
         end
 
-        set_color normal
+        set_color --reset
     end
 
 end

--- a/share/functions/fish_prompt.fish
+++ b/share/functions/fish_prompt.fish
@@ -4,7 +4,7 @@
 function fish_prompt --description 'Write out the prompt'
     set -l last_pipestatus $pipestatus
     set -lx __fish_last_status $status # Export for __fish_print_pipestatus.
-    set -l normal (set_color normal)
+    set -l normal (set_color --reset)
 
     # Color the prompt differently when we're root
     set -l color_cwd $fish_color_cwd

--- a/share/functions/fish_svn_prompt.fish
+++ b/share/functions/fish_svn_prompt.fish
@@ -82,7 +82,7 @@ function __fish_svn_prompt_parse_status --description "helper function that does
             set -l flag_var_display __fish_svn_prompt_char_{$flag_type}_display
             set -l flag_var_color __fish_svn_prompt_char_{$flag_type}_color
             # set the colour and print display character, then restore to default display colour
-            printf '%s%s%s' (set_color $$flag_var_color) $$flag_var_display (set_color normal)
+            printf '%s%s%s' (set_color $$flag_var_color) $$flag_var_display (set_color --reset)
         end
     end
 end
@@ -98,7 +98,7 @@ function fish_svn_prompt --description "Prompt function for svn"
     or return
 
     # get the current revision number
-    printf '(%s%s%s' (set_color $__fish_svn_prompt_color_revision) (__fish_print_svn_rev) (set_color normal)
+    printf '(%s%s%s' (set_color $__fish_svn_prompt_color_revision) (__fish_print_svn_rev) (set_color --reset)
 
     # resolve the status of the checkout
     # 1. perform `svn status`

--- a/share/functions/funced.fish
+++ b/share/functions/funced.fish
@@ -52,7 +52,7 @@ function funced --description 'Edit function definition'
             functions --no-details -- $funcname | fish_indent --only-unindent | fish_indent --no-indent | read -z init
         end
 
-        set -l prompt 'printf "%s%s%s> " (set_color green) $funcname (set_color normal)'
+        set -l prompt 'printf "%s%s%s> " (set_color green) $funcname (set_color --reset)'
         if read -p $prompt -c "$init" --shell cmd
             echo -n $cmd | fish_indent --only-unindent | read -lz cmd
             eval "$cmd"

--- a/share/functions/prompt_login.fish
+++ b/share/functions/prompt_login.fish
@@ -16,7 +16,7 @@ function prompt_login --description "display user name for the prompt"
 
     # Prepend the chroot environment if present
     if set -q __fish_machine[1]
-        echo -n -s (set_color yellow) "$__fish_machine" (set_color normal) ' '
+        echo -n -s (set_color yellow) "$__fish_machine" (set_color --reset) ' '
     end
 
     # If we're running via SSH, change the host color.
@@ -25,5 +25,5 @@ function prompt_login --description "display user name for the prompt"
         set color_host $fish_color_host_remote
     end
 
-    echo -n -s (set_color $fish_color_user) "$USER" (set_color normal) @ (set_color $color_host) (prompt_hostname) (set_color normal)
+    echo -n -s (set_color $fish_color_user) "$USER" (set_color --reset) @ (set_color $color_host) (prompt_hostname) (set_color --reset)
 end

--- a/share/functions/suspend.fish
+++ b/share/functions/suspend.fish
@@ -21,7 +21,7 @@ function suspend --description 'Suspend the current shell.'
 
     if status is-interactive
         echo -ns 'Suspending ' $fish_pid ': run'
-        echo -n (set_color --bold) 'kill -CONT' $fish_pid (set_color normal)
+        echo -n (set_color --bold) 'kill -CONT' $fish_pid (set_color --reset)
         echo 'from another terminal to resume'
     end
 

--- a/share/functions/vared.fish
+++ b/share/functions/vared.fish
@@ -28,7 +28,7 @@ function vared --description "Edit variable value"
                     # scoping or export rules. But if it does not exist, we make the variable
                     # global, so that it will not die when this function dies.
 
-                    read -p 'set_color green; echo '$argv'; set_color normal; echo "> "' \
+                    read -p 'set_color green; echo '$argv'; set_color --reset; echo "> "' \
                         (if not set -q $argv; echo -g; end) \
                         -c "$$argv" \
                         __fish_vared_temp_value
@@ -38,7 +38,7 @@ function vared --description "Edit variable value"
                         set -g $argv $__fish_vared_temp_value
                     end
                 else
-                    printf (_ '%s: %s is an array variable. Use %svared%s %s[n]%s to edit the n:th element of %s\n') vared $argv (set_color $fish_color_command; echo) (set_color $fish_color_normal; echo) $argv (set_color normal; echo) $argv >&2
+                    printf (_ '%s: %s is an array variable. Use %svared%s %s[n]%s to edit the n:th element of %s\n') vared $argv (set_color $fish_color_command; echo) (set_color $fish_color_normal; echo) $argv (set_color --reset; echo) $argv >&2
                 end
         end
     else

--- a/share/prompts/acidhub.fish
+++ b/share/prompts/acidhub.fish
@@ -45,8 +45,8 @@ function fish_prompt -d "Write out the prompt"
     set_color -b black
     printf '%s%s%s%s%s%s%s%s%s%s%s%s%s' (set_color -o white) '❰' (set_color green) $USER (set_color white) '❙' (set_color yellow) (prompt_pwd) (set_color white) $git_info (set_color white) '❱' (set_color white)
     if test $laststatus -eq 0
-        printf "%s✔%s≻%s " (set_color -o green) (set_color white) (set_color normal)
+        printf "%s✔%s≻%s " (set_color -o green) (set_color white) (set_color --reset)
     else
-        printf "%s✘%s≻%s " (set_color -o red) (set_color white) (set_color normal)
+        printf "%s✘%s≻%s " (set_color -o red) (set_color white) (set_color --reset)
     end
 end

--- a/share/prompts/arrow.fish
+++ b/share/prompts/arrow.fish
@@ -64,7 +64,7 @@ function fish_prompt
     set -l red (set_color -o red)
     set -l green (set_color -o green)
     set -l blue (set_color -o blue)
-    set -l normal (set_color normal)
+    set -l normal (set_color --reset)
 
     set -l arrow_color "$green"
     if test $__last_command_exit_status != 0

--- a/share/prompts/astronaut.fish
+++ b/share/prompts/astronaut.fish
@@ -4,7 +4,7 @@
 
 function fish_prompt --description 'Write out the prompt'
     set -l last_status $status
-    set -l normal (set_color normal)
+    set -l normal (set_color --reset)
     set -l status_color (set_color brgreen)
     set -l cwd_color (set_color $fish_color_cwd)
     set -l vcs_color (set_color brpurple)

--- a/share/prompts/default.fish
+++ b/share/prompts/default.fish
@@ -4,7 +4,7 @@
 function fish_prompt --description 'Write out the prompt'
     set -l last_pipestatus $pipestatus
     set -lx __fish_last_status $status # Export for __fish_print_pipestatus.
-    set -l normal (set_color normal)
+    set -l normal (set_color --reset)
 
     # Color the prompt differently when we're root
     set -l color_cwd $fish_color_cwd

--- a/share/prompts/disco.fish
+++ b/share/prompts/disco.fish
@@ -4,7 +4,7 @@
 function fish_prompt
     set -l last_status $status
 
-    set -l normal (set_color normal)
+    set -l normal (set_color --reset)
     set -l usercolor (set_color $fish_color_user)
 
     set -l delim \U25BA
@@ -68,7 +68,7 @@ function fish_right_prompt
     # We don't want the leading space.
     set -l vcs (fish_vcs_prompt '(%s)' 2>/dev/null)
 
-    set -l d (set_color brgrey)(date "+%R")(set_color normal)
+    set -l d (set_color brgrey)(date "+%R")(set_color --reset)
 
     set -l duration "$cmd_duration$CMD_DURATION"
     if test $duration -gt 100
@@ -82,6 +82,6 @@ function fish_right_prompt
     set -q VIRTUAL_ENV
     and set -l venv (string replace -r '.*/' '' -- "$VIRTUAL_ENV")
 
-    set_color normal
+    set_color --reset
     string join " " -- $venv $duration $vcs $d
 end

--- a/share/prompts/informative.fish
+++ b/share/prompts/informative.fish
@@ -10,7 +10,7 @@ function fish_prompt --description 'Informative prompt'
         printf '%s@%s %s%s%s# ' $USER (prompt_hostname) (set -q fish_color_cwd_root
                                                          and set_color $fish_color_cwd_root
                                                          or set_color $fish_color_cwd) \
-            (prompt_pwd) (set_color normal)
+            (prompt_pwd) (set_color --reset)
     else
         set -l status_color (set_color $fish_color_status)
         set -l statusb_color (set_color --bold $fish_color_status)
@@ -18,6 +18,6 @@ function fish_prompt --description 'Informative prompt'
 
         printf '[%s] %s%s@%s %s%s %s%s%s \n> ' (date "+%H:%M:%S") (set_color brblue) \
             $USER (prompt_hostname) (set_color $fish_color_cwd) $PWD $pipestatus_string \
-            (set_color normal)
+            (set_color --reset)
     end
 end

--- a/share/prompts/informative_vcs.fish
+++ b/share/prompts/informative_vcs.fish
@@ -50,7 +50,7 @@ function fish_prompt --description 'Write out the prompt'
     # PWD
     set_color $color_cwd
     echo -n (prompt_pwd)
-    set_color normal
+    set_color --reset
 
     printf '%s ' (fish_vcs_prompt)
 
@@ -58,7 +58,7 @@ function fish_prompt --description 'Write out the prompt'
     set -l statusb_color (set_color --bold $fish_color_status)
     set -l prompt_status (__fish_print_pipestatus "[" "]" "|" "$status_color" "$statusb_color" $last_pipestatus)
     echo -n $prompt_status
-    set_color normal
+    set_color --reset
 
     echo -n "$suffix "
 end

--- a/share/prompts/minimalist.fish
+++ b/share/prompts/minimalist.fish
@@ -4,6 +4,6 @@
 function fish_prompt
     set_color $fish_color_cwd
     echo -n (path basename $PWD)
-    set_color normal
+    set_color --reset
     echo -n ' ) '
 end

--- a/share/prompts/nim.fish
+++ b/share/prompts/nim.fish
@@ -34,12 +34,12 @@ function fish_prompt
         set -l field_name $argv[2]
         set -l field_value $argv[3]
 
-        set_color normal
+        set_color --reset
         set_color $retc
         echo -n '─'
         set_color -o green
         echo -n '['
-        set_color normal
+        set_color --reset
         test -n $field_name
         and echo -n $field_name:
         set_color $retc
@@ -97,7 +97,7 @@ function fish_prompt
             case visual
                 set mode (set_color --bold magenta)V
         end
-        set mode $mode(set_color normal)
+        set mode $mode(set_color --reset)
         _nim_prompt_wrapper $retc '' $mode
     end
 
@@ -121,7 +121,7 @@ function fish_prompt
     echo
 
     # Background jobs
-    set_color normal
+    set_color --reset
 
     for job in (jobs)
         set_color $retc
@@ -130,12 +130,12 @@ function fish_prompt
         echo $job
     end
 
-    set_color normal
+    set_color --reset
     set_color $retc
     echo -n '╰─>'
     set_color -o red
     echo -n '$ '
-    set_color normal
+    set_color --reset
 end
 
 # The default mode prompt would be prefixed, which ruins our alignment.

--- a/share/prompts/pythonista.fish
+++ b/share/prompts/pythonista.fish
@@ -7,23 +7,23 @@ function fish_prompt
     end
     set_color yellow
     printf '%s' $USER
-    set_color normal
+    set_color --reset
     printf ' at '
 
     set_color magenta
     echo -n (prompt_hostname)
-    set_color normal
+    set_color --reset
     printf ' in '
 
     set_color $fish_color_cwd
     printf '%s' (prompt_pwd)
-    set_color normal
+    set_color --reset
 
     # Line 2
     echo
     if test -n "$VIRTUAL_ENV"
-        printf "(%s) " (set_color blue)(path basename $VIRTUAL_ENV)(set_color normal)
+        printf "(%s) " (set_color blue)(path basename $VIRTUAL_ENV)(set_color --reset)
     end
     printf '↪ '
-    set_color normal
+    set_color --reset
 end

--- a/share/prompts/scales.fish
+++ b/share/prompts/scales.fish
@@ -17,7 +17,7 @@ function fish_prompt
         echo -n (set_color red)'# '
     end
     echo -n (set_color red)'❯'(set_color yellow)'❯'(set_color green)'❯ '
-    set_color normal
+    set_color --reset
 end
 
 # And now define the right prompt so that it's brought along
@@ -28,14 +28,14 @@ function fish_right_prompt
     end
 
     if not command -sq git
-        set_color normal
+        set_color --reset
         return
     end
 
     # Get the git directory for later use.
     # Return if not inside a Git repository work tree.
     if not set -l git_dir (command git rev-parse --git-dir 2>/dev/null)
-        set_color normal
+        set_color --reset
         return
     end
 
@@ -149,7 +149,7 @@ function fish_right_prompt
         echo -n ' '(set_color yellow)"$commit"
     end
     if test -n "$action"
-        set_color normal
+        set_color --reset
         echo -n (set_color white)':'(set_color -o brred)"$action"
     end
     if test $status_ahead -ne 0
@@ -180,5 +180,5 @@ function fish_right_prompt
         echo -n ' '(set_color white)'◼'
     end
 
-    set_color normal
+    set_color --reset
 end

--- a/share/prompts/simple.fish
+++ b/share/prompts/simple.fish
@@ -17,7 +17,7 @@ function fish_prompt
 
     set_color $color
     echo -n (prompt_pwd)
-    set_color normal
+    set_color --reset
 
     echo -n $symbol
 end

--- a/share/prompts/terlar.fish
+++ b/share/prompts/terlar.fish
@@ -11,7 +11,7 @@ function fish_prompt --description 'Write out the prompt'
     # PWD
     set_color $fish_color_cwd
     echo -n (prompt_pwd)
-    set_color normal
+    set_color --reset
 
     set -q __fish_git_prompt_showdirtystate
     or set -g __fish_git_prompt_showdirtystate 1
@@ -55,5 +55,5 @@ function fish_prompt --description 'Write out the prompt'
     end
 
     echo -n '➤ '
-    set_color normal
+    set_color --reset
 end

--- a/share/themes/ayu-mirage.theme
+++ b/share/themes/ayu-mirage.theme
@@ -13,7 +13,7 @@ fish_color_end F29E74
 fish_color_error FF3333
 fish_color_escape 95E6CB
 fish_color_history_current --bold
-fish_color_host normal
+fish_color_host --reset
 fish_color_host_remote yellow
 # fish_color_keyword $fish_color_command
 fish_color_operator FFCC66
@@ -26,8 +26,8 @@ fish_color_selection --background=FFCC66 --bold
 fish_color_status red
 fish_color_user brgreen
 fish_color_valid_path --underline
-fish_pager_color_completion normal
+fish_pager_color_completion --reset
 fish_pager_color_description B3A06D yellow
-fish_pager_color_prefix normal --bold --underline
+fish_pager_color_prefix --bold --underline
 fish_pager_color_progress brwhite --background=cyan --bold
 fish_pager_color_selected_background --background=FFCC66

--- a/share/themes/ayu.theme
+++ b/share/themes/ayu.theme
@@ -14,7 +14,7 @@ fish_color_end ED9366
 fish_color_error F51818
 fish_color_escape 4CBF99
 fish_color_history_current --bold
-fish_color_host normal
+fish_color_host --reset
 fish_color_host_remote yellow
 # fish_color_keyword $fish_color_command
 fish_color_operator FF9940
@@ -27,9 +27,9 @@ fish_color_selection --background=FF9940 --bold
 fish_color_status red
 fish_color_user brgreen
 fish_color_valid_path --underline
-fish_pager_color_completion normal
+fish_pager_color_completion --reset
 fish_pager_color_description B3A06D yellow
-fish_pager_color_prefix normal --bold --underline
+fish_pager_color_prefix --bold --underline
 fish_pager_color_progress brwhite --background=cyan --bold
 fish_pager_color_selected_background --background=FF9940
 
@@ -53,11 +53,11 @@ fish_color_cwd_root red
 fish_color_valid_path --underline
 fish_color_autosuggestion 4D5566
 fish_color_user brgreen
-fish_color_host normal
+fish_color_host --reset
 fish_color_cancel -r
-fish_pager_color_completion normal
+fish_pager_color_completion --reset
 fish_pager_color_description B3A06D yellow
-fish_pager_color_prefix normal --bold --underline
+fish_pager_color_prefix --bold --underline
 fish_pager_color_progress brwhite --background=cyan --bold
 fish_pager_color_selected_background --background=E6B450
 # fish_color_option $fish_color_param

--- a/share/themes/base16-default.theme
+++ b/share/themes/base16-default.theme
@@ -3,7 +3,7 @@
 
 [light]
 # preferred_background: f8f8f8
-fish_color_normal normal
+fish_color_normal --reset
 fish_color_autosuggestion b8b8b8
 fish_color_cancel -r
 fish_color_command a1b56c
@@ -14,7 +14,7 @@ fish_color_end ba8baf
 fish_color_error ab4642
 fish_color_escape 86c1b9
 fish_color_history_current --bold
-fish_color_host normal
+fish_color_host --reset
 fish_color_host_remote yellow
 # fish_color_keyword $fish_color_command
 fish_color_operator 7cafc2
@@ -27,15 +27,15 @@ fish_color_selection white --background=brblack --bold
 fish_color_status red
 fish_color_user brgreen
 fish_color_valid_path --underline
-fish_pager_color_completion normal
+fish_pager_color_completion --reset
 fish_pager_color_description B3A06D yellow
-fish_pager_color_prefix normal --bold --underline
+fish_pager_color_prefix --bold --underline
 fish_pager_color_progress brwhite --background=cyan --bold
 fish_pager_color_selected_background --background=brblack
 
 [dark]
 # preferred_background: 181818
-fish_color_normal normal
+fish_color_normal --reset
 fish_color_autosuggestion 585858
 fish_color_cancel -r
 fish_color_command a1b56c
@@ -46,7 +46,7 @@ fish_color_end ba8baf
 fish_color_error ab4642
 fish_color_escape 86c1b9
 fish_color_history_current --bold
-fish_color_host normal
+fish_color_host --reset
 fish_color_host_remote yellow
 # fish_color_keyword $fish_color_command
 fish_color_operator 7cafc2
@@ -59,8 +59,8 @@ fish_color_selection white --background=brblack --bold
 fish_color_status red
 fish_color_user brgreen
 fish_color_valid_path --underline
-fish_pager_color_completion normal
+fish_pager_color_completion --reset
 fish_pager_color_description B3A06D yellow
-fish_pager_color_prefix normal --bold --underline
+fish_pager_color_prefix --bold --underline
 fish_pager_color_progress brwhite --background=cyan --bold
 fish_pager_color_selected_background --background=brblack

--- a/share/themes/base16-eighties.theme
+++ b/share/themes/base16-eighties.theme
@@ -2,7 +2,7 @@
 # preferred_background: 2d2d2d
 # url: https://github.com/chriskempson/base16-default-schemes
 
-fish_color_normal normal
+fish_color_normal --reset
 fish_color_autosuggestion 747369
 fish_color_cancel -r
 fish_color_command 99cc99
@@ -13,7 +13,7 @@ fish_color_end cc99cc
 fish_color_error f2777a
 fish_color_escape 66cccc
 fish_color_history_current --bold
-fish_color_host normal
+fish_color_host --reset
 fish_color_host_remote yellow
 # fish_color_keyword $fish_color_command
 fish_color_operator 6699cc
@@ -26,8 +26,8 @@ fish_color_selection white --background=brblack --bold
 fish_color_status red
 fish_color_user brgreen
 fish_color_valid_path --underline
-fish_pager_color_completion normal
+fish_pager_color_completion --reset
 fish_pager_color_description B3A06D yellow
-fish_pager_color_prefix normal --bold --underline
+fish_pager_color_prefix --bold --underline
 fish_pager_color_progress brwhite --background=cyan --bold
 fish_pager_color_selected_background --background=brblack

--- a/share/themes/bay-cruise.theme
+++ b/share/themes/bay-cruise.theme
@@ -1,7 +1,7 @@
 # name: Bay Cruise
 # preferred_background: black
 
-fish_color_normal normal
+fish_color_normal --reset
 fish_color_autosuggestion 006363
 fish_color_cancel -r
 fish_color_command 009999
@@ -12,7 +12,7 @@ fish_color_end FFB273
 fish_color_error FF7400
 fish_color_escape 00a6b2
 fish_color_history_current --bold
-fish_color_host normal
+fish_color_host --reset
 fish_color_host_remote yellow
 # fish_color_keyword $fish_color_command
 fish_color_operator 00a6b2
@@ -25,8 +25,8 @@ fish_color_selection white --background=brblack --bold
 fish_color_status red
 fish_color_user brgreen
 fish_color_valid_path --underline
-fish_pager_color_completion normal
+fish_pager_color_completion --reset
 fish_pager_color_description B3A06D yellow
-fish_pager_color_prefix normal --bold --underline
+fish_pager_color_prefix --bold --underline
 fish_pager_color_progress brwhite --background=cyan --bold
 fish_pager_color_selected_background --background=brblack

--- a/share/themes/coolbeans.theme
+++ b/share/themes/coolbeans.theme
@@ -4,7 +4,7 @@
 fish_color_normal B2B2B2
 fish_color_autosuggestion 666
 fish_color_cancel -r
-fish_color_command normal
+fish_color_command --reset
 fish_color_comment '888'  '--italics'
 fish_color_cwd 0A0
 fish_color_cwd_root A00
@@ -12,7 +12,7 @@ fish_color_end 009900
 fish_color_error F22
 fish_color_escape 0AA
 fish_color_history_current 0AA
-fish_color_host normal
+fish_color_host --reset
 fish_color_host_remote yellow
 fish_color_keyword 00Afb8
 fish_color_operator 0AA

--- a/share/themes/default-rgb.theme
+++ b/share/themes/default-rgb.theme
@@ -70,10 +70,10 @@ fish_pager_color_selected_description ffffff --bold --italics"
 
 [unknown]
 # 16 color palette
-fish_color_normal normal
+fish_color_normal --reset
 fish_color_autosuggestion brblack
 fish_color_cancel -r
-fish_color_command normal
+fish_color_command --reset
 fish_color_comment red
 fish_color_cwd green
 fish_color_cwd_root red
@@ -81,7 +81,7 @@ fish_color_end green
 fish_color_error brred
 fish_color_escape brcyan
 fish_color_history_current --bold
-fish_color_host normal
+fish_color_host --reset
 fish_color_host_remote yellow
 # fish_color_keyword $fish_color_command
 fish_color_operator brcyan
@@ -95,6 +95,6 @@ fish_color_status red
 fish_color_user brgreen
 fish_color_valid_path --underline
 fish_pager_color_description yellow --italics
-fish_pager_color_prefix normal --bold --underline
+fish_pager_color_prefix --bold --underline
 fish_pager_color_progress brwhite --background=cyan --bold
 fish_pager_color_selected_background -r

--- a/share/themes/default.theme
+++ b/share/themes/default.theme
@@ -1,9 +1,9 @@
 # name: fish default (terminal colors)
 
-fish_color_normal normal
+fish_color_normal --reset
 fish_color_autosuggestion brblack
 fish_color_cancel -r
-fish_color_command normal
+fish_color_command --reset
 fish_color_comment red
 fish_color_cwd green
 fish_color_cwd_root red
@@ -11,7 +11,7 @@ fish_color_end green
 fish_color_error brred
 fish_color_escape brcyan
 fish_color_history_current --bold
-fish_color_host normal
+fish_color_host --reset
 fish_color_host_remote yellow
 # fish_color_keyword $fish_color_command
 fish_color_operator brcyan
@@ -25,6 +25,6 @@ fish_color_status red
 fish_color_user brgreen
 fish_color_valid_path --underline
 fish_pager_color_description yellow --italics
-fish_pager_color_prefix normal --bold --underline
+fish_pager_color_prefix --bold --underline
 fish_pager_color_progress brwhite --background=cyan --bold
 fish_pager_color_selected_background -r

--- a/share/themes/fairground.theme
+++ b/share/themes/fairground.theme
@@ -1,7 +1,7 @@
 # name: Fairground
 # preferred_background: 003
 
-fish_color_normal normal
+fish_color_normal --reset
 fish_color_autosuggestion 3BA3D0
 fish_color_cancel -r
 fish_color_command 0772A1
@@ -12,7 +12,7 @@ fish_color_end 8D003B
 fish_color_error EC3B86
 fish_color_escape 00a6b2
 fish_color_history_current --bold
-fish_color_host normal
+fish_color_host --reset
 fish_color_host_remote yellow
 # fish_color_keyword $fish_color_command
 fish_color_operator 00a6b2
@@ -25,8 +25,8 @@ fish_color_selection white --background=brblack --bold
 fish_color_status red
 fish_color_user brgreen
 fish_color_valid_path --underline
-fish_pager_color_completion normal
+fish_pager_color_completion --reset
 fish_pager_color_description B3A06D yellow
-fish_pager_color_prefix normal --bold --underline
+fish_pager_color_prefix --bold --underline
 fish_pager_color_progress brwhite --background=cyan --bold
 fish_pager_color_selected_background --background=brblack

--- a/share/themes/just-a-touch.theme
+++ b/share/themes/just-a-touch.theme
@@ -1,7 +1,7 @@
 # name: Just a Touch
 # preferred_background: black
 
-fish_color_normal normal
+fish_color_normal --reset
 fish_color_autosuggestion 9C9C9C
 fish_color_cancel -r
 fish_color_command F4F4F4
@@ -12,7 +12,7 @@ fish_color_end 969696
 fish_color_error FFA779
 fish_color_escape 00a6b2
 fish_color_history_current --bold
-fish_color_host normal
+fish_color_host --reset
 fish_color_host_remote yellow
 # fish_color_keyword $fish_color_command
 fish_color_operator 00a6b2
@@ -25,8 +25,8 @@ fish_color_selection white --background=brblack --bold
 fish_color_status red
 fish_color_user brgreen
 fish_color_valid_path --underline
-fish_pager_color_completion normal
+fish_pager_color_completion --reset
 fish_pager_color_description B3A06D yellow
-fish_pager_color_prefix normal --bold --underline
+fish_pager_color_prefix --bold --underline
 fish_pager_color_progress brwhite --background=cyan --bold
 fish_pager_color_selected_background --background=brblack

--- a/share/themes/lava.theme
+++ b/share/themes/lava.theme
@@ -1,7 +1,7 @@
 # name: Lava
 # preferred_background: 232323
 
-fish_color_normal normal
+fish_color_normal --reset
 fish_color_command FF9400
 fish_color_quote BF9C30
 fish_color_redirection BF5B30
@@ -19,11 +19,11 @@ fish_color_cwd_root red
 fish_color_valid_path --underline
 fish_color_autosuggestion FFC473
 fish_color_user brgreen
-fish_color_host normal
+fish_color_host --reset
 fish_color_cancel -r
-fish_pager_color_completion normal
+fish_pager_color_completion --reset
 fish_pager_color_description B3A06D yellow
-fish_pager_color_prefix normal --bold --underline
+fish_pager_color_prefix --bold --underline
 fish_pager_color_progress brwhite --background=cyan --bold
 fish_pager_color_selected_background --background=brblack
 # fish_color_option $fish_color_param

--- a/share/themes/mono-lace.theme
+++ b/share/themes/mono-lace.theme
@@ -1,7 +1,7 @@
 # name: Mono Lace
 # preferred_background: 'white'
 
-fish_color_normal normal
+fish_color_normal --reset
 fish_color_autosuggestion 777777
 fish_color_cancel -r
 fish_color_command 000000
@@ -12,7 +12,7 @@ fish_color_end 767676
 fish_color_error b2b2b2
 fish_color_escape 00a6b2
 fish_color_history_current --bold
-fish_color_host normal
+fish_color_host --reset
 fish_color_host_remote yellow
 # fish_color_keyword $fish_color_command
 fish_color_operator 00a6b2
@@ -25,8 +25,8 @@ fish_color_selection white --background=brblack --bold
 fish_color_status red
 fish_color_user brgreen
 fish_color_valid_path --underline
-fish_pager_color_completion normal
+fish_pager_color_completion --reset
 fish_pager_color_description B3A06D yellow
-fish_pager_color_prefix normal --bold --underline
+fish_pager_color_prefix --bold --underline
 fish_pager_color_progress brwhite --background=cyan --bold
 fish_pager_color_selected_background --background=brblack

--- a/share/themes/mono-smoke.theme
+++ b/share/themes/mono-smoke.theme
@@ -1,7 +1,7 @@
 # name: Mono Smoke
 # preferred_background: 'black'
 
-fish_color_normal normal
+fish_color_normal --reset
 fish_color_command ffffff
 fish_color_quote a8a8a8
 fish_color_redirection 808080
@@ -19,11 +19,11 @@ fish_color_valid_path --underline
 fish_color_cwd green
 fish_color_autosuggestion 777777
 fish_color_user brgreen
-fish_color_host normal
+fish_color_host --reset
 fish_color_cancel -r
-fish_pager_color_completion normal
+fish_pager_color_completion --reset
 fish_pager_color_description B3A06D yellow
-fish_pager_color_prefix normal --bold --underline
+fish_pager_color_prefix --bold --underline
 fish_pager_color_progress brwhite --background=cyan --bold
 fish_pager_color_selected_background --background=brblack
 # fish_color_option $fish_color_param

--- a/share/themes/none.theme
+++ b/share/themes/none.theme
@@ -1,18 +1,18 @@
 # name: (Almost) No Colors
 # preferred_background: 'black'
 
-fish_color_normal normal
+fish_color_normal --reset
 fish_color_autosuggestion brblack
 fish_color_cancel
 fish_color_command
 fish_color_comment
-fish_color_cwd normal
-fish_color_cwd_root normal
+fish_color_cwd --reset
+fish_color_cwd_root --reset
 fish_color_end
 fish_color_error
 fish_color_escape
 fish_color_history_current
-fish_color_host normal
+fish_color_host --reset
 fish_color_host_remote yellow
 # fish_color_keyword $fish_color_command
 fish_color_operator
@@ -22,10 +22,10 @@ fish_color_quote
 fish_color_redirection
 fish_color_search_match -r
 fish_color_selection -r
-fish_color_status normal
-fish_color_user normal
+fish_color_status --reset
+fish_color_user --reset
 fish_color_valid_path
-fish_pager_color_completion normal
+fish_pager_color_completion --reset
 fish_pager_color_description brblack
 fish_pager_color_prefix '--underline'
 fish_pager_color_progress brblack

--- a/share/themes/nord.theme
+++ b/share/themes/nord.theme
@@ -3,7 +3,7 @@
 # preferred_background: 2e3440
 # url: https://www.nordtheme.com
 
-fish_color_normal normal
+fish_color_normal --reset
 fish_color_autosuggestion 4c566a
 fish_color_cancel --reverse
 fish_color_command 88c0d0
@@ -29,6 +29,6 @@ fish_color_user a3be8c
 fish_color_valid_path --underline
 fish_pager_color_completion e5e9f0
 fish_pager_color_description ebcb8b --italics
-fish_pager_color_prefix normal --bold --underline
+fish_pager_color_prefix --bold --underline
 fish_pager_color_progress 3b4252 --background=d08770 --bold
 fish_pager_color_selected_background --background=434c5e

--- a/share/themes/old-school.theme
+++ b/share/themes/old-school.theme
@@ -1,7 +1,7 @@
 # name: Old School
 # preferred_background: black
 
-fish_color_normal normal
+fish_color_normal --reset
 fish_color_autosuggestion 777777
 fish_color_cancel -r
 fish_color_command 00FF00
@@ -12,7 +12,7 @@ fish_color_end FF7B7B
 fish_color_error A40000
 fish_color_escape 00a6b2
 fish_color_history_current --bold
-fish_color_host normal
+fish_color_host --reset
 fish_color_host_remote yellow
 # fish_color_keyword $fish_color_command
 fish_color_operator 00a6b2
@@ -25,8 +25,8 @@ fish_color_selection white --background=brblack --bold
 fish_color_status red
 fish_color_user brgreen
 fish_color_valid_path --underline
-fish_pager_color_completion normal
+fish_pager_color_completion --reset
 fish_pager_color_description B3A06D yellow
-fish_pager_color_prefix normal --bold --underline
+fish_pager_color_prefix --bold --underline
 fish_pager_color_progress brwhite --background=cyan --bold
 fish_pager_color_selected_background --background=brblack

--- a/share/themes/seaweed.theme
+++ b/share/themes/seaweed.theme
@@ -1,7 +1,7 @@
 # name: Seaweed
 # preferred_background: 232323
 
-fish_color_normal normal
+fish_color_normal --reset
 fish_color_autosuggestion 64DF85
 fish_color_cancel -r
 fish_color_command 00BF32
@@ -12,7 +12,7 @@ fish_color_end 8EEB00
 fish_color_error 60B9CE
 fish_color_escape 00a6b2
 fish_color_history_current --bold
-fish_color_host normal
+fish_color_host --reset
 fish_color_host_remote yellow
 # fish_color_keyword $fish_color_command
 fish_color_operator 00a6b2
@@ -25,8 +25,8 @@ fish_color_selection white --background=brblack --bold
 fish_color_status red
 fish_color_user brgreen
 fish_color_valid_path --underline
-fish_pager_color_completion normal
+fish_pager_color_completion --reset
 fish_pager_color_description B3A06D yellow
-fish_pager_color_prefix normal --bold --underline
+fish_pager_color_prefix --bold --underline
 fish_pager_color_progress brwhite --background=cyan --bold
 fish_pager_color_selected_background --background=brblack

--- a/share/themes/snow-day.theme
+++ b/share/themes/snow-day.theme
@@ -1,7 +1,7 @@
 # name: Snow Day
 # preferred_background: white
 
-fish_color_normal normal
+fish_color_normal --reset
 fish_color_command 164CC9
 fish_color_quote 4C3499
 fish_color_redirection 248E8E
@@ -18,12 +18,12 @@ fish_color_cwd green
 fish_color_cwd_root red
 fish_color_valid_path --underline
 fish_color_autosuggestion 7596E4
-fish_color_host normal
+fish_color_host --reset
 fish_color_user brgreen
 fish_color_cancel -r
-fish_pager_color_completion normal
+fish_pager_color_completion --reset
 fish_pager_color_description B3A06D yellow
-fish_pager_color_prefix normal --bold --underline
+fish_pager_color_prefix --bold --underline
 fish_pager_color_progress brwhite --background=cyan --bold
 fish_pager_color_selected_background --background=brblack
 # fish_color_option $fish_color_param

--- a/share/themes/solarized.theme
+++ b/share/themes/solarized.theme
@@ -3,7 +3,7 @@
 
 [light]
 # preferred_background: fdf6e3
-fish_color_normal normal
+fish_color_normal --reset
 fish_color_command 586e75
 fish_color_quote 839496
 fish_color_redirection 6c71c4
@@ -21,7 +21,7 @@ fish_color_cwd_root red
 fish_color_valid_path --underline
 fish_color_autosuggestion 93a1a1
 fish_color_user brgreen
-fish_color_host normal
+fish_color_host --reset
 fish_color_cancel -r
 fish_pager_color_completion green
 fish_pager_color_description B3A06D
@@ -35,7 +35,7 @@ fish_color_status red
 
 [dark]
 # preferred_background: 002b36
-fish_color_normal normal
+fish_color_normal --reset
 fish_color_autosuggestion 586e75
 fish_color_cancel -r
 fish_color_command 93a1a1
@@ -46,7 +46,7 @@ fish_color_end 268bd2
 fish_color_error dc322f
 fish_color_escape 00a6b2
 fish_color_history_current --bold
-fish_color_host normal
+fish_color_host --reset
 fish_color_host_remote yellow
 # fish_color_keyword $fish_color_command
 fish_color_operator 00a6b2

--- a/share/themes/tomorrow-night-bright.theme
+++ b/share/themes/tomorrow-night-bright.theme
@@ -2,7 +2,7 @@
 # preferred_background: black
 # url: https://github.com/chriskempson/tomorrow-theme
 
-fish_color_normal normal
+fish_color_normal --reset
 fish_color_autosuggestion 969896
 fish_color_cancel -r
 fish_color_command c397d8
@@ -13,7 +13,7 @@ fish_color_end c397d8
 fish_color_error d54e53
 fish_color_escape 00a6b2
 fish_color_history_current --bold
-fish_color_host normal
+fish_color_host --reset
 fish_color_host_remote yellow
 # fish_color_keyword $fish_color_command
 fish_color_operator 00a6b2
@@ -26,8 +26,8 @@ fish_color_selection white --background=brblack --bold
 fish_color_status red
 fish_color_user brgreen
 fish_color_valid_path --underline
-fish_pager_color_completion normal
+fish_pager_color_completion --reset
 fish_pager_color_description B3A06D yellow
-fish_pager_color_prefix normal --bold --underline
+fish_pager_color_prefix --bold --underline
 fish_pager_color_progress brwhite --background=cyan --bold
 fish_pager_color_selected_background --background=brblack

--- a/share/themes/tomorrow.theme
+++ b/share/themes/tomorrow.theme
@@ -3,7 +3,7 @@
 
 [light]
 # preferred_background: white
-fish_color_normal normal
+fish_color_normal --reset
 fish_color_autosuggestion 8e908c
 fish_color_cancel -r
 fish_color_command 8959a8
@@ -14,7 +14,7 @@ fish_color_end 8959a8
 fish_color_error c82829
 fish_color_escape 00a6b2
 fish_color_history_current --bold
-fish_color_host normal
+fish_color_host --reset
 fish_color_host_remote yellow
 # fish_color_keyword $fish_color_command
 fish_color_operator 00a6b2
@@ -27,15 +27,15 @@ fish_color_selection white --background=brblack --bold
 fish_color_status red
 fish_color_user brgreen
 fish_color_valid_path --underline
-fish_pager_color_completion normal
+fish_pager_color_completion --reset
 fish_pager_color_description B3A06D yellow
-fish_pager_color_prefix normal --bold --underline
+fish_pager_color_prefix --bold --underline
 fish_pager_color_progress brwhite --background=cyan --bold
 fish_pager_color_selected_background --background=brblack
 
 [dark]
 # preferred_background: 232323
-fish_color_normal normal
+fish_color_normal --reset
 fish_color_command b294bb
 fish_color_quote b5bd68
 fish_color_redirection 8abeb7
@@ -54,10 +54,10 @@ fish_color_valid_path --underline
 fish_color_autosuggestion 969896
 fish_color_user brgreen
 fish_color_cancel -r
-fish_color_host normal
-fish_pager_color_completion normal
+fish_color_host --reset
+fish_pager_color_completion --reset
 fish_pager_color_description B3A06D yellow
-fish_pager_color_prefix normal --bold --underline
+fish_pager_color_prefix --bold --underline
 fish_pager_color_progress brwhite --background=cyan --bold
 fish_pager_color_selected_background --background=brblack
 # fish_color_option $fish_color_param

--- a/src/builtins/shared.rs
+++ b/src/builtins/shared.rs
@@ -16,7 +16,7 @@ pub type BuiltinCmd = fn(&Parser, &mut IoStreams, &mut [&wstr]) -> BuiltinResult
 
 /// The default prompt for the read command.
 pub const DEFAULT_READ_PROMPT: &wstr =
-    L!("set_color green; echo -n read; set_color normal; echo -n \"> \"");
+    L!("set_color green; echo -n read; set_color --reset; echo -n \"> \"");
 
 localizable_consts!(
     /// Error message on missing argument.

--- a/tests/checks/__fish_migrate.fish
+++ b/tests/checks/__fish_migrate.fish
@@ -89,7 +89,7 @@ echo no default universal variables
         # CHECK: fish_color_autosuggestion red
         # CHECK: fish_color_command green --theme=default
         # CHECK: fish_color_autosuggestion red
-        # CHECK: fish_color_command normal --theme=default
+        # CHECK: fish_color_command --reset --theme=default
     '
 }
 

--- a/tests/checks/fish_config.fish
+++ b/tests/checks/fish_config.fish
@@ -183,7 +183,7 @@ echo >$__fish_config_dir/themes/custom-from-userconf.theme \
 
 {
     print-sample-colors
-    # CHECK: normal=normal --theme=default
+    # CHECK: normal=--reset --theme=default
     # CHECK: autosuggestion=brblack --theme=default
 
     fish_config theme choose custom-from-userconf --color-theme=unknown
@@ -203,12 +203,12 @@ echo >$__fish_config_dir/themes/custom-from-userconf.theme \
 
     fish_config theme choose default --color-theme=unknown
     print-sample-colors
-    # CHECK: normal=normal --theme=default
+    # CHECK: normal=--reset --theme=default
     # CHECK: autosuggestion=brblack --theme=default
 
     set -S fish_color_normal
     # CHECK: $fish_color_normal: set in global scope, unexported, with 2 elements
-    # CHECK: $fish_color_normal[1]: |normal|
+    # CHECK: $fish_color_normal[1]: |--reset|
     # CHECK: $fish_color_normal[2]: |--theme=default|
     # CHECK: $fish_color_normal: set in universal scope, unexported, with 2 elements
     # CHECK: $fish_color_normal[1]: |yellow|
@@ -217,7 +217,7 @@ echo >$__fish_config_dir/themes/custom-from-userconf.theme \
     echo yes | fish_config theme save default
     set -S fish_color_normal
     # CHECK: $fish_color_normal: set in universal scope, unexported, with 1 elements
-    # CHECK: $fish_color_normal[1]: |normal|
+    # CHECK: $fish_color_normal[1]: |--reset|
 }
 
 {

--- a/tests/checks/string.fish
+++ b/tests/checks/string.fish
@@ -153,7 +153,7 @@ begin
 end
 
 # Only the longest run between carriage returns is kept because the rest is overwritten.
-string length --visible (set_color normal)abcdef\rfooba(set_color red)raaa
+string length --visible (set_color --reset)abcdef\rfooba(set_color red)raaa
 # (foobaraaa)
 # CHECK: 9
 

--- a/tests/pexpects/nullterm.py
+++ b/tests/pexpects/nullterm.py
@@ -13,5 +13,5 @@ sendline, expect_prompt = sp.sendline, sp.expect_prompt
 expect_prompt()
 sendline("set_color --italics")
 expect_prompt()
-sendline("set_color normal")
+sendline("set_color --reset")
 expect_prompt()


### PR DESCRIPTION
As mentioned in #12507, make `set_color --reset` preferred over `set_color normal`.

It's hard to say how risky this change is given the number of files being touched. It passes all the tests of course, but I do not know how good the test coverage is.