### PR TITLE
completions/terraform: add missing subcommands

### DIFF
--- a/localization/po/de.po
+++ b/localization/po/de.po
@@ -10841,6 +10841,9 @@ msgstr ""
 msgid "Check whether specified profile is enabled"
 msgstr ""
 
+msgid "Check whether the configuration is valid"
+msgstr ""
+
 msgid "Check whether the firewalld daemon is active"
 msgstr ""
 
@@ -13599,6 +13602,9 @@ msgid "Create a space"
 msgstr ""
 
 msgid "Create a sparse volume"
+msgstr ""
+
+msgid "Create a stack"
 msgstr ""
 
 msgid "Create a stacked branch referring to the source branch"
@@ -21138,6 +21144,9 @@ msgid "Don't ask about patches that are depended on by matched patches (with --m
 msgstr ""
 
 msgid "Don't ask any interactive question"
+msgstr ""
+
+msgid "Don't ask for input for unlock confirmation"
 msgstr ""
 
 msgid "Don't ask for missing credentials"
@@ -29000,6 +29009,9 @@ msgstr ""
 msgid "Generate http://www.dita-op.org's Eclipse configuration to allow editing"
 msgstr ""
 
+msgid "Generate import and resource blocks for found results"
+msgstr ""
+
 msgid "Generate incremental stream from snapshot"
 msgstr ""
 
@@ -35936,6 +35948,9 @@ msgstr ""
 msgid "List sources that are bound to zone"
 msgstr ""
 
+msgid "List stacks for a given organization and/or project"
+msgstr ""
+
 msgid "List startable machine images"
 msgstr ""
 
@@ -37469,6 +37484,9 @@ msgstr ""
 msgid "Manage Flexible Resources between Primary and Secondary Controller "
 msgstr ""
 
+msgid "Manage HCP Terraform stack operations"
+msgstr ""
+
 msgid "Manage OPAM repositories"
 msgstr ""
 
@@ -37512,6 +37530,12 @@ msgid "Manage configuration."
 msgstr ""
 
 msgid "Manage delayed environment variable expansion"
+msgstr ""
+
+msgid "Manage deployment groups"
+msgstr ""
+
+msgid "Manage deployment runs"
 msgstr ""
 
 msgid "Manage devices in array, and possibly start it"
@@ -37578,6 +37602,9 @@ msgid "Manage set of tracked repositories"
 msgstr ""
 
 msgid "Manage settings"
+msgstr ""
+
+msgid "Manage stack configuration"
 msgstr ""
 
 msgid "Manage stashes"
@@ -38166,6 +38193,9 @@ msgid "Merges GWT servlet elements into deployment descriptor (and non GWT servl
 msgstr ""
 
 msgid "Message to print after patch failure"
+msgstr ""
+
+msgid "Metadata related commands"
 msgstr ""
 
 msgid "Method and interface name"
@@ -41042,6 +41072,9 @@ msgstr ""
 msgid "Output current account details"
 msgstr ""
 
+msgid "Output declared modules in a machine-readable format"
+msgstr ""
+
 msgid "Output delimited values"
 msgstr ""
 
@@ -43556,6 +43589,9 @@ msgstr ""
 msgid "Prepare the change to be pushed, but do not actually push it"
 msgstr ""
 
+msgid "Prepare the configuration directory for further commands"
+msgstr ""
+
 msgid "Prepend PHP's include_path with given path(s)"
 msgstr ""
 
@@ -44758,6 +44794,9 @@ msgstr ""
 
 msgid "Print full user-to-user latency"
 msgstr "Volle Benutzer-zu-Benutzer-Latenz ausgeben"
+
+msgid "Print function signatures in JSON format"
+msgstr ""
 
 msgid "Print further version info"
 msgstr ""
@@ -46916,6 +46955,9 @@ msgstr ""
 msgid "Produce long listing"
 msgstr ""
 
+msgid "Produce machine readable output in JSON format"
+msgstr ""
+
 msgid "Produce machine-readable output"
 msgstr ""
 
@@ -48773,6 +48815,9 @@ msgstr ""
 msgid "Reflect pending patches in output [DEFAULT]"
 msgstr ""
 
+msgid "Reformat Terraform Stacks configuration"
+msgstr ""
+
 msgid "Reformat Zig source into canonical form"
 msgstr ""
 
@@ -49023,6 +49068,9 @@ msgid "Release Write file descriptor"
 msgstr ""
 
 msgid "Release a closed Nexus staging repo into a permanent Nexus repo for general consumption"
+msgstr ""
+
+msgid "Release a stuck lock on the current workspace"
 msgstr ""
 
 msgid "Release hold recursively"
@@ -53603,6 +53651,9 @@ msgstr ""
 msgid "Search and build packages recursively"
 msgstr ""
 
+msgid "Search and list remote infrastructure with Terraform"
+msgstr ""
+
 msgid "Search blobs registered in the index file"
 msgstr ""
 
@@ -57989,6 +58040,9 @@ msgstr ""
 msgid "Show all config settings"
 msgstr ""
 
+msgid "Show all declared modules in a working directory"
+msgstr ""
+
 msgid "Show all env variables for an app"
 msgstr ""
 
@@ -59774,6 +59828,9 @@ msgstr ""
 msgid "Show shorter output"
 msgstr ""
 
+msgid "Show signatures and descriptions for the available functions"
+msgstr ""
+
 msgid "Show sizes in GiB, or GB with --si"
 msgstr ""
 
@@ -60018,6 +60075,9 @@ msgid "Show the current Ruby version"
 msgstr ""
 
 msgid "Show the current Ruby version & how it was selected"
+msgstr ""
+
+msgid "Show the current Stacks Plugin version"
 msgstr ""
 
 msgid "Show the current version of prt-get"
@@ -65496,6 +65556,9 @@ msgid "Switch to a commit for inspection and discardable experiment"
 msgstr ""
 
 msgid "Switch to a different tree"
+msgstr ""
+
+msgid "Switch to a different working directory before executing"
 msgstr ""
 
 msgid "Switch to a different working directory before executing the command"
@@ -73209,6 +73272,9 @@ msgid "Write out a NeXTstep/GNUstep"
 msgstr ""
 
 msgid "Write out a new empty file system volume"
+msgstr ""
+
+msgid "Write out dependency locks for the configured providers"
 msgstr ""
 
 msgid "Write out setting names"

--- a/localization/po/en.po
+++ b/localization/po/en.po
@@ -10841,6 +10841,9 @@ msgstr ""
 msgid "Check whether specified profile is enabled"
 msgstr ""
 
+msgid "Check whether the configuration is valid"
+msgstr ""
+
 msgid "Check whether the firewalld daemon is active"
 msgstr ""
 
@@ -13600,6 +13603,9 @@ msgstr ""
 
 msgid "Create a sparse volume"
 msgstr "Create a sparse volume"
+
+msgid "Create a stack"
+msgstr ""
 
 msgid "Create a stacked branch referring to the source branch"
 msgstr ""
@@ -21138,6 +21144,9 @@ msgid "Don't ask about patches that are depended on by matched patches (with --m
 msgstr ""
 
 msgid "Don't ask any interactive question"
+msgstr ""
+
+msgid "Don't ask for input for unlock confirmation"
 msgstr ""
 
 msgid "Don't ask for missing credentials"
@@ -29000,6 +29009,9 @@ msgstr ""
 msgid "Generate http://www.dita-op.org's Eclipse configuration to allow editing"
 msgstr ""
 
+msgid "Generate import and resource blocks for found results"
+msgstr ""
+
 msgid "Generate incremental stream from snapshot"
 msgstr "Generate incremental stream from snapshot"
 
@@ -35936,6 +35948,9 @@ msgstr ""
 msgid "List sources that are bound to zone"
 msgstr ""
 
+msgid "List stacks for a given organization and/or project"
+msgstr ""
+
 msgid "List startable machine images"
 msgstr ""
 
@@ -37469,6 +37484,9 @@ msgstr ""
 msgid "Manage Flexible Resources between Primary and Secondary Controller "
 msgstr ""
 
+msgid "Manage HCP Terraform stack operations"
+msgstr ""
+
 msgid "Manage OPAM repositories"
 msgstr ""
 
@@ -37512,6 +37530,12 @@ msgid "Manage configuration."
 msgstr ""
 
 msgid "Manage delayed environment variable expansion"
+msgstr ""
+
+msgid "Manage deployment groups"
+msgstr ""
+
+msgid "Manage deployment runs"
 msgstr ""
 
 msgid "Manage devices in array, and possibly start it"
@@ -37578,6 +37602,9 @@ msgid "Manage set of tracked repositories"
 msgstr ""
 
 msgid "Manage settings"
+msgstr ""
+
+msgid "Manage stack configuration"
 msgstr ""
 
 msgid "Manage stashes"
@@ -38166,6 +38193,9 @@ msgid "Merges GWT servlet elements into deployment descriptor (and non GWT servl
 msgstr ""
 
 msgid "Message to print after patch failure"
