### PR TITLE
docs: add fish_jj_prompt documentation

### DIFF
--- a/doc_src/cmds/fish_jj_prompt.rst
+++ b/doc_src/cmds/fish_jj_prompt.rst
@@ -1,0 +1,35 @@
+fish_jj_prompt - output Jujutsu information for use in a prompt
+=================================================================
+
+Synopsis
+--------
+
+.. synopsis::
+
+    fish_jj_prompt
+
+::
+
+     function fish_prompt
+          printf '%s' $PWD (fish_jj_prompt) ' $ '
+     end
+
+Description
+-----------
+
+The ``fish_jj_prompt`` function displays information about the current Jujutsu repository, if any.
+
+It currently reports whether the working copy commit has conflicts.
+
+If ``jj`` is not installed, or the current directory is not in a Jujutsu repository, ``fish_jj_prompt`` returns 1 and prints nothing.
+
+See also :doc:`fish_vcs_prompt <fish_vcs_prompt>`, which will call all supported version control prompt functions, including Jujutsu, git and Mercurial.
+
+Example
+-------
+
+A simple prompt that displays Jujutsu information::
+
+    function fish_prompt
+        printf '%s %s$' $PWD (fish_jj_prompt)
+    end

--- a/doc_src/cmds/fish_vcs_prompt.rst
+++ b/doc_src/cmds/fish_vcs_prompt.rst
@@ -21,6 +21,7 @@ The ``fish_vcs_prompt`` function displays information about the current version 
 
 It calls out to VCS-specific functions. The currently supported systems are:
 
+- :doc:`fish_jj_prompt <fish_jj_prompt>`
 - :doc:`fish_git_prompt <fish_git_prompt>`
 - :doc:`fish_hg_prompt <fish_hg_prompt>`
 - :doc:`fish_svn_prompt <fish_svn_prompt>`

--- a/doc_src/commands.rst
+++ b/doc_src/commands.rst
@@ -67,6 +67,7 @@ Helper functions
 
 Some helper functions, often to give you information for use in your prompt:
 
+- :doc:`fish_jj_prompt <cmds/fish_jj_prompt>` to print information about the current Jujutsu repository.
 - :doc:`fish_git_prompt <cmds/fish_git_prompt>` and :doc:`fish_hg_prompt <cmds/fish_hg_prompt>` to print information about the current git or mercurial repository.
 - :doc:`fish_vcs_prompt <cmds/fish_vcs_prompt>` to print information for either.
 - :doc:`fish_svn_prompt <cmds/fish_svn_prompt>` to print information about the current svn repository.

--- a/doc_src/prompt.rst
+++ b/doc_src/prompt.rst
@@ -210,7 +210,7 @@ We have now built a simple but working and usable prompt, but of course more can
 - Fish offers more helper functions:
    - ``prompt_login`` to describe the user/hostname/container or ``prompt_hostname`` to describe just the host
    - ``fish_is_root_user`` to help with changing the symbol for root.
-   - ``fish_vcs_prompt`` to show version control information (or ``fish_git_prompt`` / ``fish_hg_prompt`` / ``fish_svn_prompt`` to limit it to specific systems)
+   - ``fish_vcs_prompt`` to show version control information (or ``fish_jj_prompt`` / ``fish_git_prompt`` / ``fish_hg_prompt`` / ``fish_svn_prompt`` to limit it to specific systems)
 - You can add a right prompt by changing :doc:`fish_right_prompt <cmds/fish_right_prompt>` or a vi mode prompt by changing :doc:`fish_mode_prompt <cmds/fish_mode_prompt>`.
 - Some prompts have interesting or advanced features
    - Add the time when the prompt was printed


### PR DESCRIPTION
## Summary
- Add a command documentation page for `fish_jj_prompt`.
- Link it from the helper function list, `fish_vcs_prompt` docs, and prompt guide.

Fixes #12756

## Testing
- Checked the new and updated RST files for expected references with a Python script.
- Could not run the full Sphinx docs build locally because Sphinx is not installed in this environment.

Made with [Cursor](https://cursor.com)