### PR TITLE
completions/cargo: remove nonexistent subcommand `complete`

### DIFF
--- a/localization/po/de.po
+++ b/localization/po/de.po
@@ -28937,9 +28937,6 @@ msgstr ""
 msgid "Generate compiler predefines and select a startfile for the specified UNIX standard"
 msgstr ""
 
-msgid "Generate completion file for a shell"
-msgstr ""
-
 msgid "Generate compressed stream"
 msgstr ""
 

--- a/localization/po/es.po
+++ b/localization/po/es.po
@@ -28937,9 +28937,6 @@ msgstr ""
 msgid "Generate compiler predefines and select a startfile for the specified UNIX standard"
 msgstr ""
 
-msgid "Generate completion file for a shell"
-msgstr ""
-
 msgid "Generate compressed stream"
 msgstr ""
 

--- a/localization/po/fr.po
+++ b/localization/po/fr.po
@@ -29066,9 +29066,6 @@ msgstr ""
 msgid "Generate compiler predefines and select a startfile for the specified UNIX standard"
 msgstr "Générer les pré-définitions du compilateur et sélectionner un fichier de démarrage pour le standard UNIX spécifié"
 
-msgid "Generate completion file for a shell"
-msgstr ""
-
 msgid "Generate compressed stream"
 msgstr "Générer un flux compressé"
 

--- a/localization/po/ja_JP.po
+++ b/localization/po/ja_JP.po
@@ -28940,9 +28940,6 @@ msgstr ""
 msgid "Generate compiler predefines and select a startfile for the specified UNIX standard"
 msgstr ""
 
-msgid "Generate completion file for a shell"
-msgstr ""
-
 msgid "Generate compressed stream"
 msgstr ""
 

--- a/localization/po/pl.po
+++ b/localization/po/pl.po
@@ -28933,9 +28933,6 @@ msgstr ""
 msgid "Generate compiler predefines and select a startfile for the specified UNIX standard"
 msgstr ""
 
-msgid "Generate completion file for a shell"
-msgstr ""
-
 msgid "Generate compressed stream"
 msgstr ""
 

--- a/localization/po/pt_BR.po
+++ b/localization/po/pt_BR.po
@@ -28938,9 +28938,6 @@ msgstr ""
 msgid "Generate compiler predefines and select a startfile for the specified UNIX standard"
 msgstr ""
 
-msgid "Generate completion file for a shell"
-msgstr ""
-
 msgid "Generate compressed stream"
 msgstr ""
 

--- a/localization/po/sv.po
+++ b/localization/po/sv.po
@@ -28934,9 +28934,6 @@ msgstr ""
 msgid "Generate compiler predefines and select a startfile for the specified UNIX standard"
 msgstr ""
 
-msgid "Generate completion file for a shell"
-msgstr ""
-
 msgid "Generate compressed stream"
 msgstr ""
 

--- a/localization/po/zh_CN.po
+++ b/localization/po/zh_CN.po
@@ -28958,9 +28958,6 @@ msgstr ""
 msgid "Generate compiler predefines and select a startfile for the specified UNIX standard"
 msgstr ""
 
-msgid "Generate completion file for a shell"
-msgstr ""
-
 msgid "Generate compressed stream"
 msgstr ""
 

--- a/localization/po/zh_TW.po
+++ b/localization/po/zh_TW.po
@@ -28935,9 +28935,6 @@ msgstr ""
 msgid "Generate compiler predefines and select a startfile for the specified UNIX standard"
 msgstr ""
 
-msgid "Generate completion file for a shell"
-msgstr ""
-
 msgid "Generate compressed stream"
 msgstr ""
 

--- a/share/completions/cargo.fish
+++ b/share/completions/cargo.fish
@@ -62,6 +62,7 @@ complete -c cargo -n '__fish_seen_subcommand_from r run t test b build debug c c
 
 ## --- AUTO-GENERATED WITH `cargo complete fish` ---
 # Manually massaged to improve some descriptions
