### PR TITLE
Fix Vi mode cW deleting trailing whitespace

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,7 @@ For distributors and developers
 
 Regression fixes:
 -----------------
+- (from 4.4.0) Vi mode ``c,W`` key binding wrongly deleted trailing spaces.
 - (from 4.4) Vi mode ``x`` in :doc:`builtin read <cmds/read>` (:issue:`12724`).
 - (from 4.3.3) Repeated tab would sometimes insert smartcase completions redundantly.
 

--- a/doc_src/cmds/fish_vi_key_bindings.rst
+++ b/doc_src/cmds/fish_vi_key_bindings.rst
@@ -32,11 +32,6 @@ Fish's vi mode aims to be familiar to vim users, but there are some differences:
 **Word character handling**
     In vim, underscore (``_``) is treated as a keyword character by default, so word motions like ``w``, ``b``, and ``e`` treat ``foo_bar`` as a single word. In fish, underscore is treated as punctuation, so word motions stop at underscores. For example, pressing ``w`` on ``foo_bar`` in fish stops at the ``_``, while in vim it would jump past the entire identifier.
 
-**The** ``cw`` **command**
-    In vim, ``cw`` has special behavior: when the cursor is on a non-space character, it behaves like ``ce`` (change to end of word), but when the cursor is on a space, it behaves like ``dwi`` (delete word then insert).
-
-    In fish, ``cw`` always behaves like ``dwi`` - it deletes to the start of the next word (including trailing whitespace), then enters insert mode. To get vim's ``cw`` behavior in fish, use ``ce`` instead.
-
 Examples
 --------
 

--- a/share/functions/fish_vi_key_bindings.fish
+++ b/share/functions/fish_vi_key_bindings.fish
@@ -151,10 +151,11 @@ function fish_vi_exec_motion
                 end
             case change
                 switch $motion[1]
-                    case kill-word-vi
+                    case kill-word-vi kill-bigword-vi
+                        set -l end_kill (string replace -- -vi '' $motion[1]) # kill-word / kill-bigword
                         for i in $seq_total
                             if test $i -eq $total
-                                commandline -f kill-word
+                                commandline -f $end_kill
                             else
                                 $motion_cmd
                             end

--- a/tests/pexpects/bind.py
+++ b/tests/pexpects/bind.py
@@ -474,15 +474,15 @@ expect_prompt(
     "\r\n.*XXX def\r\n", unmatched="vi mode 'ce' should change to end of word"
 )
 
-# Test 'cW' - change WORD, deletes to start of next WORD (like vim's 'dW')
+# Test 'cW' - change WORD, changes to end of WORD keeping trailing space (like 'cE')
 send("echo abc-def ghi")
 send("\033")
 sleep(0.200)
 send(
     "0wcWXXX\r"
-)  # Move to 'abc-def', 'cW' deletes 'abc-def ' (including space), type 'XXX'
+)  # Move to 'abc-def', 'cW' changes 'abc-def' (not the space), type 'XXX'
 expect_prompt(
-    "\r\n.*XXXghi\r\n", unmatched="vi mode 'cW' should delete to start of next WORD"
+    "\r\n.*XXX ghi\r\n", unmatched="vi mode 'cW' should change to end of WORD"
 )
 
 # Test 'cE' - change to end of WORD (like vim's 'dE')


### PR DESCRIPTION
Discussion in https://github.com/fish-shell/fish-shell/discussions/12788

cW (change-WORD) changed through to the start of the next WORD, deleting the trailing whitespace. 02c0455 (Fix Vi mode cw deleting trailing whitespace, 2026-02-12) fixed this for cw but missed cW, and there is no reason for cw and cW to be inconsistent. Make cW change only to the end of the WORD, like cE and Vim, keeping the trailing whitespace.

Fixes 38e633d49b1 (fish_vi_key_bindings: add support for count, 2025-12-16).

## TODOs:
<!-- Check off what what has been done so far. -->
- [X] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [X] Changes to fish usage are reflected in user documentation/manpages.
- [X] Tests have been added for regressions fixed
- [X] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
