### PR TITLE
windows build: disable lint checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,5 +170,7 @@ jobs:
       run: |
         cargo build
     - name: tests
+      env:
+        FISH_CHECK_LINT: false
       run: |
         cargo xtask check


### PR DESCRIPTION
There is already a GitHub workflow doing lint checks so it is redundant and wastes time (4+ min).
 
Moreover, other platforms do not do it, so when it fails, it gives the appearance that there is a Windows specific build issue beyond linting.
