### PR TITLE
complete: remove unescaping of `-c`/`-p` values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 fish ?.?.? (released ???)
 =========================
 
+Deprecations and removed features
+---------------------------------
+- `--command` and `--path` options in `complete` no longer unescape their value.
+
 fish 4.7.0 (released May 05, 2026)
 ==================================
 

--- a/src/builtins/complete.rs
+++ b/src/builtins/complete.rs
@@ -316,20 +316,11 @@ pub fn complete(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) ->
                 preserve_order = true;
             }
             'p' | 'c' => {
-                if let Some(tmp) = unescape_string(
-                    w.woptarg.unwrap(),
-                    UnescapeStringStyle::Script(UnescapeFlags::SPECIAL),
-                ) {
-                    if opt == 'p' {
-                        path.push(tmp);
-                    } else {
-                        cmd_to_complete.push(tmp);
-                    }
+                let v = w.woptarg.unwrap().to_owned();
+                if opt == 'p' {
+                    path.push(v);
                 } else {
-                    err_fmt!("Invalid token '%s'", w.woptarg.unwrap())
-                        .cmd(cmd)
-                        .finish(streams);
-                    return Err(STATUS_INVALID_ARGS);
+                    cmd_to_complete.push(v);
                 }
             }
             'd' => {

--- a/tests/checks/complete.fish
+++ b/tests/checks/complete.fish
@@ -716,9 +716,6 @@ begin
     # CHECK: -command-starting-with-dash{{\t}}command
 end
 
-complete --command="foo\\"
-# CHECKERR: complete: Invalid token 'foo\'
-
 complete -c foo -a "foo\\"
 # CHECKERR: complete: foo\: contains a syntax error
 # CHECKERR: complete: Expected a string, but found an incomplete token


### PR DESCRIPTION
This removes the need to double-escape the values on the command line (once for the command line parser, another for the option handling)

This also brings it in line with the implicit case (`complete cmd ...`)

Fixes #12712



## TODOs:
<!-- Check off what what has been done so far. -->
- [X] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [X] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
