### PR TITLE
Join commands/arguments

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 fish ?.?.? (released ???)
 =========================
 
+Interactive improvements
+------------------------
+- Completion will always join candidates sharing the same description, not just when completing a single `-`. Most notably, this includes possibly joining subcommands with options (e.g. ``help`` and ``--help``)
+
 fish 4.7.1 (released May 08, 2026)
 ==================================
 

--- a/doc_src/cmds/complete.rst
+++ b/doc_src/cmds/complete.rst
@@ -99,7 +99,7 @@ When ``-a`` or ``--arguments`` is specified in conjunction with long, short, or 
 
 Command substitutions found in ``ARGUMENTS`` should return a newline-separated list of arguments, and each argument may optionally have a tab character followed by the argument description. Description given this way override a description given with ``-d`` or ``--description``.
 
-Descriptions given with ``--description`` are also used to group options given with ``-s``, ``-o`` or ``-l``. Options with the same (non-empty) description will be listed as one candidate, and one of them will be picked. If the description is empty or no description was given this is skipped.
+Descriptions given with ``--description`` are also used to group arguments given with ``-s``, ``-o``, ``-l`` or ``-a``. Arguments with the same (non-empty) description will be listed as one candidate, and one of them will be picked. If the description is empty or no description was given this is skipped.
 
 The ``-w`` or ``--wraps`` options causes the specified command to inherit completions from another command, "wrapping" the other command. The wrapping command can also have additional completions. A command can wrap multiple commands, and wrapping is transitive: if A wraps B, and B wraps C, then A automatically inherits all of C's completions. Wrapping can be removed using the ``-e`` or ``--erase`` options. Wrapping only works for completions specified with ``-c`` or ``--command`` and are ignored when specifying completions with ``-p`` or ``--path``.
 

--- a/localization/po/de.po
+++ b/localization/po/de.po
@@ -3698,6 +3698,9 @@ msgstr ""
 msgid "wait for app to exit"
 msgstr ""
 
+msgid "fish-section-tier3-from-script-explicitly-added"
+msgstr ""
+
 msgid "fish-section-tier3-from-script-implicitly-added"
 msgstr ""
 
@@ -30309,105 +30312,6 @@ msgid "Help about current supported formats"
 msgstr ""
 
 msgid "Help about supported formats"
-msgstr ""
-
-msgid "Help for autocomplete"
-msgstr ""
-
-msgid "Help for benchmark"
-msgstr ""
-
-msgid "Help for build"
-msgstr ""
-
-msgid "Help for check"
-msgstr ""
-
-msgid "Help for chromastyles"
-msgstr ""
-
-msgid "Help for cjpm"
-msgstr ""
-
-msgid "Help for config"
-msgstr ""
-
-msgid "Help for convert"
-msgstr ""
-
-msgid "Help for doc"
-msgstr ""
-
-msgid "Help for drafts"
-msgstr ""
-
-msgid "Help for env"
-msgstr ""
-
-msgid "Help for expired"
-msgstr ""
-
-msgid "Help for future"
-msgstr ""
-
-msgid "Help for gen"
-msgstr ""
-
-msgid "Help for hugo"
-msgstr ""
-
-msgid "Help for import"
-msgstr ""
-
-msgid "Help for init"
-msgstr ""
-
-msgid "Help for install"
-msgstr ""
-
-msgid "Help for jekyll"
-msgstr ""
-
-msgid "Help for list"
-msgstr ""
-
-msgid "Help for man"
-msgstr ""
-
-msgid "Help for new"
-msgstr ""
-
-msgid "Help for run"
-msgstr ""
-
-msgid "Help for server"
-msgstr ""
-
-msgid "Help for site"
-msgstr ""
-
-msgid "Help for test"
-msgstr ""
-
-msgid "Help for theme"
-msgstr ""
-
-msgid "Help for toJSON"
-msgstr ""
-
-msgid "Help for toTOML"
-msgstr ""
-
-msgid "Help for toYAML"
-msgstr ""
-
-msgid "Help for ulimit"
-msgstr ""
-
-msgid "Help for undraft"
-msgstr ""
-
-msgid "Help for version"
 msgstr ""
 
 msgid "Help screen"

--- a/localization/po/de.po
+++ b/localization/po/de.po
@@ -2024,7 +2024,7 @@ msgstr ""
 msgid "Getting Help"
 msgstr ""
 
-msgid "Help for this command"
+msgid "Help for `%s`"
 msgstr ""
 
 msgid "Home directory expansion ~USER"

--- a/localization/po/en.po
+++ b/localization/po/en.po
@@ -2024,7 +2024,7 @@ msgstr ""
 msgid "Getting Help"
 msgstr ""
 
-msgid "Help for this command"
+msgid "Help for `%s`"
 msgstr ""
 
 msgid "Home directory expansion ~USER"

--- a/localization/po/en.po
+++ b/localization/po/en.po
@@ -3698,6 +3698,9 @@ msgstr "vi-like key bindings for fish"
 msgid "wait for app to exit"
 msgstr ""
 
+msgid "fish-section-tier3-from-script-explicitly-added"
+msgstr ""
+
 msgid "fish-section-tier3-from-script-implicitly-added"
 msgstr ""
 
@@ -30309,105 +30312,6 @@ msgid "Help about current supported formats"
 msgstr ""
 
 msgid "Help about supported formats"
-msgstr ""
-
-msgid "Help for autocomplete"
-msgstr ""
-
-msgid "Help for benchmark"
-msgstr ""
-
-msgid "Help for build"
-msgstr ""
-
-msgid "Help for check"
-msgstr ""
-
-msgid "Help for chromastyles"
-msgstr ""
-
-msgid "Help for cjpm"
-msgstr ""
-
-msgid "Help for config"
-msgstr ""
-
-msgid "Help for convert"
-msgstr ""
-
-msgid "Help for doc"
-msgstr ""
-
-msgid "Help for drafts"
-msgstr ""
-
-msgid "Help for env"
-msgstr ""
-
-msgid "Help for expired"
-msgstr ""
-
-msgid "Help for future"
-msgstr ""
-
-msgid "Help for gen"
-msgstr ""
-
-msgid "Help for hugo"
-msgstr ""
-
-msgid "Help for import"
-msgstr ""
-
-msgid "Help for init"
-msgstr ""
-
-msgid "Help for install"
-msgstr ""
-
-msgid "Help for jekyll"
-msgstr ""
-
-msgid "Help for list"
-msgstr ""
-
-msgid "Help for man"
-msgstr ""
-
-msgid "Help for new"
-msgstr ""
-
-msgid "Help for run"
-msgstr ""
-
-msgid "Help for server"
-msgstr ""
-
-msgid "Help for site"
-msgstr ""
-
-msgid "Help for test"
-msgstr ""
-
-msgid "Help for theme"
-msgstr ""
-
-msgid "Help for toJSON"
-msgstr ""
-
-msgid "Help for toTOML"
-msgstr ""
-
-msgid "Help for toYAML"
-msgstr ""
-
-msgid "Help for ulimit"
-msgstr ""
-
-msgid "Help for undraft"
-msgstr ""
-
-msgid "Help for version"
 msgstr ""
 
 msgid "Help screen"

--- a/localization/po/es.po
+++ b/localization/po/es.po
@@ -3698,6 +3698,9 @@ msgstr ""
 msgid "wait for app to exit"
 msgstr ""
 
+msgid "fish-section-tier3-from-script-explicitly-added"
+msgstr ""
+
 msgid "fish-section-tier3-from-script-implicitly-added"
 msgstr ""
 
@@ -30309,105 +30312,6 @@ msgid "Help about current supported formats"
 msgstr ""
 
 msgid "Help about supported formats"
