### PR TITLE
fix(__fish_print_hostnames): handle quoted and multi-path ssh Include

### DIFF
--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -68,15 +68,23 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
             for config in $argv
                 if test -r "$config" -a -f "$config"
                     set paths $paths (
-                    # Keep only Include lines and remove Include syntax
+                    # Keep only Include lines and remove Include syntax.
+                    # ssh_config allows multiple pathnames per Include directive;
+                    # split them explicitly because fish command substitutions split on newlines.
                     string replace -rfi '^\s*Include\s+' '' <$config \
                     # Normalize whitespace
-                    | string trim | string replace -r -a '\s+' ' ')
+                    | string trim | string replace -r -a '\s+' ' ' | string split ' ')
                 end
             end
 
             set -l new_paths
             for path in $paths
+                # ssh_config allows pathnames to be quoted. Those quotes are
+                # syntactic and should not suppress wildcard expansion here.
+                # For example: Include "~/.ssh/conf.d/*"
+                set path (string replace -r '^"(.*)"$' '$1' -- $path)
+                set path (string replace -r "^'(.*)'\$" '$1' -- $path)
+
                 # while ssh_config is using brackets to resolve env, they should be removed
                 # example
                 # in ssh_config: ${SOME_PATH}

--- a/tests/checks/__fish_print_hostnames.fish
+++ b/tests/checks/__fish_print_hostnames.fish
@@ -1,0 +1,35 @@
+# RUN: fish=%fish %fish %s
+#
+# Regression tests for __fish_print_hostnames' handling of ssh_config
+# Include directives.
+
+mkdir -p $HOME/.ssh/conf.d $HOME/.ssh/extra.d
+
+# Quoted Include path containing a wildcard. The surrounding quotes are
+# syntactic in ssh_config and must not suppress wildcard expansion.
+echo 'Include "~/.ssh/conf.d/*.conf"' >$HOME/.ssh/config
+
+# Multiple whitespace-separated pathnames on a single Include line must
+# each be processed.
+echo 'Include ~/.ssh/multi-a ~/.ssh/multi-b' >>$HOME/.ssh/config
+
+# Multiple whitespace-separated pathnames combined with wildcards on the
+# same Include line: every path must be split out and globbed.
+echo 'Include ~/.ssh/extra.d/x-*.conf ~/.ssh/extra.d/y-*.conf' >>$HOME/.ssh/config
+
+echo 'Host __fish_test_hostnames_quoted_b' >$HOME/.ssh/conf.d/b.conf
+echo 'Host __fish_test_hostnames_quoted_a' >$HOME/.ssh/conf.d/a.conf
+echo 'Host __fish_test_hostnames_multi_a'  >$HOME/.ssh/multi-a
+echo 'Host __fish_test_hostnames_multi_b'  >$HOME/.ssh/multi-b
+echo 'Host __fish_test_hostnames_glob_x1'  >$HOME/.ssh/extra.d/x-1.conf
+echo 'Host __fish_test_hostnames_glob_x2'  >$HOME/.ssh/extra.d/x-2.conf
+echo 'Host __fish_test_hostnames_glob_y1'  >$HOME/.ssh/extra.d/y-1.conf
+
+__fish_print_hostnames | string match -e __fish_test_hostnames_ | sort -u
+# CHECK: __fish_test_hostnames_glob_x1
+# CHECK: __fish_test_hostnames_glob_x2
+# CHECK: __fish_test_hostnames_glob_y1
+# CHECK: __fish_test_hostnames_multi_a
+# CHECK: __fish_test_hostnames_multi_b
+# CHECK: __fish_test_hostnames_quoted_a
+# CHECK: __fish_test_hostnames_quoted_b


### PR DESCRIPTION
ssh_config allows a single Include directive to list multiple whitespace-separated pathnames and to wrap each in quotes. The previous implementation treated the whole line as one pathname and preserved the quotes, so directives like

    Include "~/.ssh/conf.d/*.conf"
    Include ~/.ssh/a ~/.ssh/b

were silently ignored.

- Split the Include argument on whitespace before path expansion
- Strip surrounding single/double quotes from each pathname so the wildcard is still seen by glob expansion
- Add regression test covering quoted wildcard, multi-path, and multi-path-with-wildcard Includes

Fixes #9958

## TODOs:
<!-- Check off what what has been done so far. -->
- [x] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