+msgstr ""
+
+msgid "Metadata related commands"
 msgstr ""
 
 msgid "Method and interface name"
@@ -41042,6 +41072,9 @@ msgstr ""
 msgid "Output current account details"
 msgstr ""
 
+msgid "Output declared modules in a machine-readable format"
+msgstr ""
+
 msgid "Output delimited values"
 msgstr ""
 
@@ -43556,6 +43589,9 @@ msgstr ""
 msgid "Prepare the change to be pushed, but do not actually push it"
 msgstr ""
 
+msgid "Prepare the configuration directory for further commands"
+msgstr ""
+
 msgid "Prepend PHP's include_path with given path(s)"
 msgstr ""
 
@@ -44758,6 +44794,9 @@ msgstr ""
 
 msgid "Print full user-to-user latency"
 msgstr "Print full user-to-user latency"
+
+msgid "Print function signatures in JSON format"
+msgstr ""
 
 msgid "Print further version info"
 msgstr ""
@@ -46916,6 +46955,9 @@ msgstr ""
 msgid "Produce long listing"
 msgstr ""
 
+msgid "Produce machine readable output in JSON format"
+msgstr ""
+
 msgid "Produce machine-readable output"
 msgstr ""
 
@@ -48773,6 +48815,9 @@ msgstr ""
 msgid "Reflect pending patches in output [DEFAULT]"
 msgstr ""
 
+msgid "Reformat Terraform Stacks configuration"
+msgstr ""
+
 msgid "Reformat Zig source into canonical form"
 msgstr ""
 
@@ -49023,6 +49068,9 @@ msgid "Release Write file descriptor"
 msgstr ""
 
 msgid "Release a closed Nexus staging repo into a permanent Nexus repo for general consumption"
+msgstr ""
+
+msgid "Release a stuck lock on the current workspace"
 msgstr ""
 
 msgid "Release hold recursively"
@@ -53603,6 +53651,9 @@ msgstr ""
 msgid "Search and build packages recursively"
 msgstr ""
 
+msgid "Search and list remote infrastructure with Terraform"
+msgstr ""
+
 msgid "Search blobs registered in the index file"
 msgstr ""
 
@@ -57989,6 +58040,9 @@ msgstr ""
 msgid "Show all config settings"
 msgstr ""
 
+msgid "Show all declared modules in a working directory"
+msgstr ""
+
 msgid "Show all env variables for an app"
 msgstr ""
 
@@ -59774,6 +59828,9 @@ msgstr ""
 msgid "Show shorter output"
 msgstr ""
 
+msgid "Show signatures and descriptions for the available functions"
+msgstr ""
+
 msgid "Show sizes in GiB, or GB with --si"
 msgstr ""
 
@@ -60018,6 +60075,9 @@ msgid "Show the current Ruby version"
 msgstr ""
 
 msgid "Show the current Ruby version & how it was selected"
+msgstr ""
+
+msgid "Show the current Stacks Plugin version"
 msgstr ""
 
 msgid "Show the current version of prt-get"
@@ -65496,6 +65556,9 @@ msgid "Switch to a commit for inspection and discardable experiment"
 msgstr ""
 
 msgid "Switch to a different tree"
+msgstr ""
+
+msgid "Switch to a different working directory before executing"
 msgstr ""
 
 msgid "Switch to a different working directory before executing the command"
@@ -73209,6 +73272,9 @@ msgid "Write out a NeXTstep/GNUstep"
 msgstr ""
 
 msgid "Write out a new empty file system volume"
+msgstr ""
+
+msgid "Write out dependency locks for the configured providers"
 msgstr ""
 
 msgid "Write out setting names"

--- a/localization/po/es.po
+++ b/localization/po/es.po
@@ -10841,6 +10841,9 @@ msgstr ""
 msgid "Check whether specified profile is enabled"
 msgstr ""
 
+msgid "Check whether the configuration is valid"
+msgstr ""
+
 msgid "Check whether the firewalld daemon is active"
 msgstr ""
 
@@ -13599,6 +13602,9 @@ msgid "Create a space"
 msgstr ""
 
 msgid "Create a sparse volume"
+msgstr ""
+
+msgid "Create a stack"
 msgstr ""
 
 msgid "Create a stacked branch referring to the source branch"
@@ -21138,6 +21144,9 @@ msgid "Don't ask about patches that are depended on by matched patches (with --m
 msgstr ""
 
 msgid "Don't ask any interactive question"
+msgstr ""
+
+msgid "Don't ask for input for unlock confirmation"
 msgstr ""
 
 msgid "Don't ask for missing credentials"
@@ -29000,6 +29009,9 @@ msgstr ""
 msgid "Generate http://www.dita-op.org's Eclipse configuration to allow editing"
 msgstr ""
 
+msgid "Generate import and resource blocks for found results"
+msgstr ""
+
 msgid "Generate incremental stream from snapshot"
 msgstr ""
 
@@ -35936,6 +35948,9 @@ msgstr ""
 msgid "List sources that are bound to zone"
 msgstr ""
 
+msgid "List stacks for a given organization and/or project"
+msgstr ""
+
 msgid "List startable machine images"
 msgstr ""
 
@@ -37469,6 +37484,9 @@ msgstr ""
 msgid "Manage Flexible Resources between Primary and Secondary Controller "
 msgstr ""
 
+msgid "Manage HCP Terraform stack operations"
+msgstr ""
+
 msgid "Manage OPAM repositories"
 msgstr ""
 
@@ -37512,6 +37530,12 @@ msgid "Manage configuration."
 msgstr ""
 
 msgid "Manage delayed environment variable expansion"
+msgstr ""
+
+msgid "Manage deployment groups"
+msgstr ""
+
+msgid "Manage deployment runs"
 msgstr ""
 
 msgid "Manage devices in array, and possibly start it"
@@ -37578,6 +37602,9 @@ msgid "Manage set of tracked repositories"
 msgstr ""
 
 msgid "Manage settings"
+msgstr ""
+
+msgid "Manage stack configuration"
 msgstr ""
 
 msgid "Manage stashes"
@@ -38166,6 +38193,9 @@ msgid "Merges GWT servlet elements into deployment descriptor (and non GWT servl
 msgstr ""
 
 msgid "Message to print after patch failure"
+msgstr ""
+
+msgid "Metadata related commands"
 msgstr ""
 
 msgid "Method and interface name"
@@ -41042,6 +41072,9 @@ msgstr ""
 msgid "Output current account details"
 msgstr ""
 
+msgid "Output declared modules in a machine-readable format"
+msgstr ""
+
 msgid "Output delimited values"
 msgstr ""
 
@@ -43556,6 +43589,9 @@ msgstr ""
 msgid "Prepare the change to be pushed, but do not actually push it"
 msgstr ""
 
+msgid "Prepare the configuration directory for further commands"
+msgstr ""
+
 msgid "Prepend PHP's include_path with given path(s)"
 msgstr ""
 
@@ -44757,6 +44793,9 @@ msgid "Print full superblock information, backup roots etc."
 msgstr ""
 
 msgid "Print full user-to-user latency"
+msgstr ""
+
+msgid "Print function signatures in JSON format"
 msgstr ""
 
 msgid "Print further version info"
@@ -46916,6 +46955,9 @@ msgstr ""
 msgid "Produce long listing"
 msgstr ""
 
+msgid "Produce machine readable output in JSON format"
+msgstr ""
+
 msgid "Produce machine-readable output"
 msgstr ""
 
@@ -48773,6 +48815,9 @@ msgstr ""
 msgid "Reflect pending patches in output [DEFAULT]"
 msgstr ""
 
+msgid "Reformat Terraform Stacks configuration"
+msgstr ""
+
 msgid "Reformat Zig source into canonical form"
 msgstr ""
 
@@ -49023,6 +49068,9 @@ msgid "Release Write file descriptor"
 msgstr ""
 
 msgid "Release a closed Nexus staging repo into a permanent Nexus repo for general consumption"
+msgstr ""
+
+msgid "Release a stuck lock on the current workspace"
 msgstr ""
 
 msgid "Release hold recursively"
@@ -53603,6 +53651,9 @@ msgstr ""
 msgid "Search and build packages recursively"
 msgstr ""
 
+msgid "Search and list remote infrastructure with Terraform"
+msgstr ""
+
 msgid "Search blobs registered in the index file"
 msgstr ""
 
@@ -57989,6 +58040,9 @@ msgstr ""
 msgid "Show all config settings"
 msgstr ""
 
+msgid "Show all declared modules in a working directory"
+msgstr ""
+
 msgid "Show all env variables for an app"
 msgstr ""
 
@@ -59774,6 +59828,9 @@ msgstr ""
 msgid "Show shorter output"
 msgstr ""
 
+msgid "Show signatures and descriptions for the available functions"
+msgstr ""
+
 msgid "Show sizes in GiB, or GB with --si"
 msgstr ""
 
@@ -60018,6 +60075,9 @@ msgid "Show the current Ruby version"
 msgstr ""
 
 msgid "Show the current Ruby version & how it was selected"