-msgstr ""
-
-msgid "Help for autocomplete"
-msgstr ""
-
-msgid "Help for benchmark"
-msgstr ""
-
-msgid "Help for build"
-msgstr ""
-
-msgid "Help for check"
-msgstr ""
-
-msgid "Help for chromastyles"
-msgstr ""
-
-msgid "Help for cjpm"
-msgstr ""
-
-msgid "Help for config"
-msgstr ""
-
-msgid "Help for convert"
-msgstr ""
-
-msgid "Help for doc"
-msgstr ""
-
-msgid "Help for drafts"
-msgstr ""
-
-msgid "Help for env"
-msgstr ""
-
-msgid "Help for expired"
-msgstr ""
-
-msgid "Help for future"
-msgstr ""
-
-msgid "Help for gen"
-msgstr ""
-
-msgid "Help for hugo"
-msgstr ""
-
-msgid "Help for import"
-msgstr ""
-
-msgid "Help for init"
-msgstr ""
-
-msgid "Help for install"
-msgstr ""
-
-msgid "Help for jekyll"
-msgstr ""
-
-msgid "Help for list"
-msgstr ""
-
-msgid "Help for man"
-msgstr ""
-
-msgid "Help for new"
-msgstr ""
-
-msgid "Help for run"
-msgstr ""
-
-msgid "Help for server"
-msgstr ""
-
-msgid "Help for site"
-msgstr ""
-
-msgid "Help for test"
-msgstr ""
-
-msgid "Help for theme"
-msgstr ""
-
-msgid "Help for toJSON"
-msgstr ""
-
-msgid "Help for toTOML"
-msgstr ""
-
-msgid "Help for toYAML"
-msgstr ""
-
-msgid "Help for ulimit"
-msgstr ""
-
-msgid "Help for undraft"
-msgstr ""
-
-msgid "Help for version"
 msgstr ""
 
 msgid "Help screen"

--- a/localization/po/es.po
+++ b/localization/po/es.po
@@ -2024,7 +2024,7 @@ msgstr ""
 msgid "Getting Help"
 msgstr ""
 
-msgid "Help for this command"
+msgid "Help for `%s`"
 msgstr ""
 
 msgid "Home directory expansion ~USER"

--- a/localization/po/fr.po
+++ b/localization/po/fr.po
@@ -2153,8 +2153,8 @@ msgstr "Encore plus d’aide et développement"
 msgid "Getting Help"
 msgstr "Obtenir de l’aide"
 
-msgid "Help for this command"
-msgstr ""
+msgid "Help for `%s`"
+msgstr "Aide sur « %s »"
 
 msgid "Home directory expansion ~USER"
 msgstr "Expansion du dossier principal ~USER"

--- a/localization/po/fr.po
+++ b/localization/po/fr.po
@@ -3827,6 +3827,9 @@ msgstr ""
 msgid "wait for app to exit"
 msgstr ""
 
+msgid "fish-section-tier3-from-script-explicitly-added"
+msgstr ""
+
 msgid "fish-section-tier3-from-script-implicitly-added"
 msgstr ""
 
@@ -30439,105 +30442,6 @@ msgstr "Aide à propos des formats actuellement supportés"
 
 msgid "Help about supported formats"
 msgstr "Aide à propos des formats supportés"
-
-msgid "Help for autocomplete"
-msgstr "Aide sur « autocomplete »"
-
-msgid "Help for benchmark"
-msgstr "Aide sur le banc d’essai"
-
-msgid "Help for build"
-msgstr ""
-
-msgid "Help for check"
-msgstr "Aide sur « check »"
-
-msgid "Help for chromastyles"
-msgstr "Aide sur « chromastyles »"
-
-msgid "Help for cjpm"
-msgstr ""
-
-msgid "Help for config"
-msgstr "Aide sur « config »"
-
-msgid "Help for convert"
-msgstr "Aide sur « convert »"
-
-msgid "Help for doc"
-msgstr "Aide sur « doc »"
-
-msgid "Help for drafts"
-msgstr "Aide pour « drafts »"
-
-msgid "Help for env"
-msgstr "Aide sur « env »"
-
-msgid "Help for expired"
-msgstr "Aide pour « expired »"
-
-msgid "Help for future"
-msgstr "Aide pour « future »"
-
-msgid "Help for gen"
-msgstr "Aide sur « gen »"
-
-msgid "Help for hugo"
-msgstr "Afficher l’aide"
-
-msgid "Help for import"
-msgstr "Aide pour « import »"
-
-msgid "Help for init"
-msgstr ""
-
-msgid "Help for install"
-msgstr ""
-
-msgid "Help for jekyll"
-msgstr "Aide pour « jekyll »"
-
-msgid "Help for list"
-msgstr "Aide pour « list »"
-
-msgid "Help for man"
-msgstr "Aide pour « man »"
-
-msgid "Help for new"
-msgstr "Aide pour « new »"
-
-msgid "Help for run"
-msgstr ""
-
-msgid "Help for server"
-msgstr "Aide pour « server »"
-
-msgid "Help for site"
-msgstr "Aide pour « site »"
-
-msgid "Help for test"
-msgstr ""
-
-msgid "Help for theme"
-msgstr "Aide pour « theme »"
-
-msgid "Help for toJSON"
-msgstr "Aide sur « toJSON »"
-
-msgid "Help for toTOML"
-msgstr "Aide sur « toTOML »"
-
-msgid "Help for toYAML"
-msgstr "Aide sur « toYAML »"
-
-msgid "Help for ulimit"
-msgstr "Aide sur « ulimit »"
-
-msgid "Help for undraft"
-msgstr "Aide pour « undraft »"
-
-msgid "Help for version"
-msgstr "Aide pour « version »"
 
 msgid "Help screen"
 msgstr ""

--- a/localization/po/ja_JP.po
+++ b/localization/po/ja_JP.po
@@ -3701,6 +3701,9 @@ msgstr "fish 用の vi 風キーバインド"
 msgid "wait for app to exit"
 msgstr "アプリが終了するまで待機"
 
+msgid "fish-section-tier3-from-script-explicitly-added"
+msgstr ""
+
 msgid "fish-section-tier3-from-script-implicitly-added"
 msgstr ""
 
@@ -30312,105 +30315,6 @@ msgid "Help about current supported formats"
 msgstr ""
 
 msgid "Help about supported formats"
-msgstr ""
-
-msgid "Help for autocomplete"
-msgstr ""
-
-msgid "Help for benchmark"
-msgstr ""
-
-msgid "Help for build"
-msgstr ""
-
-msgid "Help for check"
-msgstr ""
-
-msgid "Help for chromastyles"
-msgstr ""
-
-msgid "Help for cjpm"
-msgstr ""
-
-msgid "Help for config"
-msgstr ""
-
-msgid "Help for convert"
-msgstr ""
-
-msgid "Help for doc"
-msgstr ""
-
-msgid "Help for drafts"
-msgstr ""
-
-msgid "Help for env"
-msgstr ""
-
-msgid "Help for expired"
-msgstr ""
-
-msgid "Help for future"
-msgstr ""
-
-msgid "Help for gen"
-msgstr ""
-
-msgid "Help for hugo"
-msgstr ""
-
-msgid "Help for import"
-msgstr ""
-
-msgid "Help for init"
-msgstr ""
-
-msgid "Help for install"
-msgstr ""
-
-msgid "Help for jekyll"
-msgstr ""
-
-msgid "Help for list"
-msgstr ""
-
-msgid "Help for man"
-msgstr ""
-
-msgid "Help for new"
-msgstr ""
-
-msgid "Help for run"
-msgstr ""
-
-msgid "Help for server"
-msgstr ""
-
-msgid "Help for site"
-msgstr ""
-
-msgid "Help for test"
-msgstr ""
-
-msgid "Help for theme"
-msgstr ""
-
-msgid "Help for toJSON"
-msgstr ""
-
-msgid "Help for toTOML"
-msgstr ""
-
-msgid "Help for toYAML"
-msgstr ""
-
-msgid "Help for ulimit"
-msgstr ""
-
-msgid "Help for undraft"
-msgstr ""
-
-msgid "Help for version"
 msgstr ""
 
 msgid "Help screen"

