### PR TITLE
Refactor multiple equality checks to use `contains` for default mode prompt

### DIFF
--- a/share/functions/fish_default_mode_prompt.fish
+++ b/share/functions/fish_default_mode_prompt.fish
@@ -1,7 +1,6 @@
 function fish_default_mode_prompt --description "Display vi prompt mode"
     # Do nothing if not in vi mode
-    if test "$fish_key_bindings" = fish_vi_key_bindings
-        or test "$fish_key_bindings" = fish_hybrid_key_bindings
+    if contains "$fish_key_bindings" fish_{vi,hybrid}_key_bindings
         switch $fish_bind_mode
             case default
                 set_color --bold red


### PR DESCRIPTION
In the Default key-bindings mode prompt:  
Instead of `test $var = foo && test $var = bar`, use `contains $var foo bar`

- Looks cleaner and easier to read.
- More DRY (avoids repetition of the common string) 


## TODOs:
<!-- Check off what what has been done so far. -->
- [x] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
