### PR TITLE
complete control sequence sanitation and prompt filters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 fish ?.?.? (released ???)
 =========================
 
+Interactive improvements
+------------------------
+- Several prompt and listing functions now strip control characters from filesystem-derived data, matching what :doc:`prompt_pwd <cmds/prompt_pwd>` already did. Affected: the ``arrow``, ``informative`` and ``minimalist`` sample prompts, :doc:`fish_git_prompt <cmds/fish_git_prompt>`, ``fish_hg_prompt``, ``fish_fossil_prompt``, :doc:`dirh <cmds/dirh>`, :doc:`dirs <cmds/dirs>`, :doc:`cdh <cmds/cdh>`, :doc:`fish_add_path <cmds/fish_add_path>` (verbose mode) and :doc:`funced <cmds/funced>` (save-confirmation message). The shared filter is exposed as the internal ``__fish_strip_ctrl`` helper. The character class has also been extended to cover C1 (U+0080..U+009F) and the PUA range fish uses for raw invalid-UTF-8 filename bytes.
+
 fish 4.7.1 (released May 08, 2026)
 ==================================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ fish ?.?.? (released ???)
 
 Interactive improvements
 ------------------------
-- Several prompt and listing functions now strip control characters from filesystem-derived data, matching what :doc:`prompt_pwd <cmds/prompt_pwd>` already did. Affected: the ``arrow``, ``informative`` and ``minimalist`` sample prompts, :doc:`fish_git_prompt <cmds/fish_git_prompt>`, ``fish_hg_prompt``, ``fish_fossil_prompt``, :doc:`dirh <cmds/dirh>`, :doc:`dirs <cmds/dirs>`, :doc:`cdh <cmds/cdh>`, :doc:`fish_add_path <cmds/fish_add_path>` (verbose mode) and :doc:`funced <cmds/funced>` (save-confirmation message). The shared filter is exposed as the internal ``__fish_strip_ctrl`` helper. The character class has also been extended to cover C1 (U+0080..U+009F) and the PUA range fish uses for raw invalid-UTF-8 filename bytes.
+- Sample prompts and the dirh, dirs, cdh, fish_add_path and funced functions now strip control characters from filesystem-derived data, matching :doc:`prompt_pwd <cmds/prompt_pwd>`.
 
 fish 4.7.1 (released May 08, 2026)
 ==================================

--- a/share/functions/__fish_strip_ctrl.fish
+++ b/share/functions/__fish_strip_ctrl.fish
@@ -1,0 +1,4 @@
+# localization: skip(private)
+function __fish_strip_ctrl --description 'Strip control characters from arguments'
+    string replace -ra '[\x00-\x1f\x7f-\x9f\x{f680}-\x{f69f}]' '' -- $argv
+end

--- a/share/functions/cdh.fish
+++ b/share/functions/cdh.fish
@@ -59,7 +59,7 @@ function cdh --description "Menu based cd command"
         if set -q home_dir[2]
             set dir "~$home_dir[2]"
         end
-        printf '%s %s %2d) %s %s%s%s\n' (set_color $label_color) $letters[$i] $i (set_color --reset) $dir_color $dir $dir_color_reset
+        printf '%s %s %2d) %s %s%s%s\n' (set_color $label_color) $letters[$i] $i (set_color --reset) $dir_color (__fish_strip_ctrl $dir) $dir_color_reset
     end
 
     # Ask the user which directory from their history they want to cd to.

--- a/share/functions/dirh.fish
+++ b/share/functions/dirh.fish
@@ -15,17 +15,17 @@ function dirh --description "Print the current directory history (the prev and n
         # This can't be (seq $dirc -1 1) because of BSD.
         set -l dirnum (seq 1 $dirc)
         for i in $dirnum[-1..1]
-            printf '%2d) %s\n' $i $dirprev_rev[$i]
+            printf '%2d) %s\n' $i (__fish_strip_ctrl $dirprev_rev[$i])
         end
     end
 
-    echo (set_color $fish_color_history_current)'   ' $PWD(set_color --reset)
+    echo (set_color $fish_color_history_current)'   ' (__fish_strip_ctrl $PWD)(set_color --reset)
 
     set -l dirc (count $dirnext)
     if test $dirc -gt 0
         set -l dirnext_rev $dirnext[-1..1]
         for i in (seq $dirc)
-            printf '%2d) %s\n' $i $dirnext_rev[$i]
+            printf '%2d) %s\n' $i (__fish_strip_ctrl $dirnext_rev[$i])
         end
     end
     echo

--- a/share/functions/dirs.fish
+++ b/share/functions/dirs.fish
@@ -16,6 +16,6 @@ function dirs --description 'Print directory stack'
     end
 
     # Replace $HOME with ~.
-    string replace -r '^'"$HOME"'($|/)' '~$1' -- $PWD $dirstack | string join " "
+    __fish_strip_ctrl (string replace -r '^'"$HOME"'($|/)' '~$1' -- $PWD $dirstack) | string join " "
     return 0
 end

--- a/share/functions/fish_add_path.fish
+++ b/share/functions/fish_add_path.fish
@@ -56,10 +56,11 @@ function fish_add_path --description "Add paths to the PATH"
             # path does not exist
             if set -q _flag_verbose
                 # print a message in verbose mode
+                set -l p_disp (__fish_strip_ctrl "$p")
                 if test -f "$p"
-                    printf (_ "Skipping path because it is a file instead of a directory: %s\n") "$p"
+                    printf (_ "Skipping path because it is a file instead of a directory: %s\n") "$p_disp"
                 else
-                    printf (_ "Skipping non-existent path: %s\n") "$p"
+                    printf (_ "Skipping non-existent path: %s\n") "$p_disp"
                 end
             end
             continue
@@ -71,7 +72,7 @@ function fish_add_path --description "Add paths to the PATH"
                 set -a indexes $ind
                 set -a newpaths $p
             else if set -q _flag_verbose
-                printf (_ "Skipping already included path: %s\n") "$p"
+                printf (_ "Skipping already included path: %s\n") (__fish_strip_ctrl "$p")
             end
         else if not contains -- $p $newpaths
             # Without move, we only add it if it's not in.

--- a/share/functions/fish_fossil_prompt.fish
+++ b/share/functions/fish_fossil_prompt.fish
@@ -5,7 +5,7 @@ function fish_fossil_prompt --description 'Write out the fossil prompt'
     end
 
     # Read branch and bookmark (bail if not checkout)
-    set -l branch (fossil branch current 2>/dev/null)
+    set -l branch (__fish_strip_ctrl (fossil branch current 2>/dev/null))
     or return 127
 
     set -q fish_color_fossil_clean

--- a/share/functions/fish_git_prompt.fish
+++ b/share/functions/fish_git_prompt.fish
@@ -476,9 +476,9 @@ function __fish_git_prompt_operation_branch_bare --description "fish_git_prompt 
     set -l total
 
     if test -d $git_dir/rebase-merge
-        set branch (cat $git_dir/rebase-merge/head-name 2>/dev/null)
-        set step (cat $git_dir/rebase-merge/msgnum 2>/dev/null)
-        set total (cat $git_dir/rebase-merge/end 2>/dev/null)
+        set branch (__fish_strip_ctrl (cat $git_dir/rebase-merge/head-name 2>/dev/null))
+        set step (__fish_strip_ctrl (cat $git_dir/rebase-merge/msgnum 2>/dev/null))
+        set total (__fish_strip_ctrl (cat $git_dir/rebase-merge/end 2>/dev/null))
         if test -f $git_dir/rebase-merge/interactive
             set operation "|REBASE-i"
         else
