### PR TITLE
benchmark: fix unresolved import error

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -711,7 +711,7 @@ mod tests {
 #[cfg(test)]
 mod bench {
     extern crate test;
-    use crate::common::bytes2wcstring;
+    use fish_widestring::bytes2wcstring;
     use test::Bencher;
 
     #[bench]


### PR DESCRIPTION
Follow-up to https://github.com/fish-shell/fish-shell/pull/12625

```rust
error[E0432]: unresolved import `crate::common::bytes2wcstring`
   --> src/common.rs:714:9
    |
714 |     use crate::common::bytes2wcstring;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `bytes2wcstring` in `common`
```