+msgstr ""
+
+msgid "Show the current Stacks Plugin version"
 msgstr ""
 
 msgid "Show the current version of prt-get"
@@ -65496,6 +65556,9 @@ msgid "Switch to a commit for inspection and discardable experiment"
 msgstr ""
 
 msgid "Switch to a different tree"
+msgstr ""
+
+msgid "Switch to a different working directory before executing"
 msgstr ""
 
 msgid "Switch to a different working directory before executing the command"
@@ -73209,6 +73272,9 @@ msgid "Write out a NeXTstep/GNUstep"
 msgstr ""
 
 msgid "Write out a new empty file system volume"
+msgstr ""
+
+msgid "Write out dependency locks for the configured providers"
 msgstr ""
 
 msgid "Write out setting names"

--- a/localization/po/fr.po
+++ b/localization/po/fr.po
@@ -10970,6 +10970,9 @@ msgstr ""
 msgid "Check whether specified profile is enabled"
 msgstr ""
 
+msgid "Check whether the configuration is valid"
+msgstr ""
+
 msgid "Check whether the firewalld daemon is active"
 msgstr ""
 
@@ -13729,6 +13732,9 @@ msgstr ""
 
 msgid "Create a sparse volume"
 msgstr "Créer un volume creux"
+
+msgid "Create a stack"
+msgstr ""
 
 msgid "Create a stacked branch referring to the source branch"
 msgstr "Créer une branche empilée se référant à la branche source"
@@ -21268,6 +21274,9 @@ msgstr "Ne pas demander les patchs dont dépendent ceux trouvés (avec --match o
 
 msgid "Don't ask any interactive question"
 msgstr "Ne poser aucune question interactive"
+
+msgid "Don't ask for input for unlock confirmation"
+msgstr ""
 
 msgid "Don't ask for missing credentials"
 msgstr ""
@@ -29129,6 +29138,9 @@ msgstr ""
 msgid "Generate http://www.dita-op.org's Eclipse configuration to allow editing"
 msgstr ""
 
+msgid "Generate import and resource blocks for found results"
+msgstr ""
+
 msgid "Generate incremental stream from snapshot"
 msgstr "Générer un flux incrémental depuis un instantané"
 
@@ -36065,6 +36077,9 @@ msgstr ""
 msgid "List sources that are bound to zone"
 msgstr ""
 
+msgid "List stacks for a given organization and/or project"
+msgstr ""
+
 msgid "List startable machine images"
 msgstr "Lister les images de machines pouvant être démarrées"
 
@@ -37598,6 +37613,9 @@ msgstr ""
 msgid "Manage Flexible Resources between Primary and Secondary Controller "
 msgstr ""
 
+msgid "Manage HCP Terraform stack operations"
+msgstr ""
+
 msgid "Manage OPAM repositories"
 msgstr ""
 
@@ -37641,6 +37659,12 @@ msgid "Manage configuration."
 msgstr "Gérer la configuration"
 
 msgid "Manage delayed environment variable expansion"
+msgstr ""
+
+msgid "Manage deployment groups"
+msgstr ""
+
+msgid "Manage deployment runs"
 msgstr ""
 
 msgid "Manage devices in array, and possibly start it"
@@ -37708,6 +37732,9 @@ msgstr "Mettre à jour le jeu des dépôts suivis"
 
 msgid "Manage settings"
 msgstr "Gérer les paramètres"
+
+msgid "Manage stack configuration"
+msgstr ""
 
 msgid "Manage stashes"
 msgstr "Gérer les remisages"
@@ -38295,6 +38322,9 @@ msgid "Merges GWT servlet elements into deployment descriptor (and non GWT servl
 msgstr ""
 
 msgid "Message to print after patch failure"
+msgstr ""
+
+msgid "Metadata related commands"
 msgstr ""
 
 msgid "Method and interface name"
@@ -41171,6 +41201,9 @@ msgstr ""
 msgid "Output current account details"
 msgstr ""
 
+msgid "Output declared modules in a machine-readable format"
+msgstr ""
+
 msgid "Output delimited values"
 msgstr ""
 
@@ -43685,6 +43718,9 @@ msgstr "Préparer le dossier source"
 msgid "Prepare the change to be pushed, but do not actually push it"
 msgstr ""
 
+msgid "Prepare the configuration directory for further commands"
+msgstr ""
+
 msgid "Prepend PHP's include_path with given path(s)"
 msgstr ""
 
@@ -44887,6 +44923,9 @@ msgstr ""
 
 msgid "Print full user-to-user latency"
 msgstr "Afficher la latence totale inter-utilisateurs"
+
+msgid "Print function signatures in JSON format"
+msgstr ""
 
 msgid "Print further version info"
 msgstr ""
@@ -47045,6 +47084,9 @@ msgstr ""
 msgid "Produce long listing"
 msgstr ""
 
+msgid "Produce machine readable output in JSON format"
+msgstr ""
+
 msgid "Produce machine-readable output"
 msgstr "Produire une sortie lisible par un programme"
 
@@ -48902,6 +48944,9 @@ msgstr ""
 msgid "Reflect pending patches in output [DEFAULT]"
 msgstr ""
 
+msgid "Reformat Terraform Stacks configuration"
+msgstr ""
+
 msgid "Reformat Zig source into canonical form"
 msgstr ""
 
@@ -49152,6 +49197,9 @@ msgid "Release Write file descriptor"
 msgstr ""
 
 msgid "Release a closed Nexus staging repo into a permanent Nexus repo for general consumption"
+msgstr ""
+
+msgid "Release a stuck lock on the current workspace"
 msgstr ""
 
 msgid "Release hold recursively"
@@ -53732,6 +53780,9 @@ msgstr "Rechercher une mise à jour pour les paquets de développement"
 msgid "Search and build packages recursively"
 msgstr "Rechercher et construire les paquets récursivement"
 
+msgid "Search and list remote infrastructure with Terraform"
+msgstr ""
+
 msgid "Search blobs registered in the index file"
 msgstr ""
 
@@ -58118,6 +58169,9 @@ msgstr "Afficher toutes les branches"
 msgid "Show all config settings"
 msgstr ""
 
+msgid "Show all declared modules in a working directory"
+msgstr ""
+
 msgid "Show all env variables for an app"
 msgstr ""
 
@@ -59903,6 +59957,9 @@ msgstr ""
 msgid "Show shorter output"
 msgstr "Afficher une sortie plus concise"
 
+msgid "Show signatures and descriptions for the available functions"
+msgstr ""
+
 msgid "Show sizes in GiB, or GB with --si"
 msgstr ""
 
@@ -60147,6 +60204,9 @@ msgid "Show the current Ruby version"
 msgstr "Afficher la version actuelle de Ruby"
 
 msgid "Show the current Ruby version & how it was selected"
+msgstr ""
+
+msgid "Show the current Stacks Plugin version"
 msgstr ""
 
 msgid "Show the current version of prt-get"
@@ -65625,6 +65685,9 @@ msgid "Switch to a commit for inspection and discardable experiment"
 msgstr ""
 
 msgid "Switch to a different tree"
+msgstr ""
+
+msgid "Switch to a different working directory before executing"
 msgstr ""
 
 msgid "Switch to a different working directory before executing the command"
@@ -73339,6 +73402,9 @@ msgstr ""
 
 msgid "Write out a new empty file system volume"
 msgstr "Créer un système de fichiers vierge"
+
+msgid "Write out dependency locks for the configured providers"
+msgstr ""
 
 msgid "Write out setting names"
 msgstr ""

--- a/localization/po/ja_JP.po
+++ b/localization/po/ja_JP.po
@@ -10844,6 +10844,9 @@ msgstr ""
 msgid "Check whether specified profile is enabled"
 msgstr ""
 
+msgid "Check whether the configuration is valid"
+msgstr ""
+
 msgid "Check whether the firewalld daemon is active"
 msgstr ""
 
@@ -13602,6 +13605,9 @@ msgid "Create a space"
 msgstr ""
 
 msgid "Create a sparse volume"
+msgstr ""
+
+msgid "Create a stack"
 msgstr ""
 
 msgid "Create a stacked branch referring to the source branch"
@@ -21141,6 +21147,9 @@ msgid "Don't ask about patches that are depended on by matched patches (with --m
 msgstr ""
 
 msgid "Don't ask any interactive question"
+msgstr ""
+
+msgid "Don't ask for input for unlock confirmation"
 msgstr ""
 
 msgid "Don't ask for missing credentials"
@@ -29003,6 +29012,9 @@ msgstr ""
 msgid "Generate http://www.dita-op.org's Eclipse configuration to allow editing"
 msgstr ""
 
+msgid "Generate import and resource blocks for found results"
+msgstr ""
+
 msgid "Generate incremental stream from snapshot"
 msgstr ""
 
@@ -35939,6 +35951,9 @@ msgstr ""
 msgid "List sources that are bound to zone"
 msgstr ""
 
