### PR TITLE
Add fish_trace_depth

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Interactive improvements
 Improved terminal support
 -------------------------
 
+Scripting improvements
+----------------------
+- :envvar:`fish_trace_depth` can be set to limit the number of levels that :envvar:`fish_trace` will print. Setting it to 0 will only show top-level commands.
+
 Other improvements
 ------------------
 - History is no longer corrupted with NUL bytes when fish receives SIGTERM or SIGHUP (:issue:`10300`).

--- a/doc_src/fish_for_bash_users.rst
+++ b/doc_src/fish_for_bash_users.rst
@@ -453,7 +453,6 @@ By now it has become apparent that fish puts much more of a focus on its builtin
 Other facilities
 ----------------
 
-Bash has ``set -x`` or ``set -o xtrace`` to print all commands that are being executed. In fish, this would be enabled by setting :envvar:`fish_trace`.
+Bash has ``set -x`` or ``set -o xtrace`` to print all commands that are being executed. In fish, this would be enabled by setting :envvar:`fish_trace`. :envvar:`fish_trace_depth` can also be set to limit the number of levels printed.
 
 Or, if your intention is to *profile* how long each line of a script takes, you can use ``fish --profile`` - see the :doc:`page for the fish command <cmds/fish>`.
-

--- a/doc_src/language.rst
+++ b/doc_src/language.rst
@@ -1630,6 +1630,11 @@ You can change the settings of fish by changing the values of certain variables.
    It goes to stderr by default.
    Set it to ``all`` to also trace execution of key bindings, event handlers as well as prompt and title functions.
 
+.. envvar:: fish_trace_depth
+
+   if set to a nonnegative integer, will limit the number of levels printed by :envvar:`fish_trace`.
+   The first level is '0' which will print only top-level commands.
+
 .. envvar:: FISH_DEBUG
 
    Controls which debug categories :command:`fish` enables for output, analogous to the ``--debug`` option.

--- a/share/completions/set.fish
+++ b/share/completions/set.fish
@@ -73,6 +73,7 @@ function __fish_complete_special_vars
         fish_term24bit "set to 0 to use the color palette instead of true-colors" \
         fish_term256 "set to 0 to use the 16-color palette instead of 256" \
         fish_trace "Enables execution tracing (if set to non-empty value)" \
+        fish_trace_depth "How many levels deep to trace execution with fish_trace" \
         fish_transient_prompt "set to 1 to re-run prompts before pushing them to scrollback" \
         fish_user_paths "A list of dirs to prepend to PATH"
     __fish_complete_special_vars_ifndef fish_color_option 'defaults to $fish_color_param'

--- a/src/env_dispatch.rs
+++ b/src/env_dispatch.rs
@@ -84,6 +84,7 @@ static VAR_DISPATCH_TABLE: once_cell::sync::Lazy<VarDispatchTable> =
             vars!(handle_fish_use_posix_spawn_change),
         );
         table.add_anon(L!("fish_trace"), vars!(handle_fish_trace));
+        table.add_anon(L!("fish_trace_depth"), vars!(handle_fish_trace_depth));
         table.add_anon(
             L!("fish_cursor_selection_mode"),
             vars!(handle_fish_cursor_selection_mode_change),
@@ -347,6 +348,22 @@ fn handle_fish_trace(vars: &EnvStack) {
     );
 }
 
+fn handle_fish_trace_depth(vars: &EnvStack) {
+    let Some(depth_str) = vars.get(L!("fish_trace_depth")) else {
+        crate::trace::trace_set_depth_default();
+        return;
+    };
+    let Some(new_depth) = fish_wcstoi(&depth_str.as_string())
+        .ok()
+        .and_then(|v| usize::try_from(v).ok())
+    else {
+        flog!(env_dispatch, "Invalid trace depth, using default");
+        crate::trace::trace_set_depth_default();
+        return;
+    };
+    crate::trace::trace_set_depth(new_depth);
+}
+
 pub fn env_dispatch_init(vars: &EnvStack) {
     use once_cell::sync::Lazy;
 
@@ -367,6 +384,7 @@ fn run_inits(vars: &EnvStack) {
     handle_read_limit_change(vars);
     handle_fish_use_posix_spawn_change(vars);
     handle_fish_trace(vars);
+    handle_fish_trace_depth(vars);
 }
 
 /// Updates our idea of whether we support term256 and term24bit (see issue #10222).

--- a/src/global_safety.rs
+++ b/src/global_safety.rs
@@ -1,7 +1,7 @@
 use crate::flog::flog;
 use std::cell::{Ref, RefMut};
 use std::sync::MutexGuard;
-use std::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicUsize, Ordering};
 
 #[derive(Debug, Default)]
 pub struct RelaxedAtomicBool(AtomicBool);
