### PR TITLE
checks: run with all features enabled

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,6 +32,8 @@ jobs:
             features: ""
           - rust_version: "stable"
             features: "--no-default-features"
+          - rust_version: "stable"
+            features: "--all-features"
           - rust_version: "msrv"
             features: ""
     steps:

--- a/build_tools/check.sh
+++ b/build_tools/check.sh
@@ -99,7 +99,7 @@ if $lint; then
         cargo deny --all-features --locked --exclude-dev check licenses
     fi
     PATH="$build_dir:$PATH" cargo xtask format --all --check
-    for features in "" --no-default-features; do
+    for features in "" --no-default-features --all-features; do
         cargo clippy --workspace --all-targets $features
     done
 fi


### PR DESCRIPTION
As discussed in #12649, we should check builds with all Cargo features enabled. Previously, this did cause issues with the `benchmark` feature, since that only works with nightly Rust. #12653 resolves that by only enabling the `benchmark` feature with the nightly toolchain, so now we can use `--all-features` with stable Rust.