### PR TITLE
man-pages: force encoding when reading doc sources

### DIFF
--- a/doc_src/conf.py
+++ b/doc_src/conf.py
@@ -218,7 +218,7 @@ latex_engine = "xelatex"
 
 def get_command_description(path, name):
     """Return the description for a command, by parsing its synopsis line"""
-    with open(path) as opened:
+    with open(path, encoding="utf8") as opened:
         for line in opened:
             if line.startswith(name + " - "):
                 _, desc = line.split(" - ", 1)


### PR DESCRIPTION
Force the encoding to not be dependent on the environment locale.

In particular on Windows, the encoding could default to an ANSI page code, which would fail to load any file containing bytes 0x80+, i.e any multi-byte UTF-8 character.