### PR TITLE
webconfig: Highlight table entries on hover

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Other improvements
 ------------------
 - History is no longer corrupted with NUL bytes when fish receives SIGTERM or SIGHUP (:issue:`10300`).
 - :doc:`fish_update_completions <cmds/fish_update_completions>` now handles groff ``\X'...'`` device control escapes, fixing completion generation for man pages produced by help2man 1.50 and later (such as coreutils 9.10).
+- Improve user experience when removing history entries via the :doc:`web-based config <cmds/fish_config>`.
 
 For distributors and developers
 -------------------------------

--- a/share/tools/web_config/fishconfig.css
+++ b/share/tools/web_config/fishconfig.css
@@ -56,6 +56,7 @@ tt {
 .tab:hover,
 #tab_contents .master_element:hover,
 .color_scheme_choice_container:hover,
+.data_table > tr:hover,
 .prompt_choices_list > .ng-scope:hover {
     background-color: #DDE;
 }
@@ -284,6 +285,7 @@ tt {
     width: 100%;
     padding-left: 10px;
     padding-right: 10px;
+    border-spacing: 0;
 }
 
 .data_table_row {}
@@ -310,7 +312,8 @@ tt {
 }
 
 .history_delete {
-    width: 20px;
+    width: 30px;
+    text-align: center;
 }
 
 .data_table_cell,


### PR DESCRIPTION
It's a bit cumbersome to remove history entries in the web interface, as you cannot tell if you're hovering over the correct item. This PR adds row highlighting on hover to history and other tables.

Preview:
<img width="1108" height="75" alt="Screenshot From 2026-04-20 10-58-03" src="https://github.com/user-attachments/assets/062e97b7-3de6-475a-aef4-f6e406c6e684" />


## TODOs:
<!-- Check off what what has been done so far. -->
- [ ] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