--- a/localization/po/ja_JP.po
+++ b/localization/po/ja_JP.po
@@ -2024,8 +2024,8 @@ msgstr "さらなるヘルプと開発"
 msgid "Getting Help"
 msgstr "ヘルプの参照"
 
-msgid "Help for this command"
-msgstr "このコマンドのヘルプ"
+msgid "Help for `%s`"
+msgstr "`%s` のヘルプ"
 
 msgid "Home directory expansion ~USER"
 msgstr "ホームディレクトリ展開 ~USER"

--- a/localization/po/pl.po
+++ b/localization/po/pl.po
@@ -2020,7 +2020,7 @@ msgstr ""
 msgid "Getting Help"
 msgstr ""
 
-msgid "Help for this command"
+msgid "Help for `%s`"
 msgstr ""
 
 msgid "Home directory expansion ~USER"

--- a/localization/po/pl.po
+++ b/localization/po/pl.po
@@ -3694,6 +3694,9 @@ msgstr ""
 msgid "wait for app to exit"
 msgstr ""
 
+msgid "fish-section-tier3-from-script-explicitly-added"
+msgstr ""
+
 msgid "fish-section-tier3-from-script-implicitly-added"
 msgstr ""
 
@@ -30305,105 +30308,6 @@ msgid "Help about current supported formats"
 msgstr ""
 
 msgid "Help about supported formats"
-msgstr ""
-
-msgid "Help for autocomplete"
-msgstr ""
-
-msgid "Help for benchmark"
-msgstr ""
-
-msgid "Help for build"
-msgstr ""
-
-msgid "Help for check"
-msgstr ""
-
-msgid "Help for chromastyles"
-msgstr ""
-
-msgid "Help for cjpm"
-msgstr ""
-
-msgid "Help for config"
-msgstr ""
-
-msgid "Help for convert"
-msgstr ""
-
-msgid "Help for doc"
-msgstr ""
-
-msgid "Help for drafts"
-msgstr ""
-
-msgid "Help for env"
-msgstr ""
-
-msgid "Help for expired"
-msgstr ""
-
-msgid "Help for future"
-msgstr ""
-
-msgid "Help for gen"
-msgstr ""
-
-msgid "Help for hugo"
-msgstr ""
-
-msgid "Help for import"
-msgstr ""
-
-msgid "Help for init"
-msgstr ""
-
-msgid "Help for install"
-msgstr ""
-
-msgid "Help for jekyll"
-msgstr ""
-
-msgid "Help for list"
-msgstr ""
-
-msgid "Help for man"
-msgstr ""
-
-msgid "Help for new"
-msgstr ""
-
-msgid "Help for run"
-msgstr ""
-
-msgid "Help for server"
-msgstr ""
-
-msgid "Help for site"
-msgstr ""
-
-msgid "Help for test"
-msgstr ""
-
-msgid "Help for theme"
-msgstr ""
-
-msgid "Help for toJSON"
-msgstr ""
-
-msgid "Help for toTOML"
-msgstr ""
-
-msgid "Help for toYAML"
-msgstr ""
-
-msgid "Help for ulimit"
-msgstr ""
-
-msgid "Help for undraft"
-msgstr ""
-
-msgid "Help for version"
 msgstr ""
 
 msgid "Help screen"

--- a/localization/po/pt_BR.po
+++ b/localization/po/pt_BR.po
@@ -2025,7 +2025,7 @@ msgstr ""
 msgid "Getting Help"
 msgstr ""
 
-msgid "Help for this command"
+msgid "Help for `%s`"
 msgstr ""
 
 msgid "Home directory expansion ~USER"

--- a/localization/po/pt_BR.po
+++ b/localization/po/pt_BR.po
@@ -3699,6 +3699,9 @@ msgstr ""
 msgid "wait for app to exit"
 msgstr ""
 
+msgid "fish-section-tier3-from-script-explicitly-added"
+msgstr ""
+
 msgid "fish-section-tier3-from-script-implicitly-added"
 msgstr ""
 
@@ -30310,105 +30313,6 @@ msgid "Help about current supported formats"
 msgstr ""
 
 msgid "Help about supported formats"
-msgstr ""
-
-msgid "Help for autocomplete"
-msgstr ""
-
-msgid "Help for benchmark"
-msgstr ""
-
-msgid "Help for build"
-msgstr ""
-
-msgid "Help for check"
-msgstr ""
-
-msgid "Help for chromastyles"
-msgstr ""
-
-msgid "Help for cjpm"
-msgstr ""
-
-msgid "Help for config"
-msgstr ""
-
-msgid "Help for convert"
-msgstr ""
-
-msgid "Help for doc"
-msgstr ""
-
-msgid "Help for drafts"
-msgstr ""
-
-msgid "Help for env"
-msgstr ""
-
-msgid "Help for expired"
-msgstr ""
-
-msgid "Help for future"
-msgstr ""
-
-msgid "Help for gen"
-msgstr ""
-
-msgid "Help for hugo"
-msgstr ""
-
-msgid "Help for import"
-msgstr ""
-
-msgid "Help for init"
-msgstr ""
-
-msgid "Help for install"
-msgstr ""
-
-msgid "Help for jekyll"
-msgstr ""
-
-msgid "Help for list"
-msgstr ""
-
-msgid "Help for man"
-msgstr ""
-
-msgid "Help for new"
-msgstr ""
-
-msgid "Help for run"
-msgstr ""
-
-msgid "Help for server"
-msgstr ""
-
-msgid "Help for site"
-msgstr ""
-
-msgid "Help for test"
-msgstr ""
-
-msgid "Help for theme"
-msgstr ""
-
-msgid "Help for toJSON"
-msgstr ""
-
-msgid "Help for toTOML"
-msgstr ""
-
-msgid "Help for toYAML"
-msgstr ""
-
-msgid "Help for ulimit"
-msgstr ""
-
-msgid "Help for undraft"
-msgstr ""
-
-msgid "Help for version"
 msgstr ""
 
 msgid "Help screen"

--- a/localization/po/sv.po
+++ b/localization/po/sv.po
@@ -3695,6 +3695,9 @@ msgstr ""
 msgid "wait for app to exit"
 msgstr ""
 
+msgid "fish-section-tier3-from-script-explicitly-added"
+msgstr ""
+
 msgid "fish-section-tier3-from-script-implicitly-added"
 msgstr ""
 
@@ -30306,105 +30309,6 @@ msgid "Help about current supported formats"
 msgstr ""
 
 msgid "Help about supported formats"