+msgid "List stacks for a given organization and/or project"
+msgstr ""
+
 msgid "List startable machine images"
 msgstr ""
 
@@ -37472,6 +37487,9 @@ msgstr ""
 msgid "Manage Flexible Resources between Primary and Secondary Controller "
 msgstr ""
 
+msgid "Manage HCP Terraform stack operations"
+msgstr ""
+
 msgid "Manage OPAM repositories"
 msgstr ""
 
@@ -37515,6 +37533,12 @@ msgid "Manage configuration."
 msgstr ""
 
 msgid "Manage delayed environment variable expansion"
+msgstr ""
+
+msgid "Manage deployment groups"
+msgstr ""
+
+msgid "Manage deployment runs"
 msgstr ""
 
 msgid "Manage devices in array, and possibly start it"
@@ -37581,6 +37605,9 @@ msgid "Manage set of tracked repositories"
 msgstr ""
 
 msgid "Manage settings"
+msgstr ""
+
+msgid "Manage stack configuration"
 msgstr ""
 
 msgid "Manage stashes"
@@ -38169,6 +38196,9 @@ msgid "Merges GWT servlet elements into deployment descriptor (and non GWT servl
 msgstr ""
 
 msgid "Message to print after patch failure"
+msgstr ""
+
+msgid "Metadata related commands"
 msgstr ""
 
 msgid "Method and interface name"
@@ -41045,6 +41075,9 @@ msgstr ""
 msgid "Output current account details"
 msgstr ""
 
+msgid "Output declared modules in a machine-readable format"
+msgstr ""
+
 msgid "Output delimited values"
 msgstr ""
 
@@ -43559,6 +43592,9 @@ msgstr ""
 msgid "Prepare the change to be pushed, but do not actually push it"
 msgstr ""
 
+msgid "Prepare the configuration directory for further commands"
+msgstr ""
+
 msgid "Prepend PHP's include_path with given path(s)"
 msgstr ""
 
@@ -44760,6 +44796,9 @@ msgid "Print full superblock information, backup roots etc."
 msgstr ""
 
 msgid "Print full user-to-user latency"
+msgstr ""
+
+msgid "Print function signatures in JSON format"
 msgstr ""
 
 msgid "Print further version info"
@@ -46919,6 +46958,9 @@ msgstr ""
 msgid "Produce long listing"
 msgstr ""
 
+msgid "Produce machine readable output in JSON format"
+msgstr ""
+
 msgid "Produce machine-readable output"
 msgstr ""
 
@@ -48776,6 +48818,9 @@ msgstr ""
 msgid "Reflect pending patches in output [DEFAULT]"
 msgstr ""
 
+msgid "Reformat Terraform Stacks configuration"
+msgstr ""
+
 msgid "Reformat Zig source into canonical form"
 msgstr ""
 
@@ -49026,6 +49071,9 @@ msgid "Release Write file descriptor"
 msgstr ""
 
 msgid "Release a closed Nexus staging repo into a permanent Nexus repo for general consumption"
+msgstr ""
+
+msgid "Release a stuck lock on the current workspace"
 msgstr ""
 
 msgid "Release hold recursively"
@@ -53606,6 +53654,9 @@ msgstr ""
 msgid "Search and build packages recursively"
 msgstr ""
 
+msgid "Search and list remote infrastructure with Terraform"
+msgstr ""
+
 msgid "Search blobs registered in the index file"
 msgstr ""
 
@@ -57992,6 +58043,9 @@ msgstr ""
 msgid "Show all config settings"
 msgstr ""
 
+msgid "Show all declared modules in a working directory"
+msgstr ""
+
 msgid "Show all env variables for an app"
 msgstr ""
 
@@ -59777,6 +59831,9 @@ msgstr ""
 msgid "Show shorter output"
 msgstr ""
 
+msgid "Show signatures and descriptions for the available functions"
+msgstr ""
+
 msgid "Show sizes in GiB, or GB with --si"
 msgstr ""
 
@@ -60021,6 +60078,9 @@ msgid "Show the current Ruby version"
 msgstr ""
 
 msgid "Show the current Ruby version & how it was selected"
+msgstr ""
+
+msgid "Show the current Stacks Plugin version"
 msgstr ""
 
 msgid "Show the current version of prt-get"
@@ -65499,6 +65559,9 @@ msgid "Switch to a commit for inspection and discardable experiment"
 msgstr ""
 
 msgid "Switch to a different tree"
+msgstr ""
+
+msgid "Switch to a different working directory before executing"
 msgstr ""
 
 msgid "Switch to a different working directory before executing the command"
@@ -73212,6 +73275,9 @@ msgid "Write out a NeXTstep/GNUstep"
 msgstr ""
 
 msgid "Write out a new empty file system volume"
+msgstr ""
+
+msgid "Write out dependency locks for the configured providers"
 msgstr ""
 
 msgid "Write out setting names"

--- a/localization/po/pl.po
+++ b/localization/po/pl.po
@@ -10837,6 +10837,9 @@ msgstr ""
 msgid "Check whether specified profile is enabled"
 msgstr ""
 
+msgid "Check whether the configuration is valid"
+msgstr ""
+
 msgid "Check whether the firewalld daemon is active"
 msgstr ""
 
@@ -13595,6 +13598,9 @@ msgid "Create a space"
 msgstr ""
 
 msgid "Create a sparse volume"
+msgstr ""
+
+msgid "Create a stack"
 msgstr ""
 
 msgid "Create a stacked branch referring to the source branch"
@@ -21134,6 +21140,9 @@ msgid "Don't ask about patches that are depended on by matched patches (with --m
 msgstr ""
 
 msgid "Don't ask any interactive question"
+msgstr ""
+
+msgid "Don't ask for input for unlock confirmation"
 msgstr ""
 
 msgid "Don't ask for missing credentials"
@@ -28996,6 +29005,9 @@ msgstr ""
 msgid "Generate http://www.dita-op.org's Eclipse configuration to allow editing"
 msgstr ""
 
+msgid "Generate import and resource blocks for found results"
+msgstr ""
+
 msgid "Generate incremental stream from snapshot"
 msgstr ""
 
@@ -35932,6 +35944,9 @@ msgstr ""
 msgid "List sources that are bound to zone"
 msgstr ""
 
+msgid "List stacks for a given organization and/or project"
+msgstr ""
+
 msgid "List startable machine images"
 msgstr ""
 
@@ -37465,6 +37480,9 @@ msgstr ""
 msgid "Manage Flexible Resources between Primary and Secondary Controller "
 msgstr ""
 
+msgid "Manage HCP Terraform stack operations"
+msgstr ""
+
 msgid "Manage OPAM repositories"
 msgstr ""
 
@@ -37508,6 +37526,12 @@ msgid "Manage configuration."
 msgstr ""
 
 msgid "Manage delayed environment variable expansion"
+msgstr ""
+
+msgid "Manage deployment groups"
+msgstr ""
+
+msgid "Manage deployment runs"
 msgstr ""
 
 msgid "Manage devices in array, and possibly start it"
@@ -37574,6 +37598,9 @@ msgid "Manage set of tracked repositories"
 msgstr ""
 
 msgid "Manage settings"
+msgstr ""
+
+msgid "Manage stack configuration"
 msgstr ""
 
 msgid "Manage stashes"
@@ -38162,6 +38189,9 @@ msgid "Merges GWT servlet elements into deployment descriptor (and non GWT servl
 msgstr ""
 
 msgid "Message to print after patch failure"
+msgstr ""
+
+msgid "Metadata related commands"
 msgstr ""
 
 msgid "Method and interface name"
@@ -41038,6 +41068,9 @@ msgstr ""
 msgid "Output current account details"
 msgstr ""
 
+msgid "Output declared modules in a machine-readable format"
+msgstr ""
+
 msgid "Output delimited values"
 msgstr ""
 
@@ -43552,6 +43585,9 @@ msgstr ""
 msgid "Prepare the change to be pushed, but do not actually push it"
 msgstr ""
 
+msgid "Prepare the configuration directory for further commands"
+msgstr ""
+
 msgid "Prepend PHP's include_path with given path(s)"
 msgstr ""
 
@@ -44753,6 +44789,9 @@ msgid "Print full superblock information, backup roots etc."
 msgstr ""
 
 msgid "Print full user-to-user latency"
+msgstr ""
+
+msgid "Print function signatures in JSON format"
 msgstr ""
 
 msgid "Print further version info"
@@ -46912,6 +46951,9 @@ msgstr ""
 msgid "Produce long listing"
 msgstr ""
 
+msgid "Produce machine readable output in JSON format"
+msgstr ""
+
 msgid "Produce machine-readable output"
 msgstr ""
 
@@ -48769,6 +48811,9 @@ msgstr ""
 msgid "Reflect pending patches in output [DEFAULT]"
 msgstr ""
 
+msgid "Reformat Terraform Stacks configuration"
+msgstr ""
+
 msgid "Reformat Zig source into canonical form"
 msgstr ""
 
