### PR TITLE
git completion: only suggest files/directories with --no-index

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -1563,11 +1563,11 @@ complete -f -c git -n '__fish_git_using_command describe' -l first-parent -d 'Fo
 
 ### diff
 complete -c git -n __fish_git_needs_command -a diff -d 'Show changes between commits and working tree'
-complete -c git -n '__fish_git_using_command diff' -n 'not contains -- -- (commandline -xpc)' -ka '(__fish_git_ranges)'
-complete -c git -n '__fish_git_using_command diff' -n 'not contains -- -- (commandline -xpc)' -ka '(__fish_git_complete_stashes)'
+complete -c git -n '__fish_git_using_command diff' -n 'not contains -- -- (commandline -xpc)' -n 'not __fish_git_contains_opt no-index' -ka '(__fish_git_ranges)'
+complete -c git -n '__fish_git_using_command diff' -n 'not contains -- -- (commandline -xpc)' -n 'not __fish_git_contains_opt no-index' -ka '(__fish_git_complete_stashes)'
 begin
     set -lx __fish_git_recent_commits_arg --all
-    __fish_git_add_revision_completion -n '__fish_git_using_command diff'
+    __fish_git_add_revision_completion -n '__fish_git_using_command diff' -n 'not __fish_git_contains_opt no-index'
 end
 complete -c git -n '__fish_git_using_command diff' -l cached -d 'Show diff of changes in the index'
 complete -c git -n '__fish_git_using_command diff' -l staged -d 'Show diff of changes in the index'


### PR DESCRIPTION
Fixes #12773. See: https://asciinema.org/a/8jATYMRPdPZBkSN4

I had a look at the completion tests and wasn't able to find any that exercise the completion scripts for specific commands - it appears to me that the existing tests exercise the completion mechanism itself. But please let me know if there is a good way of adding tests for this.

## TODOs:
<!-- Check off what what has been done so far. -->
- [x] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
