### PR TITLE
Support SHELL_PROMPT_PREFIX, SHELL_PROMPT_SUFFIX, and SHELL_WELCOME

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Deprecations and removed features
 
 Interactive improvements
 ------------------------
+- fish now supports the ``SHELL_PROMPT_PREFIX``, ``SHELL_PROMPT_SUFFIX``, and ``SHELL_WELCOME`` environment variables. The prefix and suffix are automatically prepended and appended to the left prompt, and the welcome message is displayed on startup after the greeting. These variables are a standard interface used by tools like systemd's ``run0`` (:issue:`10924`).
 - The tab completion pager now left-justifies the description of each column (:issue:`12546`).
 
 New or improved bindings

--- a/doc_src/cmds/fish_greeting.rst
+++ b/doc_src/cmds/fish_greeting.rst
@@ -22,6 +22,8 @@ When an interactive fish starts, it executes fish_greeting and displays its outp
 
 The default fish_greeting is a function that prints a variable of the same name (``$fish_greeting``), so you can also just change that if you just want to change the text.
 
+If :envvar:`SHELL_WELCOME` is set, it is displayed after the greeting. This is a standard environment variable that may be set by tools like systemd's ``run0`` to display session information.
+
 While you could also just put ``echo`` calls into config.fish, fish_greeting takes care of only being used in interactive shells, so it won't be used e.g. with ``scp`` (which executes a shell), which prevents some errors.
 
 Example

--- a/doc_src/cmds/fish_prompt.rst
+++ b/doc_src/cmds/fish_prompt.rst
@@ -24,6 +24,8 @@ The exit status of commands within ``fish_prompt`` will not modify the value of 
 
 If :envvar:`fish_transient_prompt` is set to 1, ``fish_prompt --final-rendering`` is run before executing the commandline.
 
+If :envvar:`SHELL_PROMPT_PREFIX` or :envvar:`SHELL_PROMPT_SUFFIX` are set, they are automatically prepended and appended to the left prompt. This applies to all prompts regardless of whether ``fish_prompt`` has been customized.
+
 ``fish`` ships with a number of example prompts that can be chosen with the ``fish_config`` command.
 
 

--- a/doc_src/language.rst
+++ b/doc_src/language.rst
@@ -1646,6 +1646,18 @@ You can change the settings of fish by changing the values of certain variables.
 
    the current file creation mask. The preferred way to change the umask variable is through the :doc:`umask <cmds/umask>` function. An attempt to set umask to an invalid value will always fail.
 
+.. envvar:: SHELL_PROMPT_PREFIX
+
+   if set, this string is automatically prepended to the left prompt. This is a standard environment variable that may be set by tools like systemd's ``run0`` to indicate special shell sessions.
+
+.. envvar:: SHELL_PROMPT_SUFFIX
+
+   if set, this string is automatically appended to the left prompt. This is a standard environment variable that may be set by tools like systemd's ``run0`` to indicate special shell sessions.
+
+.. envvar:: SHELL_WELCOME
+
+   if set, this string is displayed when an interactive shell starts, after the greeting. This is a standard environment variable that may be set by tools like systemd's ``run0`` to display session information.
+
 .. envvar:: BROWSER
 
    your preferred web browser. If this variable is set, fish will use the specified browser instead of the system default browser to display the fish documentation.

--- a/doc_src/prompt.rst
+++ b/doc_src/prompt.rst
@@ -19,6 +19,8 @@ Unlike other shells, fish's prompt is built by running a function - :doc:`fish_p
 
 These functions are run, and whatever they print is displayed as the prompt (minus one trailing newline).
 
+If the :envvar:`SHELL_PROMPT_PREFIX` or :envvar:`SHELL_PROMPT_SUFFIX` environment variables are set, they are automatically prepended and appended to the left prompt.
+
 Here, we will just be writing a simple fish_prompt.
 
 Our first prompt

--- a/share/functions/__fish_config_interactive.fish
+++ b/share/functions/__fish_config_interactive.fish
@@ -34,6 +34,13 @@ function __fish_config_interactive -d "Initializations that should be performed 
         fish_greeting
     end
 
+    # Display SHELL_WELCOME if set. This is a standard environment variable (introduced by
+    # systemd v257) intended for shells to display when they first initialize.
+    if status --is-interactive
+        and set -q SHELL_WELCOME[1]
+        echo $SHELL_WELCOME
+    end
+
     #
     # Completions for SysV startup scripts. These aren't bound to any
     # specific command, so they can't be autoloaded.

--- a/src/reader/reader.rs
+++ b/src/reader/reader.rs
@@ -5155,6 +5155,17 @@ impl<'a> Reader<'a> {
 
                 self.left_prompt_buff =
                     join_strings(&self.exec_prompt_cmd(prompt_cmd, final_prompt), '\n');
+
+                // Support the SHELL_PROMPT_PREFIX and SHELL_PROMPT_SUFFIX environment
+                // variables as standardized by systemd v257. Prepend the prefix and
+                // append the suffix to the left prompt so that all prompts
+                // automatically pick them up.
+                if let Some(prefix) = self.vars().get_unless_empty(L!("SHELL_PROMPT_PREFIX")) {
+                    self.left_prompt_buff.insert_utfstr(0, &prefix.as_string());
+                }
+                if let Some(suffix) = self.vars().get_unless_empty(L!("SHELL_PROMPT_SUFFIX")) {
+                    self.left_prompt_buff.push_utfstr(&suffix.as_string());
+                }
             }
 
             // Don't execute the right prompt if it is undefined fish_right_prompt


### PR DESCRIPTION
Add support for the SHELL_PROMPT_PREFIX, SHELL_PROMPT_SUFFIX, and
SHELL_WELCOME environment variables as standardized by systemd v257.

SHELL_PROMPT_PREFIX and SHELL_PROMPT_SUFFIX are automatically prepended
and appended to the left prompt at the shell level, so all prompts
(default, custom, and sample) pick them up without modification.

SHELL_WELCOME is displayed after the greeting when an interactive shell
starts.

These variables provide a standard interface for tools like systemd's
run0 to communicate session context to the shell.

Fixes https://github.com/fish-shell/fish-shell/issues/10924
