### PR TITLE
default mode prompt variants

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 fish ?.?.? (released ???)
 =========================
 
+Other Improvements
+------------------
+- Add variants to mode prompt indicating the active mode in the vi key bindings.
+
 fish 4.8.1 (released July 14, 2026)
 ===================================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Regression fixes:
 -----------------
 - (From 4.6.0) Chinese and Japanese translation of error messages owned by the C library (:issue:`12895`).
 
+Other Improvements
+------------------
+- Add variants to mode prompt indicating the active mode in the vi key bindings.
+
 fish 4.8.1 (released July 14, 2026)
 ===================================
 

--- a/doc_src/language.rst
+++ b/doc_src/language.rst
@@ -1648,6 +1648,39 @@ You can change the settings of fish by changing the values of certain variables.
 
    the current file creation mask. The preferred way to change the umask variable is through the :doc:`umask <cmds/umask>` function. An attempt to set umask to an invalid value will always fail.
 
+.. envvar:: fish_default_mode_prompt_variant
+
+   Select one of the 3 variants of the default :doc:`mode prompt <cmds/fish_mode_prompt>`:
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 10 35 15 15 15 25
+
+      * - Mode
+        - Description
+        - Indicator String
+        - Surrounding
+        - Dimming
+        - Trigger Values
+      * - Default
+        - Historical, simple & plain default
+        - Single letter
+        - ``[letter]``
+        - None
+        - anything other than below
+      * - Dim
+        - More Noticeable indicating string
+        - Single letter
+        - ``[letter]``
+        - Square Brackets
+        - ``dim`` ``dimmed``
+      * - Triple
+        - Unsurrounded, self-contained indicator
+        - Triple-letter
+        - None
+        - None
+        - ``triple`` ``three`` ``3``
+
 .. envvar:: SHELL_PROMPT_PREFIX
 
    if set, this string is automatically prepended to the left prompt. This is a standard environment variable that may be set by tools like systemd's ``run0`` to indicate special shell sessions.

--- a/share/functions/fish_default_mode_prompt.fish
+++ b/share/functions/fish_default_mode_prompt.fish
@@ -5,23 +5,40 @@ function fish_default_mode_prompt --description "Display vi prompt mode"
     end
     switch $fish_bind_mode
         case default
-            set_color --bold red
-            echo '[N]'
+            set -f color red
+            set -f text NOR
         case insert
-            set_color --bold green
-            echo '[I]'
+            set -f color green
+            set -f text INS
         case replace_one
-            set_color --bold green
-            echo '[R]'
+            set -f color green
+            set -f text RE1
         case replace
-            set_color --bold cyan
-            echo '[R]'
+            set -f color cyan
+            set -f text REP
         case visual
-            set_color --bold magenta
-            echo '[V]'
+            set -f color magenta
+            set -f text VIS
         case operator f F t T
-            set_color --bold cyan
-            echo '[N]'
+            set -f color cyan
+            set -f text NOR
+    end
+
+    set_color --bold $color
+    switch "$fish_mode_prompt_variant"
+        case dim dimmed
+            set_color --dim
+            echo -n [
+
+            set_color --reset --bold $color
+            echo -n (string sub --length=1 -- $text)
+
+            set_color --dim
+            echo ]
+        case triple 3 three
+            echo $text
+        case \*
+            echo [(string sub --length=1 -- $text)]
     end
     set_color --reset
     echo -n ' '


### PR DESCRIPTION
To make the mode more noticeable, the square brackets surrounding the letter indicating the mode are dimmed. This highlights what actually changes when the mode is switched.

<img width="393" height="514" alt="dim-showcase" src="https://github.com/user-attachments/assets/b79a3105-f3f4-4e03-a320-753f469aca61" />

## TODOs:
<!-- Check off what what has been done so far. -->
- [x] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
