### PR TITLE
fix acidhub prompt to properly handle bare git repo

### DIFF
--- a/share/prompts/acidhub.fish
+++ b/share/prompts/acidhub.fish
@@ -14,6 +14,7 @@ function fish_prompt -d "Write out the prompt"
         set git_branch (set_color -o blue)"$git_branch"
         set -l git_status
         if git rev-parse --quiet --verify HEAD >/dev/null
+            and not git rev-parse --is-bare-repository >/dev/null
             and not command git diff-index --quiet HEAD --
 
             for i in (git status --porcelain | string sub -l 2 | sort | uniq)


### PR DESCRIPTION
Fixes #12807 


## TODOs:
<!-- Check off what what has been done so far. -->
- [ ] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
