### PR TITLE
git completions: prioritize recent commits for rebase --interactive

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -2161,6 +2161,7 @@ complete -x -c git -n '__fish_git_using_command push' -l exec -d 'Same as --rece
 ### rebase
 complete -f -c git -n __fish_git_needs_command -a rebase -d 'Reapply commit sequence on a new base'
 __fish_git_add_revision_completion -n '__fish_git_using_command rebase'
+complete -f -c git -n '__fish_git_using_command rebase' -n 'string match -rq -- "^-i|^--interactive" (commandline -xpc)' -ka '(__fish_git_recent_commits)'
 complete -f -c git -n '__fish_git_using_command rebase' -n __fish_git_is_rebasing -l continue -d 'Restart the rebasing process'
 complete -f -c git -n '__fish_git_using_command rebase' -n __fish_git_is_rebasing -l abort -d 'Abort the rebase operation'
 complete -f -c git -n '__fish_git_using_command rebase' -n __fish_git_is_rebasing -l edit-todo -d 'Edit the todo list'


### PR DESCRIPTION
When using `git rebase -i` or `git rebase --interactive`, the user is always specifying a commit, not a branch. This change prioritizes recent commits in the completion list when the interactive flag is detected, while still keeping branches and tags available below.

Fixes #12537

## TODOs:
- [x] If addressing an issue, a commit message mentions `Fixes #12537`
- [ ] Changes to fish usage are reflected in user documentation/manpages
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->