### PR TITLE
Formatting/Typo fixes

### DIFF
--- a/src/exec.rs
+++ b/src/exec.rs
@@ -472,8 +472,8 @@ fn can_use_posix_spawn_for_job(job: &Job, dup2s: &Dup2List) -> bool {
     // For example if you were to write:
     //   cmd 6< /dev/null
     // it is possible that the open() of /dev/null would result in fd 6. Here even if we attempted
-    // to add a dup2 action, it would be ignored and the CLO_EXEC bit would remain. So don't use
-    // posix_spawn in this case; instead we'll call fork() and clear the CLO_EXEC bit manually.
+    // to add a dup2 action, it would be ignored and the CLOEXEC bit would remain. So don't use
+    // posix_spawn in this case; instead we'll call fork() and clear the CLOEXEC bit manually.
     for action in dup2s.get_actions() {
         if action.src == action.target {
             return false;

--- a/src/fd_monitor.rs
+++ b/src/fd_monitor.rs
@@ -29,7 +29,7 @@ cfg_if!(
 /// signal an event, making the fd readable.  Multiple calls to `post()` may be coalesced.
 /// On Linux this uses eventfd, on other systems this uses a pipe.
 /// [`try_consume()`](FdEventSignaller::try_consume) may be used to consume the event.
-/// Importantly this is async signal safe. Of course it is `CLO_EXEC` as well.
+/// Importantly this is async signal safe. Of course it is `CLOEXEC` as well.
 pub struct FdEventSignaller {
     // Always the read end of the fd; maybe the write end as well.
     fd: OwnedFd,

--- a/src/fds.rs
+++ b/src/fds.rs
@@ -105,7 +105,7 @@ pub fn heightenize_fd(fd: OwnedFd, input_has_cloexec: bool) -> nix::Result<Owned
     Ok(unsafe { OwnedFd::from_raw_fd(newfd) })
 }
 
-/// Sets CLO_EXEC on a given fd according to the value of `should_set`.
+/// Sets CLOEXEC on a given fd according to the value of `should_set`.
 pub fn set_cloexec(fd: RawFd, should_set: bool /* = true */) -> c_int {
     // Note we don't want to overwrite existing flags like O_NONBLOCK which may be set. So fetch the
     // existing flags and modify them.

--- a/src/fork_exec/postfork.rs
+++ b/src/fork_exec/postfork.rs
@@ -145,8 +145,8 @@ pub fn child_setup_process(
             err = unsafe { libc::dup2(act.src, act.target) };
         } else {
             // This is a weird case like /bin/cmd 6< file.txt
-            // The opened file (which is CLO_EXEC) wants to be dup2'd to its own fd.
-            // We need to unset the CLO_EXEC flag.
+            // The opened file (which is CLOEXEC) wants to be dup2'd to its own fd.
+            // We need to unset the CLOEXEC flag.
             err = clear_cloexec(act.src);
         }
         if err < 0 {
@@ -498,7 +498,7 @@ pub(crate) fn signal_safe_report_exec_error(
 /// Returns the interpreter for the specified script. Returns None if file is not a script with a
 /// shebang.
 fn get_interpreter<'a>(command: &CStr, buffer: &'a mut [u8]) -> Option<&'a CStr> {
-    // OK to not use CLO_EXEC here because this is only called after fork.
+    // OK to not use CLOEXEC here because this is only called after fork.
     let fd = unsafe { libc::open(command.as_ptr(), libc::O_RDONLY) };
     let mut idx = 0;
     if fd >= 0 {

--- a/src/io.rs
+++ b/src/io.rs
@@ -581,7 +581,7 @@ impl IoChain {
                 }
                 _ => {
                     // We have a path-based redirection. Resolve it to a file.
-                    // Mark it as CLO_EXEC because we don't want it to be open in any child.
+                    // Mark it as CLOEXEC because we don't want it to be open in any child.
                     let path = path_apply_working_directory(&spec.target, pwd);
                     let oflags = spec.oflags();
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1108,7 +1108,7 @@ impl Parser {
 
     /// Flush profiling data to the given filename.
     pub fn flush_profiling(&mut self, path: &OsStr) {
-        // Save profiling information. OK to not use CLO_EXEC here because this is called while fish is
+        // Save profiling information. OK to not use CLOEXEC here because this is called while fish is
         // exiting (and hence will not fork).
         let mut f = match std::fs::File::create(path) {
             Ok(f) => f,

--- a/src/redirection.rs
+++ b/src/redirection.rs
@@ -139,7 +139,7 @@ impl Dup2List {
     pub fn add_dup2(&mut self, src: RawFd, target: RawFd) {
         assert!(src >= 0 && target >= 0, "Invalid fd in add_dup2");
         // Note: record these even if src and target is the same.
-        // This is a note that we must clear the CLO_EXEC bit.
+        // This is a note that we must clear the CLOEXEC bit.
         self.actions.push(Dup2Action { src, target });
     }
 

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -377,13 +377,11 @@ impl<'c> Iterator for Tokenizer<'c> {
         let buff = &self.start[self.token_cursor..];
         let mut at_cmd_pos = false;
         let token = match this_char {
-            '\0'=> {
+            '\0' => {
                 self.has_next = false;
                 None
             }
-            '\r'|  // carriage-return
-            '\n'|  // newline
-            ';'=> {
+            '\r' | '\n' | ';' => {
                 let mut result = Tok::new(TokenType::End);
                 result.offset = start_pos as u32;
                 result.length = 1;
@@ -395,17 +393,22 @@ impl<'c> Iterator for Tokenizer<'c> {
                     while self.token_cursor < self.start.len() {
                         let c = self.start.char_at(self.token_cursor);
                         if c != '\n' && c != '\r' && c != ' ' && c != '\t' {
-                            break
+                            break;
                         }
                         self.token_cursor += 1;
                     }
                 }
                 Some(result)
             }
-            '{' if self.brace_statement_parser.as_ref()
+            '{' if self
+                .brace_statement_parser
+                .as_ref()
                 .is_some_and(|parser| parser.at_command_position) =>
             {
-                self.brace_statement_parser.as_mut().unwrap().unclosed_brace_statements += 1;
+                self.brace_statement_parser
+                    .as_mut()
+                    .unwrap()
+                    .unclosed_brace_statements += 1;
                 let mut result = Tok::new(TokenType::LeftBrace);
                 result.offset = start_pos as u32;
                 result.length = 1;
@@ -414,7 +417,9 @@ impl<'c> Iterator for Tokenizer<'c> {
                 Some(result)
             }
             '}' => {
-                let brace_count = self.brace_statement_parser.as_mut()
+                let brace_count = self
+                    .brace_statement_parser
+                    .as_mut()
                     .map(|parser| &mut parser.unclosed_brace_statements);
                 if brace_count.as_ref().is_none_or(|count| **count == 0) {
                     return Some(self.call_error(
@@ -432,7 +437,7 @@ impl<'c> Iterator for Tokenizer<'c> {
                 self.token_cursor += 1;
                 Some(result)
             }
-            '&'=> {
+            '&' => {
                 if next_char == Some('&') {
                     // && is and.
                     let mut result = Tok::new(TokenType::AndAnd);
@@ -443,8 +448,8 @@ impl<'c> Iterator for Tokenizer<'c> {
                     Some(result)
                 } else if next_char == Some('>') || next_char == Some('|') {
                     // &> and &| redirect both stdout and stderr.
-                    let redir = PipeOrRedir::try_from(buff).
-                        expect("Should always succeed to parse a &> or &| redirection");
+                    let redir = PipeOrRedir::try_from(buff)
+                        .expect("Should always succeed to parse a &> or &| redirection");
                     let mut result = Tok::new(redir.token_type());
                     result.offset = start_pos as u32;
                     result.length = redir.consumed as u32;
@@ -460,18 +465,18 @@ impl<'c> Iterator for Tokenizer<'c> {
                     Some(result)
                 }
             }
-            '|'=> {
+            '|' => {
                 if next_char == Some('|') {
                     // || is or.
-                        let mut result=Tok::new(TokenType::OrOr);
+                    let mut result = Tok::new(TokenType::OrOr);
                     result.offset = start_pos as u32;
                     result.length = 2;
                     self.token_cursor += 2;
                     at_cmd_pos = true;
                     Some(result)
                 } else {
-                    let pipe = PipeOrRedir::try_from(buff).
-                        expect("Should always succeed to parse a | pipe");
+                    let pipe = PipeOrRedir::try_from(buff)
+                        .expect("Should always succeed to parse a | pipe");
                     let mut result = Tok::new(pipe.token_type());
                     result.offset = start_pos as u32;
                     result.length = pipe.consumed as u32;
@@ -480,17 +485,20 @@ impl<'c> Iterator for Tokenizer<'c> {
                     Some(result)
                 }
             }
-            '>'| '<' => {
+            '>' | '<' => {
                 // There's some duplication with the code in the default case below. The key
                 // difference here is that we must never parse these as a string; a failed
                 // redirection is an error!
                 match PipeOrRedir::try_from(buff) {
                     Ok(redir_or_pipe) => {
                         if redir_or_pipe.fd < 0 {
-                            Some(self.call_error(TokenizerError::InvalidRedirect, self.token_cursor,
-                                            self.token_cursor,
-                                            Some(redir_or_pipe.consumed),
-                                            redir_or_pipe.consumed))
+                            Some(self.call_error(
+                                TokenizerError::InvalidRedirect,
+                                self.token_cursor,
+                                self.token_cursor,
+                                Some(redir_or_pipe.consumed),
+                                redir_or_pipe.consumed,
+                            ))
                         } else {
                             let mut result = Tok::new(redir_or_pipe.token_type());
                             result.offset = start_pos as u32;
@@ -499,53 +507,61 @@ impl<'c> Iterator for Tokenizer<'c> {
                             Some(result)
                         }
                     }
-                    Err(()) => Some(self.call_error(TokenizerError::InvalidRedirect, self.token_cursor,
-                                            self.token_cursor,
-                                            Some(0),
-                                            0))
+                    Err(()) => Some(self.call_error(
+                        TokenizerError::InvalidRedirect,
+                        self.token_cursor,
+                        self.token_cursor,
+                        Some(0),
+                        0,
+                    )),
                 }
             }
-                _ => {
-                    // Maybe a redirection like '2>&1', maybe a pipe like 2>|, maybe just a string.
-                    let error_location = self.token_cursor;
-                    let redir_or_pipe = if this_char.is_ascii_digit() {
-                        PipeOrRedir::try_from(buff).ok()
-                    } else {
-                        None
-                    };
+            _ => {
+                // Maybe a redirection like '2>&1', maybe a pipe like 2>|, maybe just a string.
+                let error_location = self.token_cursor;
+                let redir_or_pipe = if this_char.is_ascii_digit() {
+                    PipeOrRedir::try_from(buff).ok()
+                } else {
+                    None
+                };
 
-                    match redir_or_pipe {
-                        Some(redir_or_pipe) => {
-                            // It looks like a redirection or a pipe. But we don't support piping fd 0. Note
-                            // tSome(hat fd 0 may be -1, indicating overflow; but we don't treat that as a
-                            // tokenizer error.
-                            if redir_or_pipe.is_pipe && redir_or_pipe.fd == 0 {
-                                Some(self.call_error(TokenizerError::InvalidPipe, error_location,
-                                                        error_location, Some(redir_or_pipe.consumed),
-                                                        redir_or_pipe.consumed))
-                            }
-                            else {
-                                let mut result = Tok::new(redir_or_pipe.token_type());
-                                result.offset = start_pos as u32;
-                                result.length = redir_or_pipe.consumed as u32;
-                                self.token_cursor += redir_or_pipe.consumed;
-                                at_cmd_pos = redir_or_pipe.is_pipe;
-                                Some(result)
-                            }
+                match redir_or_pipe {
+                    Some(redir_or_pipe) => {
+                        // It looks like a redirection or a pipe. But we don't support piping fd 0. Note
+                        // tSome(hat fd 0 may be -1, indicating overflow; but we don't treat that as a
+                        // tokenizer error.
+                        if redir_or_pipe.is_pipe && redir_or_pipe.fd == 0 {
+                            Some(self.call_error(
+                                TokenizerError::InvalidPipe,
+                                error_location,
+                                error_location,
+                                Some(redir_or_pipe.consumed),
+                                redir_or_pipe.consumed,
+                            ))
+                        } else {
+                            let mut result = Tok::new(redir_or_pipe.token_type());
+                            result.offset = start_pos as u32;
+                            result.length = redir_or_pipe.consumed as u32;
+                            self.token_cursor += redir_or_pipe.consumed;
+                            at_cmd_pos = redir_or_pipe.is_pipe;
+                            Some(result)
                         }
-                        None => {
-                            // Not a redirection or pipe, so just a string.
-                            let s = self.read_string();
-                            at_cmd_pos = self.brace_statement_parser.as_ref()
-                                .is_some_and(|parser| parser.at_command_position) && {
+                    }
+                    None => {
+                        // Not a redirection or pipe, so just a string.
+                        let s = self.read_string();
+                        at_cmd_pos = self
+                            .brace_statement_parser
+                            .as_ref()
+                            .is_some_and(|parser| parser.at_command_position)
+                            && {
                                 let text = self.text_of(&s);
                                 parser_keywords_is_subcommand(&unescape_keyword(
                                     TokenType::String,
-                                    text)
-                                ) ||
-                                variable_assignment_equals_pos(text).is_some()
+                                    text,
+                                )) || variable_assignment_equals_pos(text).is_some()
                             };
-                            Some(s)
+                        Some(s)
                     }
                 }
             }

--- a/src/universal_notifier/notifyd.rs
+++ b/src/universal_notifier/notifyd.rs
@@ -61,14 +61,14 @@ impl NotifydNotifier {
             );
             return None;
         }
-        // Mark us for non-blocking reads, and CLO_EXEC.
+        // Mark us for non-blocking reads, and CLOEXEC.
         let _ = make_fd_nonblocking(notify_fd);
         let _ = set_cloexec(notify_fd, true);
 
         // Serious hack: notify_fd is likely the read end of a pipe. The other end is owned by
-        // libnotify, which does not mark it as CLO_EXEC (it should!). The next fd is probably
+        // libnotify, which does not mark it as CLOEXEC (it should!). The next fd is probably
         // notify_fd + 1. Do it ourselves. If the implementation changes and some other FD gets
-        // marked as CLO_EXEC, that's probably a good thing.
+        // marked as CLOEXEC, that's probably a good thing.
         let _ = set_cloexec(notify_fd + 1, true);
 
         Some(Self {

--- a/tests/checks/fds.fish
+++ b/tests/checks/fds.fish
@@ -37,7 +37,7 @@ $helper print_fds 5>&2
 
 # This attempts to trip a case where the file opened in fish
 # has the same fd as the redirection. In this case, the dup2
-# does not clear the CLO_EXEC bit.
+# does not clear the CLOEXEC bit.
 
 $helper print_fds 4</dev/null
 # CHECK: 0 1 2 4


### PR DESCRIPTION
Remove a couple of unhelpful comments that stopped rustfmt for working (https://github.com/rust-lang/rustfmt/issues/4119)
Fix typo `CLO_EXEC` to `CLOEXEC`
