### PR TITLE
sanitize displayed control characters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ fish ?.?.? (released ???)
 
 Interactive improvements
 ------------------------
-- Filesystem-derived bytes (paths, argv0, command names, source lines) are now stripped of control characters before being printed in error messages and listings, in the same spirit as the :doc:`prompt_pwd <cmds/prompt_pwd>` fix. Affected sites include :doc:`cd <cmds/cd>` errors, the OSC 0/1 terminal title, parse-error display, "Unknown command" / "Unknown builtin" / "Could not find" errors, redirection warnings, the ``Defined in`` / ``copied in`` annotation in :doc:`functions <cmds/functions>` and :doc:`type <cmds/type>` output, the ``is a function/builtin/<path>`` lines in :doc:`type <cmds/type>` output, :doc:`jobs <cmds/jobs>` ``-c`` listings, :doc:`fish_indent <cmds/fish_indent>` error messages, :doc:`test <cmds/test>` parser errors, and bash history entries imported by :doc:`history <cmds/history>` (sanitized at the storage boundary so typed entries are unaffected). Data-returning builtins such as :doc:`pwd <cmds/pwd>`, :doc:`realpath <cmds/realpath>`, :doc:`type <cmds/type>` ``--path``, :doc:`functions <cmds/functions>` ``--details``, :doc:`status <cmds/status>` ``filename``, and the :doc:`path <cmds/path>` builtin still preserve their bytes so script captures are not affected.
+- Builtin error messages and listings now strip control characters from filesystem-derived data (paths, argv0, command names, source lines). Data-returning builtins like :doc:`pwd <cmds/pwd>`, :doc:`realpath <cmds/realpath>` and :doc:`type <cmds/type>` ``--path`` still pass bytes through unchanged.
 
 fish 4.7.1 (released May 08, 2026)
 ==================================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 fish ?.?.? (released ???)
 =========================
 
+Interactive improvements
+------------------------
+- Filesystem-derived bytes (paths, argv0, command names, source lines) are now stripped of control characters before being printed in error messages and listings, in the same spirit as the :doc:`prompt_pwd <cmds/prompt_pwd>` fix. Affected sites include :doc:`cd <cmds/cd>` errors, the OSC 0/1 terminal title, parse-error display, "Unknown command" / "Unknown builtin" / "Could not find" errors, redirection warnings, the ``Defined in`` / ``copied in`` annotation in :doc:`functions <cmds/functions>` and :doc:`type <cmds/type>` output, the ``is a function/builtin/<path>`` lines in :doc:`type <cmds/type>` output, :doc:`jobs <cmds/jobs>` ``-c`` listings, :doc:`fish_indent <cmds/fish_indent>` error messages, :doc:`test <cmds/test>` parser errors, and bash history entries imported by :doc:`history <cmds/history>` (sanitized at the storage boundary so typed entries are unaffected). Data-returning builtins such as :doc:`pwd <cmds/pwd>`, :doc:`realpath <cmds/realpath>`, :doc:`type <cmds/type>` ``--path``, :doc:`functions <cmds/functions>` ``--details``, :doc:`status <cmds/status>` ``filename``, and the :doc:`path <cmds/path>` builtin still preserve their bytes so script captures are not affected.
+
 fish 4.7.1 (released May 08, 2026)
 ==================================
 