@@ -24,6 +24,30 @@ impl RelaxedAtomicBool {
 impl Clone for RelaxedAtomicBool {
     fn clone(&self) -> Self {
         Self(AtomicBool::new(self.load()))
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct RelaxedAtomicUsize(AtomicUsize);
+
+impl RelaxedAtomicUsize {
+    pub const fn new(value: usize) -> Self {
+        Self(AtomicUsize::new(value))
+    }
+    pub fn load(&self) -> usize {
+        self.0.load(Ordering::Relaxed)
+    }
+    pub fn store(&self, value: usize) {
+        self.0.store(value, Ordering::Relaxed);
+    }
+    pub fn swap(&self, value: usize) -> usize {
+        self.0.swap(value, Ordering::Relaxed)
+    }
+}
+
+impl Clone for RelaxedAtomicUsize {
+    fn clone(&self) -> Self {
+        Self(AtomicUsize::new(self.load()))
     }
 }
 

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -1,14 +1,28 @@
 use crate::{
-    flog::log_extra_to_flog_file, global_safety::RelaxedAtomicBool, parser::Parser, prelude::*,
+    flog::log_extra_to_flog_file,
+    global_safety::{RelaxedAtomicBool, RelaxedAtomicUsize},
+    parser::Parser,
+    prelude::*,
 };
 use fish_common::escape;
 
 static DO_TRACE: RelaxedAtomicBool = RelaxedAtomicBool::new(false);
 static DO_TRACE_ALL: RelaxedAtomicBool = RelaxedAtomicBool::new(false);
 
+const TRACE_DEPTH_DEFAULT: usize = usize::MAX;
+static TRACE_DEPTH: RelaxedAtomicUsize = RelaxedAtomicUsize::new(TRACE_DEPTH_DEFAULT);
+
 pub fn trace_set_enabled(enable: Vec<WString>) {
     DO_TRACE.store(!enable.is_empty());
     DO_TRACE_ALL.store(enable.iter().any(|s| s == "all"));
+}
+
+pub fn trace_set_depth(depth: usize) {
+    TRACE_DEPTH.store(depth);
+}
+
+pub fn trace_set_depth_default() {
+    TRACE_DEPTH.store(TRACE_DEPTH_DEFAULT);
 }
 
 /// return whether tracing is enabled.
@@ -25,9 +39,16 @@ pub fn trace_enabled(parser: &Parser) -> bool {
 /// Trace an "argv": a list of arguments where the first is the command.
 // Allow the `&Vec` parameter as this function only exists temporarily for the FFI
 pub fn trace_argv<S: AsRef<wstr>>(parser: &Parser, command: &wstr, args: &[S]) {
+    let current_depth = parser.blocks_size() - 1;
+
+    // If the user requested traces only to a given depth, we may stop early.
+    if current_depth > TRACE_DEPTH.load() {
+        return;
+    }
+
     // Format into a string to prevent interleaving with flog in other threads.
     // Add the + prefix.
-    let mut trace_text = L!("-").repeat(parser.blocks_size() - 1);
+    let mut trace_text = L!("-").repeat(current_depth);
     trace_text.push('>');
 
     if !command.is_empty() {

--- a/tests/checks/trace.fish
+++ b/tests/checks/trace.fish
@@ -65,6 +65,220 @@ end
 # CHECKERR: -> echo inside3
 # CHECKERR: > end if
 
+# Now check tracing with a limited trace depth.
+# First, we set depth high enough to show everything.
+
+set fish_trace_depth 2
+# CHECKERR: > set fish_trace_depth 2
+
+for i in 1 2
+    for j in a b
+        echo $i $j
+    end
+end
+
+# CHECK: 1 a
+# CHECK: 1 b
+# CHECK: 2 a
+# CHECK: 2 b
+
+# CHECKERR: > for 1 2
+# CHECKERR: -> for a b
+# CHECKERR: --> echo 1 a
+# CHECKERR: --> echo 1 b
+# CHECKERR: -> end for
+# CHECKERR: -> for a b
+# CHECKERR: --> echo 2 a
+# CHECKERR: --> echo 2 b
+# CHECKERR: -> end for
+# CHECKERR: > end for
+
+# Next, we limit depth by one step so it doesn't show the inner commands.
+
+set fish_trace_depth 1
+# CHECKERR: > set fish_trace_depth 1
+
+for i in 1 2
+    for j in a b
+        echo $i $j
+    end
+end
+
+# CHECK: 1 a
+# CHECK: 1 b
+# CHECK: 2 a
+# CHECK: 2 b
+
+# CHECKERR: > for 1 2
+# CHECKERR: -> for a b
+# CHECKERR: -> end for
+# CHECKERR: -> for a b
+# CHECKERR: -> end for
+# CHECKERR: > end for
+
+# Finally, we limit depth fully so it only shows the outermost commands.
+
+set fish_trace_depth 0
+# CHECKERR: > set fish_trace_depth 0
+
+for i in 1 2
+    for j in a b
+        echo $i $j
+    end
+end
+
+# CHECK: 1 a
+# CHECK: 1 b
+# CHECK: 2 a
+# CHECK: 2 b
+
+# CHECKERR: > for 1 2
+# CHECKERR: > end for
+
+# Now test setting the depth based on a specific context we care about.
+
+set fish_trace_depth 0
+# CHECKERR: > set fish_trace_depth 0
+
+for i in 1 2 3
+    if test "$i" -eq 2
+        set fish_trace_depth 10
+    else
+        set fish_trace_depth 0
+    end
+
+    for j in a b
+        echo $i $j
+    end
+end
+
+# CHECK: 1 a
+# CHECK: 1 b
+# CHECK: 2 a
+# CHECK: 2 b
+# CHECK: 3 a
+# CHECK: 3 b
+
+# i=1 only shows the outermost command because depth stays 0
+# CHECKERR: > for 1 2 3
+
+# i=2 picks up again after setting depth to 10
+# CHECKERR: -> end if
+# CHECKERR: -> for a b
+# CHECKERR: --> echo 2 a
+# CHECKERR: --> echo 2 b
+# CHECKERR: -> end for
+
+# i=3 shows depth being set back to 0 and then no more inside the loop
+# CHECKERR: -> if
+# CHECKERR: -> test 3 -eq 2
+# CHECKERR: -> else
+# CHECKERR: --> set fish_trace_depth 0
+# CHECKERR: > end for
+
+# Now, test increasing the depth after exceeding the previous depth. We set
+# depth in a local scope so it's automatically reset.
+
+set fish_trace_depth 1
+{
+    {
+        {
+            set --local fish_trace_depth 10
+            {
+                true
+            }
+        }
+    }
+}
+
+# CHECKERR: > set fish_trace_depth 1
+# These print because of the initial depth of 1.
+# CHECKERR: > begin
+# CHECKERR: -> begin
+# Then we jump to the entries that only print after depth is set to 10.
+# CHECKERR: ---> begin
+# CHECKERR: ----> true
+# CHECKERR: ---> end begin
+# The locally set depth of 10 goes out of scope here, so we don't see the
+# intermediate "end if", only the entries from the original depth of 1.
+# CHECKERR: -> end begin
+# CHECKERR: > end begin
+
+# Test that erasing fish_trace_depth does return to the default.
+
+set fish_trace_depth 0
+set -e fish_trace_depth
+{ { true } }
+# CHECKERR: > set fish_trace_depth 0
+# CHECKERR: > set -e fish_trace_depth
+# CHECKERR: > begin
+# CHECKERR: -> begin
+# CHECKERR: --> true
+# CHECKERR: -> end begin
+# CHECKERR: > end begin
+
+# Test some invalid depth values. They should be ignored, and tracing should
+# proceed as if no depth was given, i.e. show everything.
+
+# Set to a low value first to confirm that invalid values return to the default.
+set fish_trace_depth 0
+set fish_trace_depth a
+{ { { } } }
+
+# CHECKERR: > set fish_trace_depth 0
+# CHECKERR: > set fish_trace_depth a
+# CHECKERR: > begin
+# CHECKERR: -> begin
+# CHECKERR: --> begin
+# CHECKERR: --> end begin
+# CHECKERR: -> end begin
+# CHECKERR: > end begin
+
+# Set to a low value first to confirm that invalid values return to the default.
+set fish_trace_depth 0
+set fish_trace_depth -1
+{ { { } } }
+
+# CHECKERR: > set fish_trace_depth 0
+# CHECKERR: > set fish_trace_depth -1
+# CHECKERR: > begin
+# CHECKERR: -> begin
+# CHECKERR: --> begin
+# CHECKERR: --> end begin
+# CHECKERR: -> end begin
+# CHECKERR: > end begin
+
+# Set to a low value first to confirm that invalid values return to the default.
+set fish_trace_depth 0
+# u64 max + 1
+set fish_trace_depth 18446744073709551616
+{ { { } } }
+
+# CHECKERR: > set fish_trace_depth 0
+# CHECKERR: > set fish_trace_depth 18446744073709551616
+# CHECKERR: > begin
+# CHECKERR: -> begin
+# CHECKERR: --> begin
+# CHECKERR: --> end begin
+# CHECKERR: -> end begin
+# CHECKERR: > end begin
+
+# Set to a low value first to confirm that invalid values return to the default.
+set fish_trace_depth 0
+set fish_trace_depth ''
+{ { { } } }
+
+# CHECKERR: > set fish_trace_depth 0
+# CHECKERR: > set fish_trace_depth ''
+# CHECKERR: > begin
+# CHECKERR: -> begin
+# CHECKERR: --> begin
+# CHECKERR: --> end begin
+# CHECKERR: -> end begin
+# CHECKERR: > end begin
+
+# Finally, make sure we can end tracing and see no more stderr.
+
 set -e fish_trace
 # CHECKERR: > set -e fish_trace
 


### PR DESCRIPTION
This allows limiting the depth to which fish_trace will trace execution. For example, setting it to 0 will only print top-level commands, a value of 1 will print commands inside a for loop from the top level, etc.

Fixes #9069



## TODOs:
<!-- Check off what what has been done so far. -->
- [x] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