@@ -49019,6 +49064,9 @@ msgid "Release Write file descriptor"
 msgstr ""
 
 msgid "Release a closed Nexus staging repo into a permanent Nexus repo for general consumption"
+msgstr ""
+
+msgid "Release a stuck lock on the current workspace"
 msgstr ""
 
 msgid "Release hold recursively"
@@ -53599,6 +53647,9 @@ msgstr ""
 msgid "Search and build packages recursively"
 msgstr ""
 
+msgid "Search and list remote infrastructure with Terraform"
+msgstr ""
+
 msgid "Search blobs registered in the index file"
 msgstr ""
 
@@ -57985,6 +58036,9 @@ msgstr ""
 msgid "Show all config settings"
 msgstr ""
 
+msgid "Show all declared modules in a working directory"
+msgstr ""
+
 msgid "Show all env variables for an app"
 msgstr ""
 
@@ -59770,6 +59824,9 @@ msgstr ""
 msgid "Show shorter output"
 msgstr ""
 
+msgid "Show signatures and descriptions for the available functions"
+msgstr ""
+
 msgid "Show sizes in GiB, or GB with --si"
 msgstr ""
 
@@ -60014,6 +60071,9 @@ msgid "Show the current Ruby version"
 msgstr ""
 
 msgid "Show the current Ruby version & how it was selected"
+msgstr ""
+
+msgid "Show the current Stacks Plugin version"
 msgstr ""
 
 msgid "Show the current version of prt-get"
@@ -65492,6 +65552,9 @@ msgid "Switch to a commit for inspection and discardable experiment"
 msgstr ""
 
 msgid "Switch to a different tree"
+msgstr ""
+
+msgid "Switch to a different working directory before executing"
 msgstr ""
 
 msgid "Switch to a different working directory before executing the command"
@@ -73205,6 +73268,9 @@ msgid "Write out a NeXTstep/GNUstep"
 msgstr ""
 
 msgid "Write out a new empty file system volume"
+msgstr ""
+
+msgid "Write out dependency locks for the configured providers"
 msgstr ""
 
 msgid "Write out setting names"

--- a/localization/po/pt_BR.po
+++ b/localization/po/pt_BR.po
@@ -10842,6 +10842,9 @@ msgstr ""
 msgid "Check whether specified profile is enabled"
 msgstr ""
 
+msgid "Check whether the configuration is valid"
+msgstr ""
+
 msgid "Check whether the firewalld daemon is active"
 msgstr ""
 
@@ -13600,6 +13603,9 @@ msgid "Create a space"
 msgstr ""
 
 msgid "Create a sparse volume"
+msgstr ""
+
+msgid "Create a stack"
 msgstr ""
 
 msgid "Create a stacked branch referring to the source branch"
@@ -21139,6 +21145,9 @@ msgid "Don't ask about patches that are depended on by matched patches (with --m
 msgstr ""
 
 msgid "Don't ask any interactive question"
+msgstr ""
+
+msgid "Don't ask for input for unlock confirmation"
 msgstr ""
 
 msgid "Don't ask for missing credentials"
@@ -29001,6 +29010,9 @@ msgstr ""
 msgid "Generate http://www.dita-op.org's Eclipse configuration to allow editing"
 msgstr ""
 
+msgid "Generate import and resource blocks for found results"
+msgstr ""
+
 msgid "Generate incremental stream from snapshot"
 msgstr ""
 
@@ -35937,6 +35949,9 @@ msgstr ""
 msgid "List sources that are bound to zone"
 msgstr ""
 
+msgid "List stacks for a given organization and/or project"
+msgstr ""
+
 msgid "List startable machine images"
 msgstr ""
 
@@ -37470,6 +37485,9 @@ msgstr ""
 msgid "Manage Flexible Resources between Primary and Secondary Controller "
 msgstr ""
 
+msgid "Manage HCP Terraform stack operations"
+msgstr ""
+
 msgid "Manage OPAM repositories"
 msgstr ""
 
@@ -37513,6 +37531,12 @@ msgid "Manage configuration."
 msgstr ""
 
 msgid "Manage delayed environment variable expansion"
+msgstr ""
+
+msgid "Manage deployment groups"
+msgstr ""
+
+msgid "Manage deployment runs"
 msgstr ""
 
 msgid "Manage devices in array, and possibly start it"
@@ -37579,6 +37603,9 @@ msgid "Manage set of tracked repositories"
 msgstr ""
 
 msgid "Manage settings"
+msgstr ""
+
+msgid "Manage stack configuration"
 msgstr ""
 
 msgid "Manage stashes"
@@ -38167,6 +38194,9 @@ msgid "Merges GWT servlet elements into deployment descriptor (and non GWT servl
 msgstr ""
 
 msgid "Message to print after patch failure"
+msgstr ""
+
+msgid "Metadata related commands"
 msgstr ""
 
 msgid "Method and interface name"
@@ -41043,6 +41073,9 @@ msgstr ""
 msgid "Output current account details"
 msgstr ""
 
+msgid "Output declared modules in a machine-readable format"
+msgstr ""
+
 msgid "Output delimited values"
 msgstr ""
 
@@ -43557,6 +43590,9 @@ msgstr ""
 msgid "Prepare the change to be pushed, but do not actually push it"
 msgstr ""
 
+msgid "Prepare the configuration directory for further commands"
+msgstr ""
+
 msgid "Prepend PHP's include_path with given path(s)"
 msgstr ""
 
@@ -44759,6 +44795,9 @@ msgstr ""
 
 msgid "Print full user-to-user latency"
 msgstr "Print full user-to-user latency"
+
+msgid "Print function signatures in JSON format"
+msgstr ""
 
 msgid "Print further version info"
 msgstr ""
@@ -46917,6 +46956,9 @@ msgstr ""
 msgid "Produce long listing"
 msgstr ""
 
+msgid "Produce machine readable output in JSON format"
+msgstr ""
+
 msgid "Produce machine-readable output"
 msgstr ""
 
@@ -48774,6 +48816,9 @@ msgstr ""
 msgid "Reflect pending patches in output [DEFAULT]"
 msgstr ""
 
+msgid "Reformat Terraform Stacks configuration"
+msgstr ""
+
 msgid "Reformat Zig source into canonical form"
 msgstr ""
 
@@ -49024,6 +49069,9 @@ msgid "Release Write file descriptor"
 msgstr ""
 
 msgid "Release a closed Nexus staging repo into a permanent Nexus repo for general consumption"
+msgstr ""
+
+msgid "Release a stuck lock on the current workspace"
 msgstr ""
 
 msgid "Release hold recursively"
@@ -53604,6 +53652,9 @@ msgstr ""
 msgid "Search and build packages recursively"
 msgstr ""
 
+msgid "Search and list remote infrastructure with Terraform"
+msgstr ""
+
 msgid "Search blobs registered in the index file"
 msgstr ""
 
@@ -57990,6 +58041,9 @@ msgstr ""
 msgid "Show all config settings"
 msgstr ""
 
+msgid "Show all declared modules in a working directory"
+msgstr ""
+
 msgid "Show all env variables for an app"
 msgstr ""
 
@@ -59775,6 +59829,9 @@ msgstr ""
 msgid "Show shorter output"
 msgstr ""
 
+msgid "Show signatures and descriptions for the available functions"
+msgstr ""
+
 msgid "Show sizes in GiB, or GB with --si"
 msgstr ""
 
@@ -60019,6 +60076,9 @@ msgid "Show the current Ruby version"
 msgstr ""
 
 msgid "Show the current Ruby version & how it was selected"
+msgstr ""
+
+msgid "Show the current Stacks Plugin version"
 msgstr ""
 
 msgid "Show the current version of prt-get"
@@ -65497,6 +65557,9 @@ msgid "Switch to a commit for inspection and discardable experiment"
 msgstr ""
 
 msgid "Switch to a different tree"
+msgstr ""
+
+msgid "Switch to a different working directory before executing"
 msgstr ""
 
 msgid "Switch to a different working directory before executing the command"
@@ -73210,6 +73273,9 @@ msgid "Write out a NeXTstep/GNUstep"
 msgstr ""
 
 msgid "Write out a new empty file system volume"
+msgstr ""
+
+msgid "Write out dependency locks for the configured providers"
 msgstr ""
 
 msgid "Write out setting names"

--- a/localization/po/sv.po
+++ b/localization/po/sv.po
@@ -10838,6 +10838,9 @@ msgstr ""
 msgid "Check whether specified profile is enabled"
 msgstr ""
 
+msgid "Check whether the configuration is valid"
+msgstr ""
+
 msgid "Check whether the firewalld daemon is active"
 msgstr ""
 
@@ -13596,6 +13599,9 @@ msgid "Create a space"
 msgstr ""
 
 msgid "Create a sparse volume"
+msgstr ""
+
+msgid "Create a stack"
 msgstr ""
 
 msgid "Create a stacked branch referring to the source branch"
@@ -21135,6 +21141,9 @@ msgid "Don't ask about patches that are depended on by matched patches (with --m
 msgstr ""
 
 msgid "Don't ask any interactive question"
