### PR TITLE
Fix off-by-one error in __fish_vi_delete_char

### DIFF
--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -49,10 +49,8 @@ end
 function __fish_vi_delete_char
     set -l count (__fish_vi_consume_count __fish_vi_count)
     commandline -f begin-selection
-    if test $count -gt 1
-        for i in (seq 1 (math $count - 1))
-            commandline -f forward-char
-        end
+    for i in (seq 1 $count)
+        commandline -f forward-char
     end
     commandline -f kill-selection end-selection
 end


### PR DESCRIPTION
`x` stopped working in normal mode for me. It doesn't do anything. `2x` erases one char. I think there's a logical bug here: when `$count` is 1, we don't `forward-char`, so at the end the kill selection is empty.
