### PR TITLE
Stop guessing emoji width

### DIFF
--- a/crates/fallback/src/lib.rs
+++ b/crates/fallback/src/lib.rs
@@ -25,7 +25,7 @@ pub static FISH_AMBIGUOUS_WIDTH: AtomicIsize = AtomicIsize::new(1);
 /// Valid values are 1, and 2. 1 is the typical emoji width used in Unicode 8 while some newer
 /// terminals use a width of 2 since Unicode 9.
 // For some reason, this is declared here and exposed here, but is set in `env_dispatch`.
-pub static FISH_EMOJI_WIDTH: AtomicIsize = AtomicIsize::new(1);
+pub static FISH_EMOJI_WIDTH: AtomicIsize = AtomicIsize::new(2);
 
 static WC_LOOKUP_TABLE: LazyLock<WcLookupTable> = LazyLock::new(WcLookupTable::new);
 

--- a/crates/fallback/src/lib.rs
+++ b/crates/fallback/src/lib.rs
@@ -29,32 +29,9 @@ pub static FISH_EMOJI_WIDTH: AtomicIsize = AtomicIsize::new(2);
 
 static WC_LOOKUP_TABLE: LazyLock<WcLookupTable> = LazyLock::new(WcLookupTable::new);
 
-/// A safe wrapper around the system `wcwidth()` function
-#[cfg(not(cygwin))]
-pub fn wcwidth(c: char) -> isize {
-    unsafe extern "C" {
-        pub unsafe fn wcwidth(c: libc::wchar_t) -> libc::c_int;
-    }
-
-    const {
-        assert!(size_of::<libc::wchar_t>() >= size_of::<char>());
-    }
-
-    let width = unsafe { wcwidth(c as libc::wchar_t) };
-    isize::try_from(width).unwrap()
-}
-
 // Big hack to use our versions of wcswidth where we know them to be broken, which is
 // EVERYWHERE (https://github.com/fish-shell/fish-shell/issues/2199)
 pub fn fish_wcwidth(c: char) -> isize {
-    // The system version of wcwidth should accurately reflect the ability to represent characters
-    // in the console session, but knows nothing about the capabilities of other terminal emulators
-    // or ttys. Use it from the start only if we are logged in to the physical console.
-    #[cfg(not(cygwin))]
-    if fish_common::is_console_session() {
-        return wcwidth(c);
-    }
-
     // Check for VS16 which selects emoji presentation. This "promotes" a character like U+2764
     // (width 1) to an emoji (probably width 2). So treat it as width 1 so the sums work. See #2652.
     // VS15 selects text presentation.
@@ -75,18 +52,7 @@ pub fn fish_wcwidth(c: char) -> isize {
 
     let width = WC_LOOKUP_TABLE.classify(c);
     match width {
-        WcWidth::NonCharacter | WcWidth::NonPrint | WcWidth::Combining | WcWidth::Unassigned => {
-            #[cfg(not(cygwin))]
-            {
-                // Fall back to system wcwidth in this case.
-                wcwidth(c)
-            }
-            #[cfg(cygwin)]
-            {
-                // No system wcwidth for UTF-32 on cygwin.
-                0
-            }
-        }
+        WcWidth::NonCharacter | WcWidth::NonPrint | WcWidth::Combining | WcWidth::Unassigned => 0,
         WcWidth::Ambiguous | WcWidth::PrivateUse => {
             // TR11: "All private-use characters are by default classified as Ambiguous".
             FISH_AMBIGUOUS_WIDTH.load(Ordering::Relaxed)
@@ -97,8 +63,7 @@ pub fn fish_wcwidth(c: char) -> isize {
     }
 }
 
-/// fish's internal versions of wcwidth and wcswidth, which can use an internal implementation if
-/// the system one is busted.
+/// fish's internal versions of wcwidth and wcswidth
 pub fn fish_wcswidth(s: &wstr) -> isize {
     // ascii fast path; empty iterator returns true for .all()
     if s.chars().all(|c| c.is_ascii() && !c.is_ascii_control()) {

--- a/src/env_dispatch.rs
+++ b/src/env_dispatch.rs
@@ -14,7 +14,6 @@ use crate::reader::{
 };
 use crate::screen::{IS_DUMB, ONLY_GRAYSCALE, screen_set_midnight_commander_hack};
 use crate::terminal::ColorSupport;
-use crate::tty_handoff::xtversion;
 use crate::wutil::fish_wcstoi;
 use fish_wcstringutil::{bool_from_string, string_prefixes_string};
 use std::collections::HashMap;
@@ -61,7 +60,7 @@ static VAR_DISPATCH_TABLE: once_cell::sync::Lazy<VarDispatchTable> =
             L!("fish_sequence_key_delay_ms"),
             vars!(update_wait_on_sequence_key_ms),
         );
-        table.add_anon(L!("fish_emoji_width"), vars!(guess_emoji_width));
+        table.add_anon(L!("fish_emoji_width"), vars!(handle_emoji_width));
         table.add_anon(
             L!("fish_ambiguous_width"),
             vars!(handle_change_ambiguous_width),
@@ -159,7 +158,7 @@ fn handle_timezone(var_name: &wstr, vars: &EnvStack) {
 }
 
 /// Update the value of [`FISH_EMOJI_WIDTH`](fish_fallback::FISH_EMOJI_WIDTH).
-pub fn guess_emoji_width(vars: &EnvStack) {
+pub fn handle_emoji_width(vars: &EnvStack) {
     use fish_fallback::FISH_EMOJI_WIDTH;
 
     if let Some(width_str) = vars.get(L!("fish_emoji_width")) {
@@ -171,38 +170,7 @@ pub fn guess_emoji_width(vars: &EnvStack) {
             "Overriding default fish_emoji_width w/",
             new_width
         );
-        return;
-    }
-
-    let term_program = vars
-        .get(L!("TERM_PROGRAM"))
-        .map_or_else(WString::new, |v| v.as_string());
-
-    // TODO(term-workaround)
-    if xtversion().unwrap_or(L!("")).starts_with(L!("iTerm2 ")) {
-        // iTerm2 now defaults to Unicode 9 sizes for anything after macOS 10.12
-        FISH_EMOJI_WIDTH.store(2, Ordering::Relaxed);
-        flog!(term_support, "default emoji width 2 for iTerm2");
-    } else if term_program == "Apple_Terminal" && {
-        let version = vars
-            .get(L!("TERM_PROGRAM_VERSION"))
-            .map(|v| v.as_string())
-            .and_then(|v| {
-                let mut consumed = 0;
-                crate::wutil::wcstod::wcstod(&v, '.', &mut consumed).ok()
-            })
-            .unwrap_or(0.0);
-        version as i32 >= 400
-    } {
-        // Apple Terminal on High Sierra
-        FISH_EMOJI_WIDTH.store(2, Ordering::Relaxed);
-        flog!(term_support, "default emoji width: 2 for", term_program);
     } else {
-        // Default to whatever the system's wcwidth gives for U+1F603, but only if it's at least
-        // 1 and at most 2.
-        #[cfg(not(cygwin))]
-        let width = fish_fallback::wcwidth('😃').clamp(1, 2);
-        #[cfg(cygwin)]
         let width = 2_isize;
         FISH_EMOJI_WIDTH.store(width, Ordering::Relaxed);
         flog!(term_support, "default emoji width:", width);
@@ -325,7 +293,6 @@ fn handle_locale_change(vars: &EnvStack) {
 }
 
 fn handle_term_change(vars: &EnvStack, suppress_repaint: bool) {
-    guess_emoji_width(vars);
     init_terminal(vars);
     if !suppress_repaint {
         reader_schedule_prompt_repaint();
@@ -393,7 +360,7 @@ fn run_inits(vars: &EnvStack) {
     init_locale(vars);
     init_special_chars_once();
     init_terminal(vars);
-    guess_emoji_width(vars);
+    handle_emoji_width(vars);
     update_wait_on_escape_ms(vars);
     update_wait_on_sequence_key_ms(vars);
     handle_read_limit_change(vars);

--- a/src/reader/reader.rs
+++ b/src/reader/reader.rs
@@ -39,7 +39,7 @@ use crate::editable_line::{Edit, EditableLine, line_at_cursor, range_of_line_at_
 use crate::env::EnvStack;
 use crate::env::{EnvMode, Environment, Statuses};
 use crate::env_dispatch::MIDNIGHT_COMMANDER_SID;
-use crate::env_dispatch::guess_emoji_width;
+use crate::env_dispatch::handle_emoji_width;
 use crate::exec::exec_subshell;
 use crate::expand::expand_one;
 use crate::expand::{ExpandFlags, ExpandResultCode, expand_string, expand_tilde};
@@ -385,7 +385,7 @@ pub fn reader_push<'a>(parser: &'a Parser, history_name: &wstr, conf: ReaderConf
             background_color,
         } = terminal_init(parser.vars(), inputfd);
         let input_data = input_queue.get_input_data_mut();
-        guess_emoji_width(parser.vars());
+        handle_emoji_width(parser.vars());
 
         // Provide value for `status current-command`
         parser.libdata_mut().status_vars.command = L!("fish").to_owned();


### PR DESCRIPTION
This has two halves:

The first defaults our "emoji" width to 2. That's the correct value post-Unicode-9, from 2016. The idea is that this helps with sshing to an old system from a new one, which at this point should be much more common than running an old system as a desktop. Older RHEL et al will now have to set $fish_emoji_width to 1.

The second is to stop using libc's wcwidth entirely, which helps with codepoints that doesn't know and unprintable codepoints (where it returns "-1", which is simply wrong) and simplifies the code. This goes against the idea that libc's wcwidth would reflect the "console", which I'm not sure is even the case.

Fixes #12500.

## TODOs:
<!-- Check off what what has been done so far. -->
- [X] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