-msgstr ""
-
-msgid "Help for autocomplete"
-msgstr ""
-
-msgid "Help for benchmark"
-msgstr ""
-
-msgid "Help for build"
-msgstr ""
-
-msgid "Help for check"
-msgstr ""
-
-msgid "Help for chromastyles"
-msgstr ""
-
-msgid "Help for cjpm"
-msgstr ""
-
-msgid "Help for config"
-msgstr ""
-
-msgid "Help for convert"
-msgstr ""
-
-msgid "Help for doc"
-msgstr ""
-
-msgid "Help for drafts"
-msgstr ""
-
-msgid "Help for env"
-msgstr ""
-
-msgid "Help for expired"
-msgstr ""
-
-msgid "Help for future"
-msgstr ""
-
-msgid "Help for gen"
-msgstr ""
-
-msgid "Help for hugo"
-msgstr ""
-
-msgid "Help for import"
-msgstr ""
-
-msgid "Help for init"
-msgstr ""
-
-msgid "Help for install"
-msgstr ""
-
-msgid "Help for jekyll"
-msgstr ""
-
-msgid "Help for list"
-msgstr ""
-
-msgid "Help for man"
-msgstr ""
-
-msgid "Help for new"
-msgstr ""
-
-msgid "Help for run"
-msgstr ""
-
-msgid "Help for server"
-msgstr ""
-
-msgid "Help for site"
-msgstr ""
-
-msgid "Help for test"
-msgstr ""
-
-msgid "Help for theme"
-msgstr ""
-
-msgid "Help for toJSON"
-msgstr ""
-
-msgid "Help for toTOML"
-msgstr ""
-
-msgid "Help for toYAML"
-msgstr ""
-
-msgid "Help for ulimit"
-msgstr ""
-
-msgid "Help for undraft"
-msgstr ""
-
-msgid "Help for version"
 msgstr ""
 
 msgid "Help screen"

--- a/localization/po/sv.po
+++ b/localization/po/sv.po
@@ -2021,7 +2021,7 @@ msgstr ""
 msgid "Getting Help"
 msgstr ""
 
-msgid "Help for this command"
+msgid "Help for `%s`"
 msgstr ""
 
 msgid "Home directory expansion ~USER"

--- a/localization/po/zh_CN.po
+++ b/localization/po/zh_CN.po
@@ -2045,8 +2045,8 @@ msgstr "进一步的帮助和开发"
 msgid "Getting Help"
 msgstr "获取帮助"
 
-msgid "Help for this command"
-msgstr "此命令的帮助"
+msgid "Help for `%s`"
+msgstr "显示 %s 的帮助信息"
 
 msgid "Home directory expansion ~USER"
 msgstr "主目录展开 ~USER"

--- a/localization/po/zh_CN.po
+++ b/localization/po/zh_CN.po
@@ -3719,6 +3719,9 @@ msgstr "fish 中类似 vi 的键位绑定"
 msgid "wait for app to exit"
 msgstr "等待应用程序退出"
 
+msgid "fish-section-tier3-from-script-explicitly-added"
+msgstr ""
+
 msgid "fish-section-tier3-from-script-implicitly-added"
 msgstr ""
 
@@ -30330,105 +30333,6 @@ msgid "Help about current supported formats"
 msgstr ""
 
 msgid "Help about supported formats"
-msgstr ""
-
-msgid "Help for autocomplete"
-msgstr ""
-
-msgid "Help for benchmark"
-msgstr ""
-
-msgid "Help for build"
-msgstr "显示 build 的帮助信息"
-
-msgid "Help for check"
-msgstr ""
-
-msgid "Help for chromastyles"
-msgstr ""
-
-msgid "Help for cjpm"
-msgstr "显示 cjpm 的帮助信息"
-
-msgid "Help for config"
-msgstr ""
-
-msgid "Help for convert"
-msgstr ""
-
-msgid "Help for doc"
-msgstr ""
-
-msgid "Help for drafts"
-msgstr ""
-
-msgid "Help for env"
-msgstr ""
-
-msgid "Help for expired"
-msgstr ""
-
-msgid "Help for future"
-msgstr ""
-
-msgid "Help for gen"
-msgstr ""
-
-msgid "Help for hugo"
-msgstr ""
-
-msgid "Help for import"
-msgstr ""
-
-msgid "Help for init"
-msgstr "显示 init 的帮助信息"
-
-msgid "Help for install"
-msgstr "显示 install 的帮助信息"
-
-msgid "Help for jekyll"
-msgstr ""
-
-msgid "Help for list"
-msgstr ""
-
-msgid "Help for man"
-msgstr ""
-
-msgid "Help for new"
-msgstr ""
-
-msgid "Help for run"
-msgstr "显示 run 的帮助信息"
-
-msgid "Help for server"
-msgstr ""
-
-msgid "Help for site"
-msgstr ""
-
-msgid "Help for test"
-msgstr "显示 test 的帮助信息"
-
-msgid "Help for theme"
-msgstr ""
-
-msgid "Help for toJSON"
-msgstr ""
-
-msgid "Help for toTOML"
-msgstr ""
-
-msgid "Help for toYAML"
-msgstr ""
-
-msgid "Help for ulimit"
-msgstr ""
-
-msgid "Help for undraft"
-msgstr ""
-
-msgid "Help for version"
 msgstr ""
 
 msgid "Help screen"

--- a/localization/po/zh_TW.po
+++ b/localization/po/zh_TW.po
@@ -2020,8 +2020,8 @@ msgstr "更多幫助和開發"
 msgid "Getting Help"
 msgstr "取得幫助"
 
-msgid "Help for this command"
-msgstr "此命令的說明"
+msgid "Help for `%s`"
+msgstr ""
 
 msgid "Home directory expansion ~USER"
 msgstr "家目錄展開 ~使用者"

--- a/localization/po/zh_TW.po
+++ b/localization/po/zh_TW.po
@@ -3696,6 +3696,9 @@ msgstr "vi 風格的按鍵綁定"
 msgid "wait for app to exit"
 msgstr "等待應用程式結束"
 
+msgid "fish-section-tier3-from-script-explicitly-added"
+msgstr ""
+
 msgid "fish-section-tier3-from-script-implicitly-added"
 msgstr ""
 
@@ -30307,105 +30310,6 @@ msgid "Help about current supported formats"
 msgstr ""
 
 msgid "Help about supported formats"
-msgstr ""
-
-msgid "Help for autocomplete"
-msgstr ""
-
-msgid "Help for benchmark"
-msgstr ""
-
-msgid "Help for build"
-msgstr ""
-
-msgid "Help for check"
-msgstr ""
-
-msgid "Help for chromastyles"
-msgstr ""
-
-msgid "Help for cjpm"
-msgstr ""
-
-msgid "Help for config"
-msgstr ""
-
-msgid "Help for convert"
-msgstr ""
-
-msgid "Help for doc"
-msgstr ""
-
-msgid "Help for drafts"
-msgstr ""
-
-msgid "Help for env"
-msgstr ""
-
-msgid "Help for expired"
-msgstr ""
-
-msgid "Help for future"
-msgstr ""
-
-msgid "Help for gen"
-msgstr ""
-
-msgid "Help for hugo"
-msgstr ""
-
-msgid "Help for import"
-msgstr ""
-
-msgid "Help for init"
-msgstr ""
-
-msgid "Help for install"
-msgstr ""
-
-msgid "Help for jekyll"
-msgstr ""
-
-msgid "Help for list"
-msgstr ""
-
-msgid "Help for man"
-msgstr ""
-
-msgid "Help for new"
-msgstr ""
-
-msgid "Help for run"
-msgstr ""
-
-msgid "Help for server"
-msgstr ""
-
-msgid "Help for site"
-msgstr ""
-
-msgid "Help for test"
-msgstr ""
-
-msgid "Help for theme"
-msgstr ""
-
-msgid "Help for toJSON"
-msgstr ""
-
-msgid "Help for toTOML"
-msgstr ""
-
-msgid "Help for toYAML"
-msgstr ""
-
-msgid "Help for ulimit"
-msgstr ""
-
-msgid "Help for undraft"
-msgstr ""
-
-msgid "Help for version"
 msgstr ""
 
 msgid "Help screen"

--- a/share/completions/cjpm.fish
+++ b/share/completions/cjpm.fish
@@ -1,7 +1,7 @@
 # cjpm.fish - Fish completion script for Cangjie Package Manager
 
 # Global options
-complete -c cjpm -l help -s h -d "Help for cjpm"
+complete -c cjpm -l help -s h -d (printf (_ "Help for `%s`") cjpm)
 complete -c cjpm -l version -s v -d "Version for cjpm"
 
 # Subcommands
@@ -18,7 +18,7 @@ complete -c cjpm -n __fish_use_subcommand -f -a install -d "Install a cangjie bi
 complete -c cjpm -n __fish_use_subcommand -f -a uninstall -d "Uninstall a cangjie binary"
 
 # 'init' subcommand options
-complete -c cjpm -n "__fish_seen_subcommand_from init" -f -l help -s h -d "Help for init"
+complete -c cjpm -n "__fish_seen_subcommand_from init" -f -l help -s h -d (printf (_ "Help for `%s`") init)
 complete -c cjpm -n "__fish_seen_subcommand_from init" -f -l workspace -d "Initialize a workspace's default configuration file"
 complete -c cjpm -n "__fish_seen_subcommand_from init" -f -l name -d "Specify root package name (default: current directory)" -r
 complete -c cjpm -n "__fish_seen_subcommand_from init" -l path -d "Specify path to create the module (default: current directory)" -r
@@ -31,12 +31,12 @@ complete -c cjpm -n "__fish_seen_subcommand_from run" -f -l skip-build -d "Skip 
 complete -c cjpm -n "__fish_seen_subcommand_from run" -f -l run-args -d "Arguments to pass to the executable product" -r
 complete -c cjpm -n "__fish_seen_subcommand_from run" -l target-dir -d "Specify target directory" -r
 complete -c cjpm -n "__fish_seen_subcommand_from run" -f -s g -d "Enable debug version"
-complete -c cjpm -n "__fish_seen_subcommand_from run" -f -s h -l help -d "Help for run"
+complete -c cjpm -n "__fish_seen_subcommand_from run" -f -s h -l help -d (printf (_ "Help for `%s`") run)
 complete -c cjpm -n "__fish_seen_subcommand_from run" -f -s V -l verbose -d "Enable verbose"
 complete -c cjpm -n "__fish_seen_subcommand_from run" -f -l skip-script -d "Disable script 'build.cj'"
 
 # 'install' subcommand options
-complete -c cjpm -n "__fish_seen_subcommand_from install" -f -s h -l help -d "Help for install"
+complete -c cjpm -n "__fish_seen_subcommand_from install" -f -s h -l help -d (printf (_ "Help for `%s`") install)
 complete -c cjpm -n "__fish_seen_subcommand_from install" -f -s V -l verbose -d "Enable verbose"
 complete -c cjpm -n "__fish_seen_subcommand_from install" -f -s m -l member -d "Specify a member module of the workspace" -r
 complete -c cjpm -n "__fish_seen_subcommand_from install" -f -s g -d "Enable install debug version target"
@@ -55,7 +55,7 @@ complete -c cjpm -n "__fish_seen_subcommand_from install" -f -l list -d "List al
 complete -c cjpm -n "__fish_seen_subcommand_from install" -f -l skip-script -d "Disable script 'build.cj'"
 
 # 'build' subcommand options
-complete -c cjpm -n "__fish_seen_subcommand_from build" -f -s h -l help -d "Help for build"
+complete -c cjpm -n "__fish_seen_subcommand_from build" -f -s h -l help -d (printf (_ "Help for `%s`") build)
 complete -c cjpm -n "__fish_seen_subcommand_from build" -f -s i -l incremental -d "Enable incremental compilation"
 complete -c cjpm -n "__fish_seen_subcommand_from build" -f -s j -l jobs -d "Number of jobs to spawn in parallel" -r
 complete -c cjpm -n "__fish_seen_subcommand_from build" -f -s V -l verbose -d "Enable verbose"
@@ -71,7 +71,7 @@ complete -c cjpm -n "__fish_seen_subcommand_from build" -f -l mock -d "Enable su
 complete -c cjpm -n "__fish_seen_subcommand_from build" -f -l skip-script -d "Disable script 'build.cj'"
 
 # 'test' subcommand options
-complete -c cjpm -n "__fish_seen_subcommand_from test" -f -s h -l help -d "Help for test"
+complete -c cjpm -n "__fish_seen_subcommand_from test" -f -s h -l help -d (printf (_ "Help for `%s`") test)
 complete -c cjpm -n "__fish_seen_subcommand_from test" -f -s j -l jobs -d "Number of jobs to spawn in parallel" -r
 complete -c cjpm -n "__fish_seen_subcommand_from test" -f -s V -l verbose -d "Enable verbose"
 complete -c cjpm -n "__fish_seen_subcommand_from test" -f -s g -d "Enable compile debug version tests"

--- a/share/completions/help.fish
+++ b/share/completions/help.fish
@@ -12,7 +12,7 @@ complete -c help -n __fish_is_first_arg -x -a '(
 function __fish_help_describe -a help_item
     switch $help_item
         case 'cmds/*'
-            echo (_ "Help for this command")
+            printf (_ "Help for `%s`") (string sub --start 6 -- $help_item)
         case commands
             return
         case commands#helper-commands

--- a/share/completions/hugo.fish
+++ b/share/completions/hugo.fish
@@ -65,7 +65,7 @@ complete -c hugo -n __fish_hugo_using_main_like_command -l disableRSS -f -d "Do 
 complete -c hugo -n __fish_hugo_using_main_like_command -l disableSitemap -f -d "Do not build sitemap files"
 complete -c hugo -n __fish_hugo_using_main_like_command -l enableGitInfo -f -d "Add Git revision, date and author info to the pages"
 complete -c hugo -n __fish_hugo_using_main_like_command -l forceSyncStatic -f -d "Copy all files when static is changed"
-complete -c hugo -n __fish_hugo_using_main_like_command -s h -l help -f -d "Help for hugo"
+complete -c hugo -n __fish_hugo_using_main_like_command -s h -l help -f -d (printf (_ "Help for `%s`") hugo)
 complete -c hugo -n __fish_hugo_using_main_like_command -l i18n-warnings -f -d "Print missing translations"
 complete -c hugo -n __fish_hugo_using_main_like_command -l ignoreCache -f -d "Ignore the cache directory"
 complete -c hugo -n __fish_hugo_using_main_like_command -s l -l layoutDir -f -a "(__fish_complete_directories (commandline -ct) 'Layout directory')" -d "Layout directory"
@@ -89,7 +89,7 @@ complete -c hugo -n __fish_hugo_using_main_like_command -s w -l watch -f -d "Wat
 complete -c hugo -n "not __fish_hugo_command" -f -a benchmark -d "Benchmark Hugo by building the site a number of times"
 complete -c hugo -n "__fish_hugo_using_command benchmark" -s n -l count -f -d "Number of times to build the site"
 complete -c hugo -n "__fish_hugo_using_command benchmark" -l cpuprofile -r -d "CPU profile file"
-complete -c hugo -n "__fish_hugo_using_command benchmark" -s h -l help -f -d "Help for benchmark"
+complete -c hugo -n "__fish_hugo_using_command benchmark" -s h -l help -f -d (printf (_ "Help for `%s`") benchmark)
 complete -c hugo -n "__fish_hugo_using_command benchmark" -l memprofile -r -d "Memory profile file"
 complete -c hugo -n "__fish_hugo_using_command benchmark" -l renderToMemory -f -d "Render to memory"
 complete -c hugo -n "__fish_hugo_using_command benchmark" -l stepAnalysis -f -d "Display memory and timing of different steps of the program"
@@ -98,52 +98,52 @@ complete -c hugo -n "__fish_hugo_using_command benchmark" -l templateMetricsHint
 
 # check
 complete -c hugo -n "not __fish_hugo_command" -f -a check -d "Perform some verification checks"
