### PR TITLE
ShellCheck xtask

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,19 @@ jobs:
     - name: check rustfmt
       run: find build.rs crates src -type f -name '*.rs' | xargs rustfmt --check
 
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2, build_tools/update-dependencies.sh
+    - uses: ./.github/actions/rust-toolchain@stable
+    - name: Update package database
+      run: sudo apt-get update
+    - name: Install deps
+      run: |
+        sudo apt install ripgrep shellcheck
+    - name: shellcheck
+      run: |
+        cargo xtask shellcheck
 
   clippy:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -523,6 +548,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +587,12 @@ dependencies = [
  "getrandom 0.3.4",
  "libc",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -1195,6 +1242,9 @@ dependencies = [
  "clap",
  "fish-build-helper",
  "fish-tempfile",
+ "ignore",
+ "lazy_static",
+ "pcre2",
  "walkdir",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,9 @@ fish-wcstringutil = { path = "crates/wcstringutil" }
 fish-widecharwidth = { path = "crates/widecharwidth" }
 fish-widestring = { path = "crates/widestring" }
 fish-wgetopt = { path = "crates/wgetopt" }
+ignore = "0.4.25"
 itertools = "0.14.0"
+lazy_static = "1.5.0"
 libc = "0.2.177"
 # lru pulls in hashbrown by default, which uses a faster (though less DoS resistant) hashing algo.
 # disabling default features uses the stdlib instead, but it doubles the time to rewrite the history

--- a/build_tools/check.sh
+++ b/build_tools/check.sh
@@ -98,6 +98,9 @@ if $lint; then
     if command -v cargo-deny >/dev/null; then
         cargo deny --all-features --locked --exclude-dev check licenses
     fi
+
+    cargo xtask shellcheck
+
     PATH="$build_dir:$PATH" cargo xtask format --all --check
     for features in "" --no-default-features --all-features; do
         cargo clippy --workspace --all-targets $features

--- a/build_tools/check.sh
+++ b/build_tools/check.sh
@@ -60,7 +60,7 @@ cargo() {
     fi
 }
 
-# shellcheck disable=2329
+# shellcheck disable=2317,2329
 cleanup () {
     if [ -n "$gettext_template_dir" ] && [ -e "$gettext_template_dir" ]; then
         rm -r "$gettext_template_dir"

--- a/build_tools/make_tarball.sh
+++ b/build_tools/make_tarball.sh
@@ -16,7 +16,7 @@ manifest=$tmpdir/Cargo.toml
 lockfile=$tmpdir/Cargo.lock
 
 sed "s/^version = \".*\"\$/version = \"$VERSION\"/g" Cargo.toml >"$manifest"
-awk -v version=$VERSION '
+awk -v version="$VERSION" '
     /^name = "fish"$/ { ok=1 }
     ok == 1 && /^version = ".*"$/ {
         ok = 2;

--- a/build_tools/release-notes.sh
+++ b/build_tools/release-notes.sh
@@ -86,10 +86,13 @@ if test -z "$CI" || [ "$(git -C "$workspace_root" tag | wc -l)" -gt 1 ]; then {
     echo
     echo 'Download links:'
     echo 'To download the source code for fish, we suggest the file named ``fish-'"$version"'.tar.xz``.'
+    # shellcheck disable=2016
     echo 'The file downloaded from ``Source code (tar.gz)`` will not build correctly.'
+    # shellcheck disable=2016
     echo 'A GPG signature using `this key <'"${FISH_GPG_PUBLIC_KEY_URL:-???}"'>`__ is available as ``fish-'"$version"'.tar.xz.asc``.'
     echo
     echo 'The files called ``fish-'"$version"'-linux-*.tar.xz`` contain'
+    # shellcheck disable=2016
     echo '`standalone fish binaries <https://github.com/fish-shell/fish-shell/?tab=readme-ov-file#building-fish-with-cargo>`__'
     echo 'for any Linux with the given CPU architecture.'
 } >"$relnotes_tmp/fake-workspace"/CHANGELOG.rst

--- a/build_tools/release.sh
+++ b/build_tools/release.sh
@@ -72,7 +72,7 @@ integration_branch=$(
         --format='%(refname:strip=2)'
 )
 [ -n "$integration_branch" ] ||
-    git merge-base --is-ancestor $remote/master HEAD
+    git merge-base --is-ancestor "$remote"/master HEAD
 
 sed -n 1p CHANGELOG.rst | grep -q '^fish .*(released .*)$'
 sed -n 2p CHANGELOG.rst | grep -q '^===*$'
@@ -113,9 +113,9 @@ CreateCommit "Release $version"
 # Tags must be full objects, not lightweight tags, for
 # git_version-gen.sh to work.
 git -c "user.signingKey=$committer" \
-    tag --sign --message="Release $version" $version
+    tag --sign --message="Release $version" "$version"
 
-git push $remote $version
+git push "$remote" "$version"
 
 TIMEOUT=
 gh() {
@@ -173,6 +173,7 @@ actual_tag_oid=$(git ls-remote "$remote" |
 (
     cd "$tmpdir/local-tarball/fish-$version"
     uv --no-managed-python venv
+    # shellcheck disable=1091
     . .venv/bin/activate
     cmake -GNinja -DCMAKE_BUILD_TYPE=Debug .
     ninja doc
@@ -180,14 +181,17 @@ actual_tag_oid=$(git ls-remote "$remote" |
 CopyDocs() {
     rm -rf "$fish_site/site/docs/$1"
     cp -r "$tmpdir/local-tarball/fish-$version/cargo/fish-docs/html" "$fish_site/site/docs/$1"
-    git -C $fish_site add "site/docs/$1"
+    git -C "$fish_site" add "site/docs/$1"
 }
 minor_version=${version%.*}
 CopyDocs "$minor_version"
 latest_release=$(
     releases=$(git tag | grep '^[0-9]*\.[0-9]*\.[0-9]*.*' |
-        sed $(: "De-prioritize release candidates (1.2.3-rc0)") \
-        's/-/~/g' | LC_ALL=C sort --version-sort)
+        sed '
+            # De-prioritize release candidates (1.2.3-rc0)
+            s/-/~/g
+        ' | LC_ALL=C sort --version-sort
+    )
     printf %s\\n "$releases" | tail -1
 )
 if [ "$version" = "$latest_release" ]; then
@@ -272,7 +276,7 @@ done
 )
 
 if [ -n "$integration_branch" ]; then {
-    git push $remote "$version^{commit}":refs/heads/$integration_branch
+    git push "$remote" "$version^{commit}:refs/heads/$integration_branch"
 } else {
     changelog=$(cat - CHANGELOG.rst <<EOF
 fish ?.?.? (released ???)
@@ -283,7 +287,7 @@ EOF
     printf %s\\n "$changelog" >CHANGELOG.rst
     git add CHANGELOG.rst
     CreateCommit "start new cycle"
-    git push $remote HEAD:master
+    git push "$remote" HEAD:master
 } fi
 
 milestone_version="$(

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -10,4 +10,7 @@ anstyle.workspace = true
 clap.workspace = true
 fish-build-helper.workspace = true
 fish-tempfile.workspace = true
+ignore.workspace = true
+lazy_static.workspace = true
+pcre2.workspace = true
 walkdir.workspace = true

--- a/crates/xtask/src/lib.rs
+++ b/crates/xtask/src/lib.rs
@@ -14,6 +14,7 @@ macro_rules! fail {
 }
 
 pub mod format;
+pub mod shellcheck;
 
 pub trait CommandExt {
     fn run_or_fail(&mut self);

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1,7 +1,7 @@
 use clap::{Parser, Subcommand};
 use fish_build_helper::as_os_strs;
 use std::{path::PathBuf, process::Command};
-use xtask::{CommandExt as _, cargo, format::FormatArgs};
+use xtask::{CommandExt as _, cargo, format::FormatArgs, shellcheck::shellcheck};
 
 #[derive(Parser)]
 #[command(
@@ -28,6 +28,9 @@ enum Task {
     },
     /// Build man pages
     ManPages,
+    /// run ShellCheck on non-fish shell scripts
+    #[command(name = "shellcheck")]
+    ShellCheck,
 }
 
 fn main() {
@@ -37,6 +40,7 @@ fn main() {
         Task::Format(format_args) => xtask::format::format(format_args),
         Task::HtmlDocs { fish_indent } => build_html_docs(fish_indent),
         Task::ManPages => cargo(["build", "--package", "fish-build-man-pages"]),
+        Task::ShellCheck => shellcheck(),
     }
 }
 

--- a/crates/xtask/src/shellcheck.rs
+++ b/crates/xtask/src/shellcheck.rs
@@ -1,0 +1,50 @@
+use fish_build_helper::workspace_root;
+use ignore::Walk;
+use lazy_static::lazy_static;
+use pcre2::bytes::Regex;
+use std::{
+    fs::File,
+    io::{BufRead, BufReader},
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+pub fn shellcheck() {
+    let file_paths = files_to_check();
+    match Command::new("shellcheck")
+        .args(file_paths)
+        .current_dir(workspace_root())
+        .status()
+    {
+        Ok(status) => {
+            std::process::exit(status.code().unwrap_or(1));
+        }
+        Err(e) => {
+            eprintln!("Failed to run shellcheck: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn is_shell_script<P: AsRef<Path>>(path: P) -> bool {
+    let file = File::open(&path).unwrap();
+    let mut first_line = String::new();
+    let Ok(_) = BufReader::new(file).read_line(&mut first_line) else {
+        return false;
+    };
+    lazy_static! {
+        static ref SHEBANG_REGEX: Regex = Regex::new("^#!.*[^i]sh").unwrap();
+    }
+    SHEBANG_REGEX
+        .is_match(first_line.trim().as_bytes())
+        .unwrap()
+}
+
+fn files_to_check() -> Vec<PathBuf> {
+    Walk::new(workspace_root())
+        .map(|path| path.unwrap_or_else(|e| fail!("Error traversing workspace: {e}")))
+        .filter(|path| path.file_type().unwrap().is_file())
+        .map(|path| path.into_path())
+        .filter(|path| is_shell_script(path))
+        .collect()
+}

--- a/vagrants/bsds/build_fish_on_bsd.sh
+++ b/vagrants/bsds/build_fish_on_bsd.sh
@@ -8,7 +8,6 @@ set -e
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 if [ $# -eq 0 ]; then


### PR DESCRIPTION
Refresh of #11608. Implement running ShellCheck via an xtask. The new approach reduces the implementation complexity by getting rid of state and instead recomputes the list of files to check each time by invoking ripgrep, or grep if ripgrep is not available. Recent versions of ripgrep, starting with 15.0.0 (released 2025-10-16) have improved handling for jj repos, so custom ignore files should be less of an issue now than when this approach was first proposed. For grep, I just added manual excludes for VCS and build directories. With that, both tools are fast enough that there is no point in caching their results, which removes the need to handle cache updates.

## TODOs:
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] User-visible changes noted in CHANGELOG.rst
