### PR TITLE
Completions: Added 'updates' -directory to the kernel module locations.

### DIFF
--- a/share/functions/__fish_print_modules.fish
+++ b/share/functions/__fish_print_modules.fish
@@ -1,5 +1,5 @@
 # localization: skip(private)
 # Helper function for completions that need to enumerate Linux modules
 function __fish_print_modules
-    find /lib/modules/(uname -r)/{kernel,misc} -type f 2>/dev/null | sed -e 's$/.*/\([^/.]*\).*$\1$'
+    find /lib/modules/(uname -r)/{kernel,misc,updates} -type f 2>/dev/null | sed -e 's$/.*/\([^/.]*\).*$\1$'
 end


### PR DESCRIPTION
Linux kernel modules installed by target 'modules_install' are installed to '/usr/lib/(uname -r)/updates'. This applies to both out-of-tree kernel modules, or when building in-tree modules individually.

Module tools like 'modprobe' and 'modinfo' search the 'updates'-directory automatically, so it should be expected that fish autocomplete to provide these modules as well.

Documentation describing the default install directory: https://www.kernel.org/doc/html/latest/kbuild/modules.html
Tested with Arch (kernel 6.18.24-1-lts, fish 4.6.0) and Fedora (kernel 6.19.13-200.fc43.x86_64, fish 4.2.0).


## TODOs:
<!-- Check off what what has been done so far. -->
- [ ] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
