### PR TITLE
docs: fix typo in MANPATH guidance string

### DIFF
--- a/share/tools/create_manpage_completions.py
+++ b/share/tools/create_manpage_completions.py
@@ -2102,7 +2102,7 @@ def get_paths_from_man_locations():
         parent_paths = ["/usr/share/man", "/usr/local/man", "/usr/local/share/man"]
         print(
             "Unable to get the manpath, falling back to %s." % ":".join(parent_paths),
-            "Explictly set $MANPATH to fix this error.",
+            "Explicitly set $MANPATH to fix this error.",
             file=sys.stderr,
         )
 


### PR DESCRIPTION
## Summary
- fix the typo in the `MANPATH` guidance string in `create_manpage_completions.py`

## Related issue
- N/A

## Guideline alignment
- Reviewed [CONTRIBUTING.rst](https://github.com/fish-shell/fish-shell/blob/master/CONTRIBUTING.rst) and the PR template
- Kept this to a single wording fix in one file with no behavior change

## Validation/testing note
- Not run locally; wording-only change

## TODOs:
- [x] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>` (N/A)
- [x] Changes to fish usage are reflected in user documentation/manpages. (N/A)
- [x] Tests have been added for regressions fixed. (N/A)
- [x] User-visible changes noted in CHANGELOG.rst. (N/A)
