### PR TITLE
Add fish_omitted_newline_indicator to customize the no-newline indic…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ fish ?.?.? (released ???)
 
 Interactive improvements
 ------------------------
+- :envvar:`fish_omitted_newline_indicator` can be set to customize the indicator shown when a command's output doesn't end with a newline (:issue:`12605`).
 - On the first run after upgrading from an older version, fish will try harder to check if the current theme matches a historical default, in which case fish won't create ``~/.config/fish/conf.d/fish_frozen_theme.fish``.
   This means that on systems where fish version 3.x was installed originally, the update will avoid creating that file (:issue:`12725`).
 

--- a/doc_src/language.rst
+++ b/doc_src/language.rst
@@ -1575,6 +1575,22 @@ You can change the settings of fish by changing the values of certain variables.
 
    controls whether fish assumes emoji render as 2 cells or 1 cell wide. This is necessary because the correct value changed from 1 to 2 in Unicode 9, and some terminals may not be aware. Set this if you see graphical glitching related to emoji (or other "special" characters). It defaults to 2.
 
+.. envvar:: fish_omitted_newline_indicator
+
+   sets the string displayed when a command's output does not end with a newline. The default depends on the environment: ``⏎`` (U+23CE) in a regular terminal, ``¶`` (U+00B6) under WSL, and ``^J`` in a console session.
+
+   Set it to a custom string to change the indicator::
+
+      set -g fish_omitted_newline_indicator "↵"
+
+   Set it to an empty string to hide the indicator entirely::
+
+      set -g fish_omitted_newline_indicator ""
+
+   Erase the variable to restore the platform default::
+
+      set -e fish_omitted_newline_indicator
+
 .. envvar:: fish_autosuggestion_enabled
 
    controls if :ref:`autosuggestions` are enabled. Set it to 0 to disable, anything else to enable. By default they are on.

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,7 +1,7 @@
 //! Prototypes for various functions, mostly string utilities, that are used by most parts of fish.
 
 use crate::{
-    global_safety::{AtomicRef, RelaxedAtomicBool},
+    global_safety::RelaxedAtomicBool,
     prelude::*,
     terminal::Outputter,
     termsize::Termsize,
@@ -10,9 +10,10 @@ use crate::{
 use fish_fallback::fish_wcwidth;
 use fish_widestring::subslice_position;
 use nix::sys::termios::Termios;
+use once_cell::sync::Lazy;
 use std::{
     env,
-    sync::{MutexGuard, OnceLock, atomic::Ordering},
+    sync::{Mutex, MutexGuard, OnceLock, atomic::Ordering},
 };
 
 use fish_common::*;
@@ -25,12 +26,17 @@ pub fn shell_modes() -> MutexGuard<'static, Termios> {
     crate::reader::SHELL_MODES.lock().unwrap()
 }
 
-/// Character representing an omitted newline at the end of text.
-pub fn get_omitted_newline_str() -> &'static str {
-    OMITTED_NEWLINE_STR.load()
+/// Indicator shown when output doesn't end with a newline. Defaults to platform-specific symbol;
+/// overridden by $fish_omitted_newline_indicator.
+pub fn get_omitted_newline_str() -> String {
+    OMITTED_NEWLINE_STR.lock().unwrap().clone()
 }
 
-static OMITTED_NEWLINE_STR: AtomicRef<str> = AtomicRef::new(&"");
+pub fn set_omitted_newline_str(s: &str) {
+    *OMITTED_NEWLINE_STR.lock().unwrap() = s.to_owned();
+}
+
+static OMITTED_NEWLINE_STR: Lazy<Mutex<String>> = Lazy::new(|| Mutex::new(String::new()));
 
 /// Profiling flag. True if commands should be profiled.
 pub static PROFILING_ACTIVE: RelaxedAtomicBool = RelaxedAtomicBool::new(false);
@@ -62,17 +68,26 @@ pub fn has_working_tty_timestamps() -> bool {
 /// todo!("Maybe remove the box? It is only needed for get_bg_context.")
 pub type CancelChecker = Box<dyn Fn() -> bool>;
 
+/// Reset the omitted-newline indicator to the platform default (⏎ / ¶ / ^J).
+pub fn reset_omitted_newline_str_to_default() {
+    if is_windows_subsystem_for_linux(WSL::Any) {
+        set_omitted_newline_str("\u{00b6}"); // "pilcrow" (¶)
+    } else if is_console_session() {
+        set_omitted_newline_str("^J");
+    } else {
+        set_omitted_newline_str("\u{23CE}"); // "return symbol" (⏎)
+    }
+}
+
 pub fn init_special_chars_once() {
+    reset_omitted_newline_str_to_default();
     if is_windows_subsystem_for_linux(WSL::Any) {
         // neither of \u23CE and \u25CF can be displayed in the default fonts on Windows, though
         // they can be *encoded* just fine. Use alternative glyphs.
-        OMITTED_NEWLINE_STR.store(&"\u{00b6}"); // "pilcrow"
         OBFUSCATION_READ_CHAR.store(u32::from('\u{2022}'), Ordering::Relaxed); // "bullet" (•)
     } else if is_console_session() {
-        OMITTED_NEWLINE_STR.store(&"^J");
         OBFUSCATION_READ_CHAR.store(u32::from('*'), Ordering::Relaxed);
     } else {
-        OMITTED_NEWLINE_STR.store(&"\u{23CE}"); // "return symbol" (⏎)
         OBFUSCATION_READ_CHAR.store(
             u32::from(
                 '\u{25CF}', // "black circle" (●)

--- a/src/env_dispatch.rs
+++ b/src/env_dispatch.rs
@@ -1,4 +1,4 @@
-use crate::common::init_special_chars_once;
+use crate::common::{init_special_chars_once, reset_omitted_newline_str_to_default, set_omitted_newline_str};
 use crate::complete::complete_invalidate_path;
 use crate::env::{DEFAULT_READ_BYTE_LIMIT, READ_BYTE_LIMIT};
 use crate::env::{EnvMode, EnvStack, Environment as _, setenv_lock, unsetenv_lock};
@@ -91,6 +91,10 @@ static VAR_DISPATCH_TABLE: once_cell::sync::Lazy<VarDispatchTable> =
         table.add_anon(
             L!("fish_cursor_end_mode"),
             vars!(handle_fish_cursor_end_mode_change),
+        );
+        table.add_anon(
+            L!("fish_omitted_newline_indicator"),
+            vars!(handle_fish_omitted_newline_indicator),
         );
 
         table
@@ -347,6 +351,14 @@ fn handle_fish_trace(vars: &EnvStack) {
     );
 }
 
+fn handle_fish_omitted_newline_indicator(vars: &EnvStack) {
+    // Use get (not get_unless_empty): an empty string explicitly hides the indicator.
+    match vars.get(L!("fish_omitted_newline_indicator")) {
+        Some(var) => set_omitted_newline_str(&var.as_string().chars().collect::<String>()),
+        None => reset_omitted_newline_str_to_default(),
+    }
+}
+
 pub fn env_dispatch_init(vars: &EnvStack) {
     use once_cell::sync::Lazy;
 
@@ -360,6 +372,7 @@ pub fn env_dispatch_init(vars: &EnvStack) {
 fn run_inits(vars: &EnvStack) {
     init_locale(vars);
     init_special_chars_once();
+    handle_fish_omitted_newline_indicator(vars);
     init_terminal(vars);
     handle_emoji_width(vars);
     update_wait_on_escape_ms(vars);

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -690,9 +690,10 @@ fn abandon_line_string(screen_width: Option<usize>) -> Vec<u8> {
     let omitted_newline_str = get_omitted_newline_str();
 
     // Do the PROMPT_SP hack.
-    // Don't need to check for fish_wcwidth errors; this is done when setting up
-    // omitted_newline_char in common.rs.
-    let non_space_width = omitted_newline_str.chars().count();
+    let non_space_width: usize = omitted_newline_str
+        .chars()
+        .map(|c| usize::try_from(fish_wcwidth_visible(c)).unwrap_or(0))
+        .sum();
     // We do `>` rather than `>=` because the code below might require one extra space.
     if screen_width > non_space_width {
         abandon_line_string

--- a/tests/checks/tmux-omitted-newline.fish
+++ b/tests/checks/tmux-omitted-newline.fish
@@ -6,5 +6,27 @@ isolated-tmux send-keys "echo -n 12" Enter
 tmux-sleep
 isolated-tmux capture-pane -p
 # CHECK: prompt 0> echo -n 12
-# CHECK: 12{{\u23CE|\^J|\u00b6|}}
+# CHECK: 12{{⏎|\^J|¶|}}
 # CHECK: prompt 1>
+
+# Test that $fish_omitted_newline_indicator overrides the default.
+isolated-tmux send-keys "set -g fish_omitted_newline_indicator NL; echo -n hello" Enter
+tmux-sleep
+isolated-tmux capture-pane -p
+# CHECK: prompt 0> echo -n 12
+# CHECK: 12{{⏎|\^J|¶|}}
+# CHECK: prompt 1> set -g fish_omitted_newline_indicator NL; echo -n hello
+# CHECK: helloNL
+# CHECK: prompt 2>
+
+# Test that erasing the variable restores the platform default.
+isolated-tmux send-keys "set -e fish_omitted_newline_indicator; echo -n bye" Enter
+tmux-sleep
+isolated-tmux capture-pane -p
+# CHECK: prompt 0> echo -n 12
+# CHECK: 12{{⏎|\^J|¶|}}
+# CHECK: prompt 1> set -g fish_omitted_newline_indicator NL; echo -n hello
+# CHECK: helloNL
+# CHECK: prompt 2> set -e fish_omitted_newline_indicator; echo -n bye
+# CHECK: bye{{⏎|\^J|¶|}}
+# CHECK: prompt 3>


### PR DESCRIPTION
…ator

The symbol shown when output doesn't end with a newline (⏎ by default) can now be overridden via $fish_omitted_newline_indicator. Setting it to an empty string hides the indicator; erasing it restores the platform default (⏎ / ¶ / ^J).

Fixes #12605



## TODOs:
<!-- Check off what what has been done so far. -->
- [x] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
