### PR TITLE
fix(fish_git_prompt): remove trailing space in bare repositories

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Interactive improvements
 - :envvar:`fish_color_valid_path` now respects background and underline colors (:issue:`12622`).
 - :doc:`funced <cmds/funced>` will no longer lose work if there are parse errors multiple times without new changes to the file.
 - Fixed a case where directory completions were sorted in a surprising order (:issue:`12695`).
+- :doc:`fish_git_prompt <cmds/fish_git_prompt>` no longer adds a trailing space after the branch name in bare repositories (:issue:`12705`).
 - When at the command token, the :kbd:`alt-o` binding will now open read-only files too (:issue:`12671`).
 - Private mode in-memory history (``set fish_history``) is no longer shared with :doc:`builtin read <cmds/read>` (:issue:`12662`).
 

--- a/share/functions/fish_git_prompt.fish
+++ b/share/functions/fish_git_prompt.fish
@@ -389,9 +389,9 @@ function fish_git_prompt --description "Prompt function for Git"
     end
 
     # Formatting
-    # If we have state, a bare repo or upstream difference, add a separator.
+    # If we have status flags or upstream difference, add a separator.
     # merging is already separate.
-    if test -n "$f$c$p"
+    if test -n "$f$p"
         set f "$space$f"
     end
     set -l format $argv[1]

--- a/tests/checks/git.fish
+++ b/tests/checks/git.fish
@@ -210,3 +210,15 @@ end
 
 $fish -c 'complete -C "git -C ./.gi"'
 # CHECK: ./.git/	Directory
+
+# Test bare repo doesn't produce trailing space (issue #12705)
+set -l bare_tmp (mktemp -d)
+git clone --bare . $bare_tmp/bare.git >/dev/null 2>&1
+cd $bare_tmp/bare.git
+set -e __fish_git_prompt_showdirtystate
+set -e __fish_git_prompt_show_informative_status
+set -e __fish_git_prompt_showuntrackedfiles
+set -l bare_output (fish_git_prompt)
+string match -qr '^\s*\(BARE:\S+\)$' -- $bare_output
+and echo "bare repo prompt has no trailing space"
+#CHECK: bare repo prompt has no trailing space


### PR DESCRIPTION
The condition that prepends a space separator to status flags incorrectly included $c (bare repo marker) in the check. Since $c is printed before the branch name, it should not trigger a separator after it. This caused output like 'BARE:master ' instead of 'BARE:master'.

Remove $c from the condition so the separator is only added when there are actual status flags or upstream differences to display.

Fixes #12705



## TODOs:
<!-- Check off what what has been done so far. -->
- [x] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
