### PR TITLE
Fix and clean up some things in `build_tools/check.sh`

### DIFF
--- a/build_tools/check.sh
+++ b/build_tools/check.sh
@@ -89,6 +89,7 @@ fi
 
 gettext_template_dir=$(mktemp -d)
 (
+    # shellcheck disable=2030
     export FISH_GETTEXT_EXTRACTION_DIR="$gettext_template_dir"
     cargo build --workspace --all-targets --features=gettext-extract
 )
@@ -125,6 +126,7 @@ fi
 # Using "()" not "{}" because we do want a subshell (for the export)
 system_tests() (
     [ -n "$*" ] && export "$@"
+    # shellcheck disable=2031
     export FISH_GETTEXT_EXTRACTION_DIR="$gettext_template_dir"
     "$workspace_root/tests/test_driver.py" "$build_dir"
 )

--- a/build_tools/check.sh
+++ b/build_tools/check.sh
@@ -141,7 +141,7 @@ if $is_cygwin; then
 
     # shellcheck disable=2059
     printf "=== Running ${green}integration tests ${yellow}without${green} symlinks${reset}\n"
-    system_tests "$cygwin_var"=winsymlinks
+    system_tests "$cygwin_var"=
 else
     # shellcheck disable=2059
     printf "=== Running ${green}integration tests${reset}\n"

--- a/build_tools/check.sh
+++ b/build_tools/check.sh
@@ -124,7 +124,7 @@ fi
 
 # Using "()" not "{}" because we do want a subshell (for the export)
 system_tests() (
-    [ -n "$@" ] && export "$@"
+    [ -n "$*" ] && export "$@"
     export FISH_GETTEXT_EXTRACTION_DIR="$gettext_template_dir"
     "$workspace_root/tests/test_driver.py" "$build_dir"
 )

--- a/build_tools/check.sh
+++ b/build_tools/check.sh
@@ -113,7 +113,8 @@ fi
 # - https://github.com/msys2/MSYS2-packages/issues/5784
 (
     if $is_cygwin; then
-        export PATH="$PATH:$(rustc --print target-libdir)"
+        PATH="$PATH:$(rustc --print target-libdir)"
+        export PATH
     fi
     cargo test --no-default-features --workspace --all-targets
 )

--- a/build_tools/check.sh
+++ b/build_tools/check.sh
@@ -60,6 +60,7 @@ cargo() {
     fi
 }
 
+# shellcheck disable=2329
 cleanup () {
     if [ -n "$gettext_template_dir" ] && [ -e "$gettext_template_dir" ]; then
         rm -r "$gettext_template_dir"

--- a/build_tools/check.sh
+++ b/build_tools/check.sh
@@ -132,11 +132,11 @@ system_tests() (
 if $is_cygwin; then
     # shellcheck disable=2059
     printf "=== Running ${green}integration tests ${yellow}with${green} symlinks${reset}\n"
-    system_tests $cygwin_var=winsymlinks
+    system_tests "$cygwin_var"=winsymlinks
 
     # shellcheck disable=2059
     printf "=== Running ${green}integration tests ${yellow}without${green} symlinks${reset}\n"
-    system_tests $cygwin_var=winsymlinks
+    system_tests "$cygwin_var"=winsymlinks
 else
     # shellcheck disable=2059
     printf "=== Running ${green}integration tests${reset}\n"

--- a/build_tools/check.sh
+++ b/build_tools/check.sh
@@ -125,6 +125,7 @@ fi
 
 # Using "()" not "{}" because we do want a subshell (for the export)
 system_tests() (
+    # shellcheck disable=2163
     [ -n "$*" ] && export "$@"
     # shellcheck disable=2031
     export FISH_GETTEXT_EXTRACTION_DIR="$gettext_template_dir"

--- a/build_tools/check.sh
+++ b/build_tools/check.sh
@@ -130,13 +130,16 @@ system_tests() (
 )
 
 if $is_cygwin; then
-    echo -e "=== Running ${green}integration tests ${yellow}with${green} symlinks${reset}"
+    # shellcheck disable=2059
+    printf "=== Running ${green}integration tests ${yellow}with${green} symlinks${reset}\n"
     system_tests $cygwin_var=winsymlinks
 
-    echo -e "=== Running ${green}integration tests ${yellow}without${green} symlinks${reset}"
+    # shellcheck disable=2059
+    printf "=== Running ${green}integration tests ${yellow}without${green} symlinks${reset}\n"
     system_tests $cygwin_var=winsymlinks
 else
-    echo -e "=== Running ${green}integration tests${reset}"
+    # shellcheck disable=2059
+    printf "=== Running ${green}integration tests${reset}\n"
     system_tests
 fi
 

--- a/build_tools/check.sh
+++ b/build_tools/check.sh
@@ -129,7 +129,6 @@ system_tests() (
     "$workspace_root/tests/test_driver.py" "$build_dir"
 )
 
-test_cmd='FISH_GETTEXT_EXTRACTION_DIR="$gettext_template_dir" "$workspace_root/tests/test_driver.py" "$build_dir"'
 if $is_cygwin; then
     echo -e "=== Running ${green}integration tests ${yellow}with${green} symlinks${reset}"
     system_tests $cygwin_var=winsymlinks


### PR DESCRIPTION
Some of these things would have been caught if we had ShellCheck as part of our checks. I tried adding that in #11608, but that hasn't seen activity in a while. https://github.com/BurntSushi/ripgrep/commit/94ea38da3029347006ad0dcae4886c76b04d8d88 has been released, which might help with some of the concerns raised on the old PR.

In the code in `build_tools/check.sh`, I noticed that the Cygwin branch of the last if statement has two identical invocations of `system_tests`, whereas the messages printed before them claim some difference about symlinks. Looks like a bug. Maybe @Nahor wants to have a look at it.