### PR TITLE
Improve test isolation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -233,6 +233,8 @@ unused_trait_names = "warn"
 # In the future, they might change to flag other methods of printing.
 print_stdout = "deny"
 print_stderr = "deny"
+# usage in tests is fine since it avoids interacting with TopicMonitor
+# and is configured in clippy.toml with `allow-print-in-tests`
 
 [lints]
 workspace = true

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+allow-print-in-tests = true

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -1559,7 +1559,7 @@ mod tests {
         tests::prelude::*,
     };
     use fish_widestring::{ANY_STRING, str2wcstring};
-    use std::collections::{HashSet, hash_map::RandomState};
+    use std::collections::{HashMap, HashSet, hash_map::RandomState};
 
     fn expand_test_impl(
         input: &wstr,
@@ -2004,13 +2004,9 @@ mod tests {
     #[test]
     fn test_replace_home_directory_with_tilde() {
         use super::replace_home_directory_with_tilde as rhdwt;
-        use crate::env::{EnvMode, EnvSetMode, EnvStack};
-        let vars = EnvStack::new();
-        vars.set_one(
-            L!("HOME"),
-            EnvSetMode::new(EnvMode::GLOBAL, false),
-            L!("/home/testuser").to_owned(),
-        );
+        let vars = TestEnvironment {
+            vars: HashMap::from([(L!("HOME").to_owned(), L!("/home/testuser").to_owned())]),
+        };
 
         assert_eq!(rhdwt("/home/testuser/", &vars), "~/");
         assert_eq!(rhdwt("/home/testuser/Documents/", &vars), "~/Documents/");

--- a/src/threads/threads.rs
+++ b/src/threads/threads.rs
@@ -458,7 +458,7 @@ mod tests {
         let made = spawn(move || {
             ctx2.val.fetch_add(2, Ordering::Release);
             ctx2.condvar.notify_one();
-            printf!("condvar signalled\n");
+            println!("condvar signalled");
         });
         assert!(made);
 
@@ -466,9 +466,9 @@ mod tests {
         let (_lock, timeout) = ctx
             .condvar
             .wait_timeout_while(lock, Duration::from_secs(5), |()| {
-                printf!("looping with lock held\n");
+                println!("looping with lock held");
                 if ctx.val.load(Ordering::Acquire) != 5 {
-                    printf!("test_pthread: value did not yet reach goal\n");
+                    println!("test_pthread: value did not yet reach goal");
                     return true;
                 }
                 false

--- a/src/wutil/mod.rs
+++ b/src/wutil/mod.rs
@@ -476,50 +476,65 @@ mod tests {
         fn relative_path() {
             let wd = L!("/home/user/");
             let path = L!("projects");
-            eprintf!("(%s, %s)\n", wd, path);
-            assert_eq!(path_normalize_for_cd(wd, path), L!("/home/user/projects"));
+            assert_eq!(
+                path_normalize_for_cd(wd, path),
+                L!("/home/user/projects"),
+                "Normalized path for ({wd}, {path})"
+            );
         }
 
         #[test]
         fn absolute_path() {
             let wd = L!("/home/user/");
             let path = L!("/etc");
-            eprintf!("(%s, %s)\n", wd, path);
-            assert_eq!(path_normalize_for_cd(wd, path), L!("/etc"));
+            assert_eq!(
+                path_normalize_for_cd(wd, path),
+                L!("/etc"),
+                "Normalized path for ({wd}, {path})"
+            );
         }
 
         #[test]
         fn parent_directory() {
             let wd = L!("/home/user/projects/");
             let path = L!("../docs");
-            eprintf!("(%s, %s)\n", wd, path);
-            assert_eq!(path_normalize_for_cd(wd, path), L!("/home/user/docs"));
+            assert_eq!(
+                path_normalize_for_cd(wd, path),
+                L!("/home/user/docs"),
+                "Normalized path for ({wd}, {path})"
+            );
         }
 
         #[test]
         fn current_directory() {
             let wd = L!("/home/user/");
             let path = L!("./");
-            eprintf!("(%s, %s)\n", wd, path);
-            assert_eq!(path_normalize_for_cd(wd, path), L!("/home/user"));
+            assert_eq!(
+                path_normalize_for_cd(wd, path),
+                L!("/home/user"),
+                "Normalized path for ({wd}, {path})"
+            );
         }
 
         #[test]
         fn nested_parent_directory() {
             let wd = L!("/home/user/projects/");
             let path = L!("../../");
-            eprintf!("(%s, %s)\n", wd, path);
-            assert_eq!(path_normalize_for_cd(wd, path), L!("/home"));
+            assert_eq!(
+                path_normalize_for_cd(wd, path),
+                L!("/home"),
+                "Normalized path for ({wd}, {path})"
+            );
         }
 
         #[test]
         fn complex_path() {
             let wd = L!("/home/user/projects/");
             let path = L!("./../other/projects/./.././../docs");
-            eprintf!("(%s, %s)\n", wd, path);
             assert_eq!(
                 path_normalize_for_cd(wd, path),
-                L!("/home/user/other/projects/./.././../docs")
+                L!("/home/user/other/projects/./.././../docs"),
+                "Normalized path for ({wd}, {path})"
             );
         }
 
@@ -527,34 +542,43 @@ mod tests {
         fn root_directory() {
             let wd = L!("/");
             let path = L!("..");
-            eprintf!("(%s, %s)\n", wd, path);
-            assert_eq!(path_normalize_for_cd(wd, path), L!("/.."));
+            assert_eq!(
+                path_normalize_for_cd(wd, path),
+                L!("/.."),
+                "Normalized path for ({wd}, {path})"
+            );
         }
 
         #[test]
         fn up_to_root_directory() {
             let wd = L!("/foo/");
             let path = L!("..");
-            eprintf!("(%s, %s)\n", wd, path);
-            assert_eq!(path_normalize_for_cd(wd, path), L!("/"));
+            assert_eq!(
+                path_normalize_for_cd(wd, path),
+                L!("/"),
+                "Normalized path for ({wd}, {path})"
+            );
         }
 
         #[test]
         fn empty_path() {
             let wd = L!("/home/user/");
             let path = L!("");
-            eprintf!("(%s, %s)\n", wd, path);
-            assert_eq!(path_normalize_for_cd(wd, path), L!("/home/user/"));
+            assert_eq!(
+                path_normalize_for_cd(wd, path),
+                L!("/home/user/"),
+                "Normalized path for ({wd}, {path})"
+            );
         }
 
         #[test]
         fn trailing_slash() {
             let wd = L!("/home/user/projects/");
             let path = L!("docs/");
-            eprintf!("(%s, %s)\n", wd, path);
             assert_eq!(
                 path_normalize_for_cd(wd, path),
-                L!("/home/user/projects/docs/")
+                L!("/home/user/projects/docs/"),
+                "Normalized path for ({wd}, {path})"
             );
         }
     }


### PR DESCRIPTION
Fix a couple test-panics that occur when running each test in isolation with `cargo test $test_name`, or when running `cargo nextest run`, which has a process-based isolation model.

- **Fix `Principal topic monitor not initialized`**
- **Fix `threads::init() was not called at startup!`**
- **Fix `Principal topic monitor not initialized` panic**

Note that this also includes a linting change since I use `println!` to avoid interacting with `TopicMonitor` indirectly through `printf!`. IMO is that completely fine for tests, and we already use it in `crates/printf`.



## TODOs:
<!-- Check off what what has been done so far. -->
- [ ] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
