### PR TITLE
Save history on SIGTERM and SIGHUP before exit

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Improved terminal support
 
 Other improvements
 ------------------
+- History is no longer corrupted with NUL bytes when fish receives SIGTERM or SIGHUP (:issue:`10300`).
 - ``fish_update_completions`` now handles groff ``\X'...'`` device control escapes, fixing completion generation for man pages produced by help2man 1.50 and later (such as coreutils 9.10).
 
 For distributors and developers

--- a/src/bin/fish.rs
+++ b/src/bin/fish.rs
@@ -53,7 +53,7 @@ use fish::{
         Pid, get_login, is_interactive_session, mark_login, mark_no_exec, proc_init,
         set_interactive_session,
     },
-    reader::{reader_init, reader_read, term_copy_modes},
+    reader::{reader_exit_signal, reader_init, reader_read, term_copy_modes},
     signal::{signal_clear_cancel, signal_unblock_all},
     threads::{self},
     topic_monitor,
@@ -625,6 +625,16 @@ fn throwing_main() -> i32 {
     }
 
     history::save_all();
+
+    // If we deferred a fatal signal, re-raise it now so the parent sees WIFSIGNALED.
+    let exit_sig = reader_exit_signal();
+    if exit_sig != 0 {
+        unsafe {
+            libc::signal(exit_sig, libc::SIG_DFL);
+            libc::raise(exit_sig);
+        }
+    }
+
     if opts.print_rusage_self {
         print_rusage_self();
     }