-complete -c hugo -n "__fish_hugo_using_command check" -s h -l help -f -d "Help for check"
+complete -c hugo -n "__fish_hugo_using_command check" -s h -l help -f -d (printf (_ "Help for `%s`") check)
 
 # check ulimit
 complete -c hugo -n "__fish_hugo_using_command check" -f -a ulimit -d "Check system ulimit settings"
-complete -c hugo -n "__fish_hugo_using_command check ulimit" -s h -l help -f -d "Help for ulimit"
+complete -c hugo -n "__fish_hugo_using_command check ulimit" -s h -l help -f -d (printf (_ "Help for `%s`") ulimit)
 
 # config
 complete -c hugo -n "not __fish_hugo_command" -f -a config -d "Print the site configuration"
-complete -c hugo -n "__fish_hugo_using_command config" -s h -l help -f -d "Help for config"
+complete -c hugo -n "__fish_hugo_using_command config" -s h -l help -f -d (printf (_ "Help for `%s`") config)
 
 # convert
 complete -c hugo -n "not __fish_hugo_command" -f -a convert -d "Convert the content to different formats"
-complete -c hugo -n "__fish_hugo_using_command convert" -s h -l help -f -d "Help for convert"
+complete -c hugo -n "__fish_hugo_using_command convert" -s h -l help -f -d (printf (_ "Help for `%s`") convert)
 complete -c hugo -n "__fish_hugo_using_command convert" -s o -l output -f -a "(__fish_complete_directories (commandline -ct) 'Output directory')" -d "Output directory"
 complete -c hugo -n "__fish_hugo_using_command convert" -s s -l source -f -a "(__fish_complete_directories (commandline -ct) 'Source directory')" -d "Source directory"
 complete -c hugo -n "__fish_hugo_using_command convert" -l unsafe -f -d "Enable less safe operations"
 
 # convert toJSON
 complete -c hugo -n "__fish_hugo_using_command convert" -f -a toJSON -d "Convert front matter to JSON"
-complete -c hugo -n "__fish_hugo_using_command convert toJSON" -s h -l help -f -d "Help for toJSON"
+complete -c hugo -n "__fish_hugo_using_command convert toJSON" -s h -l help -f -d (printf (_ "Help for `%s`") toJSON)
 
 # convert toTOML
 complete -c hugo -n "__fish_hugo_using_command convert" -f -a toTOML -d "Convert front matter to TOML"
-complete -c hugo -n "__fish_hugo_using_command convert toTOML" -s h -l help -f -d "Help for toTOML"
+complete -c hugo -n "__fish_hugo_using_command convert toTOML" -s h -l help -f -d (printf (_ "Help for `%s`") toTOML)
 
 # convert toYAML
 complete -c hugo -n "__fish_hugo_using_command convert" -f -a toYAML -d "Convert front matter to YAML"
-complete -c hugo -n "__fish_hugo_using_command convert toYAML" -s h -l help -f -d "Help for toYAML"
+complete -c hugo -n "__fish_hugo_using_command convert toYAML" -s h -l help -f -d (printf (_ "Help for `%s`") toYAML)
 
 # env
 complete -c hugo -n "not __fish_hugo_command" -f -a env -d "Print Hugo version and environment info"
-complete -c hugo -n "__fish_hugo_using_command env" -s h -l help -f -d "Help for env"
+complete -c hugo -n "__fish_hugo_using_command env" -s h -l help -f -d (printf (_ "Help for `%s`") env)
 
 # gen
 complete -c hugo -n "not __fish_hugo_command" -f -a gen -d "Collection of several useful generators"
-complete -c hugo -n "__fish_hugo_using_command gen" -s h -l help -f -d "Help for gen"
+complete -c hugo -n "__fish_hugo_using_command gen" -s h -l help -f -d (printf (_ "Help for `%s`") gen)
 
 # gen autocomplete
 complete -c hugo -n "__fish_hugo_using_command gen" -f -a autocomplete -d "Generate shell autocompletion script for Hugo"
 complete -c hugo -n "__fish_hugo_using_command gen autocomplete" -l completionfile -r -d "Autocompletion file"
-complete -c hugo -n "__fish_hugo_using_command gen autocomplete" -s h -l help -f -d "Help for autocomplete"
+complete -c hugo -n "__fish_hugo_using_command gen autocomplete" -s h -l help -f -d (printf (_ "Help for `%s`") autocomplete)
 complete -c hugo -n "__fish_hugo_using_command gen autocomplete" -l type -f -a bash -d "Autocompletion type"
 
 # gen chromastyles
 complete -c hugo -n "__fish_hugo_using_command gen" -f -a chromastyles -d "Generate CSS stylesheet for the Chroma code highlighter"
-complete -c hugo -n "__fish_hugo_using_command gen chromastyles" -s h -l help -f -d "Help for chromastyles"
+complete -c hugo -n "__fish_hugo_using_command gen chromastyles" -s h -l help -f -d (printf (_ "Help for `%s`") chromastyles)
 complete -c hugo -n "__fish_hugo_using_command gen chromastyles" -l highlightStyle -r -d "Style used for highlighting lines"
 complete -c hugo -n "__fish_hugo_using_command gen chromastyles" -l lineStyle -r -d "Style used for line numbers"
 complete -c hugo -n "__fish_hugo_using_command gen chromastyles" -l style -r -d "Highlighter style"
@@ -151,43 +151,43 @@ complete -c hugo -n "__fish_hugo_using_command gen chromastyles" -l style -r -d 
 # gen doc
 complete -c hugo -n "__fish_hugo_using_command gen" -f -a doc -d "Generate Markdown documentation for the Hugo CLI"
 complete -c hugo -n "__fish_hugo_using_command gen doc" -l dir -f -a "(__fish_complete_directories (commandline -ct) 'Doc directory')" -d "Doc directory"
-complete -c hugo -n "__fish_hugo_using_command gen doc" -s h -l help -f -d "Help for doc"
+complete -c hugo -n "__fish_hugo_using_command gen doc" -s h -l help -f -d (printf (_ "Help for `%s`") doc)
 
 # gen man
 complete -c hugo -n "__fish_hugo_using_command gen" -f -a man -d "Generate man pages for the Hugo CLI"
 complete -c hugo -n "__fish_hugo_using_command gen man" -l dir -f -a "(__fish_complete_directories (commandline -ct) 'Man pages directory')" -d "Man pages directory"
-complete -c hugo -n "__fish_hugo_using_command gen man" -s h -l help -f -d "Help for man"
+complete -c hugo -n "__fish_hugo_using_command gen man" -s h -l help -f -d (printf (_ "Help for `%s`") man)
 
 # import
 complete -c hugo -n "not __fish_hugo_command" -f -a import -d "Import your site from others"
-complete -c hugo -n "__fish_hugo_using_command import" -s h -l help -f -d "Help for import"
+complete -c hugo -n "__fish_hugo_using_command import" -s h -l help -f -d (printf (_ "Help for `%s`") import)
 
 # import jekyll
 complete -c hugo -n "__fish_hugo_using_command import" -f -a jekyll -d "Import from Jekyll"
 complete -c hugo -n "__fish_hugo_using_command import jekyll" -l force -f -d "Allow import into non-empty target directory"
-complete -c hugo -n "__fish_hugo_using_command import jekyll" -s h -l help -f -d "Help for jekyll"
+complete -c hugo -n "__fish_hugo_using_command import jekyll" -s h -l help -f -d (printf (_ "Help for `%s`") jekyll)
 
 # list
 complete -c hugo -n "not __fish_hugo_command" -f -a list -d "List various types of content"
