### PR TITLE
Fix completion for old jj versions

### DIFF
--- a/share/completions/jj.fish
+++ b/share/completions/jj.fish
@@ -6,5 +6,5 @@ if set -l completion (COMPLETE=fish jj __this-command-does-not-exist 2>/dev/null
     # jj is new enough for dynamic completions to be implemented
     printf %s\n $completion | source
 else
-    jj util completion fish | source
+    jj util completion --fish | source
 end


### PR DESCRIPTION

## TODOs:
- [ ] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->

None of the above TODOs are applicable to this PR.

I noticed this output in my terminal when typing `jj<TAB>` with an old version of jj:
```
~> jj error: unexpected argument 'fish' found

Usage: jj util completion [OPTIONS]

For more information, try '--help'.
```