### PR TITLE
docs: fix typo in web config comment

### DIFF
--- a/share/tools/web_config/fishconfig.css
+++ b/share/tools/web_config/fishconfig.css
@@ -207,7 +207,7 @@ tt {
     border-top-left-radius: 5;
     border-bottom-left-radius: 5;
 
-    /* Pad one less than .master_element, to accomodate our border. */
+    /* Pad one less than .master_element, to accommodate our border. */
     padding-top: 5px;
     padding-bottom: 10px;
     padding-left: 4px;


### PR DESCRIPTION
## Summary

Fix a typo in a CSS source comment in `share/tools/web_config/fishconfig.css`.

## Related issue

N/A. This is a trivial comment-only fix.

## Guideline alignment

- Followed the repository contributing guide: https://github.com/fish-shell/fish-shell/blob/master/CONTRIBUTING.rst
- The change is limited to a source comment and does not affect behavior.

## Validation/testing

Not run. This is a comment-only change.

## TODOs:

- [ ] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst

N/A for the TODOs above because this PR only fixes a typo in a CSS comment.
