### PR TITLE
highlight: implement Display trait for HighlightRole

### DIFF
--- a/src/builtins/fish_indent.rs
+++ b/src/builtins/fish_indent.rs
@@ -1206,39 +1206,6 @@ fn read_file(mut f: impl Read) -> Result<WString, ()> {
     Ok(bytes2wcstring(&buf))
 }
 
-fn highlight_role_to_string(role: HighlightRole) -> &'static wstr {
-    match role {
-        HighlightRole::normal => L!("normal"),
-        HighlightRole::error => L!("error"),
-        HighlightRole::command => L!("command"),
-        HighlightRole::keyword => L!("keyword"),
-        HighlightRole::statement_terminator => L!("statement_terminator"),
-        HighlightRole::param => L!("param"),
-        HighlightRole::option => L!("option"),
-        HighlightRole::comment => L!("comment"),
-        HighlightRole::search_match => L!("search_match"),
-        HighlightRole::operat => L!("operat"),
-        HighlightRole::escape => L!("escape"),
-        HighlightRole::quote => L!("quote"),
-        HighlightRole::redirection => L!("redirection"),
-        HighlightRole::autosuggestion => L!("autosuggestion"),
-        HighlightRole::selection => L!("selection"),
-        HighlightRole::pager_progress => L!("pager_progress"),
-        HighlightRole::pager_background => L!("pager_background"),
-        HighlightRole::pager_prefix => L!("pager_prefix"),
-        HighlightRole::pager_completion => L!("pager_completion"),
-        HighlightRole::pager_description => L!("pager_description"),
-        HighlightRole::pager_secondary_background => L!("pager_secondary_background"),
-        HighlightRole::pager_secondary_prefix => L!("pager_secondary_prefix"),
-        HighlightRole::pager_secondary_completion => L!("pager_secondary_completion"),
-        HighlightRole::pager_secondary_description => L!("pager_secondary_description"),
-        HighlightRole::pager_selected_background => L!("pager_selected_background"),
-        HighlightRole::pager_selected_prefix => L!("pager_selected_prefix"),
-        HighlightRole::pager_selected_completion => L!("pager_selected_completion"),
-        HighlightRole::pager_selected_description => L!("pager_selected_description"),
-    }
-}
-
 // Entry point for Pygments CSV output.
 // Our output is a newline-separated string.
 // Each line is of the form `start,end,role`
@@ -1281,14 +1248,7 @@ fn make_pygments_csv(src: &wstr) -> Vec<u8> {
     // Now render these to a string.
     let mut result = String::with_capacity(token_ranges.len() * 32);
     for range in token_ranges {
-        writeln!(
-            result,
-            "{},{},{}",
-            range.start,
-            range.end,
-            highlight_role_to_string(range.role)
-        )
-        .unwrap();
+        writeln!(result, "{},{},{}", range.start, range.end, range.role).unwrap();
     }
     result.into_bytes()
 }

--- a/src/highlight/highlight.rs
+++ b/src/highlight/highlight.rs
@@ -1301,6 +1301,47 @@ pub enum HighlightRole {
     pager_selected_description,
 }
 
+impl From<HighlightRole> for &'static str {
+    fn from(value: HighlightRole) -> Self {
+        match value {
+            HighlightRole::normal => "normal",
+            HighlightRole::error => "error",
+            HighlightRole::command => "command",
+            HighlightRole::keyword => "keyword",
+            HighlightRole::statement_terminator => "statement_terminator",
+            HighlightRole::param => "param",
+            HighlightRole::option => "option",
+            HighlightRole::comment => "comment",
+            HighlightRole::search_match => "search_match",
+            HighlightRole::operat => "operat",
+            HighlightRole::escape => "escape",
+            HighlightRole::quote => "quote",
+            HighlightRole::redirection => "redirection",
+            HighlightRole::autosuggestion => "autosuggestion",
+            HighlightRole::selection => "selection",
+            HighlightRole::pager_progress => "pager_progress",
+            HighlightRole::pager_background => "pager_background",
+            HighlightRole::pager_prefix => "pager_prefix",
+            HighlightRole::pager_completion => "pager_completion",
+            HighlightRole::pager_description => "pager_description",
+            HighlightRole::pager_secondary_background => "pager_secondary_background",
+            HighlightRole::pager_secondary_prefix => "pager_secondary_prefix",
+            HighlightRole::pager_secondary_completion => "pager_secondary_completion",
+            HighlightRole::pager_secondary_description => "pager_secondary_description",
+            HighlightRole::pager_selected_background => "pager_selected_background",
+            HighlightRole::pager_selected_prefix => "pager_selected_prefix",
+            HighlightRole::pager_selected_completion => "pager_selected_completion",
+            HighlightRole::pager_selected_description => "pager_selected_description",
+        }
+    }
+}
+
+impl std::fmt::Display for HighlightRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        <&'static str>::from(*self).fmt(f)
+    }
+}
+
 /// Simple value type describing how a character should be highlighted.
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub struct HighlightSpec {


### PR DESCRIPTION
### Summary

Remove the ad-hoc `highlight_role_to_string()` helper and replace it with an implementation on the `HighlightRole` enum itself.

### Benefits

Avoids unnecessary conversion through `wstr`.

### Changes

- Remove the ad-hoc `highlight_role_to_string()` helper
- Add `From<HighlightRole> for &'static str` and `Display` impl