### PR TITLE
Fix wget completion flag

### DIFF
--- a/share/completions/wget.fish
+++ b/share/completions/wget.fish
@@ -11,7 +11,7 @@ complete -c wget -s a -l append-output -d "Append all messages to logfile"
 complete -c wget -s d -l debug -d "Turn on debug output"
 complete -c wget -s q -l quiet -d "Quiet mode"
 complete -c wget -s v -l verbose -d "Verbose mode"
-complete -c wget -l non-verbose -d "Turn off verbose without being completely quiet"
+complete -c wget -l no-verbose -d "Turn off verbose without being completely quiet"
 complete -c wget -o nv -d "Turn off verbose without being completely quiet"
 complete -c wget -s i -l input-file -d "Read URLs from file" -r
 complete -c wget -s F -l force-html -d "Force input to be treated as HTML"


### PR DESCRIPTION
It seems that `wget` [drop](https://forums.gentoo.org/viewtopic-p-2818438.html?sid=3f4491c241e9e59465cbff57e2fb4c1d) the `--non-verbose` flag in _Wget 1.10, released June 2005_, since then it is called `--no-verbose`.
