### PR TITLE
prompts: strip control characters from VCS state and PWD

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 fish ?.?.? (released ???)
 =========================
 
+- ``fish_hg_prompt``, ``fish_git_prompt`` and ``fish_fossil_prompt`` now strip control characters from VCS state read off disk, matching ``prompt_pwd``. The sample informative and minimalist prompts now use ``prompt_pwd`` instead of printing ``$PWD`` directly.
+
 fish 4.7.1 (released May 08, 2026)
 ==================================
 

--- a/share/functions/fish_fossil_prompt.fish
+++ b/share/functions/fish_fossil_prompt.fish
@@ -48,6 +48,9 @@ function fish_fossil_prompt --description 'Write out the fossil prompt'
 
     echo -n ' ('
     set_color magenta
+    # Strip control characters to avoid injecting terminal escape sequences into the prompt.
+    # Raw C1 bytes are stored in fish's private-use encoding at U+F680-U+F69F.
+    set branch (string replace -ra '[\x00-\x1f\x7f-\x9f\x{f680}-\x{f69f}]' '' -- $branch)
     echo -n "$branch"
     set_color --reset
     echo -n '|'

--- a/share/functions/fish_git_prompt.fish
+++ b/share/functions/fish_git_prompt.fish
@@ -475,6 +475,8 @@ function __fish_git_prompt_operation_branch_bare --description "fish_git_prompt 
     set -l step
     set -l total
 
+    # Strip control characters from these dot-files before showing them in the prompt.
+    # (git itself does not validate the contents of rebase-merge/rebase-apply state files).
     if test -d $git_dir/rebase-merge
         set branch (cat $git_dir/rebase-merge/head-name 2>/dev/null)
         set step (cat $git_dir/rebase-merge/msgnum 2>/dev/null)
@@ -505,10 +507,6 @@ function __fish_git_prompt_operation_branch_bare --description "fish_git_prompt 
         else if test -f $git_dir/BISECT_LOG
             set operation "|BISECTING"
         end
-    end
-
-    if test -n "$step" -a -n "$total"
-        set operation "$operation $step/$total"
     end
 
     if test -z "$branch"
@@ -545,6 +543,16 @@ function __fish_git_prompt_operation_branch_bare --description "fish_git_prompt 
             # Let user know they're inside the git dir of a non-bare repo
             set branch "GIT_DIR!"
         end
+    end
+
+    for var_name in branch step total
+        if set -q $var_name[1]
+            set $var_name (string replace -ra '[\x00-\x1f\x7f-\x9f\x{f680}-\x{f69f}]' '' -- $$var_name)
+        end
+    end
+
+    if test -n "$step" -a -n "$total"
+        set operation "$operation $step/$total"
     end
 
     echo $operation

--- a/share/functions/fish_hg_prompt.fish
+++ b/share/functions/fish_hg_prompt.fish
@@ -30,9 +30,14 @@ function fish_hg_prompt --description 'Write out the hg prompt'
     set -l root (fish_print_hg_root)
     or return 1
 
-    # Read branch and bookmark
+    # Read branch and bookmark.
+    # Strip control characters before showing branch/bookmark names in the prompt.
+    # Raw C1 bytes are stored in fish's private-use encoding at U+F680-U+F69F.
+    # (they live under .hg/ and are not validated by hg itself in this code path).
     set -l branch (cat $root/branch 2>/dev/null; or echo default)
+    set branch (string replace -ra '[\x00-\x1f\x7f-\x9f\x{f680}-\x{f69f}]' '' -- $branch)
     if set -l bookmark (cat $root/bookmarks.current 2>/dev/null)
+        set bookmark (string replace -ra '[\x00-\x1f\x7f-\x9f\x{f680}-\x{f69f}]' '' -- $bookmark)
         set branch "$branch|$bookmark"
     end
 

--- a/share/prompts/informative.fish
+++ b/share/prompts/informative.fish
@@ -17,7 +17,7 @@ function fish_prompt --description 'Informative prompt'
         set -l pipestatus_string (__fish_print_pipestatus "[" "]" "|" "$status_color" "$statusb_color" $last_pipestatus)
 
         printf '[%s] %s%s@%s %s%s %s%s%s \n> ' (date "+%H:%M:%S") (set_color brblue) \
-            $USER (prompt_hostname) (set_color $fish_color_cwd) $PWD $pipestatus_string \
+            $USER (prompt_hostname) (set_color $fish_color_cwd) (prompt_pwd) $pipestatus_string \
             (set_color --reset)
     end
 end

--- a/share/prompts/minimalist.fish
+++ b/share/prompts/minimalist.fish
@@ -3,7 +3,7 @@
 
 function fish_prompt
     set_color $fish_color_cwd
-    echo -n (path basename $PWD)
+    echo -n (prompt_pwd | path basename)
     set_color --reset
     echo -n ' ) '
 end

--- a/tests/checks/vcs-prompts.fish
+++ b/tests/checks/vcs-prompts.fish
@@ -1,0 +1,36 @@
+#RUN: %fish %s
+#REQUIRES: command -v git
+
+# Verify VCS prompts strip control characters from
+# state files before showing them (same class as prompt_pwd / #12629).
+
+set -l tmp (mktemp -d)
+
+# --- fish_hg_prompt ---
+# Stub `hg` to satisfy `command -sq hg` without requiring real Mercurial.
+mkdir $tmp/bin
+echo '#!/bin/sh' >$tmp/bin/hg
+chmod +x $tmp/bin/hg
+set -gx PATH $tmp/bin $PATH
+
+mkdir -p $tmp/hgrepo/.hg
+touch $tmp/hgrepo/.hg/dirstate
+printf 'main\e]0;OHNO\a\x7f\u0080\x80' >$tmp/hgrepo/.hg/branch
+
+cd $tmp/hgrepo
+fish_hg_prompt
+echo
+# CHECK: {{.*}} (main]0;OHNO)
+
+# --- fish_git_prompt: rebase-merge state with escape sequence in head-name ---
+mkdir $tmp/gitrepo
+cd $tmp/gitrepo
+git init -q
+mkdir .git/rebase-merge
+printf 'refs/heads/main\e]0;OHNO\a\x7f\u0080\x80' >.git/rebase-merge/head-name
+: >.git/rebase-merge/msgnum
+: >.git/rebase-merge/end
+
+fish_git_prompt
+echo
+# CHECK:  (main]0;OHNO|REBASE-m)


### PR DESCRIPTION
## Description

Prompts may read display strings containing control characters from repository metadata or the current working directory, then print them to the terminal.

This strips C0/C1 controls, DEL, and fish's private-use C1 range when formatting hg, git, and fossil prompt state. It also routes the informative and minimalist sample prompts through `prompt_pwd` instead of printing `$PWD` directly.

The VCS prompt change keeps raw branch/state values until the final output path so future logic can still inspect the original names before display.

### Verification

- `build/fish -n share/prompts/informative.fish share/prompts/minimalist.fish`
- `make -C build test_prompt.fish`
- `make -C build test_vcs-prompts.fish`

## TODOs

- [ ] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
