### PR TITLE
Add menu completion for --position=anywhere abbrs in non-command position

### DIFF
--- a/src/complete.rs
+++ b/src/complete.rs
@@ -1,5 +1,5 @@
 use crate::{
-    abbrs::with_abbrs,
+    abbrs::{with_abbrs, Position},
     ast::unescape_keyword,
     autoload::{Autoload, AutoloadResult},
     builtins::shared::{builtin_exists, builtin_get_desc, builtin_get_names},
@@ -689,7 +689,7 @@ impl<'ctx, 'parser> Completer<'ctx, 'parser> {
                 return;
             }
             self.complete_cmd(WString::new());
-            self.complete_abbr(WString::new());
+            self.complete_abbr(WString::new(), false);
             return;
         };
 
@@ -745,7 +745,7 @@ impl<'ctx, 'parser> Completer<'ctx, 'parser> {
             }
             // Complete command filename.
             let current_token = current_token.to_owned();
-            self.complete_abbr(current_token.clone());
+            self.complete_abbr(current_token.clone(), false);
             self.complete_cmd(current_token);
             return;
         }
@@ -834,6 +834,11 @@ impl<'ctx, 'parser> Completer<'ctx, 'parser> {
         // Maybe apply variable assignments.
         let block = self.apply_var_assignments(&var_assignments);
         if !self.ctx.check_cancel() {
+            // Complete anywhere-position abbreviations in non-command position.
+            if !in_redirection {
+                self.complete_abbr(current_argument.to_owned(), true);
+            }
+
             // This function wants the unescaped string.
             self.complete_param_expand(
                 current_argument,
@@ -1146,14 +1151,18 @@ impl<'ctx, 'parser> Completer<'ctx, 'parser> {
     }
 
     /// Attempt to complete an abbreviation for the given string.
-    fn complete_abbr(&mut self, cmd: WString) {
+    /// If `anywhere_only` is true, only abbreviations with `Position::Anywhere` are included;
+    /// otherwise all non-regex abbreviations are included.
+    fn complete_abbr(&mut self, cmd: WString, anywhere_only: bool) {
         // Copy the list of names and descriptions so as not to hold the lock across the call to
         // complete_strings.
         let mut possible_comp = Vec::new();
         let mut descs = HashMap::new();
         with_abbrs(|set| {
             for abbr in set.list() {
-                if !abbr.is_regex() {
+                if !abbr.is_regex()
+                    && (!anywhere_only || abbr.position == Position::Anywhere)
+                {
                     possible_comp.push(Completion::from_completion(abbr.key.clone()));
                     descs.insert(abbr.key.clone(), abbr.replacement.clone());
                 }

--- a/src/complete.rs
+++ b/src/complete.rs
@@ -689,7 +689,7 @@ impl<'ctx, 'parser> Completer<'ctx, 'parser> {
                 return;
             }
             self.complete_cmd(WString::new());
-            self.complete_abbr(WString::new(), false);
+            self.complete_abbr(WString::new(), true);
             return;
         };
 
@@ -745,7 +745,7 @@ impl<'ctx, 'parser> Completer<'ctx, 'parser> {
             }
             // Complete command filename.
             let current_token = current_token.to_owned();
-            self.complete_abbr(current_token.clone(), false);
+            self.complete_abbr(current_token.clone(), true);
             self.complete_cmd(current_token);
             return;
         }
@@ -834,9 +834,9 @@ impl<'ctx, 'parser> Completer<'ctx, 'parser> {
         // Maybe apply variable assignments.
         let block = self.apply_var_assignments(&var_assignments);
         if !self.ctx.check_cancel() {
-            // Complete anywhere-position abbreviations in non-command position.
+            // Complete abbr in non-command position.
             if !in_redirection {
-                self.complete_abbr(current_argument.to_owned(), true);
+                self.complete_abbr(current_argument.to_owned(), false);
             }
 
             // This function wants the unescaped string.
@@ -1150,19 +1150,18 @@ impl<'ctx, 'parser> Completer<'ctx, 'parser> {
         }
     }
 
-    /// Attempt to complete an abbreviation for the given string.
-    /// If `anywhere_only` is true, only abbreviations with `Position::Anywhere` are included;
-    /// otherwise all non-regex abbreviations are included.
-    fn complete_abbr(&mut self, cmd: WString, anywhere_only: bool) {
+    /// Attempt to complete a non-regex abbreviation for the given string.
+    fn complete_abbr(&mut self, cmd: WString, is_command_position: bool) {
         // Copy the list of names and descriptions so as not to hold the lock across the call to
         // complete_strings.
         let mut possible_comp = Vec::new();
         let mut descs = HashMap::new();
         with_abbrs(|set| {
             for abbr in set.list() {
-                if !abbr.is_regex()
-                    && (!anywhere_only || abbr.position == Position::Anywhere)
-                {
+                if abbr.is_regex() {
+                    continue;
+                }
+                if abbr.position == Position::Anywhere || is_command_position {
                     possible_comp.push(Completion::from_completion(abbr.key.clone()));
                     descs.insert(abbr.key.clone(), abbr.replacement.clone());
                 }

--- a/tests/checks/complete.fish
+++ b/tests/checks/complete.fish
@@ -645,6 +645,22 @@ abbr cat cat
 complete -C ca | string match -r '^cat(?:\t.*)?$'
 # CHECK: cat{{\t}}Abbreviation: cat
 
+# anywhere-position abbrs complete in non-command position
+abbr --position anywhere __test_pgr '| grep -i'
+complete -C'echo __test_pgr' | string match -r '^__test_pgr.*'
+# CHECK: __test_pgr{{\t}}Abbreviation: | grep -i
+
+# anywhere-position abbrs still complete in command position (regression guard)
+complete -C__test_pgr | string match -r '^__test_pgr.*'
+# CHECK: __test_pgr{{\t}}Abbreviation: | grep -i
+
+# command-position-only abbrs do NOT complete in non-command position
+abbr --position command __test_cmd_only 'git status'
+complete -C'echo __test_cmd' | string match -rq '^__test_cmd'
+echo $status
+# CHECK: 1
+abbr --erase __test_pgr __test_cmd_only
+
 complete complete-list -xa '(__fish_complete_list , "seq 2")'
 complete -C "complete-list 1,"
 # CHECK: 1,1


### PR DESCRIPTION
## Summary

Current tab completion behavior: `abbr`s can only be completed in command position (non-regex abbrs)

Desired behvaior: add completion for non-command position which would  only apply to `abbr`s with `--position=anywhere`

## Examples

```fish

## command only example:
abbr -- gst "git status"
# equivalent to:
abbr --position=command -- gst "git status"
# gst will show in menu completion when I do this:
gs<TAB>

## anywhere example:
abbr --position=anywhere -- pgr "| grep -i"
# intended use:
cat foo.log pgr<SPACE>
# expands to: 
cat foo.log | grep -i

# currently `pgr` shows during completion in command position only (although in this case, not useful in command position)
# I would like to see `pgr` show as a completion choice in non-command position:
cat foo.log pg<TAB>

# Why? I have many `p`/`pg` prefixed abbrs, completion would let me query the list as I add new choices to learn them!
# similar anywhere abbrs:
abbr -a --position anywhere -- pbat '| bat -l'
abbr -a --position anywhere -- pgr '| rg_grep -i'
abbr -a --position anywhere -- pgrv '| rg_grep -i --invert-match'
abbr -a --position anywhere -- phelp '| bat -l help'
abbr -a --position anywhere -- pini '| bat -pl ini'
abbr -a --position anywhere -- pjq '| jq .'
abbr -a --position anywhere -- pjqr '| jq -r .'
abbr -a --position anywhere -- pjqj '| jq --join-output .'
abbr -a --position anywhere -- pmd '| bat -pl md'
abbr -a --position anywhere -- prb '| bat -pl rb'
abbr -a --position anywhere -- psh '| bat -pl sh'
abbr -a --position anywhere -- pxml '| bat -l xml'
abbr -a --position anywhere -- pyml '| bat -l yml'
abbr -a --position anywhere -- puniq '| sort | uniq -c'
abbr -a --position anywhere -- psort '| sort -h'

another good use case in this set... `pj<TAB>` to see all my jq related pipe abbrs
```

right now if I don't know the exact abbr in non-command position, I can't use the abbr... but when I am learning abbrs, if I can tab complete to see choices, that helps me learn

## Changes

- BTW, existing abbr completion works for command position only.
- I added a boolean parameter `is_command_position` to `complete_abbr(&mut self, cmd: WString, is_command_position: bool)`
- `is_command_position = false` triggers existing command position completion.
- `is_command_position = true` triggers the new, non-command position completion which means only abbrs that have `--position=anywhere`
- In all cases, regex based abbrs are excluded, preserving existing behavior.

- I added three tests using my `pgr` example, see [./tests/checks/complete.fish](./tests/checks/complete.fish)

## TODOs:

- [ n/a ] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [ n/a ] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [ n/a ] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