--- a/src/builtins/cd.rs
+++ b/src/builtins/cd.rs
@@ -2,6 +2,7 @@
 
 use super::prelude::*;
 use crate::{
+    common::sanitize_for_display,
     env::{EnvMode, Environment as _},
     err_fmt, err_raw, err_str,
     fds::{BEST_O_SEARCH, wopen_dir},
@@ -120,24 +121,25 @@ pub fn cd(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Built
         return Ok(SUCCESS);
     }
 
+    let dir_in_clean = sanitize_for_display(dir_in);
     let mut err = if best_errno == ENOTDIR {
-        err_fmt!("'%s' is not a directory", dir_in)
+        err_fmt!("'%s' is not a directory", dir_in_clean)
     } else if !broken_symlink.is_empty() {
         err_fmt!(
             "'%s' is a broken symbolic link to '%s'",
-            broken_symlink,
-            broken_symlink_target
+            sanitize_for_display(&broken_symlink),
+            sanitize_for_display(&broken_symlink_target)
         )
     } else if best_errno == ELOOP {
-        err_fmt!("Too many levels of symbolic links: '%s'", dir_in)
+        err_fmt!("Too many levels of symbolic links: '%s'", dir_in_clean)
     } else if best_errno == ENOENT {
-        err_fmt!(DIR_DOES_NOT_EXIST, dir_in)
+        err_fmt!(DIR_DOES_NOT_EXIST, dir_in_clean)
     } else if best_errno == EACCES || best_errno == EPERM {
-        err_fmt!("Permission denied: '%s'", dir_in)
+        err_fmt!("Permission denied: '%s'", dir_in_clean)
     } else {
         errno::set_errno(Errno(best_errno));
         err_raw!(builtin_strerror()).cmd(L!("cd")).finish(streams);
-        err_fmt!("Unknown error trying to locate directory '%s'", dir_in)
+        err_fmt!("Unknown error trying to locate directory '%s'", dir_in_clean)
     };
 
     if !parser.is_interactive() {

--- a/src/builtins/cd.rs
+++ b/src/builtins/cd.rs
@@ -139,7 +139,10 @@ pub fn cd(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -> Built
     } else {
         errno::set_errno(Errno(best_errno));
         err_raw!(builtin_strerror()).cmd(L!("cd")).finish(streams);
-        err_fmt!("Unknown error trying to locate directory '%s'", dir_in_clean)
+        err_fmt!(
+            "Unknown error trying to locate directory '%s'",
+            dir_in_clean
+        )
     };
 
     if !parser.is_interactive() {

--- a/src/builtins/fish_indent.rs
+++ b/src/builtins/fish_indent.rs
@@ -4,7 +4,7 @@ use super::prelude::*;
 use crate::{
     ast::{self, AsNode as _, Ast, Kind, Leaf as _, Node, NodeVisitor, SourceRangeList, Traversal},
     builtins::error::Error,
-    common::{PROGRAM_NAME, get_program_name},
+    common::{PROGRAM_NAME, get_program_name, sanitize_for_display},
     env::{EnvStack, env_init, environment::Environment as _},
     err_fmt, err_str,
     global_safety::RelaxedAtomicBool,
@@ -1080,7 +1080,12 @@ fn do_indent(
                     output_location = arg;
                 }
                 Err(err) => {
-                    err_fmt!("Opening \"%s\" failed: %s", arg, err.to_string()).finish(streams);
+                    err_fmt!(
+                        "Opening \"%s\" failed: %s",
+                        sanitize_for_display(arg),
+                        err.to_string()
+                    )
+                    .finish(streams);
                     return Err(STATUS_CMD_ERROR);
                 }
             }
@@ -1180,7 +1185,7 @@ fn do_indent(
             OutputType::Check => {
                 if output_wtext != src {
                     if let Some(arg) = args.get(i) {
-                        streams.err.appendln(*arg);
+                        streams.err.appendln(&sanitize_for_display(arg));
                     }
                     retval += 1;
                 }

--- a/src/builtins/functions.rs
+++ b/src/builtins/functions.rs
@@ -1,7 +1,7 @@
 use super::prelude::*;
 use crate::{
     builtins::error::Error,
-    common::{reformat_for_screen, valid_func_name},
+    common::{reformat_for_screen, sanitize_for_display, valid_func_name},
     err_fmt, err_str,
     event::{self},
     function,
@@ -392,7 +392,7 @@ pub fn functions(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -
                 Some(path) => {
                     comment.push_utfstr(&wgettext_fmt!(
                         "Defined in %s @ line %d",
-                        path,
+                        sanitize_for_display(path),
                         props.definition_lineno()
                     ));
                 }
@@ -407,7 +407,7 @@ pub fn functions(parser: &Parser, streams: &mut IoStreams, args: &mut [&wstr]) -
                     Some(path) => {
                         comment.push_utfstr(&wgettext_fmt!(
                             ", copied in %s @ line %d",
-                            path,
+                            sanitize_for_display(path),
                             props.copy_definition_lineno()
                         ));
                     }

--- a/src/builtins/jobs.rs
+++ b/src/builtins/jobs.rs
@@ -2,6 +2,7 @@
 
 use super::prelude::*;
 use crate::{
+    common::sanitize_for_display,
     err_fmt,
     io::IoStreams,
     job_group::{JobId, MaybeJobId},
@@ -120,7 +121,7 @@ fn builtin_jobs_print(j: &Job, mode: JobsPrintMode, header: bool, streams: &mut 
             }
 
             for p in j.processes() {
-                out += &sprintf!("%s\n", p.argv0().unwrap())[..];
+                out += &sprintf!("%s\n", sanitize_for_display(p.argv0().unwrap()))[..];
             }
             streams.out.append(&out);
         }

--- a/src/builtins/shared/misc.rs
+++ b/src/builtins/shared/misc.rs
@@ -1,5 +1,6 @@
 use crate::{
     builtins::{prelude::*, *},
+    common::sanitize_for_display,
     err_fmt,
     fds::BorrowedFdFile,
     io::OutputStream,
@@ -407,7 +408,11 @@ pub fn builtin_run(parser: &Parser, argv: &mut [&wstr], streams: &mut IoStreams)
     }
 
     let Some(builtin) = builtin_lookup(argv[0]) else {
-        flogf!(error, "%s", wgettext_fmt!(UNKNOWN_BUILTIN_ERR_MSG, argv[0]));
+        flogf!(
+            error,
+            "%s",
+            wgettext_fmt!(UNKNOWN_BUILTIN_ERR_MSG, sanitize_for_display(argv[0]))
+        );
         return ProcStatus::from_exit_code(STATUS_CMD_ERROR);
     };
 
@@ -893,9 +898,12 @@ fn parsed_pid(
     match pid {
         Ok(pid @ 1..) => Ok(Pid::new(pid)),
         _ => {
-            err_fmt!("'%s' is not a valid process ID", arg)
-                .cmd(cmd)
-                .finish(streams);
+            err_fmt!(
+                "'%s' is not a valid process ID",
+                sanitize_for_display(arg)
+            )
+            .cmd(cmd)
+            .finish(streams);
             Err(STATUS_INVALID_ARGS)
         }
     }

--- a/src/builtins/shared/misc.rs
+++ b/src/builtins/shared/misc.rs
@@ -898,12 +898,9 @@ fn parsed_pid(
     match pid {
         Ok(pid @ 1..) => Ok(Pid::new(pid)),
         _ => {
-            err_fmt!(
-                "'%s' is not a valid process ID",
-                sanitize_for_display(arg)
-            )
-            .cmd(cmd)
-            .finish(streams);
+            err_fmt!("'%s' is not a valid process ID", sanitize_for_display(arg))
+                .cmd(cmd)
+                .finish(streams);
             Err(STATUS_INVALID_ARGS)
         }
     }

--- a/src/builtins/test.rs
+++ b/src/builtins/test.rs
@@ -1,5 +1,5 @@
 use super::prelude::*;
-use crate::{err_str, should_flog};
+use crate::{common::sanitize_for_display, err_str, should_flog};
 use fish_feature_flags::{FeatureFlag, feature_test};
 
 mod test_expressions {
@@ -761,7 +761,7 @@ mod test_expressions {
                 if narg > 0 {
                     commandline.push(' ');
                 }
-                commandline.push_utfstr(arg);
+                commandline.push_utfstr(&sanitize_for_display(arg));
                 narg += 1;
                 if narg == parser.error_idx {
                     len_to_err = fish_wcswidth(&commandline).unwrap_or_default();

--- a/src/builtins/type.rs
+++ b/src/builtins/type.rs
@@ -1,6 +1,7 @@
 use super::prelude::*;
 use crate::{
     builtins::error::Error,
+    common::sanitize_for_display,
     err_fmt, err_str, function,
     highlight::highlight_and_colorize,
     parse_util::{apply_indents, compute_indents},
@@ -123,7 +124,7 @@ pub fn r#type(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
                         let lineno: i32 = props.definition_lineno();
                         comment.push_utfstr(&wgettext_fmt!(
                             "Defined in %s @ line %d",
-                            path,
+                            sanitize_for_display(path),
                             lineno
                         ));
                     }
@@ -138,7 +139,7 @@ pub fn r#type(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
                             let lineno = props.copy_definition_lineno();
                             comment.push_utfstr(&wgettext_fmt!(
                                 ", copied in %s @ line %d",
-                                path,
+                                sanitize_for_display(path),
                                 lineno
                             ));
                         }
@@ -152,7 +153,7 @@ pub fn r#type(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
                     } else if !opts.short_output {
                         streams.out.append(&sprintf!(
                             "%s %s\n",
-                            wgettext_fmt!("%s is a function", arg),
+                            wgettext_fmt!("%s is a function", sanitize_for_display(arg)),
                             wgettext!("with definition")
                         ));
                         let mut def = WString::new();
@@ -174,7 +175,7 @@ pub fn r#type(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
                             streams.out.append(&def);
                         }
                     } else {
-                        streams.out.append(&wgettext_fmt!("%s is a function", arg));
+                        streams.out.append(&wgettext_fmt!("%s is a function", sanitize_for_display(arg)));
                         streams.out.append(" ");
                         streams.out.appendln(&wgettext_fmt!("(%s)", comment));
                     }
@@ -194,7 +195,7 @@ pub fn r#type(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
                 return Ok(SUCCESS);
             }
             if !opts.get_type {
-                streams.out.appendln(&wgettext_fmt!("%s is a builtin", arg));
+                streams.out.appendln(&wgettext_fmt!("%s is a builtin", sanitize_for_display(arg)));
             } else if opts.get_type {
                 streams.out.append(L!("builtin\n"));
             }
@@ -222,7 +223,11 @@ pub fn r#type(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
                 if opts.path || opts.force_path {
                     streams.out.appendln(path);
                 } else {
-                    streams.out.appendln(&wgettext_fmt!("%s is %s", arg, path));
+                    streams.out.appendln(&wgettext_fmt!(
+                        "%s is %s",
+                        sanitize_for_display(arg),
+                        sanitize_for_display(path)
+                    ));
                 }
             } else if opts.get_type {
                 streams.out.appendln(L!("file"));
@@ -238,7 +243,7 @@ pub fn r#type(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
         }
 
         if found == 0 && !opts.query && !opts.path {
-            err_fmt!("Could not find '%s'", arg)
+            err_fmt!("Could not find '%s'", sanitize_for_display(arg))
                 .cmd(cmd)
                 .finish(streams);
         }

--- a/src/builtins/type.rs
+++ b/src/builtins/type.rs
@@ -175,7 +175,10 @@ pub fn r#type(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
                             streams.out.append(&def);
                         }
                     } else {
-                        streams.out.append(&wgettext_fmt!("%s is a function", sanitize_for_display(arg)));
+                        streams.out.append(&wgettext_fmt!(
+                            "%s is a function",
+                            sanitize_for_display(arg)
+                        ));
                         streams.out.append(" ");
                         streams.out.appendln(&wgettext_fmt!("(%s)", comment));
                     }
@@ -195,7 +198,9 @@ pub fn r#type(parser: &Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> B
                 return Ok(SUCCESS);
             }
             if !opts.get_type {
-                streams.out.appendln(&wgettext_fmt!("%s is a builtin", sanitize_for_display(arg)));
+                streams
+                    .out
+                    .appendln(&wgettext_fmt!("%s is a builtin", sanitize_for_display(arg)));
             } else if opts.get_type {
                 streams.out.append(L!("builtin\n"));
             }

--- a/src/common.rs
+++ b/src/common.rs
@@ -21,6 +21,16 @@ pub const BUILD_DIR: &str = env!("FISH_RESOLVED_BUILD_DIR");
 
 pub const PACKAGE_NAME: &str = env!("CARGO_PKG_NAME");
 
+/// Strip C0, DEL, C1 and the PUA range fish uses for raw invalid-UTF-8 bytes.
+pub fn sanitize_for_display(s: &wstr) -> WString {
+    s.chars()
+        .filter(|c| {
+            let v = u32::from(*c);
+            !(v <= 0x1f || (0x7f..=0x9f).contains(&v) || (0xf680..=0xf69f).contains(&v))
+        })
+        .collect()
+}
+
 pub fn shell_modes() -> MutexGuard<'static, Termios> {
     crate::reader::SHELL_MODES.lock().unwrap()
 }
@@ -321,7 +331,7 @@ pub const ESCAPE_TEST_CHAR: usize = 4000;
 mod tests {
     use super::{
         ESCAPE_TEST_CHAR, EscapeFlags, EscapeStringStyle, UnescapeStringStyle, escape_string,
-        escape_string_with_quote, unescape_string,
+        escape_string_with_quote, sanitize_for_display, unescape_string,
     };
     use crate::tests::prelude::*;
     use fish_util::get_seeded_rng;
@@ -331,6 +341,27 @@ mod tests {
     };
     use rand::{Rng as _, RngCore as _};
     use std::fmt::Write as _;
+
+    #[test]
+    fn sanitize_strips_c0_del_and_c1() {
+        // C0 controls (including ESC), DEL and C1 are dropped.
+        let s = WString::from_chars(['a', '\x00', 'b', '\x1b', 'c', '\x7f', 'd', '\u{0080}', 'e', '\u{009f}', 'f']);
+        assert_eq!(sanitize_for_display(&s), L!("abcdef"));
+    }
+
+    #[test]
+    fn sanitize_strips_pua_invalid_utf8_bytes() {
+        // The PUA range fish uses for raw invalid-UTF-8 bytes is dropped too.
+        let s = WString::from_chars(['x', '\u{f680}', 'y', '\u{f69f}', 'z']);
+        assert_eq!(sanitize_for_display(&s), L!("xyz"));
+    }
+
+    #[test]
+    fn sanitize_keeps_latin1_supplement_and_higher() {
+        // Anything from U+00A0 onward is preserved.
+        let s = WString::from_chars(['a', '\u{00a0}', 'b', '\u{00ff}', 'c', '中', '🦀']);
+        assert_eq!(sanitize_for_display(&s), s);
+    }
 
     #[test]
     fn test_escape_string() {

--- a/src/common.rs
+++ b/src/common.rs
@@ -345,7 +345,9 @@ mod tests {
     #[test]
     fn sanitize_strips_c0_del_and_c1() {
         // C0 controls (including ESC), DEL and C1 are dropped.
-        let s = WString::from_chars(['a', '\x00', 'b', '\x1b', 'c', '\x7f', 'd', '\u{0080}', 'e', '\u{009f}', 'f']);
+        let s = WString::from_chars([
+            'a', '\x00', 'b', '\x1b', 'c', '\x7f', 'd', '\u{0080}', 'e', '\u{009f}', 'f',
+        ]);
         assert_eq!(sanitize_for_display(&s), L!("abcdef"));
     }
 

--- a/src/history/history.rs
+++ b/src/history/history.rs
@@ -16,7 +16,7 @@
 
 use crate::{
     ast::{self, Kind, Node as _},
-    common::{CancelChecker, valid_var_name},
+    common::{CancelChecker, sanitize_for_display, valid_var_name},
     env::{EnvMode, EnvSetMode, EnvStack, EnvVar, Environment},
     expand::{ExpandFlags, expand_one},
     fds::wopen_cloexec,
@@ -926,7 +926,7 @@ impl HistoryImpl {
             let Ok(line) = line else {
                 break;
             };
-            let wide_line = trim(bytes2wcstring(&line), None);
+            let wide_line = sanitize_for_display(&trim(bytes2wcstring(&line), None));
             // Add this line if it doesn't contain anything we know we can't handle.
             if should_import_bash_history_line(&wide_line) {
                 self.add(

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,5 +1,6 @@
 use crate::{
     builtins::shared::{STATUS_CMD_ERROR, STATUS_CMD_OK, STATUS_READ_TOO_MUCH},
+    common::sanitize_for_display,
     fd_monitor::{Callback, FdMonitor, FdMonitorItemId},
     fds::{BorrowedFdFile, PIPE_ERROR, make_autoclose_pipes, make_fd_nonblocking, wopen_cloexec},
     flog::{flog, flogf, should_flog},
@@ -540,6 +541,9 @@ impl IoChain {
         let mut have_error = false;
 
         let print_error = |err, target: &wstr| {
+            // Strip controls so a hostile-named target path can't inject
+            // terminal sequences via the warning.
+            let target = &sanitize_for_display(target)[..];
             // If the error is that the file doesn't exist
             // or there's a non-directory component,
             // find the first problematic component for a better message.
@@ -591,7 +595,7 @@ impl IoChain {
                         }
                         Err(err) => {
                             if oflags.contains(OFlag::O_EXCL) && err == nix::Error::EEXIST {
-                                flogf!(warning, NOCLOB_ERROR, spec.target);
+                                flogf!(warning, NOCLOB_ERROR, sanitize_for_display(&spec.target));
                             } else if spec.mode != RedirectionMode::TryInput
                                 && should_flog!(warning)
                             {

--- a/src/parse_constants.rs
+++ b/src/parse_constants.rs
@@ -1,5 +1,6 @@
 //! Constants used in the programmatic representation of fish code.
 
+use crate::common::sanitize_for_display;
 use crate::prelude::*;
 use fish_fallback::{fish_wcswidth, fish_wcwidth};
 
@@ -367,11 +368,14 @@ impl ParseError {
             return result;
         }
 
-        // Append the line of text.
+        // Append the line of text. Strip controls so a hostile source line
+        // can't inject terminal sequences when the error is shown.
         if !result.is_empty() {
             result += "\n";
         }
-        result += wstr::from_char_slice(&src.as_char_slice()[line_start..line_end]);
+        result += &sanitize_for_display(wstr::from_char_slice(
+            &src.as_char_slice()[line_start..line_end],
+        ))[..];
 
         // Append the caret line. The input source may include tabs; for that reason we
         // construct a "caret line" that has tabs in corresponding positions.

--- a/src/parse_execution.rs
+++ b/src/parse_execution.rs
@@ -14,7 +14,7 @@ use crate::{
             STATUS_UNMATCHED_WILDCARD, builtin_exists,
         },
     },
-    common::valid_var_name,
+    common::{sanitize_for_display, valid_var_name},
     complete::CompletionList,
     env::{EnvMode, EnvStackSetResult, EnvVar, EnvVarFlags, Environment as _, Statuses},
     err_fmt,
@@ -274,6 +274,9 @@ impl ExecutionContext {
     ) -> EndExecutionReason {
         // We couldn't find the specified command. This is a non-fatal error. We want to set the exit
         // status to 127, which is the standard number used by other shells like bash and zsh.
+        // Strip controls so a hostile-named binary can't inject sequences via the error.
+        let cmd_disp = sanitize_for_display(cmd);
+        let cmd = &cmd_disp[..];
 
         if err.kind() != ErrorKind::NotFound {
             // TODO: We currently handle all errors here the same,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1284,9 +1284,10 @@ impl Parser {
     }
 }
 
-// Given a file path, return something nicer. Currently we just "unexpand" tildes.
+// Given a file path, return something nicer. Currently we just "unexpand"
+// tildes and strip control characters that could disturb terminal display.
 fn user_presentable_path(path: &wstr, vars: &dyn Environment) -> WString {
-    replace_home_directory_with_tilde(path, vars)
+    crate::common::sanitize_for_display(&replace_home_directory_with_tilde(path, vars))
 }
 
 /// Print profiling information to the specified stream.

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -3,6 +3,7 @@ use crate::global_safety::RelaxedAtomicBool;
 use crate::prelude::*;
 use crate::{
     screen::{is_dumb, only_grayscale},
+    common::sanitize_for_display,
     text_face::{ResettableStyle, TextFace, TextStyling, UnderlineStyle},
     threads::MainThread,
 };
@@ -177,7 +178,8 @@ fn query_kitty_progressive_enhancements(out: &mut Outputter) -> bool {
 fn osc_0_or_1_terminal_title(out: &mut Outputter, is_1: bool, title: &[WString]) -> bool {
     out.write_bytes(if is_1 { b"\x1b]1;" } else { b"\x1b]0;" });
     for title_line in title {
-        out.write_bytes(&wcs2bytes(title_line));
+        // Drop bytes that would close or restart the OSC envelope.
+        out.write_bytes(&wcs2bytes(&sanitize_for_display(title_line)));
     }
     out.write_bytes(b"\x07"); // BEL
     true

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -2,8 +2,8 @@ use crate::global_safety::RelaxedAtomicBool;
 // Generic output functions.
 use crate::prelude::*;
 use crate::{
-    screen::{is_dumb, only_grayscale},
     common::sanitize_for_display,
+    screen::{is_dumb, only_grayscale},
     text_face::{ResettableStyle, TextFace, TextStyling, UnderlineStyle},
     threads::MainThread,
 };

--- a/tests/checks/cd-error-strips-controls.fish
+++ b/tests/checks/cd-error-strips-controls.fish
@@ -1,0 +1,13 @@
+#RUN: fish=%fish %fish %s
+
+# Verify cd error messages strip control characters from the path argument.
+# Hostile-named directories must not be able to inject terminal sequences
+# via the "directory does not exist" error.
+
+cd (printf '/tmp/__nope_a\x1bb\x07c\x9dd')
+# CHECKERR: cd: The directory '/tmp/__nope_abcd' does not exist
+# CHECKERR: {{.*}}cd.fish (line {{\d+}}):
+# CHECKERR: builtin cd $argv
+# CHECKERR: ^
+# CHECKERR: in function 'cd' with arguments {{.*}}
+# CHECKERR: {{.*}}called on line {{\d+}} of file {{.*}}


### PR DESCRIPTION
Same as  #12730 but for the rust side

Several areas that are missing sanitation of terminal control characters which can be triggered by file or
directory names:

- bash-imported history entries (sanitized at the storage boundary so the history builtin's normal display path keeps returning raw bytes for typed entries that scripts capture)
- parse-error display source line
- user_presentable_path, covers call sites for source-file errors and stack traces
- OSC 0/1 terminal title payload
- handle_command_not_found's "Unknown command" error
- redirection error warnings in io.rs like target path and NOCLOB
- functions builtin's "Defined in" / "copied in" annotation comment
- type builtin's "Defined in" / "copied in" annotation, "is a function / builtin / <path>" display, and "Could not find" error
- jobs -c argv0 listing
- fish_indent's "Opening %s failed" error and -c (check mode) failed filename print
- builtin dispatcher's "Unknown builtin" error
- parsed_pid's "not a valid process ID" error
- test parser-error commandline echo

There are some areas not filtered like pipes so that scripts that relay on unfiltered output are not impacted.

- [X] Tests have been added for regressions fixed
- [X] User-visible changes noted in CHANGELOG.rst