@@ -486,10 +486,10 @@ function __fish_git_prompt_operation_branch_bare --description "fish_git_prompt 
         end
     else
         if test -d $git_dir/rebase-apply
-            set step (cat $git_dir/rebase-apply/next 2>/dev/null)
-            set total (cat $git_dir/rebase-apply/last 2>/dev/null)
+            set step (__fish_strip_ctrl (cat $git_dir/rebase-apply/next 2>/dev/null))
+            set total (__fish_strip_ctrl (cat $git_dir/rebase-apply/last 2>/dev/null))
             if test -f $git_dir/rebase-apply/rebasing
-                set branch (cat $git_dir/rebase-apply/head-name 2>/dev/null)
+                set branch (__fish_strip_ctrl (cat $git_dir/rebase-apply/head-name 2>/dev/null))
                 set operation "|REBASE"
             else if test -f $git_dir/rebase-apply/applying
                 set operation "|AM"

--- a/share/functions/fish_hg_prompt.fish
+++ b/share/functions/fish_hg_prompt.fish
@@ -31,8 +31,8 @@ function fish_hg_prompt --description 'Write out the hg prompt'
     or return 1
 
     # Read branch and bookmark
-    set -l branch (cat $root/branch 2>/dev/null; or echo default)
-    if set -l bookmark (cat $root/bookmarks.current 2>/dev/null)
+    set -l branch (__fish_strip_ctrl (cat $root/branch 2>/dev/null); or echo default)
+    if set -l bookmark (__fish_strip_ctrl (cat $root/bookmarks.current 2>/dev/null))
         set branch "$branch|$bookmark"
     end
 

--- a/share/functions/funced.fish
+++ b/share/functions/funced.fish
@@ -130,7 +130,7 @@ function funced --description 'Edit function definition'
             else if test -n "$writepath"
                 if not set -q _flag_save
                     echo (_ "Warning: the file containing this function has not been saved. Changes may be lost when fish is closed.")
-                    set -l prompt (printf (_ 'Save function to %s? [Y/n]') "$writepath")
+                    set -l prompt (printf (_ 'Save function to %s? [Y/n]') (__fish_strip_ctrl "$writepath"))
                     read --prompt-str "$prompt " response
                     if test -z "$response"
                         or contains $response {Y,y}{E,e,}{S,s,}
@@ -144,7 +144,7 @@ function funced --description 'Edit function definition'
                     # try to write the file back
                     # cp preserves existing permissions, though it might overwrite the owner
                     if cp $tmpname "$writepath" 2>&1
-                        printf (_ "Function saved to %s") "$writepath"
+                        printf (_ "Function saved to %s") (__fish_strip_ctrl "$writepath")
                         echo
                         # read it back again - this ensures that the output of `functions --details` is correct
                         source "$writepath"
@@ -152,7 +152,7 @@ function funced --description 'Edit function definition'
                         echo (_ "Saving to original location failed; saving to user configuration instead.")
                         set writepath $__fish_config_dir/functions/(path basename "$writepath")
                         if cp $tmpname "$writepath"
-                            printf (_ "Function saved to %s") "$writepath"
+                            printf (_ "Function saved to %s") (__fish_strip_ctrl "$writepath")
                             echo
                             # read it back again - this ensures that the output of `functions --details` is correct
                             source "$writepath"

--- a/share/functions/prompt_pwd.fish
+++ b/share/functions/prompt_pwd.fish
@@ -27,7 +27,7 @@ function prompt_pwd --description 'short CWD for the prompt'
 
     for path in $argv
         # Strip control characters to avoid injecting terminal escape sequences into the prompt.
-        set -l tmp (__fish_unexpand_tilde $path | string replace -ra '[[:cntrl:]]' '')
+        set -l tmp (__fish_strip_ctrl (__fish_unexpand_tilde $path))
 
         if test "$fish_prompt_pwd_dir_length" -eq 0
             echo $tmp

