### PR TITLE
Fix nested brace space trimming

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Interactive improvements
 Other improvements
 ------------------
 - ``cd`` supports the ``-L`` and ``-P`` options, like other shells, to allow specifying whether symbolic links (symlinks) are resolved when changing directories (:issue:`7206`).
+- Nested brace expansions now strip unquoted leading and trailing spaces from entries consistently (:issue:`12794`).
 
 For distributors and developers
 -------------------------------

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -836,7 +836,14 @@ fn expand_braces(
     }
 
     let Some(brace_begin) = brace_begin else {
-        // No more brace expansions left; we can return the value as-is.
+        // No more brace expansions left; restore spaces that were protected while
+        // expanding braces and return the value as-is.
+        let mut input = input;
+        for c in input.as_char_slice_mut() {
+            if *c == BRACE_SPACE {
+                *c = ' ';
+            }
+        }
         if !out.add(input) {
             return append_overflow_error(errors, None);
         }
@@ -853,12 +860,7 @@ fn expand_braces(
             assert!(pos >= item_begin);
             let item_len = pos - item_begin;
             let item = input[item_begin..pos].to_owned();
-            let mut item = trim(item, Some(wstr::from_char_slice(&[BRACE_SPACE, '\0'])));
-            for c in item.as_char_slice_mut() {
-                if *c == BRACE_SPACE {
-                    *c = ' ';
-                }
-            }
+            let item = trim(item, Some(wstr::from_char_slice(&[BRACE_SPACE, '\0'])));
 
             // `whole_item` is a whitespace- and brace-stripped member of a single pass of brace
             // expansion, e.g. in `{ alpha , b,{c, d }}`, `alpha`, `b`, and `c, d` will, in the

--- a/tests/checks/braces.fish
+++ b/tests/checks/braces.fish
@@ -9,6 +9,12 @@ echo x-{1,2}
 echo foo-{1,2{3,4}}
 #CHECK: foo-1 foo-23 foo-24
 
+# Nested brace entries also strip unquoted leading/trailing spaces.
+echo foo-{bar, baz-{far, faz}}
+#CHECK: foo-bar foo-baz-far foo-baz-faz
+echo foo-{bar, baz-{far ,faz}}
+#CHECK: foo-bar foo-baz-far foo-baz-faz
+
 echo foo-{} # literal "{}" expands to itself
 #CHECK: foo-{}
 


### PR DESCRIPTION
## TODOs:
- [x] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [x] Changes to fish usage are reflected in user documentation/manpages. (No docs/manpage change needed; this restores consistent brace-expansion spacing.)
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst

## Summary
- Delay restoring protected brace spaces until recursive brace expansion reaches a leaf, so nested brace elements can trim their own boundary spaces.
- Add a regression test for nested brace entries with leading and trailing spaces.
- Note the fix in the unreleased changelog.

Fixes #12794.
