### PR TITLE
add example of how to set default variable values

### DIFF
--- a/doc_src/fish_for_bash_users.rst
+++ b/doc_src/fish_for_bash_users.rst
@@ -99,6 +99,15 @@ See :ref:`Shell variables <variables>` for more.
 
 .. _bash-globs:
 
+Variable defaults (``${my_variable:-"default value"}``)
+-------------------------------------------------------
+
+Fish doesn't have ``${my_variable:-fallback}`` for providing default values to unset variables. Instead, you can set default values by checking whether the variable has been set yet::
+
+  # Ensure XDG_CONFIG_HOME is set or use a default value
+  set -q XDG_CONFIG_HOME || set XDG_CONFIG_HOME $HOME/.config
+  # now use XDG_CONFIG_HOME as normal
+
 Wildcards (globs)
 -----------------
 


### PR DESCRIPTION
I added an example of how to set default values for variables to the "Fish for Bash users" documentation. When I was learning fish, this was one of the things that took me the longest to find a clean solution for and I would've really appreciated knowing.

This describes the cleanest method I have found to do this so far, but if there's a cleaner way, I'd love to learn!