### PR TITLE
Heightenize

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,8 @@ Other improvements
 - History is no longer corrupted with NUL bytes when fish receives SIGTERM or SIGHUP (:issue:`10300`).
 - :doc:`fish_update_completions <cmds/fish_update_completions>` now handles groff ``\X'...'`` device control escapes, fixing completion generation for man pages produced by help2man 1.50 and later (such as coreutils 9.10).
 - Improve user experience when removing history entries via the :doc:`web-based config <cmds/fish_config>`.
-- :doc:`funced <cmds/funced>` will no longer lose work if there are parse errors multiple times without new changes to the file
+- :doc:`funced <cmds/funced>` will no longer lose work if there are parse errors multiple times without new changes to the file.
+- Move some internal file descriptors to number 10 or higher to reduce risk of clashes with those used by the user in scripts.
 
 For distributors and developers
 -------------------------------

--- a/src/bin/fish.rs
+++ b/src/bin/fish.rs
@@ -32,6 +32,7 @@ use fish::{
     },
     eprintf, err_fmt,
     event::{self, Event},
+    fds::heightenize_fd,
     flog::{self, activate_flog_categories_by_pattern, flog, flogf, set_flog_file_fd},
     fprintf, function,
     history::{self, start_private_mode},
@@ -564,11 +565,11 @@ fn throwing_main() -> i32 {
         }
         res = reader_read(parser, libc::STDIN_FILENO, &IoChain::new());
     } else {
-        let n = wcs2bytes(&args[my_optind]);
+        let filename = &args[my_optind];
+        let n = wcs2bytes(filename);
         let path = OsStr::from_bytes(&n);
         my_optind += 1;
         // Rust sets cloexec by default, see above
-        // We don't need autoclose_fd_t when we use File, it will be closed on drop.
         match File::open(path) {
             Err(e) => {
                 flogf!(
@@ -579,24 +580,25 @@ fn throwing_main() -> i32 {
                 eprintf!("%s\n", e);
             }
             Ok(f) => {
-                let list = &args[my_optind..];
-                parser.set_var(
-                    L!("argv"),
-                    ParserEnvSetMode::default(),
-                    list.iter().map(|s| s.to_owned()).collect(),
-                );
-                let rel_filename = &args[my_optind - 1];
-                let _filename_push = parser
-                    .library_data
-                    .scoped_set(Some(Arc::new(rel_filename.to_owned())), |s| {
-                        &mut s.current_filename
-                    });
-                res = reader_read(parser, f.as_raw_fd(), &IoChain::new());
-                if res.is_err() {
-                    flog!(
-                        warning,
-                        wgettext_fmt!("Error while reading file %s", path.to_string_lossy())
+                if let Ok(f) = heightenize_fd(f.into(), true).map(File::from) {
+                    let list = &args[my_optind..];
+                    parser.set_var(
+                        L!("argv"),
+                        ParserEnvSetMode::default(),
+                        list.iter().map(|s| s.to_owned()).collect(),
                     );
+                    let _filename_push = parser
+                        .library_data
+                        .scoped_set(Some(Arc::new(filename.to_owned())), |s| {
+                            &mut s.current_filename
+                        });
+                    res = reader_read(parser, f.as_raw_fd(), &IoChain::new());
+                    if res.is_err() {
+                        flog!(
+                            warning,
+                            wgettext_fmt!("Error while reading file %s", path.to_string_lossy())
+                        );
+                    }
                 }
             }
         }

--- a/src/builtins/cd.rs
+++ b/src/builtins/cd.rs
@@ -12,7 +12,6 @@ use crate::{
 use errno::Errno;
 use libc::{EACCES, ELOOP, ENOENT, ENOTDIR, EPERM};
 use nix::unistd::fchdir;
-use std::sync::Arc;
 
 // The cd builtin. Changes the current directory to the one specified or to $HOME if none is
 // specified. The directory can be relative to any directory in the CDPATH variable.
@@ -83,46 +82,35 @@ pub fn cd(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Built
         let res = wopen_dir(&norm_dir, BEST_O_SEARCH).map_err(|err| err as i32);
 
         let res = res.and_then(|fd| {
-            match fchdir(&fd) {
-                Ok(()) => Ok(fd),
+            fchdir(&fd).map_err(|_|
                 // nix::Result::Err contains nix::errno::Errno, which does not offer an API for
                 // converting to a raw int.
-                Err(_) => Err(errno::errno().0),
-            }
+                errno::errno().0)
         });
 
-        let fd = match res {
-            Ok(fd) => fd,
-            Err(err) => {
-                // Some errors we skip and only report if nothing worked.
-                // ENOENT in particular is very low priority
-                // - if in another directory there was a *file* by the correct name
-                // we prefer *that* error because it's more specific
-                if err == ENOENT {
-                    let tmp = wreadlink(&norm_dir);
-                    // clippy doesn't like this is_some/unwrap pair, but using if let is harder to read IMO
-                    #[allow(clippy::unnecessary_unwrap)]
-                    if broken_symlink.is_empty() && tmp.is_some() {
-                        broken_symlink = norm_dir;
-                        broken_symlink_target = tmp.unwrap();
-                    } else if best_errno == 0 {
-                        best_errno = errno::errno().0;
-                    }
-                    continue;
-                } else if err == ENOTDIR {
-                    best_errno = err;
-                    continue;
+        if let Err(err) = res {
+            // Some errors we skip and only report if nothing worked.
+            // ENOENT in particular is very low priority
+            // - if in another directory there was a *file* by the correct name
+            // we prefer *that* error because it's more specific
+            if err == ENOENT {
+                let tmp = wreadlink(&norm_dir);
+                // clippy doesn't like this is_some/unwrap pair, but using if let is harder to read IMO
+                // TODO: if-let-chains
+                if let Some(tmp) = tmp.filter(|_| broken_symlink.is_empty()) {
+                    broken_symlink = norm_dir;
+                    broken_symlink_target = tmp;
+                } else if best_errno == 0 {
+                    best_errno = errno::errno().0;
                 }
+                continue;
+            } else if err == ENOTDIR {
                 best_errno = err;
-                break;
+                continue;
             }
-        };
-
-        // We need to keep around the fd for this directory, in the parser.
-        let dir_fd = Arc::new(fd);
-
-        // Stash the fd for the cwd in the parser.
-        parser.libdata_mut().cwd_fd = Some(dir_fd);
+            best_errno = err;
+            break;
+        }
 
         parser.set_var_and_fire(
             L!("PWD"),

--- a/src/fd_monitor.rs
+++ b/src/fd_monitor.rs
@@ -1,4 +1,5 @@
 use crate::fd_readable_set::{FdReadableSet, Timeout};
+use crate::fds::heightenize_fd;
 use crate::flog::flog;
 use crate::portable_atomic::AtomicU64;
 use crate::threads::assert_is_background_thread;
@@ -49,8 +50,12 @@ impl FdEventSignaller {
                     perror("eventfd");
                     exit_without_destructors(1);
                 }
+                let Ok(fd) = heightenize_fd(unsafe { OwnedFd::from_raw_fd(fd) }, true) else {
+                    perror("eventfd");
+                    exit_without_destructors(1);
+                };
                 Self {
-                    fd: unsafe { OwnedFd::from_raw_fd(fd) },
+                    fd
                 }
             } else {
                 // Implementation using pipes.

--- a/src/fds.rs
+++ b/src/fds.rs
@@ -86,7 +86,7 @@ pub fn make_autoclose_pipes() -> nix::Result<AutoClosePipes> {
 /// setting it again.
 /// Return the fd, which always has CLOEXEC set; or an invalid fd on failure, in
 /// which case an error will have been printed, and the input fd closed.
-fn heightenize_fd(fd: OwnedFd, input_has_cloexec: bool) -> nix::Result<OwnedFd> {
+pub fn heightenize_fd(fd: OwnedFd, input_has_cloexec: bool) -> nix::Result<OwnedFd> {
     let raw_fd = fd.as_raw_fd();
 
     if raw_fd >= FIRST_HIGH_FD {
@@ -145,7 +145,7 @@ pub fn open_cloexec(path: &CStr, flags: OFlag, mode: nix::sys::stat::Mode) -> ni
     // If it is that's our cancel signal, so we abort.
     loop {
         let ret = nix::fcntl::open(path, flags | OFlag::O_CLOEXEC, mode);
-        let ret = ret.map(File::from);
+        let ret = ret.and_then(|fd| heightenize_fd(fd, true)).map(File::from);
         match ret {
             Ok(file) => {
                 return Ok(file);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -44,7 +44,6 @@ use std::ffi::OsStr;
 use std::fs::File;
 use std::io::Write as _;
 use std::num::NonZeroU32;
-use std::os::fd::OwnedFd;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Duration;
@@ -281,10 +280,6 @@ pub struct LibraryData {
     /// the command line.
     pub transient_commandline: Option<WString>,
 
-    /// A file descriptor holding the current working directory, for use in openat().
-    /// This is never null and never invalid.
-    pub cwd_fd: Option<Arc<OwnedFd>>,
-
     /// Variables supporting the "status" builtin.
     pub status_vars: StatusVars,
 
@@ -475,13 +470,8 @@ impl Parser {
             blocking_query_timeout: RefCell::new(None),
         };
 
-        match open_dir(c".", BEST_O_SEARCH) {
-            Ok(fd) => {
-                result.libdata_mut().cwd_fd = Some(Arc::new(fd));
-            }
-            Err(err) => {
-                perror_nix("Unable to open the current working directory", err);
-            }
+        if let Err(err) = open_dir(c".", BEST_O_SEARCH) {
+            perror_nix("Unable to open the current working directory", err);
         }
 
         result

--- a/tests/checks/fds.fish
+++ b/tests/checks/fds.fish
@@ -1,4 +1,4 @@
-# RUN: %fish -C "set helper %fish_test_helper" %s
+# RUN: fish=%fish %fish -C "set helper %fish_test_helper" %s
 #REQUIRES: command -v %fish_test_helper
 
 # Check that we don't leave stray FDs.
@@ -89,3 +89,39 @@ $helper print_fds 19</dev/null
 
 $helper print_fds 20</dev/null
 # CHECK: 0 1 2 20
+
+# Check heightenization of the redirection file descriptors
+#
+# If heightenization does NOT work, ">$tmpfile" creates a temporary fd on a fd n
+# (n being the first free descriptor) during parsing, then "n>&1" redirects fd n
+# to fd 1 (still stdout at this stage), lastly, ">$tmpfile" redirects fd 1 is
+# redirected to the "temporary" fd n (which is now stdout instead of $tmpfile).
+#
+# If heightenization does work, ">$tmpfile" creates a temporary fd on 10+,
+# then fd n is redirected to fd 1 (still stdout), the fd 1 is redirect to
+# the "temporary" fd 10+ (still $tmpfile)
+#
+# Since we don't know what `n` will be, we need to redirect all the descriptors
+# reserved for the user
+set -l tmpfile (mktemp)
+printf 'stdout: %s\n' "$($fish -c "$helper print_fds 3>&1 4>&1 5>&1 6>&1 7>&1 8>&1 9>&1 >$tmpfile")"
+printf "tmp file: %s\n" $(cat $tmpfile)
+# CHECK: stdout:
+# CHECK: tmp file: 0 1 2 3 4 5 6 7 8 9
+
+# Check heightenization of the file descriptors when sourcing
+echo '
+path filter /proc/$fish_pid/fd/{3,4,5,6,7,8,9}
+' >"$tmpfile"
+echo start source
+$fish -c "source '$tmpfile'"
+echo end source
+# CHECK: start source
+# CHECK: end source
+
+# Check heightenization of descriptors for script files passed to fish
+echo start fish
+$fish "$tmpfile"
+echo end fish
+# CHECK: start fish
+# CHECK: end fish


### PR DESCRIPTION
- Remove the cwd_fd in parser which was causing the alternating success/error in #12618
- Heightenize a few fds:
  - file opened by `source`
  - file opened by fish when executing `fish some_script`
  - eventfd
  - ... (probably others that use `wopen_cloexec`/`open_cloexec`)

## TODOs:
<!-- Check off what what has been done so far. -->
- [X] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [X] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
