### PR TITLE
fish: don't enable private mode when --no-config is set

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 fish ?.?.? (released ???)
 =========================
 
+- ``--no-config`` no longer implicitly enables private mode, so history is read and written as usual (:issue:`12711`). Use ``--private`` to opt into private mode.
+
 fish 4.7.1 (released May 08, 2026)
 ==================================
 

--- a/src/bin/fish.rs
+++ b/src/bin/fish.rs
@@ -274,8 +274,6 @@ fn fish_parse_opt(args: &mut [WString], opts: &mut FishCmdOpts) -> ControlFlow<i
             'l' => opts.is_login = true,
             'N' => {
                 opts.no_config = true;
-                // --no-config implies private mode, we won't be saving history
-                opts.enable_private_mode = true;
             }
             'n' => opts.no_exec = true,
             RUSAGE_ARG => opts.print_rusage_self = true,

--- a/tests/checks/no-config.fish
+++ b/tests/checks/no-config.fish
@@ -13,3 +13,14 @@ set -S foo
 
 set -q fish_function_path[2]
 and echo fish_function_path has two elements
+
+# --no-config should not enable private mode (#12711).
+# Private mode is only enabled by --private.
+echo "private:$fish_private_mode"
+# CHECK: private:
+
+# History operations should work under --no-config; they fail in private mode.
+set -g fish_history fish
+builtin history merge
+echo "merge-status:$status"
+# CHECK: merge-status:0


### PR DESCRIPTION
Closes #12711.

`fish --no-config -c 'set -g fish_history fish; history merge'` errors with `history: can't merge history in private mode`. The reporter expects `--no-config` to skip default config dirs without touching history behaviour; `--private` already covers the no-history case.

The cause is in `src/bin/fish.rs`. The `-N` / `--no-config` arm sets both `opts.no_config` and `opts.enable_private_mode`:

```rust
'N' => {
    opts.no_config = true;
    // --no-config implies private mode, we won't be saving history
    opts.enable_private_mode = true;
}
```

The documented behaviour of `--no-config` (`doc_src/cmds/fish.rst`) is just "Do not read configuration files." There is no docs note that says `--no-config` should imply private mode, and `--private` is the documented way to opt into "fish will not access old or store new history."

The patch drops the implicit `enable_private_mode = true`. `--private` still triggers private mode on its own, and `--no-config --private` together still produce a private no-config shell.

## Verification

Before:

```
$ ./fish --no-config -c 'set -g fish_history fish; history merge'
history: can't merge history in private mode
```

After:

```
$ ./fish --no-config -c 'set -g fish_history fish; history merge; echo OK:$status'
OK:0

$ ./fish --private -c 'set -g fish_history fish; history merge'
history: can't merge history in private mode

$ ./fish --no-config --private -c 'set -g fish_history fish; history merge'
history: can't merge history in private mode
```

## Tests

Extended `tests/checks/no-config.fish` to assert `fish_private_mode` is unset under `--no-config` and that `history merge` succeeds.

Full local run: `python3 tests/test_driver.py target/release` -> 242 / 242 passed (6 skipped).

## Changelog

Added a bullet under the unreleased section in `CHANGELOG.rst`.