### PR TITLE
Fix `cd` generating "remote directory" path

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -358,7 +358,14 @@ pub fn path_apply_cdpath(dir: &wstr, wd: &wstr, env_vars: &dyn Environment) -> V
             // We want to return an absolute path (see issue 6220)
             if ![Some('/'), Some('~')].contains(&path.chars().next()) {
                 abspath = wd.to_owned();
-                abspath.push('/');
+
+                // Do not add a second slash if `wd` already ends with one
+                // (typically, when it's the root directory).
+                // This could result in unwanted paths (e.g. `//<path>`, which
+                // on Windows, is a remote directory).
+                if abspath.chars().next_back() != Some('/') {
+                    abspath.push('/');
+                }
             }
             abspath.push_utfstr(&path);
 

--- a/tests/checks/cd.fish
+++ b/tests/checks/cd.fish
@@ -407,3 +407,10 @@ cd (string repeat 4096 a)
 # CHECKERR: ^
 # CHECKERR: in function 'cd' with arguments '{{.*}}'
 # CHECKERR: called on line {{\d+}} of file {{.*}}/cd.fish
+
+# Ensures `cd` doesn't create `<pwd>+/+<dir>` internally, when pwd is `/`, i.e.
+# results in `//<dir>`. This test will (hopefully) fail on platforms where such
+# a path has a special meaning (e.g. Windows would fail trying to access a server
+# named "bin")
+cd /
+cd bin

--- a/tests/checks/tmux-history-search2.fish
+++ b/tests/checks/tmux-history-search2.fish
@@ -39,7 +39,7 @@ tmux-sleep
 isolated-tmux capture-pane -p
 # CHECK: prompt 5> read
 # CHECK: read> read-input
-# CHECK: read-input⏎
+# CHECK: read-input{{⏎|¶|\^J}}
 # CHECK: prompt 6> set fish_history
 # CHECK: prompt 6> true some command; read
 # CHECK: read> read-input


### PR DESCRIPTION
Fix `cd` generating "remote directory" path, which caused `cd` to be very slow (waiting for a non-existent server to respond) and fail (server couldn't be accessed).



## TODOs:
<!-- Check off what what has been done so far. -->
- [X] Tests have been added for regressions fixed