-complete -c hugo -n "__fish_hugo_using_command list" -s h -l help -f -d "Help for list"
+complete -c hugo -n "__fish_hugo_using_command list" -s h -l help -f -d (printf (_ "Help for `%s`") list)
 complete -c hugo -n "__fish_hugo_using_command list" -s s -l source -f -a "(__fish_complete_directories (commandline -ct) 'Source directory')" -d "Source directory"
 
 # list drafts
 complete -c hugo -n "__fish_hugo_using_command list" -f -a drafts -d "List all drafts"
-complete -c hugo -n "__fish_hugo_using_command list drafts" -s h -l help -f -d "Help for drafts"
+complete -c hugo -n "__fish_hugo_using_command list drafts" -s h -l help -f -d (printf (_ "Help for `%s`") drafts)
 
 # list expired
 complete -c hugo -n "__fish_hugo_using_command list" -f -a expired -d "List all expired posts"
-complete -c hugo -n "__fish_hugo_using_command list expired" -s h -l help -f -d "Help for expired"
+complete -c hugo -n "__fish_hugo_using_command list expired" -s h -l help -f -d (printf (_ "Help for `%s`") expired)
 
 # list future
 complete -c hugo -n "__fish_hugo_using_command list" -f -a future -d "List all posts dated in the future"
-complete -c hugo -n "__fish_hugo_using_command list future" -s h -l help -f -d "Help for future"
+complete -c hugo -n "__fish_hugo_using_command list future" -s h -l help -f -d (printf (_ "Help for `%s`") future)
 
 # new
 complete -c hugo -n "not __fish_hugo_command" -f -a new -d "Create new content"
 complete -c hugo -n "__fish_hugo_using_command new" -l editor -r -d "Editor to use"
-complete -c hugo -n "__fish_hugo_using_command new" -s h -l help -f -d "Help for new"
+complete -c hugo -n "__fish_hugo_using_command new" -s h -l help -f -d (printf (_ "Help for `%s`") new)
 complete -c hugo -n "__fish_hugo_using_command new" -s k -l kind -r -d "Content type to create"
 complete -c hugo -n "__fish_hugo_using_command new" -s s -l source -f -a "(__fish_complete_directories (commandline -ct) 'Source directory')" -d "Source directory"
 
@@ -195,11 +195,11 @@ complete -c hugo -n "__fish_hugo_using_command new" -s s -l source -f -a "(__fis
 complete -c hugo -n "__fish_hugo_using_command new" -f -a site -d "Create a new site"
 complete -c hugo -n "__fish_hugo_using_command new site" -l force -f -d "Create site inside non-empty directory"
 complete -c hugo -n "__fish_hugo_using_command new site" -s f -l format -r -d "Config and front matter format"
-complete -c hugo -n "__fish_hugo_using_command new site" -s h -l help -f -d "Help for site"
+complete -c hugo -n "__fish_hugo_using_command new site" -s h -l help -f -d (printf (_ "Help for `%s`") site)
 
 # new theme
 complete -c hugo -n "__fish_hugo_using_command new" -f -a theme -d "Create a new theme"
-complete -c hugo -n "__fish_hugo_using_command new theme" -s h -l help -f -d "Help for theme"
+complete -c hugo -n "__fish_hugo_using_command new theme" -s h -l help -f -d (printf (_ "Help for `%s`") theme)
 
 # server
 complete -c hugo -n "not __fish_hugo_command" -f -a server -d "Start high performance web server"
@@ -207,7 +207,7 @@ complete -c hugo -n "__fish_hugo_using_command server" -l appendPort -f -d "Appe
 complete -c hugo -n "__fish_hugo_using_command server" -l bind -r -d "Interface to which the server will bind"
 complete -c hugo -n "__fish_hugo_using_command server" -l disableFastRender -f -d "Enable full re-renders on changes"
 complete -c hugo -n "__fish_hugo_using_command server" -l disableLiveReload -f -d "Watch without enabling live browser reload on rebuild"
-complete -c hugo -n "__fish_hugo_using_command server" -s h -l help -f -d "Help for server"
+complete -c hugo -n "__fish_hugo_using_command server" -s h -l help -f -d (printf (_ "Help for `%s`") server)
 complete -c hugo -n "__fish_hugo_using_command server" -l liveReloadPort -r -d "Port for live reloading"
 complete -c hugo -n "__fish_hugo_using_command server" -l meminterval -f -d "Interval to poll memory usage"
 complete -c hugo -n "__fish_hugo_using_command server" -l memstats -f -d "Memory usage log file"
@@ -218,8 +218,8 @@ complete -c hugo -n "__fish_hugo_using_command server" -l renderToDisk -r -d "Re
 
 # undraft
 complete -c hugo -n "not __fish_hugo_command" -f -a undraft -d "Reset the content draft status"
-complete -c hugo -n "__fish_hugo_using_command undraft" -s h -l help -f -d "Help for undraft"
+complete -c hugo -n "__fish_hugo_using_command undraft" -s h -l help -f -d (printf (_ "Help for `%s`") undraft)
 
 # version
 complete -c hugo -n "not __fish_hugo_command" -f -a version -d "Print the version number of Hugo"
-complete -c hugo -n "__fish_hugo_using_command version" -s h -l help -f -d "Help for version"
+complete -c hugo -n "__fish_hugo_using_command version" -s h -l help -f -d (printf (_ "Help for `%s`") version)