+msgstr ""
+
+msgid "Don't ask for input for unlock confirmation"
 msgstr ""
 
 msgid "Don't ask for missing credentials"
@@ -28997,6 +29006,9 @@ msgstr ""
 msgid "Generate http://www.dita-op.org's Eclipse configuration to allow editing"
 msgstr ""
 
+msgid "Generate import and resource blocks for found results"
+msgstr ""
+
 msgid "Generate incremental stream from snapshot"
 msgstr ""
 
@@ -35933,6 +35945,9 @@ msgstr ""
 msgid "List sources that are bound to zone"
 msgstr ""
 
+msgid "List stacks for a given organization and/or project"
+msgstr ""
+
 msgid "List startable machine images"
 msgstr ""
 
@@ -37466,6 +37481,9 @@ msgstr ""
 msgid "Manage Flexible Resources between Primary and Secondary Controller "
 msgstr ""
 
+msgid "Manage HCP Terraform stack operations"
+msgstr ""
+
 msgid "Manage OPAM repositories"
 msgstr ""
 
@@ -37509,6 +37527,12 @@ msgid "Manage configuration."
 msgstr ""
 
 msgid "Manage delayed environment variable expansion"
+msgstr ""
+
+msgid "Manage deployment groups"
+msgstr ""
+
+msgid "Manage deployment runs"
 msgstr ""
 
 msgid "Manage devices in array, and possibly start it"
@@ -37575,6 +37599,9 @@ msgid "Manage set of tracked repositories"
 msgstr ""
 
 msgid "Manage settings"
+msgstr ""
+
+msgid "Manage stack configuration"
 msgstr ""
 
 msgid "Manage stashes"
@@ -38163,6 +38190,9 @@ msgid "Merges GWT servlet elements into deployment descriptor (and non GWT servl
 msgstr ""
 
 msgid "Message to print after patch failure"
+msgstr ""
+
+msgid "Metadata related commands"
 msgstr ""
 
 msgid "Method and interface name"
@@ -41039,6 +41069,9 @@ msgstr ""
 msgid "Output current account details"
 msgstr ""
 
+msgid "Output declared modules in a machine-readable format"
+msgstr ""
+
 msgid "Output delimited values"
 msgstr ""
 
@@ -43553,6 +43586,9 @@ msgstr ""
 msgid "Prepare the change to be pushed, but do not actually push it"
 msgstr ""
 
+msgid "Prepare the configuration directory for further commands"
+msgstr ""
+
 msgid "Prepend PHP's include_path with given path(s)"
 msgstr ""
 
@@ -44755,6 +44791,9 @@ msgstr ""
 
 msgid "Print full user-to-user latency"
 msgstr "Visa full användare-tilöl-användare-latens"
+
+msgid "Print function signatures in JSON format"
+msgstr ""
 
 msgid "Print further version info"
 msgstr ""
@@ -46913,6 +46952,9 @@ msgstr ""
 msgid "Produce long listing"
 msgstr ""
 
+msgid "Produce machine readable output in JSON format"
+msgstr ""
+
 msgid "Produce machine-readable output"
 msgstr ""
 
@@ -48770,6 +48812,9 @@ msgstr ""
 msgid "Reflect pending patches in output [DEFAULT]"
 msgstr ""
 
+msgid "Reformat Terraform Stacks configuration"
+msgstr ""
+
 msgid "Reformat Zig source into canonical form"
 msgstr ""
 
@@ -49020,6 +49065,9 @@ msgid "Release Write file descriptor"
 msgstr ""
 
 msgid "Release a closed Nexus staging repo into a permanent Nexus repo for general consumption"
+msgstr ""
+
+msgid "Release a stuck lock on the current workspace"
 msgstr ""
 
 msgid "Release hold recursively"
@@ -53600,6 +53648,9 @@ msgstr ""
 msgid "Search and build packages recursively"
 msgstr ""
 
+msgid "Search and list remote infrastructure with Terraform"
+msgstr ""
+
 msgid "Search blobs registered in the index file"
 msgstr ""
 
@@ -57986,6 +58037,9 @@ msgstr ""
 msgid "Show all config settings"
 msgstr ""
 
+msgid "Show all declared modules in a working directory"
+msgstr ""
+
 msgid "Show all env variables for an app"
 msgstr ""
 
@@ -59771,6 +59825,9 @@ msgstr ""
 msgid "Show shorter output"
 msgstr ""
 
+msgid "Show signatures and descriptions for the available functions"
+msgstr ""
+
 msgid "Show sizes in GiB, or GB with --si"
 msgstr ""
 
@@ -60015,6 +60072,9 @@ msgid "Show the current Ruby version"
 msgstr ""
 
 msgid "Show the current Ruby version & how it was selected"
+msgstr ""
+
+msgid "Show the current Stacks Plugin version"
 msgstr ""
 
 msgid "Show the current version of prt-get"
@@ -65493,6 +65553,9 @@ msgid "Switch to a commit for inspection and discardable experiment"
 msgstr ""
 
 msgid "Switch to a different tree"
+msgstr ""
+
+msgid "Switch to a different working directory before executing"
 msgstr ""
 
 msgid "Switch to a different working directory before executing the command"
@@ -73206,6 +73269,9 @@ msgid "Write out a NeXTstep/GNUstep"
 msgstr ""
 
 msgid "Write out a new empty file system volume"
+msgstr ""
+
+msgid "Write out dependency locks for the configured providers"
 msgstr ""
 
 msgid "Write out setting names"

--- a/localization/po/zh_CN.po
+++ b/localization/po/zh_CN.po
@@ -10862,6 +10862,9 @@ msgstr ""
 msgid "Check whether specified profile is enabled"
 msgstr ""
 
+msgid "Check whether the configuration is valid"
+msgstr ""
+
 msgid "Check whether the firewalld daemon is active"
 msgstr ""
 
@@ -13620,6 +13623,9 @@ msgid "Create a space"
 msgstr ""
 
 msgid "Create a sparse volume"
+msgstr ""
+
+msgid "Create a stack"
 msgstr ""
 
 msgid "Create a stacked branch referring to the source branch"
@@ -21159,6 +21165,9 @@ msgid "Don't ask about patches that are depended on by matched patches (with --m
 msgstr ""
 
 msgid "Don't ask any interactive question"
+msgstr ""
+
+msgid "Don't ask for input for unlock confirmation"
 msgstr ""
 
 msgid "Don't ask for missing credentials"
@@ -29021,6 +29030,9 @@ msgstr ""
 msgid "Generate http://www.dita-op.org's Eclipse configuration to allow editing"
 msgstr ""
 
+msgid "Generate import and resource blocks for found results"
+msgstr ""
+
 msgid "Generate incremental stream from snapshot"
 msgstr ""
 
@@ -35957,6 +35969,9 @@ msgstr ""
 msgid "List sources that are bound to zone"
 msgstr ""
 
+msgid "List stacks for a given organization and/or project"
+msgstr ""
+
 msgid "List startable machine images"
 msgstr ""
 
@@ -37490,6 +37505,9 @@ msgstr ""
 msgid "Manage Flexible Resources between Primary and Secondary Controller "
 msgstr ""
 
+msgid "Manage HCP Terraform stack operations"
+msgstr ""
+
 msgid "Manage OPAM repositories"
 msgstr ""
 
@@ -37533,6 +37551,12 @@ msgid "Manage configuration."
 msgstr ""
 
 msgid "Manage delayed environment variable expansion"
+msgstr ""
+
+msgid "Manage deployment groups"
+msgstr ""
+
+msgid "Manage deployment runs"
 msgstr ""
 
 msgid "Manage devices in array, and possibly start it"
@@ -37599,6 +37623,9 @@ msgid "Manage set of tracked repositories"
 msgstr ""
 
 msgid "Manage settings"
+msgstr ""
+
+msgid "Manage stack configuration"
 msgstr ""
 
 msgid "Manage stashes"
@@ -38187,6 +38214,9 @@ msgid "Merges GWT servlet elements into deployment descriptor (and non GWT servl
 msgstr ""
 
 msgid "Message to print after patch failure"
+msgstr ""
+
+msgid "Metadata related commands"
 msgstr ""
 
 msgid "Method and interface name"
@@ -41063,6 +41093,9 @@ msgstr ""
 msgid "Output current account details"
 msgstr ""
 
+msgid "Output declared modules in a machine-readable format"
+msgstr ""
+
 msgid "Output delimited values"
 msgstr ""
 
@@ -43577,6 +43610,9 @@ msgstr ""
 msgid "Prepare the change to be pushed, but do not actually push it"
 msgstr ""
 
+msgid "Prepare the configuration directory for further commands"
+msgstr ""
+
 msgid "Prepend PHP's include_path with given path(s)"
 msgstr ""
 
@@ -44778,6 +44814,9 @@ msgid "Print full superblock information, backup roots etc."
 msgstr ""
 
 msgid "Print full user-to-user latency"
