### PR TITLE
Add value builtin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 fish ?.?.? (released ???)
 =========================
 
+New features
+------------
+- New :doc:`value <cmds/value>` builtin that outputs its arguments as separate list elements, useful for starting pipelines with a variable, returning values from functions, and inline lists (e.g. ``set separator (value $_flag_separator ' ')[1]``).
+
 Deprecations and removed features
 ---------------------------------
 - `--command` and `--path` options in `complete` no longer unescape their value.

--- a/doc_src/cmds/argparse.rst
+++ b/doc_src/cmds/argparse.rst
@@ -108,9 +108,7 @@ To use the flags argparse has extracted::
         return 1
     end
 
-    set -l myname somedefault
-    set -ql _flag_name[1]
-    and set myname $_flag_name[-1] # here we use the *last* --name=
+    set -l myname (value somedefault $_flag_name)[-1] # use the last --name, or the default
 
 Any characters in the flag name that are not valid in a variable name (like ``-`` dashes) will be replaced with underscores.
 

--- a/doc_src/cmds/value.rst
+++ b/doc_src/cmds/value.rst
@@ -1,0 +1,55 @@
+value - output arguments as separate list elements
+===================================================
+
+Synopsis
+--------
+
+.. synopsis::
+
+    value [VALUE ...]
+
+Description
+-----------
+
+``value`` outputs each of its arguments as a separate list element, preserving each as a distinct element when captured in a command substitution::
+
+    set mode (value read write exec)[$n]
+    set separator (value $_flag_separator ' ')[1]
+    set merged (value $xs $ys | sort -u)
+
+``value`` accepts no options, reads no stdin, and always exits with status 0.
+
+Like :doc:`set <set>`, :doc:`path <path>`, and :doc:`count <count>`, ``value`` uses "nullglob" behavior: if a wildcard argument fails to expand, it silently expands to nothing rather than aborting the command.
+
+Examples
+--------
+
+Start a pipeline from a variable::
+
+    value $items | sort -u
+
+    value {foo,bar,baz}.txt | xargs -l1 cat
+
+Construct a temporary list for an environment override::
+
+    PATH=(value ~/.bin /usr/local/bin) somecommand
+
+Apply a default to an argparse flag::
+
+    set separator (value $_flag_separator ' ')[1]
+
+Return collected results from a function::
+
+    function myxargs
+        while read input
+            set -a outputs ($argv (string split ' ' -- $input))
+        end
+        value $outputs
+    end
+
+See Also
+--------
+
+- the :doc:`echo <echo>` command, for more control over output formatting
+- the :doc:`string collect <string-collect>` subcommand
+- the :doc:`count <count>` command

--- a/doc_src/cmds/value.rst
+++ b/doc_src/cmds/value.rst
@@ -21,6 +21,17 @@ Description
 
 Like :doc:`set <set>`, :doc:`path <path>`, and :doc:`count <count>`, ``value`` uses "nullglob" behavior: if a wildcard argument fails to expand, it silently expands to nothing rather than aborting the command.
 
+Fish ships a wrapper function around the builtin ``value``. When the universal variable ``fish_value_show`` is set, stdout is a terminal, and ``value`` appears to be invoked interactively at the top level, the wrapper displays element count and per-element detail instead of raw output::
+
+    > set -U fish_value_show 1
+    > value $PATH
+    3 elements
+    [1]: |/usr/local/bin|
+    [2]: |/usr/bin|
+    [3]: |/bin|
+
+Unset ``fish_value_show`` to disable this behavior. The plain builtin is always available via ``builtin value``.
+
 Examples
 --------
 

--- a/doc_src/fish_for_bash_users.rst
+++ b/doc_src/fish_for_bash_users.rst
@@ -111,7 +111,7 @@ Fish doesn't have ``${my_variable:-fallback}`` for providing default values to u
 Wildcards (globs)
 -----------------
 
-Fish only supports the ``*`` and ``**`` glob (and the deprecated ``?`` glob) as syntax. If a glob doesn't match it fails the command (like with bash's ``failglob``) unless the command is ``for``, ``set`` or ``count`` or the glob is used with an environment override (``VAR=* command``), in which case it expands to nothing (like with bash's ``nullglob`` option).
+Fish only supports the ``*`` and ``**`` glob (and the deprecated ``?`` glob) as syntax. If a glob doesn't match it fails the command (like with bash's ``failglob``) unless the command is ``for``, ``set``, ``count``, ``path`` or ``value`` or the glob is used with an environment override (``VAR=* command``), in which case it expands to nothing (like with bash's ``nullglob`` option).
 
 Globbing doesn't happen on expanded variables, so::
 

--- a/doc_src/language.rst
+++ b/doc_src/language.rst
@@ -628,7 +628,7 @@ Examples:
 
 - ``~/.*`` matches all hidden files (also known as "dotfiles") and directories in your home directory.
 
-For most commands, if any wildcard fails to expand, the command is not executed, :ref:`$status <variables-status>` is set to nonzero, and a warning is printed. This behavior is like what bash does with ``shopt -s failglob``. There are exceptions, namely :doc:`set <cmds/set>` and :doc:`path <cmds/path>`, overriding variables in :ref:`overrides <variables-override>`, :doc:`count <cmds/count>` and :doc:`for <cmds/for>`. Their globs will instead expand to zero arguments (so the command won't see them at all), like with ``shopt -s nullglob`` in bash.
+For most commands, if any wildcard fails to expand, the command is not executed, :ref:`$status <variables-status>` is set to nonzero, and a warning is printed. This behavior is like what bash does with ``shopt -s failglob``. There are exceptions, namely :doc:`set <cmds/set>`, :doc:`path <cmds/path>`, :doc:`value <cmds/value>`, overriding variables in :ref:`overrides <variables-override>`, :doc:`count <cmds/count>` and :doc:`for <cmds/for>`. Their globs will instead expand to zero arguments (so the command won't see them at all), like with ``shopt -s nullglob`` in bash.
 
 Examples::
 

--- a/localization/po/de.po
+++ b/localization/po/de.po
@@ -1847,6 +1847,9 @@ msgstr ""
 msgid "$status, the return code"
 msgstr ""
 
+msgid "%d elements\\n"
+msgstr "%d Elemente\\n"
+
 msgid "%s: %s is an array variable. Use %svared%s %s[n]%s to edit the n:th element of %s\\n"
 msgstr ""
 
@@ -2949,6 +2952,9 @@ msgid "Output startup profiling information to a file"
 msgstr ""
 
 msgid "Output timing and explain sequence"
+msgstr ""
+
+msgid "Output values as list elements"
 msgstr ""
 
 msgid "POSIX-style short option to complete"

--- a/localization/po/es.po
+++ b/localization/po/es.po
@@ -1847,6 +1847,9 @@ msgstr ""
 msgid "$status, the return code"
 msgstr "$status, el código de retorno"
 
+msgid "%d elements\\n"
+msgstr "%d elementos\\n"
+
 msgid "%s: %s is an array variable. Use %svared%s %s[n]%s to edit the n:th element of %s\\n"
 msgstr "%s: %s es una variable de tipo array. Usa %svared%s %s[n]%s para editar el elemento n de %s\\n"
 
@@ -2949,6 +2952,9 @@ msgid "Output startup profiling information to a file"
 msgstr ""
 
 msgid "Output timing and explain sequence"
+msgstr ""
+
+msgid "Output values as list elements"
 msgstr ""
 
 msgid "POSIX-style short option to complete"

--- a/localization/po/fr.po
+++ b/localization/po/fr.po
@@ -1976,6 +1976,9 @@ msgstr ""
 msgid "$status, the return code"
 msgstr ""
 
+msgid "%d elements\\n"
+msgstr "%d éléments\\n"
+
 msgid "%s: %s is an array variable. Use %svared%s %s[n]%s to edit the n:th element of %s\\n"
 msgstr "%s : %s est un tableau. Utilisez %svared%s %s[n]%s pour éditer le n-ième élément de %s\\n"
 
@@ -3078,6 +3081,9 @@ msgid "Output startup profiling information to a file"
 msgstr ""
 
 msgid "Output timing and explain sequence"
+msgstr ""
+
+msgid "Output values as list elements"
 msgstr ""
 
 msgid "POSIX-style short option to complete"

--- a/localization/po/ja_JP.po
+++ b/localization/po/ja_JP.po
@@ -1847,6 +1847,9 @@ msgstr ""
 msgid "$status, the return code"
 msgstr "$status は返り値(return code)"
 
+msgid "%d elements\\n"
+msgstr "%d 要素\\n"
+
 msgid "%s: %s is an array variable. Use %svared%s %s[n]%s to edit the n:th element of %s\\n"
 msgstr "%s: %s は配列変数です。%s の n 番目の要素を編集するには %svared%s %s[n]%s を使用してください\\n"
 
@@ -2953,6 +2956,9 @@ msgstr "起動時のプロファイリング情報をファイルに出力"
 
 msgid "Output timing and explain sequence"
 msgstr "タイミングを出力し、シーケンスを解説"
+
+msgid "Output values as list elements"
+msgstr ""
 
 msgid "POSIX-style short option to complete"
 msgstr "補完対象の POSIX 形式ショートオプション"

--- a/localization/po/pl.po
+++ b/localization/po/pl.po
@@ -1843,6 +1843,9 @@ msgstr ""
 msgid "$status, the return code"
 msgstr ""
 
+msgid "%d elements\\n"
+msgstr ""
+
 msgid "%s: %s is an array variable. Use %svared%s %s[n]%s to edit the n:th element of %s\\n"
 msgstr ""
 
@@ -2945,6 +2948,9 @@ msgid "Output startup profiling information to a file"
 msgstr ""
 
 msgid "Output timing and explain sequence"
+msgstr ""
+
+msgid "Output values as list elements"
 msgstr ""
 
 msgid "POSIX-style short option to complete"

--- a/localization/po/pt_BR.po
+++ b/localization/po/pt_BR.po
@@ -1848,6 +1848,9 @@ msgstr ""
 msgid "$status, the return code"
 msgstr ""
 
+msgid "%d elements\\n"
+msgstr ""
+
 msgid "%s: %s is an array variable. Use %svared%s %s[n]%s to edit the n:th element of %s\\n"
 msgstr ""
 
@@ -2950,6 +2953,9 @@ msgid "Output startup profiling information to a file"
 msgstr ""
 
 msgid "Output timing and explain sequence"
+msgstr ""
+
+msgid "Output values as list elements"
 msgstr ""
 
 msgid "POSIX-style short option to complete"

--- a/localization/po/sv.po
+++ b/localization/po/sv.po
@@ -1844,6 +1844,9 @@ msgstr ""
 msgid "$status, the return code"
 msgstr ""
 
+msgid "%d elements\\n"
+msgstr ""
+
 msgid "%s: %s is an array variable. Use %svared%s %s[n]%s to edit the n:th element of %s\\n"
 msgstr ""
 
@@ -2946,6 +2949,9 @@ msgid "Output startup profiling information to a file"
 msgstr ""
 
 msgid "Output timing and explain sequence"
+msgstr ""
+
+msgid "Output values as list elements"
 msgstr ""
 
 msgid "POSIX-style short option to complete"

--- a/localization/po/zh_CN.po
+++ b/localization/po/zh_CN.po
@@ -1868,6 +1868,9 @@ msgstr ""
 msgid "$status, the return code"
 msgstr "$status 退出代码"
 
+msgid "%d elements\\n"
+msgstr "%d 个元素\\n"
+
 msgid "%s: %s is an array variable. Use %svared%s %s[n]%s to edit the n:th element of %s\\n"
 msgstr "%s: %s 是一个数组变量。使用 %svared%s %s[n]%s 编辑第 n 个元素于 %s\\n"
 
@@ -2971,6 +2974,9 @@ msgstr "将启动分析信息输出到文件"
 
 msgid "Output timing and explain sequence"
 msgstr "输出时序和解释序列"
+
+msgid "Output values as list elements"
+msgstr ""
 
 msgid "POSIX-style short option to complete"
 msgstr "要补全的 POSIX 风格短选项"

--- a/localization/po/zh_TW.po
+++ b/localization/po/zh_TW.po
@@ -1843,6 +1843,9 @@ msgstr "$PATH"
 msgid "$status, the return code"
 msgstr "$status，回傳的代碼"
 
+msgid "%d elements\\n"
+msgstr "%d 個元素\\n"
+
 msgid "%s: %s is an array variable. Use %svared%s %s[n]%s to edit the n:th element of %s\\n"
 msgstr "%s：%s 是陣列變數。請使用 %svared%s %s[n]%s 來編輯 %s 的第 n 個元素\\n"
 
@@ -2946,6 +2949,9 @@ msgstr "將啟動時的效能側寫資訊輸出到檔案"
 
 msgid "Output timing and explain sequence"
 msgstr "輸出時機並解釋序列"
+
+msgid "Output values as list elements"
+msgstr ""
 
 msgid "POSIX-style short option to complete"
 msgstr "要補全的 POSIX 式短選項"

--- a/share/functions/value.fish
+++ b/share/functions/value.fish
@@ -1,0 +1,14 @@
+# localization: tier1
+
+if not status is-interactive
+    exit
+end
+
+function value --description "Output values as list elements"
+    if set -q fish_value_show; and isatty stdout; and string match -q 'value *' -- (status current-commandline)
+        printf (_ '%d elements\n') (count $argv)
+        builtin value (set -S argv | string replace -r '^\$argv' '' -- $argv)[2..]
+    else
+        builtin value $argv
+    end
+end

--- a/share/help_sections
+++ b/share/help_sections
@@ -119,6 +119,7 @@ cmds/true
 cmds/type
 cmds/ulimit
 cmds/umask
+cmds/value
 cmds/vared
 cmds/wait
 cmds/while

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -46,6 +46,7 @@ pub mod test;
 pub mod r#true;
 pub mod r#type;
 pub mod ulimit;
+pub mod value;
 pub mod wait;
 
 mod prelude {

--- a/src/builtins/shared/misc.rs
+++ b/src/builtins/shared/misc.rs
@@ -353,6 +353,10 @@ const BUILTIN_DATAS: &[BuiltinData] = &[
         func: ulimit::ulimit,
     },
     BuiltinData {
+        name: L!("value"),
+        func: value::value,
+    },
+    BuiltinData {
         name: L!("wait"),
         func: wait::wait,
     },

--- a/src/builtins/value.rs
+++ b/src/builtins/value.rs
@@ -1,0 +1,10 @@
+use super::prelude::*;
+
+pub fn value(_parser: &mut Parser, streams: &mut IoStreams, argv: &mut [&wstr]) -> BuiltinResult {
+    for arg in &argv[1..] {
+        streams
+            .out
+            .append_with_separation(*arg, SeparationType::Explicitly, true);
+    }
+    Ok(SUCCESS)
+}

--- a/src/parse_execution.rs
+++ b/src/parse_execution.rs
@@ -796,11 +796,12 @@ impl ExecutionContext {
             };
         } else {
             // Not implicit cd.
-            let glob_behavior = if [L!("set"), L!("count"), L!("path")].contains(&&cmd[..]) {
-                WildcardNoMatchBehavior::Allow
-            } else {
-                WildcardNoMatchBehavior::Fail
-            };
+            let glob_behavior =
+                if [L!("count"), L!("path"), L!("set"), L!("value")].contains(&&cmd[..]) {
+                    WildcardNoMatchBehavior::Allow
+                } else {
+                    WildcardNoMatchBehavior::Fail
+                };
             // Form the list of arguments. The command is the first argument, followed by any arguments
             // from expanding the command, followed by the argument nodes themselves. E.g. if the
             // command is '$gco foo' and $gco is git checkout.

--- a/tests/checks/value.fish
+++ b/tests/checks/value.fish
@@ -1,0 +1,29 @@
+#RUN: %fish %s
+
+value foo
+# CHECK: foo
+
+count (value a b c)
+# CHECK: 3
+
+echo (value a b c)[2]
+# CHECK: b
+
+value
+echo $status
+# CHECK: 0
+
+# unmatched globs expand to nothing
+value this-file-does-not-exist-*.zzz
+echo "status: $status"
+# CHECK: status: 0
+
+set result (value x y z)
+echo $result[1] $result[3]
+# CHECK: x z
+
+builtin value direct
+# CHECK: direct
+
+count (value '' notempty)
+# CHECK: 2


### PR DESCRIPTION
## Summary

New `value` builtin that outputs its arguments as separate list elements.
This is basically an identity function, and is something I find myself
frequently reaching for as I write more fish. A function that simply outputs
its arguments is a first-class way to start pipelines from variables, provide
defaults for argparse flags, override a variable with a list, and return values
from functions.

A function wrapping `string collect -- $argv` can do the output correctly,
but only a builtin can be in the glob allowlist. With `value` as a builtin,
unmatched wildcards can expand to nothing (like `set`, `count`, and `path`)
instead of aborting.

### Use cases

```fish
# Start a pipeline from a variable
value $items | sort -u

# Argparse flag defaults — one line instead of two
set -l myname (value somedefault $_flag_name)[-1]

# Temporary list for an environment override
PATH=(value ~/.bin /usr/local/bin) somecommand

# Return collected results from a function
function myxargs
    while read input
        set -a outputs ($argv (string split ' ' -- $input) | string collect)
    end
    value $outputs
end
```

### Commits

1. **feat: add value builtin** — builtin, glob allowlist, tests, docs, changelog
2. **feat: add value wrapper function** — opt-in inspection mode gated on `fish_value_show`, i18n translations