### PR TITLE
highlight: derive Display trait for HighlightRole

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,7 @@ dependencies = [
  "rust-embed",
  "rustc_version",
  "serial_test",
+ "strum_macros",
  "unix_path",
  "xterm-color",
 ]
@@ -1077,6 +1078,18 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ rust-embed = { version = "8.11.0", features = [
 ] }
 rustc_version = "0.4.1"
 serial_test = { version = "3", default-features = false }
+strum_macros = "0.28.0"
 widestring = "1.2.0"
 unicode-segmentation = "1.12.0"
 unicode-width = "0.2.0"
@@ -131,6 +132,7 @@ num-traits.workspace = true
 once_cell.workspace = true
 pcre2.workspace = true
 rand.workspace = true
+strum_macros.workspace = true
 xterm-color.workspace = true
 
 [target.'cfg(not(target_has_atomic = "64"))'.dependencies]

--- a/src/highlight/highlight.rs
+++ b/src/highlight/highlight.rs
@@ -34,6 +34,7 @@ use fish_widestring::{
     WString, wstr,
 };
 use std::collections::{HashMap, hash_map::Entry};
+use strum_macros::Display;
 
 use super::file_tester::IsFile;
 
@@ -1257,7 +1258,8 @@ fn get_fallback(role: HighlightRole) -> HighlightRole {
 }
 
 /// Describes the role of a span of text.
-#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq, Display)]
+#[strum(serialize_all = "snake_case")]
 #[repr(u8)]
 pub enum HighlightRole {
     #[default]
@@ -1292,47 +1294,6 @@ pub enum HighlightRole {
     PagerSelectedPrefix,
     PagerSelectedCompletion,
     PagerSelectedDescription,
-}
-
-impl From<HighlightRole> for &'static str {
-    fn from(value: HighlightRole) -> Self {
-        match value {
-            HighlightRole::Normal => "normal",
-            HighlightRole::Error => "error",
-            HighlightRole::Command => "command",
-            HighlightRole::Keyword => "keyword",
-            HighlightRole::StatementTerminator => "statement_terminator",
-            HighlightRole::Param => "param",
-            HighlightRole::Option => "option",
-            HighlightRole::Comment => "comment",
-            HighlightRole::SearchMatch => "search_match",
-            HighlightRole::Operat => "operat",
-            HighlightRole::Escape => "escape",
-            HighlightRole::Quote => "quote",
-            HighlightRole::Redirection => "redirection",
-            HighlightRole::Autosuggestion => "autosuggestion",
-            HighlightRole::Selection => "selection",
-            HighlightRole::PagerProgress => "pager_progress",
-            HighlightRole::PagerBackground => "pager_background",
-            HighlightRole::PagerPrefix => "pager_prefix",
-            HighlightRole::PagerCompletion => "pager_completion",
-            HighlightRole::PagerDescription => "pager_description",
-            HighlightRole::PagerSecondaryBackground => "pager_secondary_background",
-            HighlightRole::PagerSecondaryPrefix => "pager_secondary_prefix",
-            HighlightRole::PagerSecondaryCompletion => "pager_secondary_completion",
-            HighlightRole::PagerSecondaryDescription => "pager_secondary_description",
-            HighlightRole::PagerSelectedBackground => "pager_selected_background",
-            HighlightRole::PagerSelectedPrefix => "pager_selected_prefix",
-            HighlightRole::PagerSelectedCompletion => "pager_selected_completion",
-            HighlightRole::PagerSelectedDescription => "pager_selected_description",
-        }
-    }
-}
-
-impl std::fmt::Display for HighlightRole {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        <&'static str>::from(*self).fmt(f)
-    }
 }
 
 /// Simple value type describing how a character should be highlighted.


### PR DESCRIPTION
Add back the `strum_macros::Display` implementation, but use `#[strum(serialize_all = "snake_case")]`.

cc: @krobelus