+msgstr ""
+
+msgid "Print function signatures in JSON format"
 msgstr ""
 
 msgid "Print further version info"
@@ -46937,6 +46976,9 @@ msgstr ""
 msgid "Produce long listing"
 msgstr ""
 
+msgid "Produce machine readable output in JSON format"
+msgstr ""
+
 msgid "Produce machine-readable output"
 msgstr ""
 
@@ -48794,6 +48836,9 @@ msgstr ""
 msgid "Reflect pending patches in output [DEFAULT]"
 msgstr ""
 
+msgid "Reformat Terraform Stacks configuration"
+msgstr ""
+
 msgid "Reformat Zig source into canonical form"
 msgstr ""
 
@@ -49044,6 +49089,9 @@ msgid "Release Write file descriptor"
 msgstr ""
 
 msgid "Release a closed Nexus staging repo into a permanent Nexus repo for general consumption"
+msgstr ""
+
+msgid "Release a stuck lock on the current workspace"
 msgstr ""
 
 msgid "Release hold recursively"
@@ -53624,6 +53672,9 @@ msgstr ""
 msgid "Search and build packages recursively"
 msgstr ""
 
+msgid "Search and list remote infrastructure with Terraform"
+msgstr ""
+
 msgid "Search blobs registered in the index file"
 msgstr ""
 
@@ -58010,6 +58061,9 @@ msgstr ""
 msgid "Show all config settings"
 msgstr ""
 
+msgid "Show all declared modules in a working directory"
+msgstr ""
+
 msgid "Show all env variables for an app"
 msgstr ""
 
@@ -59795,6 +59849,9 @@ msgstr ""
 msgid "Show shorter output"
 msgstr ""
 
+msgid "Show signatures and descriptions for the available functions"
+msgstr ""
+
 msgid "Show sizes in GiB, or GB with --si"
 msgstr ""
 
@@ -60039,6 +60096,9 @@ msgid "Show the current Ruby version"
 msgstr ""
 
 msgid "Show the current Ruby version & how it was selected"
+msgstr ""
+
+msgid "Show the current Stacks Plugin version"
 msgstr ""
 
 msgid "Show the current version of prt-get"
@@ -65517,6 +65577,9 @@ msgid "Switch to a commit for inspection and discardable experiment"
 msgstr ""
 
 msgid "Switch to a different tree"
+msgstr ""
+
+msgid "Switch to a different working directory before executing"
 msgstr ""
 
 msgid "Switch to a different working directory before executing the command"
@@ -73230,6 +73293,9 @@ msgid "Write out a NeXTstep/GNUstep"
 msgstr ""
 
 msgid "Write out a new empty file system volume"
+msgstr ""
+
+msgid "Write out dependency locks for the configured providers"
 msgstr ""
 
 msgid "Write out setting names"

--- a/localization/po/zh_TW.po
+++ b/localization/po/zh_TW.po
@@ -10839,6 +10839,9 @@ msgstr ""
 msgid "Check whether specified profile is enabled"
 msgstr ""
 
+msgid "Check whether the configuration is valid"
+msgstr ""
+
 msgid "Check whether the firewalld daemon is active"
 msgstr ""
 
@@ -13597,6 +13600,9 @@ msgid "Create a space"
 msgstr ""
 
 msgid "Create a sparse volume"
+msgstr ""
+
+msgid "Create a stack"
 msgstr ""
 
 msgid "Create a stacked branch referring to the source branch"
@@ -21136,6 +21142,9 @@ msgid "Don't ask about patches that are depended on by matched patches (with --m
 msgstr ""
 
 msgid "Don't ask any interactive question"
+msgstr ""
+
+msgid "Don't ask for input for unlock confirmation"
 msgstr ""
 
 msgid "Don't ask for missing credentials"
@@ -28998,6 +29007,9 @@ msgstr ""
 msgid "Generate http://www.dita-op.org's Eclipse configuration to allow editing"
 msgstr ""
 
+msgid "Generate import and resource blocks for found results"
+msgstr ""
+
 msgid "Generate incremental stream from snapshot"
 msgstr ""
 
@@ -35934,6 +35946,9 @@ msgstr ""
 msgid "List sources that are bound to zone"
 msgstr ""
 
+msgid "List stacks for a given organization and/or project"
+msgstr ""
+
 msgid "List startable machine images"
 msgstr ""
 
@@ -37467,6 +37482,9 @@ msgstr ""
 msgid "Manage Flexible Resources between Primary and Secondary Controller "
 msgstr ""
 
+msgid "Manage HCP Terraform stack operations"
+msgstr ""
+
 msgid "Manage OPAM repositories"
 msgstr ""
 
@@ -37510,6 +37528,12 @@ msgid "Manage configuration."
 msgstr ""
 
 msgid "Manage delayed environment variable expansion"
+msgstr ""
+
+msgid "Manage deployment groups"
+msgstr ""
+
+msgid "Manage deployment runs"
 msgstr ""
 
 msgid "Manage devices in array, and possibly start it"
@@ -37576,6 +37600,9 @@ msgid "Manage set of tracked repositories"
 msgstr ""
 
 msgid "Manage settings"
+msgstr ""
+
+msgid "Manage stack configuration"
 msgstr ""
 
 msgid "Manage stashes"
@@ -38164,6 +38191,9 @@ msgid "Merges GWT servlet elements into deployment descriptor (and non GWT servl
 msgstr ""
 
 msgid "Message to print after patch failure"
+msgstr ""
+
+msgid "Metadata related commands"
 msgstr ""
 
 msgid "Method and interface name"
@@ -41040,6 +41070,9 @@ msgstr ""
 msgid "Output current account details"
 msgstr ""
 
+msgid "Output declared modules in a machine-readable format"
+msgstr ""
+
 msgid "Output delimited values"
 msgstr ""
 
@@ -43554,6 +43587,9 @@ msgstr ""
 msgid "Prepare the change to be pushed, but do not actually push it"
 msgstr ""
 
+msgid "Prepare the configuration directory for further commands"
+msgstr ""
+
 msgid "Prepend PHP's include_path with given path(s)"
 msgstr ""
 
@@ -44755,6 +44791,9 @@ msgid "Print full superblock information, backup roots etc."
 msgstr ""
 
 msgid "Print full user-to-user latency"
+msgstr ""
+
+msgid "Print function signatures in JSON format"
 msgstr ""
 
 msgid "Print further version info"
@@ -46914,6 +46953,9 @@ msgstr ""
 msgid "Produce long listing"
 msgstr ""
 
+msgid "Produce machine readable output in JSON format"
+msgstr ""
+
 msgid "Produce machine-readable output"
 msgstr ""
 
@@ -48771,6 +48813,9 @@ msgstr ""
 msgid "Reflect pending patches in output [DEFAULT]"
 msgstr ""
 
+msgid "Reformat Terraform Stacks configuration"
+msgstr ""
+
 msgid "Reformat Zig source into canonical form"
 msgstr ""
 
@@ -49021,6 +49066,9 @@ msgid "Release Write file descriptor"
 msgstr ""
 
 msgid "Release a closed Nexus staging repo into a permanent Nexus repo for general consumption"
+msgstr ""
+
+msgid "Release a stuck lock on the current workspace"
 msgstr ""
 
 msgid "Release hold recursively"
@@ -53601,6 +53649,9 @@ msgstr ""
 msgid "Search and build packages recursively"
 msgstr ""
 
+msgid "Search and list remote infrastructure with Terraform"
+msgstr ""
+
 msgid "Search blobs registered in the index file"
 msgstr ""
 
@@ -57987,6 +58038,9 @@ msgstr ""
 msgid "Show all config settings"
 msgstr ""
 
+msgid "Show all declared modules in a working directory"
+msgstr ""
+
 msgid "Show all env variables for an app"
 msgstr ""
 
@@ -59772,6 +59826,9 @@ msgstr ""
 msgid "Show shorter output"
 msgstr ""
 
+msgid "Show signatures and descriptions for the available functions"
+msgstr ""
+
 msgid "Show sizes in GiB, or GB with --si"
 msgstr ""
 
@@ -60016,6 +60073,9 @@ msgid "Show the current Ruby version"
 msgstr ""
 
 msgid "Show the current Ruby version & how it was selected"
+msgstr ""
+
+msgid "Show the current Stacks Plugin version"
 msgstr ""
 
 msgid "Show the current version of prt-get"
@@ -65494,6 +65554,9 @@ msgid "Switch to a commit for inspection and discardable experiment"
 msgstr ""
 
 msgid "Switch to a different tree"
+msgstr ""
+
+msgid "Switch to a different working directory before executing"
 msgstr ""
 
 msgid "Switch to a different working directory before executing the command"
@@ -73207,6 +73270,9 @@ msgid "Write out a NeXTstep/GNUstep"
 msgstr ""
 
 msgid "Write out a new empty file system volume"
+msgstr ""
+
+msgid "Write out dependency locks for the configured providers"
 msgstr ""
 
 msgid "Write out setting names"