--- a/src/builtins/fish_key_reader.rs
+++ b/src/builtins/fish_key_reader.rs
@@ -27,7 +27,8 @@ use crate::{
     print_help::print_help,
     proc::set_interactive_session,
     reader::{
-        check_exit_loop_maybe_warning, reader_init, reader_sighup, set_shell_modes, terminal_init,
+        check_exit_loop_maybe_warning, reader_init, reader_set_exit_signal, set_shell_modes,
+        terminal_init,
     },
     threads,
     topic_monitor::topic_monitor_init,
@@ -96,7 +97,7 @@ fn process_input(
         use QueryResultEvent::*;
         let kevt = match input_queue.readch() {
             CharEvent::Implicit(ImplicitEvent::Eof) => {
-                reader_sighup();
+                reader_set_exit_signal(libc::SIGHUP);
                 continue;
             }
             CharEvent::Key(kevt) => kevt,

--- a/src/reader/reader.rs
+++ b/src/reader/reader.rs
@@ -178,8 +178,7 @@ fn zeroed_termios() -> Termios {
 
 pub static SHELL_MODES: LazyLock<Mutex<Termios>> = LazyLock::new(|| Mutex::new(zeroed_termios()));
 
-/// The valid terminal modes on startup.
-/// Warning: this is read from the SIGTERM handler! Hence the raw global.
+/// The valid terminal modes on startup. Raw global for async-signal-safe access.
 static TERMINAL_MODE_ON_STARTUP: OnceLock<libc::termios> = OnceLock::new();
 
 /// Mode we use to execute programs.
@@ -193,9 +192,9 @@ static STATUS_COUNT: AtomicU64 = AtomicU64::new(0);
 /// This variable is set to a signal by the signal handler when ^C is pressed.
 static INTERRUPTED: AtomicI32 = AtomicI32::new(0);
 
-/// If set, SIGHUP has been received. This latches to true.
-/// This is set from a signal handler.
-static SIGHUP_RECEIVED: RelaxedAtomicBool = RelaxedAtomicBool::new(false);
+/// Stores the signal (SIGHUP or SIGTERM) that should cause fish to exit, or 0 if none.
+/// Set from a signal handler.
+static EXIT_SIGNAL: AtomicI32 = AtomicI32::new(0);
 
 // Get the terminal mode on startup. This is "safe" because it's async-signal safe.
 pub fn safe_get_terminal_mode_on_startup() -> Option<&'static libc::termios> {
@@ -217,8 +216,7 @@ fn redirect_tty_after_sighup() {
     use std::fs::OpenOptions;
 
     // If we have received SIGHUP, redirect the tty to avoid a user script triggering SIGTTIN or
-    // SIGTTOU.
-    assert!(reader_received_sighup(), "SIGHUP not received");
+    // SIGTTOU. The caller checks reader_exit_signal() == SIGHUP before calling this.
     static TTY_REDIRECTED: RelaxedAtomicBool = RelaxedAtomicBool::new(false);
     if TTY_REDIRECTED.swap(true) {
         return;
@@ -291,7 +289,7 @@ pub fn terminal_init(vars: &dyn Environment, inputfd: RawFd) -> TerminalInitResu
         use ImplicitEvent::{CheckExit, Eof};
         use QueryResultEvent::*;
         match input_queue.readch() {
-            Implicit(Eof) => reader_sighup(),
+            Implicit(Eof) => reader_set_exit_signal(libc::SIGHUP),
             Implicit(CheckExit) => {}
             CharEvent::QueryResult(Response(QueryResponse::PrimaryDeviceAttribute)) => {
                 break;
@@ -896,9 +894,8 @@ fn read_i(parser: &Parser) {
     reader_pop();
 
     // If we got SIGHUP, ensure the tty is redirected and release tty handoff without
-    // trying to muck with protocols.
-    if reader_received_sighup() {
-        // If we are the top-level reader, then we translate SIGHUP into exit_forced.
+    // trying to muck with protocols. SIGTERM does not redirect; the terminal is still valid.
+    if reader_exit_signal() == libc::SIGHUP {
         redirect_tty_after_sighup();
     }
 
@@ -1048,7 +1045,6 @@ pub fn reader_deinit(restore_foreground_pgroup: bool) {
 /// Restore the term mode if we own the terminal and are interactive (#8705).
 /// It's important we do this before restore_foreground_process_group,
 /// otherwise we won't think we own the terminal.
-/// THIS FUNCTION IS CALLED FROM A SIGNAL HANDLER. IT MUST BE ASYNC-SIGNAL-SAFE.
 pub fn safe_restore_term_mode() {
     if !is_interactive_session() || getpgrp().as_raw() != unsafe { libc::tcgetpgrp(STDIN_FILENO) } {
         return;
@@ -1350,14 +1346,20 @@ pub fn reader_test_and_clear_interrupted() -> i32 {
     res
 }
 
-/// Mark that we encountered SIGHUP and must (soon) exit. This is invoked from a signal handler.
-pub fn reader_sighup() {
+/// Mark that we received an exit signal (SIGHUP or SIGTERM). Invoked from a signal handler.
+pub fn reader_set_exit_signal(sig: i32) {
     // Beware, we may be in a signal handler.
-    SIGHUP_RECEIVED.store(true);
+    EXIT_SIGNAL.store(sig, Ordering::Relaxed);
 }
 
-fn reader_received_sighup() -> bool {
-    SIGHUP_RECEIVED.load()
+/// Return the exit signal we received, or 0 if none.
+pub fn reader_exit_signal() -> i32 {
+    EXIT_SIGNAL.load(Ordering::Relaxed)
+}
+
+/// Whether we received SIGHUP or SIGTERM and should exit.
+fn reader_received_exit_signal() -> bool {
+    reader_exit_signal() != 0
 }
 
 impl ReaderData {
@@ -2877,7 +2879,7 @@ impl<'a> Reader<'a> {
             CharEvent::Implicit(implicit_event) => {
                 use ImplicitEvent::*;
                 match implicit_event {
-                    Eof => reader_sighup(),
+                    Eof => reader_set_exit_signal(libc::SIGHUP),
                     CheckExit => (),
                     FocusIn => {
                         event::fire_generic(self.parser, L!("fish_focus_in").to_owned(), vec![]);
@@ -5018,10 +5020,7 @@ pub fn fish_is_unwinding_for_exit() -> bool {
     let exit_state = EXIT_STATE.load(Ordering::Relaxed);
     let exit_state: ExitState = unsafe { std::mem::transmute(exit_state) };
     match exit_state {
-        ExitState::None => {
-            // Cancel if we got SIGHUP.
-            reader_received_sighup()
-        }
+        ExitState::None => reader_received_exit_signal(),
         ExitState::RunningHandlers => {
             // We intend to exit but we want to allow these handlers to run.
             false
@@ -6522,8 +6521,7 @@ impl<'a> Reader<'a> {
 /// Check if we should exit the reader loop.
 /// Return true if we should exit.
 pub fn check_exit_loop_maybe_warning(data: Option<&mut Reader>) -> bool {
-    // sighup always forces exit.
-    if reader_received_sighup() {
+    if reader_received_exit_signal() {
         return true;
     }
 

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -1,10 +1,10 @@
 use crate::common::exit_without_destructors;
 use crate::event::{enqueue_signal, is_signal_observed};
 use crate::prelude::*;
-use crate::reader::{reader_handle_sigint, reader_sighup, safe_restore_term_mode};
+use crate::reader::{reader_handle_sigint, reader_set_exit_signal};
 use crate::termsize::safe_termsize_invalidate_tty;
 use crate::topic_monitor::{Generation, GenerationsList, Topic, topic_monitor_principal};
-use crate::tty_handoff::{safe_deactivate_tty_protocols, safe_mark_tty_invalid};
+use crate::tty_handoff::safe_mark_tty_invalid;
 use crate::wutil::fish_wcstoi;
 use errno::{errno, set_errno};
 use fish_util::perror;
@@ -88,25 +88,15 @@ extern "C" fn fish_signal_handler(
             // Respond to a winch signal by telling the termsize container.
             safe_termsize_invalidate_tty();
         }
-        libc::SIGHUP => {
+        libc::SIGHUP | libc::SIGTERM => {
             // Exit unless the signal was trapped.
             if !observed {
-                reader_sighup();
-                safe_mark_tty_invalid();
-            }
-            topic_monitor_principal().post(Topic::SigHupInt);
-        }
-        libc::SIGTERM => {
-            // Handle sigterm. The only thing we do is restore the front process ID and disable protocols, then die.
-            if !observed {
-                safe_restore_term_mode();
-                safe_deactivate_tty_protocols();
-                // Safety: signal() and raise() are async-signal-safe.
-                unsafe {
-                    libc::signal(libc::SIGTERM, libc::SIG_DFL);
-                    libc::raise(libc::SIGTERM);
+                reader_set_exit_signal(sig);
+                if sig == libc::SIGHUP {
+                    safe_mark_tty_invalid();
                 }
             }
+            topic_monitor_principal().post(Topic::SigHupInt);
         }
         libc::SIGINT => {
             // Cancel unless the signal was trapped.
@@ -177,7 +167,7 @@ fn set_interactive_handlers() {
     act.sa_flags = libc::SA_SIGINFO;
     sigaction(libc::SIGTTIN, &act, nullptr);
 
-    // SIGTERM restores the terminal controlling process before dying.
+    // SIGTERM defers to allow graceful history save before exit.
     act.sa_sigaction = signal_handler;
     act.sa_flags = libc::SA_SIGINFO;
     sigaction(libc::SIGTERM, &act, nullptr);

--- a/tests/pexpects/sigterm_history.py
+++ b/tests/pexpects/sigterm_history.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+from pexpect_helper import SpawnedProc
+import os
+import pexpect
+import signal
+import sys
+
+sp = SpawnedProc()
+fish_pid = sp.spawn.pid
+assert fish_pid is not None
+sp.expect_prompt()
+
+# Set up a fish_exit handler that prints a marker to stdout.
+sp.sendline("function __test_exit --on-event fish_exit; echo SIGTERM_CLEANUP_OK; end")
+sp.expect_prompt()
+
+# Run a command to populate history.
+sp.sendline("echo sigterm_history_test_%d" % fish_pid)
+sp.expect_prompt()
+
+# Send SIGTERM.
+os.kill(fish_pid, signal.SIGTERM)
+
+# Try to catch the cleanup marker before EOF.
+idx = sp.spawn.expect(["SIGTERM_CLEANUP_OK", pexpect.EOF], timeout=5)
+if idx == 1:
+    print("FAIL: fish_exit did not fire on SIGTERM (no cleanup marker in output)")
+    sys.exit(1)
+
+# Drain remaining output.
+sp.spawn.expect(pexpect.EOF, timeout=5)
+sp.spawn.close()
+
+# Verify death was by signal (re-raised SIGTERM), not normal exit.
+if sp.spawn.signalstatus != signal.SIGTERM:
+    print(
+        "FAIL: expected SIGTERM, got signal=%s exit=%s"
+        % (sp.spawn.signalstatus, sp.spawn.exitstatus)
+    )
+    sys.exit(1)
+
+# Check history file for NUL bytes.
+histfile = os.path.join(os.environ["XDG_DATA_HOME"], "fish", "fish_history")
+with open(histfile, "rb") as f:
+    raw = f.read()
+assert len(raw) != 0, "history file is empty"
+nul_count = raw.count(b"\x00")
+if nul_count > 0:
+    print("FAIL: history file contains %d NUL bytes" % nul_count)
+    sys.exit(1)


### PR DESCRIPTION
The SIGTERM handler immediately re-raised with `SIG_DFL`, so fish died without saving history. During system shutdown this can produce NUL bytes in the history file when journaled metadata survives but unfsynced data blocks don't. Still [being reported](https://github.com/fish-shell/fish-shell/issues/10300#issuecomment-4160077591).

SIGHUP already deferred via a flag but never re-raised, so the parent saw a normal exit instead of signal death.

The fix unifies both signals: the handler stores the signal number in a single `AtomicI32` and posts to the topic monitor. The reader loop exits normally, `throwing_main()` saves history, then re-raises the original signal with `SIG_DFL` so the parent sees `WIFSIGNALED`.

Fixes #10300

## TODOs:
- [x] Commit message mentions `Fixes issue #10300`
- [x] Changes to fish usage are reflected in user documentation/manpages (N/A)
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst