### PR TITLE
Propagate SIGINT from function processes

### DIFF
--- a/src/exec.rs
+++ b/src/exec.rs
@@ -38,6 +38,7 @@ use crate::proc::{
 };
 use crate::reader::{reader_run_count, restore_term_mode};
 use crate::redirection::{Dup2List, dup2_list_resolve_chain};
+use crate::signal::RawSignal;
 use crate::threads::{ThreadPool, is_forked_child};
 use crate::trace::trace_if_enabled_with_args;
 use crate::tty_handoff::TtyHandoff;
@@ -46,8 +47,8 @@ use errno::{errno, set_errno};
 use fish_common::{ScopeGuard, exit_without_destructors, truncate_at_nul, write_loop};
 use fish_widestring::{ToWString as _, bytes2wcstring, wcs2bytes, wcs2zstring};
 use libc::{
-    EACCES, ENOENT, ENOEXEC, ENOTDIR, EPIPE, EXIT_FAILURE, EXIT_SUCCESS, STDERR_FILENO,
-    STDIN_FILENO, STDOUT_FILENO,
+    EACCES, ENOENT, ENOEXEC, ENOTDIR, EPIPE, EXIT_FAILURE, EXIT_SUCCESS, SIGINT, SIGQUIT,
+    STDERR_FILENO, STDIN_FILENO, STDOUT_FILENO,
 };
 use nix::{
     fcntl::OFlag,
@@ -1102,7 +1103,14 @@ fn exec_block_or_func_process(
         // Note this may fail if the function was erased.
         get_performer_for_function(p, j, &io_chain)?
     };
-    p.status.set(performer(parser, None, None));
+    let status = performer(parser, None, None);
+    p.status.set(status);
+    if status.signal_exited() {
+        let sig = status.signal_code();
+        if is_interactive_session() && [SIGINT, SIGQUIT].contains(&sig) {
+            j.group().cancel_with_signal(RawSignal::new(sig));
+        }
+    }
 
     // If we have a block output buffer, populate it now.
     let mut buffer_contents = vec![];

--- a/src/parse_execution.rs
+++ b/src/parse_execution.rs
@@ -136,6 +136,10 @@ impl ExecutionContext {
         &self.pstree
     }
 
+    pub fn cancel_signal(&self) -> Option<RawSignal> {
+        self.cancel_signal
+    }
+
     pub fn eval_node(
         &mut self,
         ctx: &mut OperationContext<'_>,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -709,6 +709,8 @@ impl Parser {
         let sig = signal_check_cancel();
         if sig != 0 {
             EvalRes::new(ProcStatus::from_signal(RawSignal::new(sig)))
+        } else if let Some(sig) = execution_context.cancel_signal() {
+            EvalRes::new(ProcStatus::from_signal(sig))
         } else {
             let status = ProcStatus::from_exit_code(self.last_status());
             let break_expand = reason == EndExecutionReason::Error;

--- a/tests/pexpects/sigint.py
+++ b/tests/pexpects/sigint.py
@@ -2,7 +2,8 @@
 from pexpect_helper import SpawnedProc
 
 sp = SpawnedProc()
-sendline, sleep, expect_prompt, expect_str = (
+send, sendline, sleep, expect_prompt, expect_str = (
+    sp.send,
     sp.sendline,
     sp.sleep,
     sp.expect_prompt,
@@ -25,4 +26,14 @@ expect_prompt()
 
 sendline("echo it worked")
 expect_str("it worked")
+expect_prompt()
+
+sendline("function interrupt_test; sleep 1; echo hello; end")
+expect_prompt()
+sendline("while true; interrupt_test; end")
+sleep(0.30)
+send("\x03")  # ctrl-c
+expect_prompt()
+sendline("echo loop interrupted")
+expect_str("loop interrupted")
 expect_prompt()


### PR DESCRIPTION
Fixes #11673.

Summary:
- cancel the surrounding interactive job group when a function or block process returns SIGINT/SIGQUIT
- preserve the ExecutionContext cancellation signal when returning eval status
- add pexpect coverage for Ctrl-C inside an interactive function loop

Tests:
- CARGO_HOME=/tmp/fish-11673-cargo-home CARGO_TARGET_DIR=/tmp/fish-11673-target cargo build
- PATH=/tmp/fish-11673-py/bin:$PATH CARGO_HOME=/tmp/fish-11673-cargo-home CARGO_TARGET_DIR=/tmp/fish-11673-target /tmp/fish-11673-py/bin/python tests/test_driver.py /tmp/fish-11673-target/debug tests/pexpects/sigint.py tests/pexpects/signals.py
- PATH=/tmp/fish-11673-py/bin:$PATH CARGO_HOME=/tmp/fish-11673-cargo-home CARGO_TARGET_DIR=/tmp/fish-11673-target /tmp/fish-11673-py/bin/python tests/test_driver.py /tmp/fish-11673-target/debug tests/checks/sigint.fish tests/checks/sigint2.fish
- CARGO_HOME=/tmp/fish-11673-cargo-home CARGO_TARGET_DIR=/tmp/fish-11673-target cargo test test_cancellation
- cargo fmt --check
- git diff --check