### PR TITLE
prompt_pwd: strip control characters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Other improvements
 ------------------
 - History is no longer corrupted with NUL bytes when fish receives SIGTERM or SIGHUP (:issue:`10300`).
 - ``fish_update_completions`` now handles groff ``\X'...'`` device control escapes, fixing completion generation for man pages produced by help2man 1.50 and later (such as coreutils 9.10).
+- Control characters such as escape are now stripped when printing the prompt in `prompt_pwd`.
 
 For distributors and developers
 -------------------------------

--- a/share/functions/prompt_pwd.fish
+++ b/share/functions/prompt_pwd.fish
@@ -27,6 +27,9 @@ function prompt_pwd --description 'short CWD for the prompt'
 
     for path in $argv
         set -l tmp (__fish_unexpand_tilde $path)
+        # Strip control characters (e.g. ESC) so malicious directory names
+        # can't inject terminal escape sequences into the prompt.
+        set tmp (string replace -ra '[[:cntrl:]]' '' -- $tmp)
 
         if test "$fish_prompt_pwd_dir_length" -eq 0
             echo $tmp

--- a/tests/checks/prompt.fish
+++ b/tests/checks/prompt.fish
@@ -14,3 +14,7 @@ prompt_pwd -D 0 /usr/share/fish/prompts
 
 prompt_pwd -d1 -D 3 /usr/local/share/fish/prompts
 # CHECK: /u/l/share/fish/prompts
+
+# Ensure control characters in paths are stripped
+prompt_pwd -d 0 /foo/(printf '\e]0;OHNO\a')bar
+# CHECK: /foo/]0;OHNObar


### PR DESCRIPTION
If a directory has a control sequence in it, then prompt_pwd would emit it to the console, which could cause weirdness or even things like modifying the pasteboard.

Strip control from prompt_pwd's output, in the same way as we do in __fish_paste.fish.

Credit to "evilrabbit" for reporting this.

## TODOs:
<!-- Check off what what has been done so far. -->
- [x] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