--- a/share/completions/terraform.fish
+++ b/share/completions/terraform.fish
@@ -1,13 +1,16 @@
 # Returns 0 if the command has not had a subcommand yet
-# Does not currently account for -chdir
 function __fish_terraform_needs_command
     set -l cmd (commandline -xpc)
-
-    if test (count $cmd) -eq 1
-        return 0
+    set -e cmd[1]
+    for arg in $cmd
+        switch $arg
+            case '-chdir=*'
+                continue
+            case '*'
+                return 1
+        end
     end
-
-    return 1
+    return 0
 end
 
 function __fish_terraform_workspaces
@@ -17,6 +20,7 @@ end
 # general options
 complete -f -c terraform -n "not __fish_terraform_needs_command" -o version -d "Print version information"
 complete -f -c terraform -o help -d "Show help"
+complete -x -c terraform -n __fish_terraform_needs_command -o chdir -a "(__fish_complete_directories)" -d "Switch to a different working directory before executing"
 
 ### apply/destroy
 set -l apply apply destroy
@@ -39,6 +43,10 @@ complete -f -c terraform -n __fish_terraform_needs_command -a console -d "Intera
 complete -r -c terraform -n "__fish_seen_subcommand_from console" -o state -d "Path to a Terraform state file"
 complete -f -c terraform -n "__fish_seen_subcommand_from console" -o var -d "Set a variable in the Terraform configuration"
 complete -r -c terraform -n "__fish_seen_subcommand_from console" -o var-file -d "Set variables from a file"
+
+### force-unlock
+complete -f -c terraform -n __fish_terraform_needs_command -a force-unlock -d "Release a stuck lock on the current workspace"
+complete -f -c terraform -n "__fish_seen_subcommand_from force-unlock" -o force -d "Don't ask for input for unlock confirmation"
 
 ### fmt
 complete -f -c terraform -n __fish_terraform_needs_command -a fmt -d "Rewrite config files to canonical format"
@@ -104,6 +112,18 @@ complete -f -c terraform -n "__fish_seen_subcommand_from login" -a "(__fish_prin
 complete -f -c terraform -n __fish_terraform_needs_command -a logout -d "Removes auth token for the given hostname"
 complete -f -c terraform -n "__fish_seen_subcommand_from logout" -a "(__fish_print_hostnames)"
 
+### metadata
+set -l metadata_commands functions
+complete -f -c terraform -n __fish_terraform_needs_command -a metadata -d "Metadata related commands"
+complete -f -c terraform -n "__fish_seen_subcommand_from metadata && not __fish_seen_subcommand_from $metadata_commands" -a functions -d "Show signatures and descriptions for the available functions"
+complete -f -c terraform -n "__fish_seen_subcommand_from metadata && __fish_seen_subcommand_from functions" -o json -d "Print function signatures in JSON format"
+
+### modules
+complete -f -c terraform -n __fish_terraform_needs_command -a modules -d "Show all declared modules in a working directory"
+complete -f -c terraform -n "__fish_seen_subcommand_from modules" -o json -d "Output declared modules in a machine-readable format"
+complete -f -c terraform -n "__fish_seen_subcommand_from modules" -o var -d "Set a variable in the Terraform configuration"
+complete -r -c terraform -n "__fish_seen_subcommand_from modules" -o var-file -d "Set variables from a file"
+
 ### output
 complete -f -c terraform -n __fish_terraform_needs_command -a output -d "Read an output from a state file"
 complete -r -c terraform -n "__fish_seen_subcommand_from output" -o state -d "Path to the state file to read"
@@ -138,9 +158,17 @@ complete -r -c terraform -n "__fish_seen_subcommand_from $plan" -o var-file -d "
 complete -f -c terraform -n __fish_terraform_needs_command -a providers -d "Print tree of modules with their provider requirements"
 complete -f -c terraform -n "__fish_seen_subcommand_from providers" -a "lock mirror schema"
 
+### query
+complete -f -c terraform -n __fish_terraform_needs_command -a query -d "Search and list remote infrastructure with Terraform"
+complete -f -c terraform -n "__fish_seen_subcommand_from query" -o var -d "Set a variable in the Terraform configuration"
+complete -r -c terraform -n "__fish_seen_subcommand_from query" -o var-file -d "Set variables from a file"
+complete -r -c terraform -n "__fish_seen_subcommand_from query" -o generate-config-out -d "Generate import and resource blocks for found results"
+complete -f -c terraform -n "__fish_seen_subcommand_from query" -o json -d "Produce machine readable output in JSON format"
+complete -f -c terraform -n "__fish_seen_subcommand_from query" -o no-color -d "If specified, output won't contain any color"
+
 ### refresh
 complete -f -c terraform -n __fish_terraform_needs_command -a refresh -d "Update local state file against real resources"
-complete -f -c terraform -n "__fish_seen_subcommand_from $apply" -o compact-warnings -d "Show only error summaries"
+complete -f -c terraform -n "__fish_seen_subcommand_from refresh" -o compact-warnings -d "Show only error summaries"
 complete -r -c terraform -n "__fish_seen_subcommand_from refresh" -o backup -d "Path to backup the existing state file"
 complete -f -c terraform -n "__fish_seen_subcommand_from refresh" -o input=true -d "Ask for input for variables if not directly set"
 complete -f -c terraform -n "__fish_seen_subcommand_from refresh" -o lock=false -d "Don't hold a state lock"
@@ -155,7 +183,21 @@ complete -r -c terraform -n "__fish_seen_subcommand_from refresh" -o var-file -d
 ### show
 complete -f -c terraform -n __fish_terraform_needs_command -a show -d "Inspect Terraform state or plan"
 complete -f -c terraform -n "__fish_seen_subcommand_from show" -o no-color -d "If specified, output won't contain any color"
-complete -f -c terraform -n "__fish_seen_subcommand_from validate" -o json -d "Produce output in JSON format"
+complete -f -c terraform -n "__fish_seen_subcommand_from show" -o json -d "Produce output in JSON format"
+
+### stacks
+set -l stacks_commands init providers-lock validate create list version fmt configuration deployment-group deployment-run
+complete -f -c terraform -n __fish_terraform_needs_command -a stacks -d "Manage HCP Terraform stack operations"
+complete -f -c terraform -n "__fish_seen_subcommand_from stacks && not __fish_seen_subcommand_from $stacks_commands" -a init -d "Prepare the configuration directory for further commands"
+complete -f -c terraform -n "__fish_seen_subcommand_from stacks && not __fish_seen_subcommand_from $stacks_commands" -a providers-lock -d "Write out dependency locks for the configured providers"
+complete -f -c terraform -n "__fish_seen_subcommand_from stacks && not __fish_seen_subcommand_from $stacks_commands" -a validate -d "Check whether the configuration is valid"
+complete -f -c terraform -n "__fish_seen_subcommand_from stacks && not __fish_seen_subcommand_from $stacks_commands" -a create -d "Create a stack"
+complete -f -c terraform -n "__fish_seen_subcommand_from stacks && not __fish_seen_subcommand_from $stacks_commands" -a list -d "List stacks for a given organization and/or project"
+complete -f -c terraform -n "__fish_seen_subcommand_from stacks && not __fish_seen_subcommand_from $stacks_commands" -a version -d "Show the current Stacks Plugin version"
+complete -f -c terraform -n "__fish_seen_subcommand_from stacks && not __fish_seen_subcommand_from $stacks_commands" -a fmt -d "Reformat Terraform Stacks configuration"
+complete -f -c terraform -n "__fish_seen_subcommand_from stacks && not __fish_seen_subcommand_from $stacks_commands" -a configuration -d "Manage stack configuration"
+complete -f -c terraform -n "__fish_seen_subcommand_from stacks && not __fish_seen_subcommand_from $stacks_commands" -a deployment-group -d "Manage deployment groups"
+complete -f -c terraform -n "__fish_seen_subcommand_from stacks && not __fish_seen_subcommand_from $stacks_commands" -a deployment-run -d "Manage deployment runs"
 
 ### state
 complete -r -c terraform -n __fish_terraform_needs_command -a state -d "Advanced state management"


### PR DESCRIPTION
Compared against "terraform -help" from v1.15.4.  The completion was missing the following top-level subcommands:

```
force-unlock  Release a stuck lock on the current workspace
metadata      Metadata related commands
modules       Show all declared modules in a working directory
query         Search and list remote infrastructure with Terraform
stacks        Manage HCP Terraform stack operations
```

Also add the global "-chdir" option, which switches the working directory before running the subcommand, and teach "__fish_terraform_needs_command" to skip past it so subcommands are still offered after e.g. "terraform -chdir=foo".

While at it, fix two unrelated bugs:

* The "refresh" section conditioned "-compact-warnings" on "$apply" instead of "refresh", so it was only offered for apply/destroy (where it's already covered).

* The "show" section had a stray "validate -json" completion (a copy of the entry in the validate section).  Replace it with the actually-missing "show -json".


Full disclosure: i got help from an LLM to write this. Let me know if this breaks any guidelines.