### PR TITLE
feat: dynamic cargo xtask completions for fish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -64,7 +64,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -152,8 +152,20 @@ checksum = "793207c7fa6300a0608d1080b858e5fdbe713cdc1c8db9fb17777d8a13e63df0"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex",
+ "clap_lex 0.7.7",
  "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e962dae2b1e5007fe9e3db363ddc43a8bf25546d279f7a8a4401204690e80c"
+dependencies = [
+ "clap",
+ "clap_lex 1.1.0",
+ "is_executable",
+ "shlex",
 ]
 
 [[package]]
@@ -173,6 +185,12 @@ name = "clap_lex"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
@@ -252,7 +270,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -274,7 +292,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -567,6 +585,15 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
+]
+
+[[package]]
+name = "is_executable"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baabb8b4867b26294d818bf3f651a454b6901431711abb96e296245888d6e8c4"
+dependencies = [
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1210,7 +1237,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1221,12 +1248,86 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
@@ -1241,6 +1342,7 @@ dependencies = [
  "anstyle",
  "anyhow",
  "clap",
+ "clap_complete",
  "fish-build-helper",
  "fish-common",
  "fish-tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ bitflags = "2.5.0"
 cc = "1.0.94"
 cfg-if = "1.0.3"
 clap = { version = "4.5.54", features = ["derive"] }
+clap_complete = { version = "4.6.4", features = ["unstable-dynamic"] }
 errno = "0.3.0"
 fish-build-helper = { path = "crates/build-helper" }
 fish-build-man-pages = { path = "crates/build-man-pages" }

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 anstyle.workspace = true
 anyhow.workspace = true
 clap.workspace = true
+clap_complete.workspace = true
 fish-build-helper.workspace = true
 fish-common.workspace = true
 fish-tempfile.workspace = true

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
+use clap_complete::CompleteEnv;
 use fish_build_helper::as_os_strs;
 use std::{path::PathBuf, process::Command};
 use xtask::{CommandExt, cargo, format::FormatArgs, gettext::GettextArgs, shellcheck::shellcheck};
@@ -36,7 +37,29 @@ enum Task {
     ShellCheck,
 }
 
+/// Only used to enable completion generation.
+/// [`clap_complete`] is not built to account for the situation we have here, where the CLI does not
+/// correspond to a top-level shell command.
+/// We work around this here by pretending that we are building a CLI for the `cargo` command, which
+/// only has the single subcommand `xtask`.
+/// These completions can then be combined with the regular cargo completions.
+#[derive(Parser)]
+#[command(name = "cargo")]
+struct FakeCargoWrapperForCompletion {
+    #[command(subcommand)]
+    xtask: FakeCliForCompletion,
+}
+
+#[derive(Subcommand)]
+enum FakeCliForCompletion {
+    /// Run fish's xtasks
+    #[command(subcommand)]
+    Xtask(Task),
+}
+
 fn main() -> Result<()> {
+    CompleteEnv::with_factory(FakeCargoWrapperForCompletion::command).complete();
+
     let cli = Cli::parse();
     match cli.task {
         Task::Check => run_checks(),

--- a/share/completions/cargo.fish
+++ b/share/completions/cargo.fish
@@ -850,3 +850,16 @@ if command -q cargo-asm
         complete -c cargo -n "__fish_seen_subcommand_from asm; and not __fish_is_switch" -xa "(__fish_cargo asm)"
     end
 end
+
+# Determine whether the working directory is in a fish workspace.
+function __fish_is_in_fish_workspace
+    cargo metadata --offline --no-deps --format-version=1 2>/dev/null |
+        jq --exit-status -r '.packages | map(select(.name == "fish" and .homepage == "https://fishshell.com")) | any' >/dev/null
+end
+
+# The sed command is a hack to only activate the conditions in fish workspaces.
+# Ideally, this would be handled by the completion generator,
+# but `clap_complete` does not have this capability.
+COMPLETE=fish cargo xtask 2>/dev/null |
+    sed 's/^complete /complete --condition "__fish_is_in_fish_workspace "/' |
+    source


### PR DESCRIPTION
Use `clap_complete` to generate completions for our xtasks. This comes with two complications:
- Due to the unusual CLI of the whole xtask CLI definition being itself a subcommand under `cargo` (via the `cargo xtask` alias), we need to tell `clap_complete` that we're generating completions for `cargo`, which is fairly straightforward to do via two new types which are only used for generating completions.
- Our completions for `cargo xtask` only make sense within fish's workspace, so we need to ensure that they are not active elsewhere. `clap_complete` does not support adding such conditions, so we hack them together by post-processing its output with sed.



## TODOs:
- [ ] User-visible changes noted in CHANGELOG.rst
