### PR TITLE
gate benchmark feature behind nightly cfg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,6 +296,7 @@ dependencies = [
  "rand",
  "rsconf",
  "rust-embed",
+ "rustc_version",
  "serial_test",
  "unix_path",
  "xterm-color",
@@ -890,6 +891,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,6 +928,12 @@ name = "sdd"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ rust-embed = { version = "8.11.0", features = [
     "include-exclude",
     "interpolate-folder-path",
 ] }
+rustc_version = "0.4.1"
 serial_test = { version = "3", default-features = false }
 widestring = "1.2.0"
 unicode-segmentation = "1.12.0"
@@ -156,6 +157,7 @@ fish-build-helper.workspace = true
 fish-gettext-mo-file-parser.workspace = true
 phf_codegen = { workspace = true, optional = true }
 rsconf.workspace = true
+rustc_version.workspace = true
 
 [target.'cfg(windows)'.build-dependencies]
 unix_path.workspace = true

--- a/build.rs
+++ b/build.rs
@@ -6,6 +6,10 @@ use rsconf::Target;
 use std::path::{Path, PathBuf};
 
 fn main() {
+    let is_nightly =
+        rustc_version::version_meta().unwrap().channel == rustc_version::Channel::Nightly;
+    rsconf::declare_cfg("nightly", is_nightly);
+
     setup_paths();
 
     // Add our default to enable tools that don't go through CMake, like "cargo test" and the

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -2889,7 +2889,7 @@ end
 }
 
 // Run with cargo +nightly bench --features=benchmark
-#[cfg(feature = "benchmark")]
+#[cfg(all(nightly, feature = "benchmark"))]
 #[cfg(test)]
 mod bench {
     extern crate test;

--- a/src/common.rs
+++ b/src/common.rs
@@ -707,7 +707,7 @@ mod tests {
     }
 }
 
-#[cfg(feature = "benchmark")]
+#[cfg(all(nightly, feature = "benchmark"))]
 #[cfg(test)]
 mod bench {
     extern crate test;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "benchmark", feature(test))]
+#![cfg_attr(all(nightly, feature = "benchmark"), feature(test))]
 #![allow(non_camel_case_types)]
 
 pub const BUILD_VERSION: &str = env!("FISH_BUILD_VERSION");


### PR DESCRIPTION
this allows clippy to run cleanly with `--all-features`:

```sh
cargo clippy --workspace --all-targets --all-features
```