### PR TITLE
completions/cargo: avoid auto-installing toolchain via rustup

### DIFF
--- a/share/completions/cargo.fish
+++ b/share/completions/cargo.fish
@@ -3,7 +3,7 @@
 ## --- WRITTEN MANUALLY ---
 
 function __fish_cargo
-    cargo --color=never $argv
+    RUSTUP_AUTO_INSTALL=0 cargo --color=never $argv
 end
 
 set -l __fish_cargo_subcommands (__fish_cargo --list 2>&1 | string replace -rf '^\s+([^\s]+)\s*(.*)' '$1\t$2' | string escape)


### PR DESCRIPTION
When cargo is installed via rustup, running cargo actually goes through a proxy managed by rustup. This proxy determines the actual toolchain to use, depending on environment variables, directory overrides etc. In some cases, the proxy may automatically install the selected toolchain if it's not yet installed, for example when first working on a project that pins its rust toolchain via a `rust-toolchain.toml` file. In that case, running cargo in the completion script can block the prompt for a very long time. To avoid this, we instruct the rustup proxy not to auto-install any toolchain with an environment variable.

- [n/a] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [n/a] Changes to fish usage are reflected in user documentation/manpages.
- [n/a] Tests have been added for regressions fixed
- [n/a] User-visible changes noted in CHANGELOG.rst