### PR TITLE
config: use default XDG_DATA_DIRS when unset or empty

### DIFF
--- a/share/config.fish
+++ b/share/config.fish
@@ -34,13 +34,14 @@ set -l __extra_functionsdir
 set -l __extra_confdir
 status get-file __fish_build_paths.fish | source
 
-# Compute the directories for vendor configuration.  We want to include
-# all of XDG_DATA_DIRS, as well as the __extra_* dirs defined above.
-set -l xdg_data_dirs
-if set -q XDG_DATA_DIRS
+# Compute the directories for vendor configuration. We want to include
+# all of XDG_DATA_DIRS, or its default when unset or empty, as well as
+# the __extra_* dirs defined above.
+set -l xdg_data_dirs /usr/local/share /usr/share
+if set -q XDG_DATA_DIRS; and string length -q -- $XDG_DATA_DIRS[1]
     set --path xdg_data_dirs $XDG_DATA_DIRS
-    set xdg_data_dirs (string replace -r '([^/])/$' '$1' -- $xdg_data_dirs)/fish
 end
+set xdg_data_dirs (string replace -r '([^/])/$' '$1' -- $xdg_data_dirs)/fish
 
 set -g __fish_vendor_completionsdirs
 set -g __fish_vendor_functionsdirs

--- a/tests/checks/xdg-data-dirs-default.fish
+++ b/tests/checks/xdg-data-dirs-default.fish
@@ -1,0 +1,34 @@
+#RUN: fish=%fish %fish %s
+
+# Cygwin/MSYS path handling differs from the XDG fallback fish uses elsewhere.
+# REQUIRES: %fish -c "not __fish_is_cygwin"
+
+set -l dir (mktemp -d)
+mkdir -p $dir/xdg-config $dir/xdg-data $dir/xdg-cache $dir/xdg-runtime
+
+set -e FISH_UNIT_TESTS_RUNNING
+env HOME=$dir XDG_CONFIG_HOME=$dir/xdg-config XDG_DATA_HOME=$dir/xdg-data XDG_CACHE_HOME=$dir/xdg-cache XDG_RUNTIME_DIR=$dir/xdg-runtime $fish -c '
+    contains -- /usr/share/fish/vendor_functions.d $fish_function_path
+    and echo unset_function_path_has_usr_share
+    contains -- /usr/share/fish/vendor_completions.d $fish_complete_path
+    and echo unset_complete_path_has_usr_share
+    contains -- /usr/share/fish/vendor_conf.d $__fish_vendor_confdirs
+    and echo unset_vendor_conf_has_usr_share
+'
+# CHECK: unset_function_path_has_usr_share
+# CHECK: unset_complete_path_has_usr_share
+# CHECK: unset_vendor_conf_has_usr_share
+
+env HOME=$dir XDG_CONFIG_HOME=$dir/xdg-config XDG_DATA_HOME=$dir/xdg-data XDG_CACHE_HOME=$dir/xdg-cache XDG_RUNTIME_DIR=$dir/xdg-runtime XDG_DATA_DIRS= $fish -c '
+    contains -- /usr/share/fish/vendor_functions.d $fish_function_path
+    and echo empty_function_path_has_usr_share
+    contains -- /usr/share/fish/vendor_completions.d $fish_complete_path
+    and echo empty_complete_path_has_usr_share
+    contains -- /usr/share/fish/vendor_conf.d $__fish_vendor_confdirs
+    and echo empty_vendor_conf_has_usr_share
+'
+# CHECK: empty_function_path_has_usr_share
+# CHECK: empty_complete_path_has_usr_share
+# CHECK: empty_vendor_conf_has_usr_share
+
+rm -rf $dir


### PR DESCRIPTION
Fixes #11349.

When `XDG_DATA_DIRS` was unset or empty, `share/config.fish` skipped the XDG fallback entirely and only kept the build-time extra vendor directories. That dropped the standard `/usr/share/fish/vendor_*` paths from `fish_function_path`, `fish_complete_path`, and `__fish_vendor_confdirs`.

This initializes vendor directories from `/usr/local/share:/usr/share` and only overrides them when `XDG_DATA_DIRS` has a non-empty value. The new check covers both the unset and empty-string cases.

## Test plan

- `python3 tests/test_driver.py build tests/checks/xdg-data-dirs-default.fish tests/checks/default-setup-path.fish tests/checks/config-paths.fish`
- manual repro with `XDG_DATA_DIRS` unset and empty against `build/fish`