### PR TITLE
fix: simplify and correct trimming of features

### DIFF
--- a/src/future_feature_flags.rs
+++ b/src/future_feature_flags.rs
@@ -237,19 +237,14 @@ impl Features {
     }
 
     fn set_from_string(&self, str: &wstr) {
-        let whitespace = L!("\t\n\0x0B\0x0C\r ").as_char_slice();
-        for entry in str.as_char_slice().split(|c| *c == ',') {
+        for entry in str.split(',') {
+            let entry = entry.trim();
             if entry.is_empty() {
                 continue;
             }
 
-            // Trim leading and trailing whitespace
-            let entry = &entry[entry.iter().take_while(|c| whitespace.contains(c)).count()..];
-            let entry =
-                &entry[..entry.len() - entry.iter().take_while(|c| whitespace.contains(c)).count()];
-
             // A "no-" prefix inverts the sense.
-            let (name, value) = match entry.strip_prefix(L!("no-").as_char_slice()) {
+            let (name, value) = match entry.strip_prefix("no-") {
                 Some(suffix) => (suffix, false),
                 None => (entry, true),
             };


### PR DESCRIPTION
The previous handling was unnecessarily complex and had a bug introduced by porting from C++ to Rust: The substrings `\0x0B` and `\0x0C` in Rust mean `\0` (the NUL character) followed by the regular characters `0B` and `0C`, respectively, so feature names starting or ending with these characters would have these characters stripped away.

Replace this handling by built-in functionality, and simplify some syntax. We now trim all whitespace, instead of just certain ASCII characters, but I think there is no reason to limit trimming to ASCII.