--- a/share/prompts/arrow.fish
+++ b/share/prompts/arrow.fish
@@ -27,7 +27,7 @@ function fish_prompt
         end
 
         function _hg_branch_name
-            echo (hg branch 2>/dev/null)
+            echo (__fish_strip_ctrl (hg branch 2>/dev/null))
         end
 
         function _is_hg_dirty

--- a/share/prompts/informative.fish
+++ b/share/prompts/informative.fish
@@ -17,7 +17,7 @@ function fish_prompt --description 'Informative prompt'
         set -l pipestatus_string (__fish_print_pipestatus "[" "]" "|" "$status_color" "$statusb_color" $last_pipestatus)
 
         printf '[%s] %s%s@%s %s%s %s%s%s \n> ' (date "+%H:%M:%S") (set_color brblue) \
-            $USER (prompt_hostname) (set_color $fish_color_cwd) $PWD $pipestatus_string \
+            $USER (prompt_hostname) (set_color $fish_color_cwd) (__fish_strip_ctrl $PWD) $pipestatus_string \
             (set_color --reset)
     end
 end

--- a/share/prompts/minimalist.fish
+++ b/share/prompts/minimalist.fish
@@ -3,7 +3,7 @@
 
 function fish_prompt
     set_color $fish_color_cwd
-    echo -n (path basename $PWD)
+    echo -n (__fish_strip_ctrl (path basename $PWD))
     set_color --reset
     echo -n ' ) '
 end

--- a/tests/checks/prompt-pwd-strips-controls.fish
+++ b/tests/checks/prompt-pwd-strips-controls.fish
@@ -1,0 +1,23 @@
+#RUN: %fish %s
+
+# Verify prompt_pwd strips terminal-control sequences from the path before
+# returning. Protects prompts (and any other caller) from injection via
+# hostile filenames in $PWD.
+
+# Use dir-length=0 so prompt_pwd does not shorten the path.
+
+# C0 + DEL: ESC, BEL, DEL
+prompt_pwd -d 0 (printf '/tmp/a\x1bb\x07c\x7fd')
+# CHECK: /tmp/abcd
+
+# C1 (UTF-8 codepoints): U+009B (CSI) and U+009D (OSC)
+prompt_pwd -d 0 (printf '/tmp/a\u009bb\u009dc')
+# CHECK: /tmp/abc
+
+# Raw single-byte C1 in a path (invalid UTF-8, fish stores as PUA).
+prompt_pwd -d 0 (printf '/tmp/a\x9bb\x9dc')
+# CHECK: /tmp/abc
+
+# Latin-1 supplement (NBSP, ÿ) must be preserved.
+prompt_pwd -d 0 (printf '/tmp/a\u00a0b\u00ffc')
+# CHECK: /tmp/a{{.}}b{{.}}c


### PR DESCRIPTION
The issue fixed in commit 90e4a1c addressed missing sanitation of control characters reaching the terminal but there are several additional sites with the same issue. After running semgrep on the this to find all related issues in other areas, it turned out that there are quite a few functions that are affected and can lead to terminal sequence injection (spoofing terminal content, clipboard overwrite etc)

This PR addresses the following remaining areas:

- some example prompts echo $PWD or `path basename $PWD`
- fish_git_prompt reads the rebase head-name and step/total from files under .git/rebase-*/ 
- fish_hg_prompt reads .hg/branch and .hg/bookmarks.current
- fish_fossil_prompt uses `fossil branch current` raw
- dirh, dirs and cdh listings echo $PWD and dirstack entries
- fish_add_path's verbose-mode skip messages echo the path argument
- funced save-confirmation message echoes the writepath returned by `functions --details`
- prompt_pwd itself is extended to also strip C1 and the PUA range fish uses for raw invalid-UTF-8 filename bytes

Update: I just noticed that this is also partly addressed by #12729

- [X] Tests have been added for regressions fixed
- [X] User-visible changes noted in CHANGELOG.rst