--- a/src/pager.rs
+++ b/src/pager.rs
@@ -667,9 +667,7 @@ impl Pager {
         self.unfiltered_completion_infos = process_completions_into_infos(raw_completions);
 
         // Maybe join them.
-        if *self.prefix == "-" {
-            join_completions(&mut self.unfiltered_completion_infos);
-        }
+        join_completions(&mut self.unfiltered_completion_infos);
 
         // Compute their various widths.
         self.measure_completion_infos();
@@ -1500,31 +1498,31 @@ mod tests {
         // Multiple completions, uneven comp, even desc
         pager.set_completions(
             &completions(&[
-                ("coverity_scan_master", "Local Branch"),
-                ("curly-underlines", "Local Branch"),
-                ("docker-builds", "Local Branch"),
-                ("fish-reenable-cirrus", "Local Branch"),
-                ("macos-apropos", "Local Branch"),
-                ("master", "Local Branch"),
+                ("coverity_scan_master", "Local Branch1"),
+                ("curly-underlines", "Local Branch2"),
+                ("docker-builds", "Local Branch3"),
+                ("fish-reenable-cirrus", "Local Branch4"),
+                ("macos-apropos", "Local Branch5"),
+                ("master", "Local Branch6"),
             ]),
             true,
         );
         validate!(
             &mut pager,
             80,
-            "coverity_scan_master  (Local Branch)  fish-reenable-cirrus  (Local Branch)",
-            "curly-underlines      (Local Branch)  macos-apropos         (Local Branch)",
-            "docker-builds         (Local Branch)  master                (Local Branch)",
+            "coverity_scan_master  (Local Branch1)  fish-reenable-cirrus  (Local Branch4)",
+            "curly-underlines      (Local Branch2)  macos-apropos         (Local Branch5)",
+            "docker-builds         (Local Branch3)  master                (Local Branch6)",
         );
         validate!(
             &mut pager,
             40,
-            "coverity_scan_master  (Local Branch)",
-            "curly-underlines      (Local Branch)",
-            "docker-builds         (Local Branch)",
-            "fish-reenable-cirrus  (Local Branch)",
-            "macos-apropos         (Local Branch)",
-            "master                (Local Branch)",
+            "coverity_scan_master  (Local Branch1)",
+            "curly-underlines      (Local Branch2)",
+            "docker-builds         (Local Branch3)",
+            "fish-reenable-cirrus  (Local Branch4)",
+            "macos-apropos         (Local Branch5)",
+            "master                (Local Branch6)",
         );
         validate!(
             &mut pager,
@@ -1650,6 +1648,40 @@ mod tests {
             "фиш  (123456789)",
             "abc  (鱼殼層)   ",
             "鱼-  (१२३४५६७८९)",
+        );
+
+        // Multiple completions, uneven comp, shared desc
+        pager.set_completions(
+            &completions(&[
+                ("coverity_scan_master", "Local Branch1"),
+                ("curly-underlines", "Local Branch1"),
+                ("docker-builds", "Local Branch1"),
+                ("fish-reenable-cirrus", "Local Branch2"),
+                ("macos-apropos", "Local Branch3"),
+                ("master", "Local Branch3"),
+            ]),
+            true,
+        );
+        validate!(
+            &mut pager,
+            80,
+            "coverity_scan_master  curly-underlines  docker-builds  (Local Branch1)",
+            "fish-reenable-cirrus                                   (Local Branch2)",
+            "macos-apropos  master                                  (Local Branch3)",
+        );
+        validate!(
+            &mut pager,
+            40,
+            "coverity_scan_master  c…  (Local Branc…)",
+            "fish-reenable-cirrus     (Local Branch2)",
+            "macos-apropos  master    (Local Branch3)",
+        );
+        validate!(
+            &mut pager,
+            20,
+            "coverity_…  (Local…)",
+            "fish-reen…  (Local…)",
+            "macos-apr…  (Local…)",
         );
 
         // Newlines in prefix

--- a/tests/checks/tmux-complete.fish
+++ b/tests/checks/tmux-complete.fish
@@ -43,7 +43,7 @@ isolated-tmux capture-pane -p
 # CHECK: aabc  aaBd
 
 # Check that a larger-than-screen completion list does not stomp a multiline commandline (#8509).
-isolated-tmux send-keys C-u 'complete -c foo3 -fa "(seq $LINES)\t(string repeat -n $COLUMNS d)"' Enter \
+isolated-tmux send-keys C-u 'complete -c foo3 -fa \'(set desc (string repeat -n $COLUMNS d); for i in (seq $LINES); echo -e "$i\t$desc$i"; end)\'' Enter \
     C-l begin Enter foo3 Enter "echo some trailing line" \
     C-p C-e Space Tab Tab
 tmux-sleep

--- a/tests/checks/tmux-complete2.fish
+++ b/tests/checks/tmux-complete2.fish
@@ -35,7 +35,7 @@ isolated-tmux send-keys 'echo $FISH_TEST_v' Tab
 tmux-sleep
 isolated-tmux capture-pane -p
 # CHECK: prompt 1> echo $FISH_TEST_VAR_
-# CHECK: …TEST_VAR_1  (Variable: /)  …TEST_VAR_2  (Variable: /)
+# CHECK: …TEST_VAR_1  …TEST_VAR_2  (Variable: /)
 
 mkdir -p clang/include
 touch clang/INSTALL.txt

--- a/tests/checks/tmux-complete5.fish
+++ b/tests/checks/tmux-complete5.fish
@@ -1,0 +1,75 @@
+#RUN: %fish %s
+#REQUIRES: command -v tmux
+#REQUIRES: uname -r | grep -qv Microsoft
+
+isolated-tmux-start -C 'set -g fish_autosuggestion_enabled 0'
+
+# Join short options
+isolated-tmux send-keys 'complete foo -f -a "-a\\\\tshort -b\\\\tshort"' Enter
+tmux-sleep
+isolated-tmux send-keys C-l 'foo ' Tab
+tmux-sleep
+isolated-tmux capture-pane -p
+# CHECK: prompt 1> foo -
+# CHECK: -a{{ +}}-b{{ +}}(short)
+
+# Join short and long options
+isolated-tmux send-keys C-u 'complete -e foo; complete foo -f -a "-a\\\\tshort/long --long\\\\tshort/long"' Enter
+tmux-sleep
+isolated-tmux send-keys C-l 'foo ' Tab
+tmux-sleep
+isolated-tmux capture-pane -p
+# CHECK: prompt 2> foo -
+# CHECK: -a{{ +}}--long{{ +}}(short/long)
+
+# Join long options
+isolated-tmux send-keys C-u 'complete -e foo; complete foo -f -a "--long1\\\\tlong --long2\\\\tlong"' Enter
+tmux-sleep
+isolated-tmux send-keys C-l 'foo ' Tab
+tmux-sleep
+isolated-tmux capture-pane -p
+# CHECK: prompt 3> foo --long
+# CHECK: --long1{{ +}}--long2{{ +}}(long)
+
+# Join command options
+isolated-tmux send-keys C-u 'complete -e foo; complete foo -f -a "command_1st\\\\tmy\\ cmd command_2nd\\\\tmy\\ cmd"' Enter
+tmux-sleep
+isolated-tmux send-keys C-l 'foo ' Tab
+tmux-sleep
+isolated-tmux capture-pane -p
+# CHECK: prompt 4> foo command_
+# CHECK: command_1st{{ +}}command_2nd{{ +}}(my cmd)
+
+###
+### Mix of options and commands
+###
+isolated-tmux send-keys C-u 'complete -e foo; complete foo -f -a "-a\\\\tdescription -b\\\\tdescription --long1\\\\tdescription --long2\\\\tdescription command_1st\\\\tdescription command_2nd\\\\tdescription"' Enter
+tmux-sleep
+
+### nothing => all options and commands
+isolated-tmux send-keys C-l 'foo ' Tab
+tmux-sleep
+isolated-tmux capture-pane -p
+# CHECK: prompt 5> foo
+# CHECK: command_1st{{ +}}command_2nd{{ +}}-a{{ +}}-b{{ +}}--long1{{ +}}--long2{{ +}}(description)
+
+### `-` => short and long options
+isolated-tmux send-keys C-u C-l 'foo -' Tab
+tmux-sleep
+isolated-tmux capture-pane -p
+# CHECK: prompt 5> foo -
+# CHECK: -a{{ +}}-b{{ +}}--long1{{ +}}--long2{{ +}}(description)
+
+### `--` => long options
+isolated-tmux send-keys C-u C-l 'foo --' Tab
+tmux-sleep
+isolated-tmux capture-pane -p
+# CHECK: prompt 5> foo --long
+# CHECK: --long1{{ +}}--long2{{ +}}(description)
+
+### `c` => commands
+isolated-tmux send-keys C-u C-l 'foo c' Tab
+tmux-sleep
+isolated-tmux capture-pane -p
+# CHECK: prompt 5> foo command_
+# CHECK: command_1st{{ +}}command_2nd{{ +}}(description)


### PR DESCRIPTION
To further support commands and options aliasing (e.g.  `jj bookmark [e|edit]` and `jj squash [-o|--onto|-d|--destination]`), this PR allows joining completion candidates at all time instead of only when completing a single `-`.

More generally, this is related to `clap-rs` [Command::visible_alias](https://docs.rs/clap/latest/clap/struct.Command.html#method.visible_alias) and [Arg::visible_alias](https://docs.rs/clap/latest/clap/struct.Arg.html#method.visible_alias), as well as issue clap-rs/clap#6317.

Currently, this can join commands and options together when completing after a space. I chose this behavior over joining commands and options separately because disabling this behavior can easily be done by using slightly different descriptions for the commands vs the options, while enabling it from a disabled default would be impossible.
A poster child use case for enabling it is `help` and `--help`. I also believe I encountered another RL case where command and option where synonyms, but I can't recall where (albeit it could be a scrambled a memory for a badly design UX, such as `git branch --move` vs `git remote rename`)

This PR also contains a necessary fix for fish's `help <cmd>` since they were all using the same `Help for this command` description, causing all the commands to be grouped in a single (and truncated given its length) line.

The last commit is optional. Since `Help for ...` was used in other completions, I factorized it to reduce the amount of translation needed.

## TODOs:
<!-- Check off what what has been done so far. -->
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [X] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
