### PR TITLE
highlight: derive Display trait for HighlightRole

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,6 +297,7 @@ dependencies = [
  "rsconf",
  "rust-embed",
  "serial_test",
+ "strum_macros",
  "unix_path",
  "xterm-color",
 ]
@@ -1014,6 +1015,18 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ rust-embed = { version = "8.11.0", features = [
     "interpolate-folder-path",
 ] }
 serial_test = { version = "3", default-features = false }
+strum_macros = "0.28.0"
 widestring = "1.2.0"
 unicode-segmentation = "1.12.0"
 unicode-width = "0.2.0"
@@ -128,6 +129,7 @@ num-traits.workspace = true
 once_cell.workspace = true
 pcre2.workspace = true
 rand.workspace = true
+strum_macros.workspace = true
 xterm-color.workspace = true
 
 [target.'cfg(not(target_has_atomic = "64"))'.dependencies]

--- a/src/highlight/highlight.rs
+++ b/src/highlight/highlight.rs
@@ -34,6 +34,7 @@ use fish_widestring::{
     WString, wstr,
 };
 use std::collections::{HashMap, hash_map::Entry};
+use strum_macros::Display;
 
 use super::file_tester::IsFile;
 
@@ -1264,7 +1265,7 @@ fn get_fallback(role: HighlightRole) -> HighlightRole {
 }
 
 /// Describes the role of a span of text.
-#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq, Display)]
 #[repr(u8)]
 pub enum HighlightRole {
     #[default]
@@ -1299,47 +1300,6 @@ pub enum HighlightRole {
     pager_selected_prefix,
     pager_selected_completion,
     pager_selected_description,
-}
-
-impl From<HighlightRole> for &'static str {
-    fn from(value: HighlightRole) -> Self {
-        match value {
-            HighlightRole::normal => "normal",
-            HighlightRole::error => "error",
-            HighlightRole::command => "command",
-            HighlightRole::keyword => "keyword",
-            HighlightRole::statement_terminator => "statement_terminator",
-            HighlightRole::param => "param",
-            HighlightRole::option => "option",
-            HighlightRole::comment => "comment",
-            HighlightRole::search_match => "search_match",
-            HighlightRole::operat => "operat",
-            HighlightRole::escape => "escape",
-            HighlightRole::quote => "quote",
-            HighlightRole::redirection => "redirection",
-            HighlightRole::autosuggestion => "autosuggestion",
-            HighlightRole::selection => "selection",
-            HighlightRole::pager_progress => "pager_progress",
-            HighlightRole::pager_background => "pager_background",
-            HighlightRole::pager_prefix => "pager_prefix",
-            HighlightRole::pager_completion => "pager_completion",
-            HighlightRole::pager_description => "pager_description",
-            HighlightRole::pager_secondary_background => "pager_secondary_background",
-            HighlightRole::pager_secondary_prefix => "pager_secondary_prefix",
-            HighlightRole::pager_secondary_completion => "pager_secondary_completion",
-            HighlightRole::pager_secondary_description => "pager_secondary_description",
-            HighlightRole::pager_selected_background => "pager_selected_background",
-            HighlightRole::pager_selected_prefix => "pager_selected_prefix",
-            HighlightRole::pager_selected_completion => "pager_selected_completion",
-            HighlightRole::pager_selected_description => "pager_selected_description",
-        }
-    }
-}
-
-impl std::fmt::Display for HighlightRole {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        <&'static str>::from(*self).fmt(f)
-    }
 }
 
 /// Simple value type describing how a character should be highlighted.


### PR DESCRIPTION
Follow-up to https://github.com/fish-shell/fish-shell/pull/12643

Replace the manual `Display` implementation for `HighlightRole` with a derived implementation using a proc-macro dependency ([`strum_macros`](https://docs.rs/strum_macros/0.28.0/strum_macros/)).