### PR TITLE
config: gate default-theme selection on __fish_initialized

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Improved terminal support
 
 Other improvements
 ------------------
+- Non-interactive shell startup is faster: ``fish_config theme choose default --no-override`` at the end of ``share/config.fish`` is now skipped when the ``__fish_initialized`` universal variable is already set, avoiding a re-parse of ``share/functions/fish_config/default.theme`` on every invocation. A fresh shell (no ``__fish_initialized`` universal yet) still runs it and seeds the default theme as before.
 - History is no longer corrupted with NUL bytes when fish receives SIGTERM or SIGHUP (:issue:`10300`).
 - :doc:`fish_update_completions <cmds/fish_update_completions>` now handles groff ``\X'...'`` device control escapes, fixing completion generation for man pages produced by help2man 1.50 and later (such as coreutils 9.10).
 - Improve user experience when removing history entries via the :doc:`web-based config <cmds/fish_config>`.

--- a/share/config.fish
+++ b/share/config.fish
@@ -207,7 +207,14 @@ end
 if status is-interactive
     __fish_migrate
 end
-fish_config theme choose default --no-override
+# Default-theme selection re-parses share/functions/fish_config/default.theme on
+# every startup and is expensive even though --no-override makes the final set
+# operations no-ops when color variables already exist. Gate on the universal
+# variable fish itself sets during first-time initialization so subsequent
+# startups skip this work. Fresh shells (no __fish_initialized universal) still
+# run it and seed the default theme as before.
+set -q __fish_initialized
+or fish_config theme choose default --no-override
 
 # As last part of initialization, source the conf directories.
 # Implement precedence (User > Admin > Extra (e.g. vendors) > Fish) by basically doing "basename".


### PR DESCRIPTION
## Summary

`share/config.fish` currently ends with an unconditional call to `fish_config theme choose default --no-override`, which re-parses `share/functions/fish_config/default.theme` on every shell startup. The `--no-override` flag makes the final `set` operations no-ops once color variables already exist, but the parse itself still runs and dominates non-interactive startup cost (~20 ms on a Linux laptop; measured with `hyperfine --warmup 5 'fish -c exit'` and `fish --profile-startup=...`).

This gates the call on the `__fish_initialized` universal variable fish itself sets during first-run initialization. After the first-ever startup for a user, the universal exists and subsequent invocations skip the theme parse entirely.

## Behaviour

- **Fresh user** (no `__fish_initialized` universal yet): unchanged — the theme-choose call runs and seeds the default theme as before, and fish sets `__fish_initialized` during its own init.
- **Existing user** (`__fish_initialized` already set): theme-choose is skipped; existing color variables (universal or fallback) remain in effect.
- **User explicitly wipes `fish_variables`**: treated as a fresh user on next launch — initial-run behaviour is restored.
- No change to `fish_config theme save ...`, `fish_config theme choose <non-default>`, `fish_config browse`, or any other subcommand.

## Measurements

```
# fish 4.6.0, Linux, minimal user config.fish
hyperfine --warmup 5 'fish -c exit'
  before: 37.9 ms ±  4.4
  after:  ~17 ms  (delta = entire theme-choose subtree, confirmed via --profile-startup)
```

The profile line

```
2577      22886 > fish_config theme choose default --no-override
```

collapses to a single `set -q` check after the gate.

## Notes

- This is a small stop-gap compatible with the direction in 190d367b (move color vars to globals, migrate saved themes to `~/.config/fish/conf.d/fish_frozen_theme.fish`). Happy to close this if `update-default-theme` is landing soon and subsumes it.
- CHANGELOG.rst entry added under "Other improvements".

## Test plan

- [x] Syntax-check: `fish -n share/config.fish`
- [x] Manual sanity: toggle `__fish_initialized` on/off and confirm gate behaviour matches expectation
- [ ] Existing test suite (I don't have a fish build environment handy — happy to run if reviewer flags a specific target)