### PR TITLE
Avoid losing work in funced when no changes between parse errors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Other improvements
 - History is no longer corrupted with NUL bytes when fish receives SIGTERM or SIGHUP (:issue:`10300`).
 - :doc:`fish_update_completions <cmds/fish_update_completions>` now handles groff ``\X'...'`` device control escapes, fixing completion generation for man pages produced by help2man 1.50 and later (such as coreutils 9.10).
 - Improve user experience when removing history entries via the :doc:`web-based config <cmds/fish_config>`.
+- funced will no longer lose work if there are parse errors multiple times without new changes to the file
 
 For distributors and developers
 -------------------------------

--- a/share/functions/funced.fish
+++ b/share/functions/funced.fish
@@ -91,9 +91,8 @@ function funced --description 'Edit function definition'
     # Repeatedly edit until it either parses successfully, or the user cancels
     # If the editor command itself fails, we assume the user cancelled or the file
     # could not be edited, and we do not try again
+    set -l checksum (__fish_md5 "$tmpname")
     while true
-        set -l checksum (__fish_md5 "$tmpname")
-
         if not $editor $tmpname
             echo (_ "Editing failed or was cancelled")
         else


### PR DESCRIPTION
From the inital dd69ca5 commit that started checking if the file was modified the initial checksum to compare against has been updated in the loop, causing funced to lose work silently if you get a parse error, can't find the issue, and want to look at the error message again.

I didn't make an issue since the fix is simple and seems to clearly be the intended behvaior.  There don't seem to be tests for funced at the moment and since the change is simple and I am slow hopefully it can just be fixed.