### PR TITLE
feat: stop language fallback at English

### DIFF
--- a/src/localization/settings.rs
+++ b/src/localization/settings.rs
@@ -227,6 +227,20 @@ impl LocalizationState {
         } else {
             (LanguagePrecedenceOrigin::Default, vec![])
         };
+        // We always have our messages available in English, so there is no point in adding
+        // additional fallback options after English.
+        // Note that this logic breaks when catalogs for different variants of English are added.
+        // If that ever happens, we would need somewhat more complex filtering to ensure that the
+        // non-default variants of English are kept if they precede the default variant in the list.
+        let language_list: Vec<String> = language_list
+            .into_iter()
+            .take_while(|lang| {
+                !(lang == "en"
+                    || lang.starts_with("en_")
+                    || lang.starts_with("C")
+                    || lang.starts_with("POSIX"))
+            })
+            .collect();
         fn update_precedence<'a, 'b: 'a, LocalizationLanguage: Copy + 'a>(
             language_list: &[String],
             get_available_languages: fn() -> &'a HashMap<&'b str, LocalizationLanguage>,


### PR DESCRIPTION
Treating `en` the same as any other language is problematic as shown by #12690. When the language precedence list contains entries after English and we don't treat English specially, a lack of translations in `en.po` (or a lack of `en.po`, once we delete it) results in translations into those subsequent languages being displayed, instead of the msgid, which is in English, and thus preferable.

By truncating the fallback list when we encounter `en`, this problem is resolved. As it is implemented now, the `en.po` catalog is never used. This is intended, as the plan is to delete it (#12745). In any case, its translations are identical to the msgids modulo some fancy quotes.

While at it, also treat `LANGUAGE` values of `C` and `POSIX` as referring to the English version of the messages.

Fixes #12690



## TODOs:
- [x] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst
