### PR TITLE
fix: prevent index out of bounds in backward-word-end

### DIFF
--- a/src/reader/reader.rs
+++ b/src/reader/reader.rs
@@ -2276,6 +2276,14 @@ impl ReaderData {
             } else {
                 buff_pos.wrapping_sub(1)
             };
+            if char_pos >= el.text().len() {
+                buff_pos = if move_right {
+                    buff_pos + 1
+                } else {
+                    buff_pos.wrapping_sub(1)
+                };
+                continue;
+            }
             let consumed = state.consume_char(el.text(), char_pos);
             if consumed {
                 buff_pos = if move_right {


### PR DESCRIPTION
Fixes #12555

When the cursor is at the end of the command line and `backward-word-end` is invoked, `char_pos` equals the text length, causing a panic at `word_motion.rs:94` (index out of bounds).

This adds a bounds check before `consume_char` to skip out-of-bounds indices and adjust `buff_pos`, matching the existing guard for forward movement on line 2269.

---
Developed with AI assistance (Claude Code)