### PR TITLE
set_color: document output more prominently

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -59,6 +59,7 @@ Other improvements
 - For compatibility with Bash, fish now accepts ``|&`` as alternate spelling of ``&|``, for piping both standard output and standard error (:issue:`11516`).
 - ``fish_indent`` now preserves comments and newlines immediately preceding a brace block (``{ }``) (:issue:`12505`).
 - A crash when suspending certain pipelines with :kbd:`ctrl-z` has been fixed (:issue:`12301`).
+- Improvements and corrections to the documentation (:issue:`12644`).
 
 For distributors and developers
 -------------------------------

--- a/doc_src/cmds/set_color.rst
+++ b/doc_src/cmds/set_color.rst
@@ -11,8 +11,10 @@ Synopsis
 Description
 -----------
 
-``set_color`` is used to control the color and styling of text in the terminal.
-*VALUE* describes that styling.
+``set_color`` controls the color and styling of text in the terminal.
+It writes non-printing color and text style escape sequences to standard output.
+
+*VALUE* describes the styling.
 *VALUE* can be a reserved color name like **red** or an RGB color value given as 3 or 6 hexadecimal digits ("F27" or "FF2277").
 A special keyword **normal** resets text formatting to terminal defaults, however it is not recommended and the **--reset** option is preferred as it is less confusing and more future-proof.
 
@@ -93,7 +95,9 @@ Notes
 3. Because of the risk of confusion, ``set_color --reset`` is recommended over ``set_color normal``.
 4. Setting the background color only affects subsequently written characters. Fish provides no way to set the background color for the entire terminal window. Configuring the window background color (and other attributes such as its opacity) has to be done using whatever mechanisms the terminal provides. Look for a config option.
 5. Some terminals use the ``--bold`` escape sequence to switch to a brighter color set rather than increasing the weight of text.
-6. ``set_color`` works by printing sequences of characters to standard output. If used in command substitution or a pipe, these characters will also be captured. This may or may not be desirable. Checking the exit status of ``isatty stdout`` before using ``set_color`` can be useful to decide not to colorize output in a script.
+6. If you use ``set_color`` in a command substitution or a pipe, these characters will also be captured.
+   This may or may not be desirable.
+   Checking the exit status of ``isatty stdout`` before using ``set_color`` can be useful to decide not to colorize output in a script.
 
 Examples
 --------


### PR DESCRIPTION
This change promotes the explanation of what `set_color` actually does from the very last note to the description.

I recently ran into the roughly the same misunderstanding described in https://github.com/fish-shell/fish-shell/issues/2378. Like the reporter of that issue, I also believed that `set_color` "set some internal shell state" and had much more magical behavior than it actually does. The changes to the documentation that stemmed from that report didn't help me avoid this misunderstanding—it was quite buried—so this is my attempt to help the next reader.

When making this change, I tried to honor some of the constraints from the original discussion, especially "keep[ing] the high-level 'it changes colors' as the first thing the user reads." I tried to lead with the user's intent, then follow it with _how_ `set_color` satisfies the intent.

## TODOs:
<!-- Check off what what has been done so far. -->
- [x] (n/a) If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [x] (n/a) Changes to fish usage are reflected in user documentation/manpages.
- [x] (n/a) Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
