### PR TITLE
`fish_title`: Don't pass default options to `prompt_pwd`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Other improvements
 - :doc:`fish_update_completions <cmds/fish_update_completions>` now handles groff ``\X'...'`` device control escapes, fixing completion generation for man pages produced by help2man 1.50 and later (such as coreutils 9.10).
 - Improve user experience when removing history entries via the :doc:`web-based config <cmds/fish_config>`.
 - :doc:`funced <cmds/funced>` will no longer lose work if there are parse errors multiple times without new changes to the file
+- The default title no longer overrides ``$fish_prompt_pwd_dir_length`` and ``$fish_prompt_pwd_full_dirs``.
 
 For distributors and developers
 -------------------------------

--- a/share/functions/fish_title.fish
+++ b/share/functions/fish_title.fish
@@ -6,13 +6,13 @@ function fish_title
     # An override for the current command is passed as the first parameter.
     # This is used by `fg` to show the true process name, among others.
     if set -q argv[1]
-        echo -- $ssh (string sub -l 20 -- $argv[1]) (prompt_pwd -d 1 -D 1)
+        echo -- $ssh (string sub -l 20 -- $argv[1]) (prompt_pwd)
     else
         # Don't print "fish" because it's redundant
         set -l command (status current-command)
         if test "$command" = fish
             set command
         end
-        echo -- $ssh (string sub -l 20 -- $command) (prompt_pwd -d 1 -D 1)
+        echo -- $ssh (string sub -l 20 -- $command) (prompt_pwd)
     end
 end


### PR DESCRIPTION
The `-d 1 -D 1` options (which happen to be `prompt_pwd`'s defaults) override user customization ($fish_prompt_pwd_dir_length and $fish_prompt_pwd_full_dirs).

Don't pass the options so the default `fish_title` can be customized using $fish_prompt_pwd_dir_length and $fish_prompt_pwd_full_dirs.

## TODOs:

- [ ] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst