### PR TITLE
fish_git_prompt: fix rename miscount in informative status

### DIFF
--- a/share/functions/fish_git_prompt.fish
+++ b/share/functions/fish_git_prompt.fish
@@ -298,7 +298,10 @@ function fish_git_prompt --description "Prompt function for Git"
                 test "$untracked" = true; and set opt -unormal
                 # Don't use `--ignored=no`; it was introduced in Git 2.16, from January 2018
                 # Ignored files are omitted by default
-                set -l stat (command git -c core.fsmonitor= status --porcelain -z $opt | string split0)
+                # Renames and copies in porcelain -z output have an extra NUL-delimited
+                # field for the source path. Filter to entries starting with a valid
+                # two-char status code followed by a space to skip those bare paths.
+                set -l stat (command git -c core.fsmonitor= status --porcelain -z $opt | string split0 | string match -r '^[ MADRCU?!]{2} .*')
 
                 set dirtystate (string match -qr '^.[ACDMRTU]' -- $stat; and echo 1)
                 if test -n "$sha"
@@ -421,7 +424,10 @@ function __fish_git_prompt_informative_status
 
     # Use git status --porcelain.
     # The v2 format is better, but we don't actually care in this case.
-    set -l stats (string sub -l 2 (git -c core.fsmonitor= status --porcelain -z $untr | string split0))
+    # Renames and copies in porcelain -z output have an extra NUL-delimited
+    # field for the source path. Filter to entries starting with a valid
+    # two-char status code followed by a space to skip those bare paths.
+    set -l stats (string sub -l 2 (git -c core.fsmonitor= status --porcelain -z $untr | string split0 | string match -r '^[ MADRCU?!]{2} .*'))
     set -l invalidstate (string match -r '^UU' $stats | count)
     set -l stagedstate (string match -r '^[ACDMRT].' $stats | count)
     set -l dirtystate (string match -r '^.[ACDMRT]' $stats | count)

--- a/share/functions/fish_git_prompt.fish
+++ b/share/functions/fish_git_prompt.fish
@@ -301,7 +301,7 @@ function fish_git_prompt --description "Prompt function for Git"
                 # Renames and copies in porcelain -z output have an extra NUL-delimited
                 # field for the source path. Filter to entries starting with a valid
                 # two-char status code followed by a space to skip those bare paths.
-                set -l stat (command git -c core.fsmonitor= status --porcelain -z $opt | string split0 | string match -r '^[ MADRCU?!]{2} .*')
+                set -l stat (command git -c core.fsmonitor= status --porcelain -z $opt | string split0 | string match -r '^[ MADRCTU?!]{2} .*')
 
                 set dirtystate (string match -qr '^.[ACDMRTU]' -- $stat; and echo 1)
                 if test -n "$sha"
@@ -427,7 +427,7 @@ function __fish_git_prompt_informative_status
     # Renames and copies in porcelain -z output have an extra NUL-delimited
     # field for the source path. Filter to entries starting with a valid
     # two-char status code followed by a space to skip those bare paths.
-    set -l stats (string sub -l 2 (git -c core.fsmonitor= status --porcelain -z $untr | string split0 | string match -r '^[ MADRCU?!]{2} .*'))
+    set -l stats (string sub -l 2 (git -c core.fsmonitor= status --porcelain -z $untr | string split0 | string match -r '^[ MADRCTU?!]{2} .*'))
     set -l invalidstate (string match -r '^UU' $stats | count)
     set -l stagedstate (string match -r '^[ACDMRT].' $stats | count)
     set -l dirtystate (string match -r '^.[ACDMRT]' $stats | count)

--- a/tests/checks/git.fish
+++ b/tests/checks/git.fish
@@ -161,6 +161,26 @@ echo
 
 set -e __fish_git_prompt_showdirtystate
 
+# Test that renames count as one staged change, not two (issue #11296).
+# git status --porcelain -z outputs rename source as a separate NUL-delimited field,
+# which should not be counted as an additional change.
+# Use a filename starting with R (in [ACDMRTU]) to trigger the miscount.
+git -c user.email=banana@example.com -c user.name=banana commit -m 'commit staged foo' >/dev/null
+echo content >Rfile
+git add Rfile
+git -c user.email=banana@example.com -c user.name=banana commit -m 'add Rfile' >/dev/null
+
+set -g __fish_git_prompt_show_informative_status 1
+mkdir -p subdir
+git mv Rfile subdir/Rfile
+fish_git_prompt
+echo
+#CHECK: (newbranch|●1)
+git reset >/dev/null 2>&1
+mv subdir/Rfile Rfile
+rmdir subdir
+set -e __fish_git_prompt_show_informative_status
+
 # Test displaying only stash count
 set -g __fish_git_prompt_show_informative_status 1
 set -g __fish_git_prompt_showstashstate 1


### PR DESCRIPTION
## Summary

- Filters `git status --porcelain -z` output to skip bare rename/copy source filenames that appear as extra NUL-delimited fields
- Adds `T` (typechange) to the status filter regex, which was previously missing
- Adds a test that renames a file starting with `R` and verifies the staged count stays at 1

When git reports a rename, `string split0` produces an extra entry for the source path. If that filename starts with a character in `[ACDMRTU]`, it gets counted as an additional staged or dirty change, inflating the prompt counts.

Fixes #11296

## Test plan

- [x] `python3 tests/test_driver.py target/debug tests/checks/git.fish` -- 241/241 pass
- [x] New test reproduces the exact scenario from #11296 (rename of file starting with `R`)