+# Subcommand `complete` no longer exists. See https://github.com/rust-lang/cargo/pull/9288
 complete -c cargo -n __fish_use_subcommand -l explain -d 'Run `rustc --explain CODE`'
 complete -c cargo -n __fish_use_subcommand -l color -d 'Coloring: auto, always, never'
 complete -c cargo -n __fish_use_subcommand -l config -d 'Override a configuration value (unstable)'
@@ -78,7 +79,6 @@ complete -c cargo -n __fish_use_subcommand -f -a bench -d 'Execute all benchmark
 complete -c cargo -n __fish_use_subcommand -f -a build -d 'Compile a local package and all of its dependencies'
 complete -c cargo -n __fish_use_subcommand -f -a check -d 'Check a local package and all of its dependencies for errors'
 complete -c cargo -n __fish_use_subcommand -f -a clean -d 'Remove artifacts that cargo has generated in the past'
-complete -c cargo -n __fish_use_subcommand -f -a complete -d 'Generate completion file for a shell'
 complete -c cargo -n __fish_use_subcommand -f -a doc -d 'Build a package\'s documentation'
 complete -c cargo -n __fish_use_subcommand -f -a fetch -d 'Fetch dependencies of a package from the network'
 complete -c cargo -n __fish_use_subcommand -f -a fix -d 'Automatically fix lint warnings reported by rustc'
@@ -234,15 +234,6 @@ complete -c cargo -n "__fish_seen_subcommand_from clean" -s v -l verbose -d 'Use
 complete -c cargo -n "__fish_seen_subcommand_from clean" -l frozen -d 'Require Cargo.lock and cache are up to date'
 complete -c cargo -n "__fish_seen_subcommand_from clean" -l locked -d 'Require Cargo.lock is up to date'
 complete -c cargo -n "__fish_seen_subcommand_from clean" -l offline -d 'Run without accessing the network'
-complete -c cargo -n "__fish_seen_subcommand_from complete" -l color -d 'Coloring: auto, always, never'
-complete -c cargo -n "__fish_seen_subcommand_from complete" -l config -d 'Override a configuration value (unstable)'
-complete -c cargo -n "__fish_seen_subcommand_from complete" -s Z -d 'Unstable (nightly-only) flags to Cargo, see \'cargo -Z help\' for details'
-complete -c cargo -n "__fish_seen_subcommand_from complete" -s h -l help -d 'Prints help information'
-complete -c cargo -n "__fish_seen_subcommand_from complete" -s V -l version -d 'Prints version information'
-complete -c cargo -n "__fish_seen_subcommand_from complete" -s v -l verbose -d 'Use verbose output (-vv very verbose/build.rs output)'
-complete -c cargo -n "__fish_seen_subcommand_from complete" -l frozen -d 'Require Cargo.lock and cache are up to date'
-complete -c cargo -n "__fish_seen_subcommand_from complete" -l locked -d 'Require Cargo.lock is up to date'
-complete -c cargo -n "__fish_seen_subcommand_from complete" -l offline -d 'Run without accessing the network'
 complete -c cargo -n "__fish_seen_subcommand_from d doc" -s p -l package -d 'Package to document'
 complete -c cargo -n "__fish_seen_subcommand_from d doc" -l exclude -d 'Exclude packages from the build'
 complete -c cargo -n "__fish_seen_subcommand_from d doc" -s j -l jobs -d 'Number of parallel jobs, defaults to # of CPUs'


### PR DESCRIPTION
This was never added to cargo, and the PR was closed without merging.
See <https://github.com/rust-lang/cargo/pull/9288>.

cargo is in the process of stabilizing a new completions feature:
`CARGO_COMPLETE=fish cargo +nightly`.

## TODOs:
<!-- Check off what what has been done so far. -->
- [x] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->

---

I added a note to the comment about how the completions were generated. I was torn on whether to remove it entirely.