### PR TITLE
completions/emerge: update against portage 3.0.79

### DIFF
--- a/localization/po/de.po
+++ b/localization/po/de.po
@@ -5141,6 +5141,9 @@ msgstr "Über die Shell auf Konfigurationsdatei zugreifen"
 msgid "Access repository settings"
 msgstr ""
 
+msgid "Account for library link-level deps during --depclean and --prune (default: y)"
+msgstr ""
+
 msgid "Account to be altered"
 msgstr ""
 
@@ -5927,6 +5930,9 @@ msgstr ""
 msgid "Add packages"
 msgstr "Pakete hinzufügen"
 
+msgid "Add packages to @world (inverse of --oneshot)"
+msgstr ""
+
 msgid "Add parts on top of the section hierarchy"
 msgstr ""
 
@@ -6587,11 +6593,20 @@ msgstr ""
 msgid "Allow automatically filling CAPTCHA"
 msgstr ""
 
+msgid "Allow autounmask to create package.license changes"
+msgstr ""
+
+msgid "Allow autounmask to create package.use changes (enabled by default)"
+msgstr ""
+
 msgid "Allow backspace and carriage return"
 msgstr "Rückschritt und Zeilenschaltung zulassen"
 
 msgid "Allow backspace, tab and carriage return"
 msgstr "Rückschritt, Tab und Zeilenschaltung zulassen"
+
+msgid "Allow backtracking after autounmask detects necessary changes"
+msgstr ""
 
 msgid "Allow binary files to be diffed"
 msgstr ""
@@ -7691,6 +7706,9 @@ msgstr ""
 msgid "Apply automated posting rules to modify txns"
 msgstr ""
 
+msgid "Apply autounmask changes and continue to execute command"
+msgstr ""
+
 msgid "Apply changes from a Differential diff"
 msgstr ""
 
@@ -7815,6 +7833,9 @@ msgid "Apply option to this zone"
 msgstr ""
 
 msgid "Apply options to a portion of the image [geometry]"
+msgstr ""
+
+msgid "Apply package moves when necessary (default: y; do not disable normally)"
 msgstr ""
 
 msgid "Apply packagefiles to the subproject"
@@ -8210,6 +8231,9 @@ msgstr "Nein als Standardantwort annehmen"
 msgid "Assume no to all questions"
 msgstr "Für alle Fragen nein annehmen"
 
+msgid "Assume packages may have implicit deps on @system (default: y)"
+msgstr ""
+
 msgid "Assume patches were created with old/new files swapped"
 msgstr ""
 
@@ -8346,6 +8370,9 @@ msgid "Assume yes when asked for confirmation"
 msgstr ""
 
 msgid "Assumes that structures should have 8 byte alignment"
+msgstr ""
+
+msgid "Atoms for which no binary packages should be built"
 msgstr ""
 
 msgid "Attach a USB device to the host"
@@ -8540,6 +8567,12 @@ msgstr ""
 msgid "Auto-confirm non-security prompts"
 msgstr ""
 
+msgid "Auto-detect regex in search strings (default: y)"
+msgstr ""
+
+msgid "Auto-enable --with-bdeps for installation actions (default: y)"
+msgstr ""
+
 msgid "Auto-gen package cache"
 msgstr "Paketcache automatisch generieren"
 
@@ -8667,6 +8700,9 @@ msgid "Automatically sync the repository"
 msgstr ""
 
 msgid "Automatically trust and import new repository signing keys"
+msgstr ""
+
+msgid "Automatically unmasks packages and generates package.use settings"
 msgstr ""
 
 msgid "Automatically update the packet display as packets are coming in"
@@ -9038,6 +9074,9 @@ msgstr ""
 msgid "Binary input mode"
 msgstr ""
 
+msgid "Binary package format to create"
+msgstr ""
+
 msgid "Binary-only mode, abort if no archive available"
 msgstr ""
 
@@ -9326,7 +9365,7 @@ msgstr ""
 msgid "Build a Windows executable"
 msgstr ""
 
-msgid "Build a binary pkg additionally"
+msgid "Build a binary package in addition to merging"
 msgstr ""
 
 msgid "Build a console executable"
@@ -10355,6 +10394,9 @@ msgstr ""
 msgid "Check and fix problems in the world file"
 msgstr ""
 
+msgid "Check and update the dependency cache of all ebuilds in repository"
+msgstr ""
+
 msgid "Check and wait until a group of devices of a filesystem is ready for mount"
 msgstr ""
 
@@ -11157,6 +11199,9 @@ msgid "Clean up cache directory"
 msgstr ""
 
 msgid "Clean up releases, stemcells, disks, etc."
+msgstr ""
+
+msgid "Clean up temp files after a build failure (useful with PORTAGE_TMPDIR on tmpfs)"
 msgstr ""
 
 msgid "Clean up the files that Cobertura Maven Plugin has created during instrumentation"
@@ -12518,6 +12563,9 @@ msgstr ""
 msgid "Consider case when comparing file names"
 msgstr "Groß-/Kleinschreibung beim Dateinamenvergleich beachten"
 
+msgid "Consider deep deps of all @world packages; bail if the operation would break any"
+msgstr ""
+
 msgid "Consider files as separate"
 msgstr ""
 
@@ -12621,6 +12669,9 @@ msgid "Continue after an error"
 msgstr "Fortsetzung nach Fehler"
 
 msgid "Continue as much as possible after an error"
+msgstr ""
+
+msgid "Continue as much as possible after an error; recalculate deps for remaining packages"
 msgstr ""
 
 msgid "Continue conversation with given id"
@@ -12804,6 +12855,9 @@ msgid "Control whether GCC places uninitialized local variables into the \"bss\"
 msgstr ""
 
 msgid "Control whether RTC is in local time"
+msgstr ""
+
+msgid "Control whether build-time deps go into ROOT or /"
 msgstr ""
 
 msgid "Control whether color is used"
@@ -17345,6 +17399,9 @@ msgstr ""
 msgid "Display a help page"
 msgstr ""
 
+msgid "Display a list of available package sets"
+msgstr ""
+
 msgid "Display a list of speedtest.net servers sorted by distance"
 msgstr ""
 
@@ -17442,6 +17499,9 @@ msgid "Display all values currently available"
 msgstr ""
 
 msgid "Display an archive's list to console"
+msgstr ""
+
+msgid "Display ancillary information required for bug reports"
 msgstr ""
 
 msgid "Display answers as exclamation points and missing packets as dots"
@@ -18662,6 +18722,9 @@ msgstr ""
 msgid "Display toolbar or menubar"
 msgstr ""
 
+msgid "Display total of unread GLEP 42 news items"
+msgstr ""
+
 msgid "Display untracked files in columns"
 msgstr ""
 
@@ -19817,6 +19880,9 @@ msgstr ""
 msgid "Do not install files from given subprojects"
 msgstr ""
 
+msgid "Do not install from binary packages for live ebuilds"
+msgstr ""
+
 msgid "Do not install recommended packages"
 msgstr ""
 
@@ -20177,6 +20243,12 @@ msgstr ""
 msgid "Do not rebuild before running tests"
 msgstr ""
 
+msgid "Do not rebuild matching packages due to --rebuild"
+msgstr ""
+
+msgid "Do not rebuild packages that depend on matching packages due to --rebuild"
+msgstr ""
+
 msgid "Do not recalculate the effective rights mask"
 msgstr ""
 
@@ -20523,6 +20595,9 @@ msgid "Do not start ghostscript in safe mode"
 msgstr ""
 
 msgid "Do not start ghostscript with the -dQUIET option"
+msgstr ""
+
+msgid "Do not start new builds if load average is at least LOAD"
 msgstr ""
 
 msgid "Do not start the commit message editor"
@@ -30959,6 +31034,9 @@ msgstr ""
 msgid "Ignore 'Content-Length' header"
 msgstr "Kopfzeile für 'Content-Length' ignorieren"
 
+msgid "Ignore @world deps; may break installed packages (use with --ask)"
+msgstr ""
+
 msgid "Ignore CD/DVD repositories"
 msgstr ""
 
@@ -31047,6 +31125,12 @@ msgid "Ignore any balance assertions"
 msgstr ""
 
 msgid "Ignore any saved configuration"
+msgstr ""
+
+msgid "Ignore binary packages whose USE flags differ from current config"
+msgstr ""
+
+msgid "Ignore binary packages whose ebuild dependencies changed since the build"
 msgstr ""
 
 msgid "Ignore bogus module names"
@@ -31211,6 +31295,9 @@ msgstr ""
 msgid "Ignore logical volume identity"
 msgstr ""
 
+msgid "Ignore matching binary packages"
+msgstr ""
+
 msgid "Ignore md5sum"
 msgstr ""
 
@@ -31251,6 +31338,9 @@ msgid "Ignore non-authenticated packages"
 msgstr "Nicht authentifizierte Pakete ignorieren"
 
 msgid "Ignore non-existing files on receiving side"
+msgstr ""
+
+msgid "Ignore non-matching binary packages"
 msgstr ""
 
 msgid "Ignore nonexistent files"
@@ -31305,6 +31395,12 @@ msgid "Ignore safety checks"
 msgstr ""
 
 msgid "Ignore scissor lines"
+msgstr ""
+
+msgid "Ignore slot/sub-slot := operator deps recorded at build time (debug only)"
+msgstr ""
+
+msgid "Ignore soname dependencies of binary and installed packages (default: y)"
 msgstr ""
 
 msgid "Ignore spaces after function names"
@@ -31913,6 +32009,9 @@ msgstr ""
 msgid "Include inherited options"
 msgstr ""
 
+msgid "Include install-time deps when --onlydeps and --onlydeps-with-rdeps=n are used"
+msgstr ""
+
 msgid "Include installed pkgs with changed USE flags"
 msgstr ""
 
@@ -32013,6 +32112,9 @@ msgid "Include residual signal in text output"
 msgstr ""
 
 msgid "Include reverse dependencies in the output"
+msgstr ""
+
+msgid "Include run-time deps when using --onlydeps (default: y)"
 msgstr ""
 
 msgid "Include secret key comment packets when exporting secret keys"
@@ -33714,6 +33816,15 @@ msgid "Like --method=md5crypt"
 msgstr ""
 
 msgid "Like --reuse-message, but allow editing commit message"
+msgstr ""
+
+msgid "Like --search, but also matches package descriptions"
+msgstr ""
+
+msgid "Like --unmerge but with CLEAN_DELAY=0; can remove critical packages"
+msgstr ""
+
+msgid "Like --update but only for packages already installed"
 msgstr ""
 
 msgid "Like --write-batch but w/o updating dest"
@@ -35642,6 +35753,9 @@ msgstr "Pakete nach Herkunft auflisten"
 msgid "List packages by provider"
 msgstr "Pakete nach Anbieter auflisten"
 
+msgid "List packages causing slot rebuilds in emerge output (default: y)"
+msgstr ""
+
 msgid "List packages depending on"
 msgstr "Pakete auflisten, die abhängen von"
 
@@ -37430,6 +37544,9 @@ msgstr ""
 msgid "Make zipfile as old as the latest entry"
 msgstr "Zip-Datei erhält Datum des jüngsten Eintrages"
 
+msgid "Makes --ask reject single Enter keypresses as answers"
+msgstr ""
+
 msgid "Makes COM type information in specified assemblies available to the project"
 msgstr ""
 
@@ -37931,6 +38048,9 @@ msgstr ""
 msgid "Match pattern against full command line"
 msgstr ""
 
+msgid "Match search strings approximately; auto-disabled for regex searches (default: y)"
+msgstr ""
+
 msgid "Match secondary date instead"
 msgstr ""
 
@@ -37959,6 +38079,9 @@ msgid "Max memory, as scaled integer (default KiB)"
 msgstr ""
 
 msgid "Max num of children"
+msgstr ""
+
+msgid "Max number of times to backtrack on dependency conflicts (default: 20)"
 msgstr ""
 
 msgid "Max objects per response"
@@ -38276,6 +38399,9 @@ msgstr ""
 msgid "Minimum drive buffer fill ratio for the ATAPI wait mode"
 msgstr ""
 
+msgid "Minimum free GiB in PORTAGE_TMPDIR before starting more jobs (default: 18)"
+msgstr ""
+
 msgid "Minimum height when --height is given in percent"
 msgstr ""
 
@@ -38299,6 +38425,9 @@ msgstr ""
 
 msgid "Minimum port to listen to"
 msgstr "Niedrigster Port, an dem gelauscht wird"
+
+msgid "Minimum similarity percentage for fuzzy search results (default: 80)"
+msgstr ""
 
 msgid "Minimum stability (empty or one of: stable, RC, beta, alpha, dev)"
 msgstr ""
@@ -39506,6 +39635,9 @@ msgstr ""
 msgid "Number of octets per line"
 msgstr ""
 
+msgid "Number of packages to build simultaneously (0 = CPU count)"
+msgstr ""
+
 msgid "Number of pages to scan before the shared memory service goes to sleep"
 msgstr ""
 
@@ -39713,6 +39845,9 @@ msgstr ""
 msgid "Offensive fortunes only"
 msgstr ""
 
+msgid "Offer to read unread news via eselect when --ask is active"
+msgstr ""
+
 msgid "Offline migration"
 msgstr ""
 
@@ -39896,6 +40031,9 @@ msgstr "Nur auf Sortierung testen"
 msgid "Only connect if safe console handling is supported"
 msgstr ""
 
+msgid "Only consider rebuilt binaries with BUILD_TIME newer than TIMESTAMP"
+msgstr ""
+
 msgid "Only consider tags matching the given glob pattern"
 msgstr ""
 
@@ -39984,6 +40122,9 @@ msgid "Only expire unused working trees older than <time>"
 msgstr ""
 
 msgid "Only fail the build afterwards; allow all non-impacted builds to continue"
+msgstr ""
+
+msgid "Only fetch remote binary packages matching these atoms"
 msgstr ""
 
 msgid "Only fixate disk "
@@ -40380,6 +40521,9 @@ msgid "Only this package's library"
 msgstr ""
 
 msgid "Only uninstall the binary NAME"
+msgstr ""
+
+msgid "Only unmask and generate package.use settings without building anything"
 msgstr ""
 
 msgid "Only update the manifest"
@@ -43496,6 +43640,9 @@ msgstr ""
 msgid "Prefer lowest versions of dependencies"
 msgstr ""
 
+msgid "Prefer matching binary packages over newer unbuilt ebuilds"
+msgstr ""
+
 msgid "Prefer reading from other devices than these"
 msgstr ""
 
@@ -43845,6 +43992,12 @@ msgid "Prevent adding rpath for each used dynamic library"
 msgstr ""
 
 msgid "Prevent any configuration changes to domain until migration ends"
+msgstr ""
+
+msgid "Prevent autounmask from creating package.accept_keywords changes"
+msgstr ""
+
+msgid "Prevent autounmask from creating package.unmask or ** keyword changes"
 msgstr ""
 
 msgid "Prevent floating point registers from being used in any manner"
@@ -47393,6 +47546,9 @@ msgstr ""
 msgid "Pull in changes from another branch"
 msgstr ""
 
+msgid "Pull in test-conditional deps for matched packages even if test is not in FEATURES"
+msgstr ""
+
 msgid "Pull list of shunned references from server"
 msgstr ""
 
@@ -48464,6 +48620,18 @@ msgstr ""
 msgid "Rebuild modules installed in node_modules in current working directory"
 msgstr ""
 
+msgid "Rebuild packages when a new slot can satisfy := deps (default: y)"
+msgstr ""
+
+msgid "Rebuild packages when build-time deps are built from source"
+msgstr ""
+
+msgid "Rebuild packages when build-time deps are installed with a new revision"
+msgstr ""
+
+msgid "Rebuild packages when build-time deps are installed with a new version"
+msgstr ""
+
 msgid "Rebuild ports containing broken binaries"
 msgstr ""
 
@@ -48504,6 +48672,9 @@ msgid "Recognize Boost format strings (only language C++)"
 msgstr ""
 
 msgid "Recognize Qt format strings (only language C++)"
+msgstr ""
+
+msgid "Recompile a package if it is now pulled from a different repository"
 msgstr ""
 
 msgid "Recompile every Sass file, even if the CSS file is newer"
@@ -48728,6 +48899,9 @@ msgstr ""
 msgid "Redeploy artifact on Weblogic server(s) or cluster(s)"
 msgstr ""
 
+msgid "Redirect all build output to logs; display on failure"
+msgstr ""
+
 msgid "Redirect all messages into a file"
 msgstr ""
 
@@ -48902,6 +49076,9 @@ msgstr ""
 msgid "Regenerate library dependency metadata"
 msgstr ""
 
+msgid "Regenerate package manifests (prefer repoman manifest)"
+msgstr ""
+
 msgid "Regex flags: use `--help` instead of `-h` to see details"
 msgstr ""
 
@@ -49023,6 +49200,9 @@ msgid "Reinstall packages"
 msgstr "Pakete neu installieren"
 
 msgid "Reinstall packages required by this package"
+msgstr ""
+
+msgid "Reinstall packages whose active USE flags changed since installation (ignores added/removed disabled flags)"
 msgstr ""
 
 msgid "Reinstall the app keeping its data"
@@ -49182,6 +49362,9 @@ msgid "Remote Path"
 msgstr ""
 
 msgid "Remote alias"
+msgstr ""
+
+msgid "Remote binary packages matching these atoms are not fetched"
 msgstr ""
 
 msgid "Remote branch ref used by `git push`"
@@ -49406,6 +49589,9 @@ msgstr ""
 msgid "Remove all but the given number of backups"
 msgstr ""
 
+msgid "Remove all but the most recently installed version in each slot"
+msgstr ""
+
 msgid "Remove all classes attributes"
 msgstr ""
 
@@ -49440,6 +49626,9 @@ msgid "Remove all gz files from cache"
 msgstr "Alle gz-Dateien aus dem Zwischenspeicher entfernen"
 
 msgid "Remove all lines matching key"
+msgstr ""
+
+msgid "Remove all matching packages without checking dependencies"
 msgstr ""
 
 msgid "Remove all mutations"
@@ -49539,6 +49728,9 @@ msgid "Remove artifacts that cargo has generated in the past"
 msgstr ""
 
 msgid "Remove associated storage volumes"
+msgstr ""
+
+msgid "Remove atoms/sets from @world. Implied by uninstall actions (use --deselect=n to prevent)"
 msgstr ""
 
 msgid "Remove auto-generated configuration files left over by the daemon"
@@ -49766,6 +49958,9 @@ msgstr ""
 msgid "Remove matching variables"
 msgstr ""
 
+msgid "Remove merge-order constraint from --tree output for readability"
+msgstr ""
+
 msgid "Remove module"
 msgstr ""
 
@@ -49815,6 +50010,9 @@ msgid "Remove only ignored files"
 msgstr ""
 
 msgid "Remove only locks with specified repository"
+msgstr ""
+
+msgid "Remove orphaned dependencies (packages not in @world and not required by other packages)"
 msgstr ""
 
 msgid "Remove orphaned libraries (not required by installed packages)"
@@ -50133,6 +50331,9 @@ msgid "Removes a package from the require-dev section"
 msgstr ""
 
 msgid "Removes a remote"
+msgstr ""
+
+msgid "Removes all but the highest installed version of a package from your system"
 msgstr ""
 
 msgid "Removes all cache"
@@ -50474,6 +50675,9 @@ msgstr ""
 msgid "Replace include directories"
 msgstr "include-Verzeichnisse ersetzen"
 
+msgid "Replace installed packages with binary packages that have been rebuilt"
+msgstr ""
+
 msgid "Replace non-graphic characters with '?'"
 msgstr "Nicht darstellbare Zeichen durch '?' ersetzen"
 
@@ -50481,6 +50685,12 @@ msgid "Replace only the last occurrence"
 msgstr ""
 
 msgid "Replace packages in the base layer"
+msgstr ""
+
+msgid "Replace packages whose ebuild SLOT metadata changed since they were built"
+msgstr ""
+
+msgid "Replace packages whose ebuild dependencies changed since they were built"
 msgstr ""
 
 msgid "Replace patch header"
@@ -50679,6 +50889,9 @@ msgid "Report on mode of file"
 msgstr ""
 
 msgid "Report outstanding replies"
+msgstr ""
+
+msgid "Report packages whose ebuild dependencies changed since installation"
 msgstr ""
 
 msgid "Report processor frequency and idle statistics"
@@ -51416,6 +51629,9 @@ msgstr ""
 msgid "Restow: delete and then stow again"
 msgstr ""
 
+msgid "Restrict --sync to specified submodule (rsync only); repeatable"
+msgstr ""
+
 msgid "Restrict access"
 msgstr ""
 
@@ -51504,6 +51720,9 @@ msgid "Resume previously canceled or interrupted scrub"
 msgstr ""
 
 msgid "Resume reactor from specified project"
+msgstr ""
+
+msgid "Resumes the most recent merge list that aborted due to an error"
 msgstr ""
 
 msgid "Resync package contents from source"
@@ -52037,6 +52256,9 @@ msgstr ""
 msgid "Root source tree"
 msgstr "Ursprung des Quellbaumes"
 
+msgid "Root to use as --quickpkg-direct source (default: /)"
+msgstr ""
+
 msgid "Rotate log every kbytes, requires -f"
 msgstr ""
 
@@ -52554,6 +52776,9 @@ msgid "Run package manager within chroot"
 msgstr ""
 
 msgid "Run package manager within jail"
+msgstr ""
+
+msgid "Run package-specific actions after emerge (usually config setup)"
 msgstr ""
 
 msgid "Run patch phase of a port"
@@ -53688,6 +53913,9 @@ msgid "Search directory for makefile"
 msgstr "Verzeichnis nach makefile durchsuchen"
 
 msgid "Search documentation"
+msgstr ""
+
+msgid "Search ebuilds for <string>. Use `%<string>` for regex"
 msgstr ""
 
 msgid "Search files according to the specified search mask"
@@ -54956,6 +55184,9 @@ msgstr ""
 msgid "Set EDNS0 Max UDP packet size"
 msgstr ""
 
+msgid "Set EPREFIX"
+msgstr ""
+
 msgid "Set GDB's working directory"
 msgstr ""
 
@@ -54992,6 +55223,9 @@ msgstr ""
 msgid "Set NDOTS value"
 msgstr ""
 
+msgid "Set PORTAGE_CONFIGROOT"
+msgstr ""
+
 msgid "Set PTRACE_O_EXITKILL ptrace option to all tracee processes"
 msgstr ""
 
@@ -55011,6 +55245,9 @@ msgid "Set RAW writing mode"
 msgstr ""
 
 msgid "Set REQUESTER PAYS for operations"
+msgstr ""
+
+msgid "Set ROOT (target root filesystem)"
 msgstr ""
 
 msgid "Set Rails environment"
@@ -55035,6 +55272,9 @@ msgid "Set SMART data for a drive"
 msgstr ""
 
 msgid "Set SO_DEBUG socket option"
+msgstr ""
+
+msgid "Set SYSROOT (root for DEPEND build-time deps)"
 msgstr ""
 
 msgid "Set TAO (Track At Once) writing mode"
@@ -58331,9 +58571,6 @@ msgstr ""
 msgid "Show camera driver manual"
 msgstr ""
 
-msgid "Show changelog of pkg. Use with --pretend"
-msgstr ""
-
 msgid "Show changes between commits and working tree"
 msgstr ""
 
@@ -59840,6 +60077,9 @@ msgstr ""
 msgid "Show signatures and descriptions for the available functions"
 msgstr ""
 
+msgid "Show similar package names when a package is not found (default: y)"
+msgstr ""
+
 msgid "Show sizes in GiB, or GB with --si"
 msgstr ""
 
@@ -61343,6 +61583,9 @@ msgstr ""
 msgid "Skip package installation for this run"
 msgstr ""
 
+msgid "Skip packages already installed (same as --noreplace; use =n to force disable)"
+msgstr ""
+
 msgid "Skip pre/post hook scripts"
 msgstr ""
 
@@ -61622,6 +61865,9 @@ msgstr ""
 msgid "Sort files by name"
 msgstr ""
 
+msgid "Sort flag lists alphabetically"
+msgstr ""
+
 msgid "Sort languages based on column"
 msgstr ""
 
@@ -61770,6 +62016,9 @@ msgid "Source-only mode"
 msgstr ""
 
 msgid "Space or comma separated list of features to activate"
+msgstr ""
+
+msgid "Space-separated atoms to never install"
 msgstr ""
 
 msgid "Space-separated options to exclude from search"
@@ -65183,6 +65432,9 @@ msgstr ""
 msgid "Substitute %{var}% variables"
 msgstr ""
 
+msgid "Substitute installed-package deps with current ebuild deps during calculations (default: y)"
+msgstr ""
+
 msgid "Substitute one word for another"
 msgstr ""
 
@@ -65270,6 +65522,9 @@ msgstr ""
 msgid "Suppress --noImplicitAny errors for indexing objects lacking index signatures"
 msgstr ""
 
+msgid "Suppress ::repository in merge list; use numbers instead"
+msgstr ""
+
 msgid "Suppress SNAPSHOT updates"
 msgstr ""
 
@@ -65302,6 +65557,9 @@ msgstr ""
 
 msgid "Suppress battery information"
 msgstr "Akku-Informationen unterdrücken"
+
+msgid "Suppress build log display on failure (show only die message and log path)"
+msgstr ""
 
 msgid "Suppress checkout"
 msgstr ""
@@ -65446,6 +65704,9 @@ msgstr "Warnung über fehlenden MDC-Integritätsschutz unterdrücken"
 
 msgid "Suppress the warning about unsafe file and home directory (--homedir) permissions"
 msgstr "Warnung über unsichere Datei- und Startverzeichnisberechtigungen (--homedir) unterdrücken"
+
+msgid "Suppress the warning shown before --unmerge actions"
+msgstr ""
 
 msgid "Suppress thermal information"
 msgstr ""
@@ -66120,6 +66381,12 @@ msgid "Temporarily lock an active home area"
 msgstr ""
 
 msgid "Temporarily offline"
+msgstr ""
+
+msgid "Temporarily override ACCEPT_PROPERTIES (e.g. =-interactive)"
+msgstr ""
+
+msgid "Temporarily override ACCEPT_RESTRICT (e.g. =-bindist)"
 msgstr ""
 
 msgid "Temporary mount point property"
@@ -67598,6 +67865,9 @@ msgstr ""
 msgid "Treat keyboard as standard US keyboard"
 msgstr ""
 
+msgid "Treat matching packages as not installed and reinstall them"
+msgstr ""
+
 msgid "Treat newlines as hard line breaks"
 msgstr ""
 
@@ -67674,6 +67944,12 @@ msgid "Treated as MOZ_LOG_FILE=<file> environment variable, overrides it"
 msgstr ""
 
 msgid "Tree location"
+msgstr ""
+
+msgid "Trigger --complete-graph when USE or IUSE changes for an installed package (default: y)"
+msgstr ""
+
+msgid "Trigger --complete-graph when an installed package version changes (default: y)"
 msgstr ""
 
 msgid "Trigger DHCP reconfiguration of all connected clients"
@@ -68831,6 +69107,9 @@ msgstr ""
 msgid "Update packages"
 msgstr ""
 
+msgid "Update packages to best available version"
+msgstr ""
+
 msgid "Update parts of an existing network's configuration"
 msgstr ""
 
@@ -68856,6 +69135,9 @@ msgid "Update remote repositories"
 msgstr ""
 
 msgid "Update remote state from local state"
+msgstr ""
+
+msgid "Update repositories. Use without arguments to update all autosync repos"
 msgstr ""
 
 msgid "Update repository indexes"
@@ -70280,6 +70562,9 @@ msgstr ""
 msgid "Use dot character instead of braille"
 msgstr ""
 
+msgid "Use ebuilds for deps; binary packages only for explicitly named atoms"
+msgstr ""
+
 msgid "Use editor to modify kernel arguments"
 msgstr ""
 
@@ -70497,6 +70782,9 @@ msgid "Use input from pipe of emerge -pv"
 msgstr ""
 
 msgid "Use insecure TLS connection"
+msgstr ""
+
+msgid "Use installed packages directly as binary packages"
 msgstr ""
 
 msgid "Use instead of host if you want to address 255.255.255.255"
@@ -71204,6 +71492,9 @@ msgstr ""
 msgid "Use the dynamic section info when displaying symbols"
 msgstr ""
 
+msgid "Use the egencache-built search index (default: y)"
+msgstr ""
+
 msgid "Use the file's modification time as the time of import."
 msgstr ""
 
@@ -71487,6 +71778,9 @@ msgid "Use translations under given directory"
 msgstr ""
 
 msgid "Use uglier formatting"
+msgstr ""
+
+msgid "Use unbuilt ebuild metadata for visibility checks on built packages"
 msgstr ""
 
 msgid "Use unicode characters in the output"
@@ -72467,6 +72761,9 @@ msgstr ""
 msgid "Warn if variadic macros are used in pedantic mode"
 msgstr ""
 
+msgid "Warn on @world packages with no available ebuild (default: y)"
+msgstr ""
+
 msgid "Warn on lint"
 msgstr ""
 
@@ -73196,6 +73493,9 @@ msgstr "Attribut-Unterpakete auf angegebenen Dateideskriptor schreiben"
 msgid "Write attribute value"
 msgstr ""
 
+msgid "Write autounmask changes to config files (implied by --ask)"
+msgstr ""
+
 msgid "Write column names in results"
 msgstr ""
 
@@ -73248,6 +73548,9 @@ msgid "Write index to a file"
 msgstr ""
 
 msgid "Write index to specified file"
+msgstr ""
+
+msgid "Write keyword/mask changes using >= operators instead of ="
 msgstr ""
 
 msgid "Write line numbers for errors"

--- a/localization/po/es.po
+++ b/localization/po/es.po
@@ -5141,6 +5141,9 @@ msgstr ""
 msgid "Access repository settings"
 msgstr ""
 
+msgid "Account for library link-level deps during --depclean and --prune (default: y)"
+msgstr ""
+
 msgid "Account to be altered"
 msgstr ""
 
@@ -5927,6 +5930,9 @@ msgstr ""
 msgid "Add packages"
 msgstr ""
 
+msgid "Add packages to @world (inverse of --oneshot)"
+msgstr ""
+
 msgid "Add parts on top of the section hierarchy"
 msgstr ""
 
@@ -6587,10 +6593,19 @@ msgstr ""
 msgid "Allow automatically filling CAPTCHA"
 msgstr ""
 
+msgid "Allow autounmask to create package.license changes"
+msgstr ""
+
+msgid "Allow autounmask to create package.use changes (enabled by default)"
+msgstr ""
+
 msgid "Allow backspace and carriage return"
 msgstr ""
 
 msgid "Allow backspace, tab and carriage return"
+msgstr ""
+
+msgid "Allow backtracking after autounmask detects necessary changes"
 msgstr ""
 
 msgid "Allow binary files to be diffed"
@@ -7691,6 +7706,9 @@ msgstr ""
 msgid "Apply automated posting rules to modify txns"
 msgstr ""
 
+msgid "Apply autounmask changes and continue to execute command"
+msgstr ""
+
 msgid "Apply changes from a Differential diff"
 msgstr ""
 
@@ -7815,6 +7833,9 @@ msgid "Apply option to this zone"
 msgstr ""
 
 msgid "Apply options to a portion of the image [geometry]"
+msgstr ""
+
+msgid "Apply package moves when necessary (default: y; do not disable normally)"
 msgstr ""
 
 msgid "Apply packagefiles to the subproject"
@@ -8210,6 +8231,9 @@ msgstr ""
 msgid "Assume no to all questions"
 msgstr ""
 
+msgid "Assume packages may have implicit deps on @system (default: y)"
+msgstr ""
+
 msgid "Assume patches were created with old/new files swapped"
 msgstr ""
 
@@ -8346,6 +8370,9 @@ msgid "Assume yes when asked for confirmation"
 msgstr ""
 
 msgid "Assumes that structures should have 8 byte alignment"
+msgstr ""
+
+msgid "Atoms for which no binary packages should be built"
 msgstr ""
 
 msgid "Attach a USB device to the host"
@@ -8540,6 +8567,12 @@ msgstr ""
 msgid "Auto-confirm non-security prompts"
 msgstr ""
 
+msgid "Auto-detect regex in search strings (default: y)"
+msgstr ""
+
+msgid "Auto-enable --with-bdeps for installation actions (default: y)"
+msgstr ""
+
 msgid "Auto-gen package cache"
 msgstr ""
 
@@ -8667,6 +8700,9 @@ msgid "Automatically sync the repository"
 msgstr ""
 
 msgid "Automatically trust and import new repository signing keys"
+msgstr ""
+
+msgid "Automatically unmasks packages and generates package.use settings"
 msgstr ""
 
 msgid "Automatically update the packet display as packets are coming in"
@@ -9038,6 +9074,9 @@ msgstr ""
 msgid "Binary input mode"
 msgstr ""
 
+msgid "Binary package format to create"
+msgstr ""
+
 msgid "Binary-only mode, abort if no archive available"
 msgstr ""
 
@@ -9326,7 +9365,7 @@ msgstr ""
 msgid "Build a Windows executable"
 msgstr ""
 
-msgid "Build a binary pkg additionally"
+msgid "Build a binary package in addition to merging"
 msgstr ""
 
 msgid "Build a console executable"
@@ -10355,6 +10394,9 @@ msgstr ""
 msgid "Check and fix problems in the world file"
 msgstr ""
 
+msgid "Check and update the dependency cache of all ebuilds in repository"
+msgstr ""
+
 msgid "Check and wait until a group of devices of a filesystem is ready for mount"
 msgstr ""
 
@@ -11157,6 +11199,9 @@ msgid "Clean up cache directory"
 msgstr ""
 
 msgid "Clean up releases, stemcells, disks, etc."
+msgstr ""
+
+msgid "Clean up temp files after a build failure (useful with PORTAGE_TMPDIR on tmpfs)"
 msgstr ""
 
 msgid "Clean up the files that Cobertura Maven Plugin has created during instrumentation"
@@ -12518,6 +12563,9 @@ msgstr ""
 msgid "Consider case when comparing file names"
 msgstr ""
 
+msgid "Consider deep deps of all @world packages; bail if the operation would break any"
+msgstr ""
+
 msgid "Consider files as separate"
 msgstr ""
 
@@ -12621,6 +12669,9 @@ msgid "Continue after an error"
 msgstr ""
 
 msgid "Continue as much as possible after an error"
+msgstr ""
+
+msgid "Continue as much as possible after an error; recalculate deps for remaining packages"
 msgstr ""
 
 msgid "Continue conversation with given id"
@@ -12804,6 +12855,9 @@ msgid "Control whether GCC places uninitialized local variables into the \"bss\"
 msgstr ""
 
 msgid "Control whether RTC is in local time"
+msgstr ""
+
+msgid "Control whether build-time deps go into ROOT or /"
 msgstr ""
 
 msgid "Control whether color is used"
@@ -17345,6 +17399,9 @@ msgstr ""
 msgid "Display a help page"
 msgstr ""
 
+msgid "Display a list of available package sets"
+msgstr ""
+
 msgid "Display a list of speedtest.net servers sorted by distance"
 msgstr ""
 
@@ -17442,6 +17499,9 @@ msgid "Display all values currently available"
 msgstr ""
 
 msgid "Display an archive's list to console"
+msgstr ""
+
+msgid "Display ancillary information required for bug reports"
 msgstr ""
 
 msgid "Display answers as exclamation points and missing packets as dots"
@@ -18662,6 +18722,9 @@ msgstr ""
 msgid "Display toolbar or menubar"
 msgstr ""
 
+msgid "Display total of unread GLEP 42 news items"
+msgstr ""
+
 msgid "Display untracked files in columns"
 msgstr ""
 
@@ -19817,6 +19880,9 @@ msgstr ""
 msgid "Do not install files from given subprojects"
 msgstr ""
 
+msgid "Do not install from binary packages for live ebuilds"
+msgstr ""
+
 msgid "Do not install recommended packages"
 msgstr ""
 
@@ -20177,6 +20243,12 @@ msgstr ""
 msgid "Do not rebuild before running tests"
 msgstr ""
 
+msgid "Do not rebuild matching packages due to --rebuild"
+msgstr ""
+
+msgid "Do not rebuild packages that depend on matching packages due to --rebuild"
+msgstr ""
+
 msgid "Do not recalculate the effective rights mask"
 msgstr ""
 
@@ -20523,6 +20595,9 @@ msgid "Do not start ghostscript in safe mode"
 msgstr ""
 
 msgid "Do not start ghostscript with the -dQUIET option"
+msgstr ""
+
+msgid "Do not start new builds if load average is at least LOAD"
 msgstr ""
 
 msgid "Do not start the commit message editor"
@@ -30959,6 +31034,9 @@ msgstr ""
 msgid "Ignore 'Content-Length' header"
 msgstr ""
 
+msgid "Ignore @world deps; may break installed packages (use with --ask)"
+msgstr ""
+
 msgid "Ignore CD/DVD repositories"
 msgstr ""
 
@@ -31047,6 +31125,12 @@ msgid "Ignore any balance assertions"
 msgstr ""
 
 msgid "Ignore any saved configuration"
+msgstr ""
+
+msgid "Ignore binary packages whose USE flags differ from current config"
+msgstr ""
+
+msgid "Ignore binary packages whose ebuild dependencies changed since the build"
 msgstr ""
 
 msgid "Ignore bogus module names"
@@ -31211,6 +31295,9 @@ msgstr ""
 msgid "Ignore logical volume identity"
 msgstr ""
 
+msgid "Ignore matching binary packages"
+msgstr ""
+
 msgid "Ignore md5sum"
 msgstr ""
 
@@ -31251,6 +31338,9 @@ msgid "Ignore non-authenticated packages"
 msgstr ""
 
 msgid "Ignore non-existing files on receiving side"
+msgstr ""
+
+msgid "Ignore non-matching binary packages"
 msgstr ""
 
 msgid "Ignore nonexistent files"
@@ -31305,6 +31395,12 @@ msgid "Ignore safety checks"
 msgstr ""
 
 msgid "Ignore scissor lines"
+msgstr ""
+
+msgid "Ignore slot/sub-slot := operator deps recorded at build time (debug only)"
+msgstr ""
+
+msgid "Ignore soname dependencies of binary and installed packages (default: y)"
 msgstr ""
 
 msgid "Ignore spaces after function names"
@@ -31913,6 +32009,9 @@ msgstr ""
 msgid "Include inherited options"
 msgstr ""
 
+msgid "Include install-time deps when --onlydeps and --onlydeps-with-rdeps=n are used"
+msgstr ""
+
 msgid "Include installed pkgs with changed USE flags"
 msgstr ""
 
@@ -32013,6 +32112,9 @@ msgid "Include residual signal in text output"
 msgstr ""
 
 msgid "Include reverse dependencies in the output"
+msgstr ""
+
+msgid "Include run-time deps when using --onlydeps (default: y)"
 msgstr ""
 
 msgid "Include secret key comment packets when exporting secret keys"
@@ -33714,6 +33816,15 @@ msgid "Like --method=md5crypt"
 msgstr ""
 
 msgid "Like --reuse-message, but allow editing commit message"
+msgstr ""
+
+msgid "Like --search, but also matches package descriptions"
+msgstr ""
+
+msgid "Like --unmerge but with CLEAN_DELAY=0; can remove critical packages"
+msgstr ""
+
+msgid "Like --update but only for packages already installed"
 msgstr ""
 
 msgid "Like --write-batch but w/o updating dest"
@@ -35642,6 +35753,9 @@ msgstr ""
 msgid "List packages by provider"
 msgstr ""
 
+msgid "List packages causing slot rebuilds in emerge output (default: y)"
+msgstr ""
+
 msgid "List packages depending on"
 msgstr ""
 
@@ -37430,6 +37544,9 @@ msgstr ""
 msgid "Make zipfile as old as the latest entry"
 msgstr ""
 
+msgid "Makes --ask reject single Enter keypresses as answers"
+msgstr ""
+
 msgid "Makes COM type information in specified assemblies available to the project"
 msgstr ""
 
@@ -37931,6 +38048,9 @@ msgstr ""
 msgid "Match pattern against full command line"
 msgstr ""
 
+msgid "Match search strings approximately; auto-disabled for regex searches (default: y)"
+msgstr ""
+
 msgid "Match secondary date instead"
 msgstr ""
 
@@ -37959,6 +38079,9 @@ msgid "Max memory, as scaled integer (default KiB)"
 msgstr ""
 
 msgid "Max num of children"
+msgstr ""
+
+msgid "Max number of times to backtrack on dependency conflicts (default: 20)"
 msgstr ""
 
 msgid "Max objects per response"
@@ -38276,6 +38399,9 @@ msgstr ""
 msgid "Minimum drive buffer fill ratio for the ATAPI wait mode"
 msgstr ""
 
+msgid "Minimum free GiB in PORTAGE_TMPDIR before starting more jobs (default: 18)"
+msgstr ""
+
 msgid "Minimum height when --height is given in percent"
 msgstr ""
 
@@ -38298,6 +38424,9 @@ msgid "Minimum payload size for sweeping pings"
 msgstr ""
 
 msgid "Minimum port to listen to"
+msgstr ""
+
+msgid "Minimum similarity percentage for fuzzy search results (default: 80)"
 msgstr ""
 
 msgid "Minimum stability (empty or one of: stable, RC, beta, alpha, dev)"
@@ -39506,6 +39635,9 @@ msgstr ""
 msgid "Number of octets per line"
 msgstr ""
 
+msgid "Number of packages to build simultaneously (0 = CPU count)"
+msgstr ""
+
 msgid "Number of pages to scan before the shared memory service goes to sleep"
 msgstr ""
 
@@ -39713,6 +39845,9 @@ msgstr ""
 msgid "Offensive fortunes only"
 msgstr ""
 
+msgid "Offer to read unread news via eselect when --ask is active"
+msgstr ""
+
 msgid "Offline migration"
 msgstr ""
 
@@ -39896,6 +40031,9 @@ msgstr ""
 msgid "Only connect if safe console handling is supported"
 msgstr ""
 
+msgid "Only consider rebuilt binaries with BUILD_TIME newer than TIMESTAMP"
+msgstr ""
+
 msgid "Only consider tags matching the given glob pattern"
 msgstr ""
 
@@ -39984,6 +40122,9 @@ msgid "Only expire unused working trees older than <time>"
 msgstr ""
 
 msgid "Only fail the build afterwards; allow all non-impacted builds to continue"
+msgstr ""
+
+msgid "Only fetch remote binary packages matching these atoms"
 msgstr ""
 
 msgid "Only fixate disk "
@@ -40380,6 +40521,9 @@ msgid "Only this package's library"
 msgstr ""
 
 msgid "Only uninstall the binary NAME"
+msgstr ""
+
+msgid "Only unmask and generate package.use settings without building anything"
 msgstr ""
 
 msgid "Only update the manifest"
@@ -43496,6 +43640,9 @@ msgstr ""
 msgid "Prefer lowest versions of dependencies"
 msgstr ""
 
+msgid "Prefer matching binary packages over newer unbuilt ebuilds"
+msgstr ""
+
 msgid "Prefer reading from other devices than these"
 msgstr ""
 
@@ -43845,6 +43992,12 @@ msgid "Prevent adding rpath for each used dynamic library"
 msgstr ""
 
 msgid "Prevent any configuration changes to domain until migration ends"
+msgstr ""
+
+msgid "Prevent autounmask from creating package.accept_keywords changes"
+msgstr ""
+
+msgid "Prevent autounmask from creating package.unmask or ** keyword changes"
 msgstr ""
 
 msgid "Prevent floating point registers from being used in any manner"
@@ -47393,6 +47546,9 @@ msgstr ""
 msgid "Pull in changes from another branch"
 msgstr ""
 
+msgid "Pull in test-conditional deps for matched packages even if test is not in FEATURES"
+msgstr ""
+
 msgid "Pull list of shunned references from server"
 msgstr ""
 
@@ -48464,6 +48620,18 @@ msgstr ""
 msgid "Rebuild modules installed in node_modules in current working directory"
 msgstr ""
 
+msgid "Rebuild packages when a new slot can satisfy := deps (default: y)"
+msgstr ""
+
+msgid "Rebuild packages when build-time deps are built from source"
+msgstr ""
+
+msgid "Rebuild packages when build-time deps are installed with a new revision"
+msgstr ""
+
+msgid "Rebuild packages when build-time deps are installed with a new version"
+msgstr ""
+
 msgid "Rebuild ports containing broken binaries"
 msgstr ""
 
@@ -48504,6 +48672,9 @@ msgid "Recognize Boost format strings (only language C++)"
 msgstr ""
 
 msgid "Recognize Qt format strings (only language C++)"
+msgstr ""
+
+msgid "Recompile a package if it is now pulled from a different repository"
 msgstr ""
 
 msgid "Recompile every Sass file, even if the CSS file is newer"
@@ -48728,6 +48899,9 @@ msgstr ""
 msgid "Redeploy artifact on Weblogic server(s) or cluster(s)"
 msgstr ""
 
+msgid "Redirect all build output to logs; display on failure"
+msgstr ""
+
 msgid "Redirect all messages into a file"
 msgstr ""
 
@@ -48902,6 +49076,9 @@ msgstr ""
 msgid "Regenerate library dependency metadata"
 msgstr ""
 
+msgid "Regenerate package manifests (prefer repoman manifest)"
+msgstr ""
+
 msgid "Regex flags: use `--help` instead of `-h` to see details"
 msgstr ""
 
@@ -49023,6 +49200,9 @@ msgid "Reinstall packages"
 msgstr ""
 
 msgid "Reinstall packages required by this package"
+msgstr ""
+
+msgid "Reinstall packages whose active USE flags changed since installation (ignores added/removed disabled flags)"
 msgstr ""
 
 msgid "Reinstall the app keeping its data"
@@ -49182,6 +49362,9 @@ msgid "Remote Path"
 msgstr ""
 
 msgid "Remote alias"
+msgstr ""
+
+msgid "Remote binary packages matching these atoms are not fetched"
 msgstr ""
 
 msgid "Remote branch ref used by `git push`"
@@ -49406,6 +49589,9 @@ msgstr ""
 msgid "Remove all but the given number of backups"
 msgstr ""
 
+msgid "Remove all but the most recently installed version in each slot"
+msgstr ""
+
 msgid "Remove all classes attributes"
 msgstr ""
 
@@ -49440,6 +49626,9 @@ msgid "Remove all gz files from cache"
 msgstr ""
 
 msgid "Remove all lines matching key"
+msgstr ""
+
+msgid "Remove all matching packages without checking dependencies"
 msgstr ""
 
 msgid "Remove all mutations"
@@ -49539,6 +49728,9 @@ msgid "Remove artifacts that cargo has generated in the past"
 msgstr ""
 
 msgid "Remove associated storage volumes"
+msgstr ""
+
+msgid "Remove atoms/sets from @world. Implied by uninstall actions (use --deselect=n to prevent)"
 msgstr ""
 
 msgid "Remove auto-generated configuration files left over by the daemon"
@@ -49766,6 +49958,9 @@ msgstr ""
 msgid "Remove matching variables"
 msgstr ""
 
+msgid "Remove merge-order constraint from --tree output for readability"
+msgstr ""
+
 msgid "Remove module"
 msgstr ""
 
@@ -49815,6 +50010,9 @@ msgid "Remove only ignored files"
 msgstr ""
 
 msgid "Remove only locks with specified repository"
+msgstr ""
+
+msgid "Remove orphaned dependencies (packages not in @world and not required by other packages)"
 msgstr ""
 
 msgid "Remove orphaned libraries (not required by installed packages)"
@@ -50133,6 +50331,9 @@ msgid "Removes a package from the require-dev section"
 msgstr ""
 
 msgid "Removes a remote"
+msgstr ""
+
+msgid "Removes all but the highest installed version of a package from your system"
 msgstr ""
 
 msgid "Removes all cache"
@@ -50474,6 +50675,9 @@ msgstr ""
 msgid "Replace include directories"
 msgstr ""
 
+msgid "Replace installed packages with binary packages that have been rebuilt"
+msgstr ""
+
 msgid "Replace non-graphic characters with '?'"
 msgstr ""
 
@@ -50481,6 +50685,12 @@ msgid "Replace only the last occurrence"
 msgstr ""
 
 msgid "Replace packages in the base layer"
+msgstr ""
+
+msgid "Replace packages whose ebuild SLOT metadata changed since they were built"
+msgstr ""
+
+msgid "Replace packages whose ebuild dependencies changed since they were built"
 msgstr ""
 
 msgid "Replace patch header"
@@ -50679,6 +50889,9 @@ msgid "Report on mode of file"
 msgstr ""
 
 msgid "Report outstanding replies"
+msgstr ""
+
+msgid "Report packages whose ebuild dependencies changed since installation"
 msgstr ""
 
 msgid "Report processor frequency and idle statistics"
@@ -51416,6 +51629,9 @@ msgstr ""
 msgid "Restow: delete and then stow again"
 msgstr ""
 
+msgid "Restrict --sync to specified submodule (rsync only); repeatable"
+msgstr ""
+
 msgid "Restrict access"
 msgstr ""
 
@@ -51504,6 +51720,9 @@ msgid "Resume previously canceled or interrupted scrub"
 msgstr ""
 
 msgid "Resume reactor from specified project"
+msgstr ""
+
+msgid "Resumes the most recent merge list that aborted due to an error"
 msgstr ""
 
 msgid "Resync package contents from source"
@@ -52037,6 +52256,9 @@ msgstr ""
 msgid "Root source tree"
 msgstr ""
 
+msgid "Root to use as --quickpkg-direct source (default: /)"
+msgstr ""
+
 msgid "Rotate log every kbytes, requires -f"
 msgstr ""
 
@@ -52554,6 +52776,9 @@ msgid "Run package manager within chroot"
 msgstr ""
 
 msgid "Run package manager within jail"
+msgstr ""
+
+msgid "Run package-specific actions after emerge (usually config setup)"
 msgstr ""
 
 msgid "Run patch phase of a port"
@@ -53688,6 +53913,9 @@ msgid "Search directory for makefile"
 msgstr ""
 
 msgid "Search documentation"
+msgstr ""
+
+msgid "Search ebuilds for <string>. Use `%<string>` for regex"
 msgstr ""
 
 msgid "Search files according to the specified search mask"
@@ -54956,6 +55184,9 @@ msgstr ""
 msgid "Set EDNS0 Max UDP packet size"
 msgstr ""
 
+msgid "Set EPREFIX"
+msgstr ""
+
 msgid "Set GDB's working directory"
 msgstr ""
 
@@ -54992,6 +55223,9 @@ msgstr ""
 msgid "Set NDOTS value"
 msgstr ""
 
+msgid "Set PORTAGE_CONFIGROOT"
+msgstr ""
+
 msgid "Set PTRACE_O_EXITKILL ptrace option to all tracee processes"
 msgstr ""
 
@@ -55011,6 +55245,9 @@ msgid "Set RAW writing mode"
 msgstr ""
 
 msgid "Set REQUESTER PAYS for operations"
+msgstr ""
+
+msgid "Set ROOT (target root filesystem)"
 msgstr ""
 
 msgid "Set Rails environment"
@@ -55035,6 +55272,9 @@ msgid "Set SMART data for a drive"
 msgstr ""
 
 msgid "Set SO_DEBUG socket option"
+msgstr ""
+
+msgid "Set SYSROOT (root for DEPEND build-time deps)"
 msgstr ""
 
 msgid "Set TAO (Track At Once) writing mode"
@@ -58331,9 +58571,6 @@ msgstr ""
 msgid "Show camera driver manual"
 msgstr ""
 
-msgid "Show changelog of pkg. Use with --pretend"
-msgstr ""
-
 msgid "Show changes between commits and working tree"
 msgstr ""
 
@@ -59840,6 +60077,9 @@ msgstr ""
 msgid "Show signatures and descriptions for the available functions"
 msgstr ""
 
+msgid "Show similar package names when a package is not found (default: y)"
+msgstr ""
+
 msgid "Show sizes in GiB, or GB with --si"
 msgstr ""
 
@@ -61343,6 +61583,9 @@ msgstr ""
 msgid "Skip package installation for this run"
 msgstr ""
 
+msgid "Skip packages already installed (same as --noreplace; use =n to force disable)"
+msgstr ""
+
 msgid "Skip pre/post hook scripts"
 msgstr ""
 
@@ -61622,6 +61865,9 @@ msgstr ""
 msgid "Sort files by name"
 msgstr ""
 
+msgid "Sort flag lists alphabetically"
+msgstr ""
+
 msgid "Sort languages based on column"
 msgstr ""
 
@@ -61770,6 +62016,9 @@ msgid "Source-only mode"
 msgstr ""
 
 msgid "Space or comma separated list of features to activate"
+msgstr ""
+
+msgid "Space-separated atoms to never install"
 msgstr ""
 
 msgid "Space-separated options to exclude from search"
@@ -65183,6 +65432,9 @@ msgstr ""
 msgid "Substitute %{var}% variables"
 msgstr ""
 
+msgid "Substitute installed-package deps with current ebuild deps during calculations (default: y)"
+msgstr ""
+
 msgid "Substitute one word for another"
 msgstr ""
 
@@ -65270,6 +65522,9 @@ msgstr ""
 msgid "Suppress --noImplicitAny errors for indexing objects lacking index signatures"
 msgstr ""
 
+msgid "Suppress ::repository in merge list; use numbers instead"
+msgstr ""
+
 msgid "Suppress SNAPSHOT updates"
 msgstr ""
 
@@ -65301,6 +65556,9 @@ msgid "Suppress any output"
 msgstr ""
 
 msgid "Suppress battery information"
+msgstr ""
+
+msgid "Suppress build log display on failure (show only die message and log path)"
 msgstr ""
 
 msgid "Suppress checkout"
@@ -65445,6 +65703,9 @@ msgid "Suppress the warning about missing MDC integrity protection"
 msgstr ""
 
 msgid "Suppress the warning about unsafe file and home directory (--homedir) permissions"
+msgstr ""
+
+msgid "Suppress the warning shown before --unmerge actions"
 msgstr ""
 
 msgid "Suppress thermal information"
@@ -66120,6 +66381,12 @@ msgid "Temporarily lock an active home area"
 msgstr ""
 
 msgid "Temporarily offline"
+msgstr ""
+
+msgid "Temporarily override ACCEPT_PROPERTIES (e.g. =-interactive)"
+msgstr ""
+
+msgid "Temporarily override ACCEPT_RESTRICT (e.g. =-bindist)"
 msgstr ""
 
 msgid "Temporary mount point property"
@@ -67598,6 +67865,9 @@ msgstr ""
 msgid "Treat keyboard as standard US keyboard"
 msgstr ""
 
+msgid "Treat matching packages as not installed and reinstall them"
+msgstr ""
+
 msgid "Treat newlines as hard line breaks"
 msgstr ""
 
@@ -67674,6 +67944,12 @@ msgid "Treated as MOZ_LOG_FILE=<file> environment variable, overrides it"
 msgstr ""
 
 msgid "Tree location"
+msgstr ""
+
+msgid "Trigger --complete-graph when USE or IUSE changes for an installed package (default: y)"
+msgstr ""
+
+msgid "Trigger --complete-graph when an installed package version changes (default: y)"
 msgstr ""
 
 msgid "Trigger DHCP reconfiguration of all connected clients"
@@ -68831,6 +69107,9 @@ msgstr ""
 msgid "Update packages"
 msgstr ""
 
+msgid "Update packages to best available version"
+msgstr ""
+
 msgid "Update parts of an existing network's configuration"
 msgstr ""
 
@@ -68856,6 +69135,9 @@ msgid "Update remote repositories"
 msgstr ""
 
 msgid "Update remote state from local state"
+msgstr ""
+
+msgid "Update repositories. Use without arguments to update all autosync repos"
 msgstr ""
 
 msgid "Update repository indexes"
@@ -70280,6 +70562,9 @@ msgstr ""
 msgid "Use dot character instead of braille"
 msgstr ""
 
+msgid "Use ebuilds for deps; binary packages only for explicitly named atoms"
+msgstr ""
+
 msgid "Use editor to modify kernel arguments"
 msgstr ""
 
@@ -70497,6 +70782,9 @@ msgid "Use input from pipe of emerge -pv"
 msgstr ""
 
 msgid "Use insecure TLS connection"
+msgstr ""
+
+msgid "Use installed packages directly as binary packages"
 msgstr ""
 
 msgid "Use instead of host if you want to address 255.255.255.255"
@@ -71204,6 +71492,9 @@ msgstr ""
 msgid "Use the dynamic section info when displaying symbols"
 msgstr ""
 
+msgid "Use the egencache-built search index (default: y)"
+msgstr ""
+
 msgid "Use the file's modification time as the time of import."
 msgstr ""
 
@@ -71487,6 +71778,9 @@ msgid "Use translations under given directory"
 msgstr ""
 
 msgid "Use uglier formatting"
+msgstr ""
+
+msgid "Use unbuilt ebuild metadata for visibility checks on built packages"
 msgstr ""
 
 msgid "Use unicode characters in the output"
@@ -72467,6 +72761,9 @@ msgstr ""
 msgid "Warn if variadic macros are used in pedantic mode"
 msgstr ""
 
+msgid "Warn on @world packages with no available ebuild (default: y)"
+msgstr ""
+
 msgid "Warn on lint"
 msgstr ""
 
@@ -73196,6 +73493,9 @@ msgstr ""
 msgid "Write attribute value"
 msgstr ""
 
+msgid "Write autounmask changes to config files (implied by --ask)"
+msgstr ""
+
 msgid "Write column names in results"
 msgstr ""
 
@@ -73248,6 +73548,9 @@ msgid "Write index to a file"
 msgstr ""
 
 msgid "Write index to specified file"
+msgstr ""
+
+msgid "Write keyword/mask changes using >= operators instead of ="
 msgstr ""
 
 msgid "Write line numbers for errors"

--- a/localization/po/fr.po
+++ b/localization/po/fr.po
@@ -5270,6 +5270,9 @@ msgstr "Accéder au fichier de configuration à partir du shell"
 msgid "Access repository settings"
 msgstr "Accéder aux paramètres du dépôt"
 
+msgid "Account for library link-level deps during --depclean and --prune (default: y)"
+msgstr ""
+
 msgid "Account to be altered"
 msgstr ""
 
@@ -6056,6 +6059,9 @@ msgstr ""
 msgid "Add packages"
 msgstr ""
 
+msgid "Add packages to @world (inverse of --oneshot)"
+msgstr ""
+
 msgid "Add parts on top of the section hierarchy"
 msgstr ""
 
@@ -6716,11 +6722,20 @@ msgstr ""
 msgid "Allow automatically filling CAPTCHA"
 msgstr "Autoriser le remplissage automatique des captchas"
 
+msgid "Allow autounmask to create package.license changes"
+msgstr ""
+
+msgid "Allow autounmask to create package.use changes (enabled by default)"
+msgstr ""
+
 msgid "Allow backspace and carriage return"
 msgstr "Afficher tels quels les retours arrière et chariot"
 
 msgid "Allow backspace, tab and carriage return"
 msgstr "Afficher tels quels les tabulations et retours arrière et chariot"
+
+msgid "Allow backtracking after autounmask detects necessary changes"
+msgstr ""
 
 msgid "Allow binary files to be diffed"
 msgstr "Autoriser les diffs de binaires"
@@ -7820,6 +7835,9 @@ msgstr ""
 msgid "Apply automated posting rules to modify txns"
 msgstr ""
 
+msgid "Apply autounmask changes and continue to execute command"
+msgstr ""
+
 msgid "Apply changes from a Differential diff"
 msgstr ""
 
@@ -7944,6 +7962,9 @@ msgid "Apply option to this zone"
 msgstr ""
 
 msgid "Apply options to a portion of the image [geometry]"
+msgstr ""
+
+msgid "Apply package moves when necessary (default: y; do not disable normally)"
 msgstr ""
 
 msgid "Apply packagefiles to the subproject"
@@ -8339,6 +8360,9 @@ msgstr "Présumer non comme réponse à la plupart des questions"
 msgid "Assume no to all questions"
 msgstr "Présumer non à toutes les questions"
 
+msgid "Assume packages may have implicit deps on @system (default: y)"
+msgstr ""
+
 msgid "Assume patches were created with old/new files swapped"
 msgstr ""
 
@@ -8475,6 +8499,9 @@ msgid "Assume yes when asked for confirmation"
 msgstr ""
 
 msgid "Assumes that structures should have 8 byte alignment"
+msgstr ""
+
+msgid "Atoms for which no binary packages should be built"
 msgstr ""
 
 msgid "Attach a USB device to the host"
@@ -8669,6 +8696,12 @@ msgstr ""
 msgid "Auto-confirm non-security prompts"
 msgstr ""
 
+msgid "Auto-detect regex in search strings (default: y)"
+msgstr ""
+
+msgid "Auto-enable --with-bdeps for installation actions (default: y)"
+msgstr ""
+
 msgid "Auto-gen package cache"
 msgstr "Générer automatiquement le cache des paquets"
 
@@ -8796,6 +8829,9 @@ msgid "Automatically sync the repository"
 msgstr "Synchroniser automatiquement le dépôt"
 
 msgid "Automatically trust and import new repository signing keys"
+msgstr ""
+
+msgid "Automatically unmasks packages and generates package.use settings"
 msgstr ""
 
 msgid "Automatically update the packet display as packets are coming in"
@@ -9167,6 +9203,9 @@ msgstr "Motif glob pour les binaires"
 msgid "Binary input mode"
 msgstr ""
 
+msgid "Binary package format to create"
+msgstr ""
+
 msgid "Binary-only mode, abort if no archive available"
 msgstr ""
 
@@ -9455,7 +9494,7 @@ msgstr ""
 msgid "Build a Windows executable"
 msgstr ""
 
-msgid "Build a binary pkg additionally"
+msgid "Build a binary package in addition to merging"
 msgstr ""
 
 msgid "Build a console executable"
@@ -10484,6 +10523,9 @@ msgstr ""
 msgid "Check and fix problems in the world file"
 msgstr ""
 
+msgid "Check and update the dependency cache of all ebuilds in repository"
+msgstr ""
+
 msgid "Check and wait until a group of devices of a filesystem is ready for mount"
 msgstr ""
 
@@ -11286,6 +11328,9 @@ msgid "Clean up cache directory"
 msgstr "Nettoyer le dossier de cache"
 
 msgid "Clean up releases, stemcells, disks, etc."
+msgstr ""
+
+msgid "Clean up temp files after a build failure (useful with PORTAGE_TMPDIR on tmpfs)"
 msgstr ""
 
 msgid "Clean up the files that Cobertura Maven Plugin has created during instrumentation"
@@ -12647,6 +12692,9 @@ msgstr "Traiter les liens symboliques brisés comme des fichiers inexistants"
 msgid "Consider case when comparing file names"
 msgstr "Agir sensiblement à la casse en comparant les noms de fichier"
 
+msgid "Consider deep deps of all @world packages; bail if the operation would break any"
+msgstr ""
+
 msgid "Consider files as separate"
 msgstr ""
 
@@ -12750,6 +12798,9 @@ msgid "Continue after an error"
 msgstr ""
 
 msgid "Continue as much as possible after an error"
+msgstr ""
+
+msgid "Continue as much as possible after an error; recalculate deps for remaining packages"
 msgstr ""
 
 msgid "Continue conversation with given id"
@@ -12933,6 +12984,9 @@ msgid "Control whether GCC places uninitialized local variables into the \"bss\"
 msgstr "Contrôle le placement par GCC des variables locales dans la section « bss » ou « data »"
 
 msgid "Control whether RTC is in local time"
+msgstr ""
+
+msgid "Control whether build-time deps go into ROOT or /"
 msgstr ""
 
 msgid "Control whether color is used"
@@ -17474,6 +17528,9 @@ msgstr "Afficher l’aide"
 msgid "Display a help page"
 msgstr "Afficher une page d’aide"
 
+msgid "Display a list of available package sets"
+msgstr ""
+
 msgid "Display a list of speedtest.net servers sorted by distance"
 msgstr ""
 
@@ -17571,6 +17628,9 @@ msgid "Display all values currently available"
 msgstr ""
 
 msgid "Display an archive's list to console"
+msgstr ""
+
+msgid "Display ancillary information required for bug reports"
 msgstr ""
 
 msgid "Display answers as exclamation points and missing packets as dots"
@@ -18791,6 +18851,9 @@ msgstr ""
 msgid "Display toolbar or menubar"
 msgstr ""
 
+msgid "Display total of unread GLEP 42 news items"
+msgstr ""
+
 msgid "Display untracked files in columns"
 msgstr ""
 
@@ -19946,6 +20009,9 @@ msgstr ""
 msgid "Do not install files from given subprojects"
 msgstr ""
 
+msgid "Do not install from binary packages for live ebuilds"
+msgstr ""
+
 msgid "Do not install recommended packages"
 msgstr "Ne pas installer les paquets recommandés"
 
@@ -20306,6 +20372,12 @@ msgstr ""
 msgid "Do not rebuild before running tests"
 msgstr ""
 
+msgid "Do not rebuild matching packages due to --rebuild"
+msgstr ""
+
+msgid "Do not rebuild packages that depend on matching packages due to --rebuild"
+msgstr ""
+
 msgid "Do not recalculate the effective rights mask"
 msgstr ""
 
@@ -20653,6 +20725,9 @@ msgstr "Ne pas démarrer ghostscript en mode sécurisé"
 
 msgid "Do not start ghostscript with the -dQUIET option"
 msgstr "Ne pas démarrer ghostscript avec l’option « -dQUIET »"
+
+msgid "Do not start new builds if load average is at least LOAD"
+msgstr ""
 
 msgid "Do not start the commit message editor"
 msgstr ""
@@ -31088,6 +31163,9 @@ msgstr ""
 msgid "Ignore 'Content-Length' header"
 msgstr "Ignorer l’en-tête « Content-Length »"
 
+msgid "Ignore @world deps; may break installed packages (use with --ask)"
+msgstr ""
+
 msgid "Ignore CD/DVD repositories"
 msgstr "Ignorer les dépôts sur CD/DVD"
 
@@ -31176,6 +31254,12 @@ msgid "Ignore any balance assertions"
 msgstr ""
 
 msgid "Ignore any saved configuration"
+msgstr ""
+
+msgid "Ignore binary packages whose USE flags differ from current config"
+msgstr ""
+
+msgid "Ignore binary packages whose ebuild dependencies changed since the build"
 msgstr ""
 
 msgid "Ignore bogus module names"
@@ -31340,6 +31424,9 @@ msgstr ""
 msgid "Ignore logical volume identity"
 msgstr ""
 
+msgid "Ignore matching binary packages"
+msgstr ""
+
 msgid "Ignore md5sum"
 msgstr ""
 
@@ -31381,6 +31468,9 @@ msgstr "Ignorer les paquets non-authentifiés"
 
 msgid "Ignore non-existing files on receiving side"
 msgstr "Ignorer les fichiers n’existant pas sur la destination"
+
+msgid "Ignore non-matching binary packages"
+msgstr ""
 
 msgid "Ignore nonexistent files"
 msgstr ""
@@ -31434,6 +31524,12 @@ msgid "Ignore safety checks"
 msgstr ""
 
 msgid "Ignore scissor lines"
+msgstr ""
+
+msgid "Ignore slot/sub-slot := operator deps recorded at build time (debug only)"
+msgstr ""
+
+msgid "Ignore soname dependencies of binary and installed packages (default: y)"
 msgstr ""
 
 msgid "Ignore spaces after function names"
@@ -32042,6 +32138,9 @@ msgstr ""
 msgid "Include inherited options"
 msgstr ""
 
+msgid "Include install-time deps when --onlydeps and --onlydeps-with-rdeps=n are used"
+msgstr ""
+
 msgid "Include installed pkgs with changed USE flags"
 msgstr ""
 
@@ -32143,6 +32242,9 @@ msgstr "Inclure le signal résiduel dans la sortie textuelle"
 
 msgid "Include reverse dependencies in the output"
 msgstr "Inclure les dépendances inverses dans la sortie"
+
+msgid "Include run-time deps when using --onlydeps (default: y)"
+msgstr ""
 
 msgid "Include secret key comment packets when exporting secret keys"
 msgstr "Inclure les paquets de commentaire de la clé privée lors de l’exportation de clés privées"
@@ -33843,6 +33945,15 @@ msgid "Like --method=md5crypt"
 msgstr ""
 
 msgid "Like --reuse-message, but allow editing commit message"
+msgstr ""
+
+msgid "Like --search, but also matches package descriptions"
+msgstr ""
+
+msgid "Like --unmerge but with CLEAN_DELAY=0; can remove critical packages"
+msgstr ""
+
+msgid "Like --update but only for packages already installed"
 msgstr ""
 
 msgid "Like --write-batch but w/o updating dest"
@@ -35771,6 +35882,9 @@ msgstr ""
 msgid "List packages by provider"
 msgstr ""
 
+msgid "List packages causing slot rebuilds in emerge output (default: y)"
+msgstr ""
+
 msgid "List packages depending on"
 msgstr "Lister les dépendances inverses"
 
@@ -37559,6 +37673,9 @@ msgstr ""
 msgid "Make zipfile as old as the latest entry"
 msgstr "Régler l’âge de l’archive à celui de la dernière modification du dernier fichier contenu modifié"
 
+msgid "Makes --ask reject single Enter keypresses as answers"
+msgstr ""
+
 msgid "Makes COM type information in specified assemblies available to the project"
 msgstr ""
 
@@ -38060,6 +38177,9 @@ msgstr ""
 msgid "Match pattern against full command line"
 msgstr ""
 
+msgid "Match search strings approximately; auto-disabled for regex searches (default: y)"
+msgstr ""
+
 msgid "Match secondary date instead"
 msgstr ""
 
@@ -38088,6 +38208,9 @@ msgid "Max memory, as scaled integer (default KiB)"
 msgstr ""
 
 msgid "Max num of children"
+msgstr ""
+
+msgid "Max number of times to backtrack on dependency conflicts (default: 20)"
 msgstr ""
 
 msgid "Max objects per response"
@@ -38405,6 +38528,9 @@ msgstr "Confiance minimale en un problème pour l’afficher"
 msgid "Minimum drive buffer fill ratio for the ATAPI wait mode"
 msgstr ""
 
+msgid "Minimum free GiB in PORTAGE_TMPDIR before starting more jobs (default: 18)"
+msgstr ""
+
 msgid "Minimum height when --height is given in percent"
 msgstr ""
 
@@ -38427,6 +38553,9 @@ msgid "Minimum payload size for sweeping pings"
 msgstr ""
 
 msgid "Minimum port to listen to"
+msgstr ""
+
+msgid "Minimum similarity percentage for fuzzy search results (default: 80)"
 msgstr ""
 
 msgid "Minimum stability (empty or one of: stable, RC, beta, alpha, dev)"
@@ -39635,6 +39764,9 @@ msgstr ""
 msgid "Number of octets per line"
 msgstr ""
 
+msgid "Number of packages to build simultaneously (0 = CPU count)"
+msgstr ""
+
 msgid "Number of pages to scan before the shared memory service goes to sleep"
 msgstr ""
 
@@ -39842,6 +39974,9 @@ msgstr ""
 msgid "Offensive fortunes only"
 msgstr ""
 
+msgid "Offer to read unread news via eselect when --ask is active"
+msgstr ""
+
 msgid "Offline migration"
 msgstr ""
 
@@ -40025,6 +40160,9 @@ msgstr "Vérifier que l’entrée est triée, sans faire le tri"
 msgid "Only connect if safe console handling is supported"
 msgstr ""
 
+msgid "Only consider rebuilt binaries with BUILD_TIME newer than TIMESTAMP"
+msgstr ""
+
 msgid "Only consider tags matching the given glob pattern"
 msgstr ""
 
@@ -40113,6 +40251,9 @@ msgid "Only expire unused working trees older than <time>"
 msgstr ""
 
 msgid "Only fail the build afterwards; allow all non-impacted builds to continue"
+msgstr ""
+
+msgid "Only fetch remote binary packages matching these atoms"
 msgstr ""
 
 msgid "Only fixate disk "
@@ -40509,6 +40650,9 @@ msgid "Only this package's library"
 msgstr ""
 
 msgid "Only uninstall the binary NAME"
+msgstr ""
+
+msgid "Only unmask and generate package.use settings without building anything"
 msgstr ""
 
 msgid "Only update the manifest"
@@ -43625,6 +43769,9 @@ msgstr "Préférer une version ultérieure"
 msgid "Prefer lowest versions of dependencies"
 msgstr ""
 
+msgid "Prefer matching binary packages over newer unbuilt ebuilds"
+msgstr ""
+
 msgid "Prefer reading from other devices than these"
 msgstr ""
 
@@ -43974,6 +44121,12 @@ msgid "Prevent adding rpath for each used dynamic library"
 msgstr ""
 
 msgid "Prevent any configuration changes to domain until migration ends"
+msgstr ""
+
+msgid "Prevent autounmask from creating package.accept_keywords changes"
+msgstr ""
+
+msgid "Prevent autounmask from creating package.unmask or ** keyword changes"
 msgstr ""
 
 msgid "Prevent floating point registers from being used in any manner"
@@ -47522,6 +47675,9 @@ msgstr "Tirer les dépendances de construction"
 msgid "Pull in changes from another branch"
 msgstr "Tirer les modifications depuis une autre branche"
 
+msgid "Pull in test-conditional deps for matched packages even if test is not in FEATURES"
+msgstr ""
+
 msgid "Pull list of shunned references from server"
 msgstr "Tirer la liste des références évitées depuis le serveur"
 
@@ -48593,6 +48749,18 @@ msgstr "Reconstruire le cache des modules pour les paquets installés"
 msgid "Rebuild modules installed in node_modules in current working directory"
 msgstr ""
 
+msgid "Rebuild packages when a new slot can satisfy := deps (default: y)"
+msgstr ""
+
+msgid "Rebuild packages when build-time deps are built from source"
+msgstr ""
+
+msgid "Rebuild packages when build-time deps are installed with a new revision"
+msgstr ""
+
+msgid "Rebuild packages when build-time deps are installed with a new version"
+msgstr ""
+
 msgid "Rebuild ports containing broken binaries"
 msgstr ""
 
@@ -48633,6 +48801,9 @@ msgid "Recognize Boost format strings (only language C++)"
 msgstr ""
 
 msgid "Recognize Qt format strings (only language C++)"
+msgstr ""
+
+msgid "Recompile a package if it is now pulled from a different repository"
 msgstr ""
 
 msgid "Recompile every Sass file, even if the CSS file is newer"
@@ -48857,6 +49028,9 @@ msgstr "Redéfinir la variable"
 msgid "Redeploy artifact on Weblogic server(s) or cluster(s)"
 msgstr ""
 
+msgid "Redirect all build output to logs; display on failure"
+msgstr ""
+
 msgid "Redirect all messages into a file"
 msgstr "Rediriger tous les messages vers un fichier"
 
@@ -49031,6 +49205,9 @@ msgstr ""
 msgid "Regenerate library dependency metadata"
 msgstr ""
 
+msgid "Regenerate package manifests (prefer repoman manifest)"
+msgstr ""
+
 msgid "Regex flags: use `--help` instead of `-h` to see details"
 msgstr ""
 
@@ -49153,6 +49330,9 @@ msgstr "Réinstaller les paquets"
 
 msgid "Reinstall packages required by this package"
 msgstr "Réinstaller les paquets requis par celui spécifié"
+
+msgid "Reinstall packages whose active USE flags changed since installation (ignores added/removed disabled flags)"
+msgstr ""
 
 msgid "Reinstall the app keeping its data"
 msgstr "Réinstaller l’application en conservant les données"
@@ -49312,6 +49492,9 @@ msgstr "Chemin distant"
 
 msgid "Remote alias"
 msgstr "Alias distant"
+
+msgid "Remote binary packages matching these atoms are not fetched"
+msgstr ""
 
 msgid "Remote branch ref used by `git push`"
 msgstr ""
@@ -49535,6 +49718,9 @@ msgstr ""
 msgid "Remove all but the given number of backups"
 msgstr "Supprimer toutes les sauvegardes sauf le nombre spécifié"
 
+msgid "Remove all but the most recently installed version in each slot"
+msgstr ""
+
 msgid "Remove all classes attributes"
 msgstr ""
 
@@ -49569,6 +49755,9 @@ msgid "Remove all gz files from cache"
 msgstr "Supprimer tous les fichiers gz du cache"
 
 msgid "Remove all lines matching key"
+msgstr ""
+
+msgid "Remove all matching packages without checking dependencies"
 msgstr ""
 
 msgid "Remove all mutations"
@@ -49668,6 +49857,9 @@ msgid "Remove artifacts that cargo has generated in the past"
 msgstr ""
 
 msgid "Remove associated storage volumes"
+msgstr ""
+
+msgid "Remove atoms/sets from @world. Implied by uninstall actions (use --deselect=n to prevent)"
 msgstr ""
 
 msgid "Remove auto-generated configuration files left over by the daemon"
@@ -49895,6 +50087,9 @@ msgstr ""
 msgid "Remove matching variables"
 msgstr ""
 
+msgid "Remove merge-order constraint from --tree output for readability"
+msgstr ""
+
 msgid "Remove module"
 msgstr ""
 
@@ -49945,6 +50140,9 @@ msgstr "Ne supprimer que les fichiers ignorés"
 
 msgid "Remove only locks with specified repository"
 msgstr "Supprimer seulement les verrous sur le dépôt spécifié"
+
+msgid "Remove orphaned dependencies (packages not in @world and not required by other packages)"
+msgstr ""
 
 msgid "Remove orphaned libraries (not required by installed packages)"
 msgstr ""
@@ -50263,6 +50461,9 @@ msgstr ""
 
 msgid "Removes a remote"
 msgstr "Supprimer un serveur distant"
+
+msgid "Removes all but the highest installed version of a package from your system"
+msgstr ""
 
 msgid "Removes all cache"
 msgstr ""
@@ -50603,6 +50804,9 @@ msgstr "Remplacer chaque pixel par sa couleur complémentaire"
 msgid "Replace include directories"
 msgstr ""
 
+msgid "Replace installed packages with binary packages that have been rebuilt"
+msgstr ""
+
 msgid "Replace non-graphic characters with '?'"
 msgstr "Afficher « ? » à la place des caractères non graphiques"
 
@@ -50610,6 +50814,12 @@ msgid "Replace only the last occurrence"
 msgstr ""
 
 msgid "Replace packages in the base layer"
+msgstr ""
+
+msgid "Replace packages whose ebuild SLOT metadata changed since they were built"
+msgstr ""
+
+msgid "Replace packages whose ebuild dependencies changed since they were built"
 msgstr ""
 
 msgid "Replace patch header"
@@ -50808,6 +51018,9 @@ msgid "Report on mode of file"
 msgstr ""
 
 msgid "Report outstanding replies"
+msgstr ""
+
+msgid "Report packages whose ebuild dependencies changed since installation"
 msgstr ""
 
 msgid "Report processor frequency and idle statistics"
@@ -51545,6 +51758,9 @@ msgstr ""
 msgid "Restow: delete and then stow again"
 msgstr ""
 
+msgid "Restrict --sync to specified submodule (rsync only); repeatable"
+msgstr ""
+
 msgid "Restrict access"
 msgstr ""
 
@@ -51633,6 +51849,9 @@ msgid "Resume previously canceled or interrupted scrub"
 msgstr ""
 
 msgid "Resume reactor from specified project"
+msgstr ""
+
+msgid "Resumes the most recent merge list that aborted due to an error"
 msgstr ""
 
 msgid "Resync package contents from source"
@@ -52166,6 +52385,9 @@ msgstr "Dossier racine du site par défaut"
 msgid "Root source tree"
 msgstr "Arbre source racine"
 
+msgid "Root to use as --quickpkg-direct source (default: /)"
+msgstr ""
+
 msgid "Rotate log every kbytes, requires -f"
 msgstr ""
 
@@ -52683,6 +52905,9 @@ msgid "Run package manager within chroot"
 msgstr ""
 
 msgid "Run package manager within jail"
+msgstr ""
+
+msgid "Run package-specific actions after emerge (usually config setup)"
 msgstr ""
 
 msgid "Run patch phase of a port"
@@ -53817,6 +54042,9 @@ msgid "Search directory for makefile"
 msgstr ""
 
 msgid "Search documentation"
+msgstr ""
+
+msgid "Search ebuilds for <string>. Use `%<string>` for regex"
 msgstr ""
 
 msgid "Search files according to the specified search mask"
@@ -55085,6 +55313,9 @@ msgstr "Paramétrer la version EDNS"
 msgid "Set EDNS0 Max UDP packet size"
 msgstr "Paramétrer la taille maximale des paquets UDP EDNS0"
 
+msgid "Set EPREFIX"
+msgstr ""
+
 msgid "Set GDB's working directory"
 msgstr ""
 
@@ -55121,6 +55352,9 @@ msgstr ""
 msgid "Set NDOTS value"
 msgstr "Paramétrer la valeur NDOTS"
 
+msgid "Set PORTAGE_CONFIGROOT"
+msgstr ""
+
 msgid "Set PTRACE_O_EXITKILL ptrace option to all tracee processes"
 msgstr ""
 
@@ -55140,6 +55374,9 @@ msgid "Set RAW writing mode"
 msgstr "Utiliser le mode d’écriture brute"
 
 msgid "Set REQUESTER PAYS for operations"
+msgstr ""
+
+msgid "Set ROOT (target root filesystem)"
 msgstr ""
 
 msgid "Set Rails environment"
@@ -55164,6 +55401,9 @@ msgid "Set SMART data for a drive"
 msgstr ""
 
 msgid "Set SO_DEBUG socket option"
+msgstr ""
+
+msgid "Set SYSROOT (root for DEPEND build-time deps)"
 msgstr ""
 
 msgid "Set TAO (Track At Once) writing mode"
@@ -58460,9 +58700,6 @@ msgstr ""
 msgid "Show camera driver manual"
 msgstr "Afficher le manuel du pilote de l’appareil photo"
 
-msgid "Show changelog of pkg. Use with --pretend"
-msgstr ""
-
 msgid "Show changes between commits and working tree"
 msgstr ""
 
@@ -59969,6 +60206,9 @@ msgstr "Afficher une sortie plus concise"
 msgid "Show signatures and descriptions for the available functions"
 msgstr ""
 
+msgid "Show similar package names when a package is not found (default: y)"
+msgstr ""
+
 msgid "Show sizes in GiB, or GB with --si"
 msgstr ""
 
@@ -61472,6 +61712,9 @@ msgstr ""
 msgid "Skip package installation for this run"
 msgstr ""
 
+msgid "Skip packages already installed (same as --noreplace; use =n to force disable)"
+msgstr ""
+
 msgid "Skip pre/post hook scripts"
 msgstr ""
 
@@ -61751,6 +61994,9 @@ msgstr ""
 msgid "Sort files by name"
 msgstr ""
 
+msgid "Sort flag lists alphabetically"
+msgstr ""
+
 msgid "Sort languages based on column"
 msgstr ""
 
@@ -61899,6 +62145,9 @@ msgid "Source-only mode"
 msgstr ""
 
 msgid "Space or comma separated list of features to activate"
+msgstr ""
+
+msgid "Space-separated atoms to never install"
 msgstr ""
 
 msgid "Space-separated options to exclude from search"
@@ -65312,6 +65561,9 @@ msgstr ""
 msgid "Substitute %{var}% variables"
 msgstr ""
 
+msgid "Substitute installed-package deps with current ebuild deps during calculations (default: y)"
+msgstr ""
+
 msgid "Substitute one word for another"
 msgstr "Remplacer un mot par un autre"
 
@@ -65399,6 +65651,9 @@ msgstr "Supporter la gestion thread-safe des exceptions sur Mingw32"
 msgid "Suppress --noImplicitAny errors for indexing objects lacking index signatures"
 msgstr ""
 
+msgid "Suppress ::repository in merge list; use numbers instead"
+msgstr ""
+
 msgid "Suppress SNAPSHOT updates"
 msgstr ""
 
@@ -65431,6 +65686,9 @@ msgstr "Masquer toute sortie"
 
 msgid "Suppress battery information"
 msgstr "Masquer les informations de la batterie"
+
+msgid "Suppress build log display on failure (show only die message and log path)"
+msgstr ""
 
 msgid "Suppress checkout"
 msgstr ""
@@ -65575,6 +65833,9 @@ msgstr "Masquer l’avertissement à propos de l’absence de système de protec
 
 msgid "Suppress the warning about unsafe file and home directory (--homedir) permissions"
 msgstr "Masquer l’avertissement à propos de permissions non sûres sur le fichier et le dossier de l’utilisateur"
+
+msgid "Suppress the warning shown before --unmerge actions"
+msgstr ""
 
 msgid "Suppress thermal information"
 msgstr "Masquer les informations de température"
@@ -66250,6 +66511,12 @@ msgstr ""
 
 msgid "Temporarily offline"
 msgstr "Temporairement hors-ligne"
+
+msgid "Temporarily override ACCEPT_PROPERTIES (e.g. =-interactive)"
+msgstr ""
+
+msgid "Temporarily override ACCEPT_RESTRICT (e.g. =-bindist)"
+msgstr ""
 
 msgid "Temporary mount point property"
 msgstr "Paramètre de point de montage temporaire"
@@ -67727,6 +67994,9 @@ msgstr "Traiter l’entrée ou la sortie comme des échantillons bruts"
 msgid "Treat keyboard as standard US keyboard"
 msgstr "Considérer que le clavier est au standard américain"
 
+msgid "Treat matching packages as not installed and reinstall them"
+msgstr ""
+
 msgid "Treat newlines as hard line breaks"
 msgstr ""
 
@@ -67803,6 +68073,12 @@ msgid "Treated as MOZ_LOG_FILE=<file> environment variable, overrides it"
 msgstr ""
 
 msgid "Tree location"
+msgstr ""
+
+msgid "Trigger --complete-graph when USE or IUSE changes for an installed package (default: y)"
+msgstr ""
+
+msgid "Trigger --complete-graph when an installed package version changes (default: y)"
 msgstr ""
 
 msgid "Trigger DHCP reconfiguration of all connected clients"
@@ -68960,6 +69236,9 @@ msgstr "Mettre à jour le ou les paquet(s)"
 msgid "Update packages"
 msgstr ""
 
+msgid "Update packages to best available version"
+msgstr ""
+
 msgid "Update parts of an existing network's configuration"
 msgstr ""
 
@@ -68985,6 +69264,9 @@ msgid "Update remote repositories"
 msgstr "Mettre à jour les dépôts distants"
 
 msgid "Update remote state from local state"
+msgstr ""
+
+msgid "Update repositories. Use without arguments to update all autosync repos"
 msgstr ""
 
 msgid "Update repository indexes"
@@ -70409,6 +70691,9 @@ msgstr ""
 msgid "Use dot character instead of braille"
 msgstr ""
 
+msgid "Use ebuilds for deps; binary packages only for explicitly named atoms"
+msgstr ""
+
 msgid "Use editor to modify kernel arguments"
 msgstr ""
 
@@ -70626,6 +70911,9 @@ msgid "Use input from pipe of emerge -pv"
 msgstr "Entuber la sortie de emerge -pv vers l’entrée standard"
 
 msgid "Use insecure TLS connection"
+msgstr ""
+
+msgid "Use installed packages directly as binary packages"
 msgstr ""
 
 msgid "Use instead of host if you want to address 255.255.255.255"
@@ -71333,6 +71621,9 @@ msgstr "Utiliser l’instruction de division"
 msgid "Use the dynamic section info when displaying symbols"
 msgstr ""
 
+msgid "Use the egencache-built search index (default: y)"
+msgstr ""
+
 msgid "Use the file's modification time as the time of import."
 msgstr "Utiliser l’horodatage de modification du fichier comme le moment de l’import"
 
@@ -71616,6 +71907,9 @@ msgid "Use translations under given directory"
 msgstr "Utiliser les traductions situés dans le dossier spécifié"
 
 msgid "Use uglier formatting"
+msgstr ""
+
+msgid "Use unbuilt ebuild metadata for visibility checks on built packages"
 msgstr ""
 
 msgid "Use unicode characters in the output"
@@ -72596,6 +72890,9 @@ msgstr "Avertir si le type de « main » est douteux"
 msgid "Warn if variadic macros are used in pedantic mode"
 msgstr ""
 
+msgid "Warn on @world packages with no available ebuild (default: y)"
+msgstr ""
+
 msgid "Warn on lint"
 msgstr ""
 
@@ -73325,6 +73622,9 @@ msgstr "Écrire les sous-paquets d’attribut dans le descripteur de fichier sp�
 msgid "Write attribute value"
 msgstr ""
 
+msgid "Write autounmask changes to config files (implied by --ask)"
+msgstr ""
+
 msgid "Write column names in results"
 msgstr ""
 
@@ -73377,6 +73677,9 @@ msgid "Write index to a file"
 msgstr "Écrire l’index dans un fichier"
 
 msgid "Write index to specified file"
+msgstr ""
+
+msgid "Write keyword/mask changes using >= operators instead of ="
 msgstr ""
 
 msgid "Write line numbers for errors"

--- a/localization/po/ja_JP.po
+++ b/localization/po/ja_JP.po
@@ -5144,6 +5144,9 @@ msgstr ""
 msgid "Access repository settings"
 msgstr ""
 
+msgid "Account for library link-level deps during --depclean and --prune (default: y)"
+msgstr ""
+
 msgid "Account to be altered"
 msgstr ""
 
@@ -5930,6 +5933,9 @@ msgstr ""
 msgid "Add packages"
 msgstr ""
 
+msgid "Add packages to @world (inverse of --oneshot)"
+msgstr ""
+
 msgid "Add parts on top of the section hierarchy"
 msgstr ""
 
@@ -6590,10 +6596,19 @@ msgstr ""
 msgid "Allow automatically filling CAPTCHA"
 msgstr ""
 
+msgid "Allow autounmask to create package.license changes"
+msgstr ""
+
+msgid "Allow autounmask to create package.use changes (enabled by default)"
+msgstr ""
+
 msgid "Allow backspace and carriage return"
 msgstr ""
 
 msgid "Allow backspace, tab and carriage return"
+msgstr ""
+
+msgid "Allow backtracking after autounmask detects necessary changes"
 msgstr ""
 
 msgid "Allow binary files to be diffed"
@@ -7694,6 +7709,9 @@ msgstr ""
 msgid "Apply automated posting rules to modify txns"
 msgstr ""
 
+msgid "Apply autounmask changes and continue to execute command"
+msgstr ""
+
 msgid "Apply changes from a Differential diff"
 msgstr ""
 
@@ -7818,6 +7836,9 @@ msgid "Apply option to this zone"
 msgstr ""
 
 msgid "Apply options to a portion of the image [geometry]"
+msgstr ""
+
+msgid "Apply package moves when necessary (default: y; do not disable normally)"
 msgstr ""
 
 msgid "Apply packagefiles to the subproject"
@@ -8213,6 +8234,9 @@ msgstr ""
 msgid "Assume no to all questions"
 msgstr ""
 
+msgid "Assume packages may have implicit deps on @system (default: y)"
+msgstr ""
+
 msgid "Assume patches were created with old/new files swapped"
 msgstr ""
 
@@ -8349,6 +8373,9 @@ msgid "Assume yes when asked for confirmation"
 msgstr ""
 
 msgid "Assumes that structures should have 8 byte alignment"
+msgstr ""
+
+msgid "Atoms for which no binary packages should be built"
 msgstr ""
 
 msgid "Attach a USB device to the host"
@@ -8543,6 +8570,12 @@ msgstr ""
 msgid "Auto-confirm non-security prompts"
 msgstr ""
 
+msgid "Auto-detect regex in search strings (default: y)"
+msgstr ""
+
+msgid "Auto-enable --with-bdeps for installation actions (default: y)"
+msgstr ""
+
 msgid "Auto-gen package cache"
 msgstr ""
 
@@ -8670,6 +8703,9 @@ msgid "Automatically sync the repository"
 msgstr ""
 
 msgid "Automatically trust and import new repository signing keys"
+msgstr ""
+
+msgid "Automatically unmasks packages and generates package.use settings"
 msgstr ""
 
 msgid "Automatically update the packet display as packets are coming in"
@@ -9041,6 +9077,9 @@ msgstr ""
 msgid "Binary input mode"
 msgstr ""
 
+msgid "Binary package format to create"
+msgstr ""
+
 msgid "Binary-only mode, abort if no archive available"
 msgstr ""
 
@@ -9329,7 +9368,7 @@ msgstr ""
 msgid "Build a Windows executable"
 msgstr ""
 
-msgid "Build a binary pkg additionally"
+msgid "Build a binary package in addition to merging"
 msgstr ""
 
 msgid "Build a console executable"
@@ -10358,6 +10397,9 @@ msgstr ""
 msgid "Check and fix problems in the world file"
 msgstr ""
 
+msgid "Check and update the dependency cache of all ebuilds in repository"
+msgstr ""
+
 msgid "Check and wait until a group of devices of a filesystem is ready for mount"
 msgstr ""
 
@@ -11160,6 +11202,9 @@ msgid "Clean up cache directory"
 msgstr ""
 
 msgid "Clean up releases, stemcells, disks, etc."
+msgstr ""
+
+msgid "Clean up temp files after a build failure (useful with PORTAGE_TMPDIR on tmpfs)"
 msgstr ""
 
 msgid "Clean up the files that Cobertura Maven Plugin has created during instrumentation"
@@ -12521,6 +12566,9 @@ msgstr ""
 msgid "Consider case when comparing file names"
 msgstr ""
 
+msgid "Consider deep deps of all @world packages; bail if the operation would break any"
+msgstr ""
+
 msgid "Consider files as separate"
 msgstr ""
 
@@ -12624,6 +12672,9 @@ msgid "Continue after an error"
 msgstr ""
 
 msgid "Continue as much as possible after an error"
+msgstr ""
+
+msgid "Continue as much as possible after an error; recalculate deps for remaining packages"
 msgstr ""
 
 msgid "Continue conversation with given id"
@@ -12807,6 +12858,9 @@ msgid "Control whether GCC places uninitialized local variables into the \"bss\"
 msgstr ""
 
 msgid "Control whether RTC is in local time"
+msgstr ""
+
+msgid "Control whether build-time deps go into ROOT or /"
 msgstr ""
 
 msgid "Control whether color is used"
@@ -17348,6 +17402,9 @@ msgstr ""
 msgid "Display a help page"
 msgstr ""
 
+msgid "Display a list of available package sets"
+msgstr ""
+
 msgid "Display a list of speedtest.net servers sorted by distance"
 msgstr ""
 
@@ -17445,6 +17502,9 @@ msgid "Display all values currently available"
 msgstr ""
 
 msgid "Display an archive's list to console"
+msgstr ""
+
+msgid "Display ancillary information required for bug reports"
 msgstr ""
 
 msgid "Display answers as exclamation points and missing packets as dots"
@@ -18665,6 +18725,9 @@ msgstr ""
 msgid "Display toolbar or menubar"
 msgstr ""
 
+msgid "Display total of unread GLEP 42 news items"
+msgstr ""
+
 msgid "Display untracked files in columns"
 msgstr ""
 
@@ -19820,6 +19883,9 @@ msgstr ""
 msgid "Do not install files from given subprojects"
 msgstr ""
 
+msgid "Do not install from binary packages for live ebuilds"
+msgstr ""
+
 msgid "Do not install recommended packages"
 msgstr ""
 
@@ -20180,6 +20246,12 @@ msgstr ""
 msgid "Do not rebuild before running tests"
 msgstr ""
 
+msgid "Do not rebuild matching packages due to --rebuild"
+msgstr ""
+
+msgid "Do not rebuild packages that depend on matching packages due to --rebuild"
+msgstr ""
+
 msgid "Do not recalculate the effective rights mask"
 msgstr ""
 
@@ -20526,6 +20598,9 @@ msgid "Do not start ghostscript in safe mode"
 msgstr ""
 
 msgid "Do not start ghostscript with the -dQUIET option"
+msgstr ""
+
+msgid "Do not start new builds if load average is at least LOAD"
 msgstr ""
 
 msgid "Do not start the commit message editor"
@@ -30962,6 +31037,9 @@ msgstr ""
 msgid "Ignore 'Content-Length' header"
 msgstr ""
 
+msgid "Ignore @world deps; may break installed packages (use with --ask)"
+msgstr ""
+
 msgid "Ignore CD/DVD repositories"
 msgstr ""
 
@@ -31050,6 +31128,12 @@ msgid "Ignore any balance assertions"
 msgstr ""
 
 msgid "Ignore any saved configuration"
+msgstr ""
+
+msgid "Ignore binary packages whose USE flags differ from current config"
+msgstr ""
+
+msgid "Ignore binary packages whose ebuild dependencies changed since the build"
 msgstr ""
 
 msgid "Ignore bogus module names"
@@ -31214,6 +31298,9 @@ msgstr ""
 msgid "Ignore logical volume identity"
 msgstr ""
 
+msgid "Ignore matching binary packages"
+msgstr ""
+
 msgid "Ignore md5sum"
 msgstr ""
 
@@ -31254,6 +31341,9 @@ msgid "Ignore non-authenticated packages"
 msgstr ""
 
 msgid "Ignore non-existing files on receiving side"
+msgstr ""
+
+msgid "Ignore non-matching binary packages"
 msgstr ""
 
 msgid "Ignore nonexistent files"
@@ -31308,6 +31398,12 @@ msgid "Ignore safety checks"
 msgstr ""
 
 msgid "Ignore scissor lines"
+msgstr ""
+
+msgid "Ignore slot/sub-slot := operator deps recorded at build time (debug only)"
+msgstr ""
+
+msgid "Ignore soname dependencies of binary and installed packages (default: y)"
 msgstr ""
 
 msgid "Ignore spaces after function names"
@@ -31916,6 +32012,9 @@ msgstr ""
 msgid "Include inherited options"
 msgstr ""
 
+msgid "Include install-time deps when --onlydeps and --onlydeps-with-rdeps=n are used"
+msgstr ""
+
 msgid "Include installed pkgs with changed USE flags"
 msgstr ""
 
@@ -32016,6 +32115,9 @@ msgid "Include residual signal in text output"
 msgstr ""
 
 msgid "Include reverse dependencies in the output"
+msgstr ""
+
+msgid "Include run-time deps when using --onlydeps (default: y)"
 msgstr ""
 
 msgid "Include secret key comment packets when exporting secret keys"
@@ -33717,6 +33819,15 @@ msgid "Like --method=md5crypt"
 msgstr ""
 
 msgid "Like --reuse-message, but allow editing commit message"
+msgstr ""
+
+msgid "Like --search, but also matches package descriptions"
+msgstr ""
+
+msgid "Like --unmerge but with CLEAN_DELAY=0; can remove critical packages"
+msgstr ""
+
+msgid "Like --update but only for packages already installed"
 msgstr ""
 
 msgid "Like --write-batch but w/o updating dest"
@@ -35645,6 +35756,9 @@ msgstr ""
 msgid "List packages by provider"
 msgstr ""
 
+msgid "List packages causing slot rebuilds in emerge output (default: y)"
+msgstr ""
+
 msgid "List packages depending on"
 msgstr ""
 
@@ -37433,6 +37547,9 @@ msgstr ""
 msgid "Make zipfile as old as the latest entry"
 msgstr ""
 
+msgid "Makes --ask reject single Enter keypresses as answers"
+msgstr ""
+
 msgid "Makes COM type information in specified assemblies available to the project"
 msgstr ""
 
@@ -37934,6 +38051,9 @@ msgstr ""
 msgid "Match pattern against full command line"
 msgstr ""
 
+msgid "Match search strings approximately; auto-disabled for regex searches (default: y)"
+msgstr ""
+
 msgid "Match secondary date instead"
 msgstr ""
 
@@ -37962,6 +38082,9 @@ msgid "Max memory, as scaled integer (default KiB)"
 msgstr ""
 
 msgid "Max num of children"
+msgstr ""
+
+msgid "Max number of times to backtrack on dependency conflicts (default: 20)"
 msgstr ""
 
 msgid "Max objects per response"
@@ -38279,6 +38402,9 @@ msgstr ""
 msgid "Minimum drive buffer fill ratio for the ATAPI wait mode"
 msgstr ""
 
+msgid "Minimum free GiB in PORTAGE_TMPDIR before starting more jobs (default: 18)"
+msgstr ""
+
 msgid "Minimum height when --height is given in percent"
 msgstr ""
 
@@ -38301,6 +38427,9 @@ msgid "Minimum payload size for sweeping pings"
 msgstr ""
 
 msgid "Minimum port to listen to"
+msgstr ""
+
+msgid "Minimum similarity percentage for fuzzy search results (default: 80)"
 msgstr ""
 
 msgid "Minimum stability (empty or one of: stable, RC, beta, alpha, dev)"
@@ -39509,6 +39638,9 @@ msgstr ""
 msgid "Number of octets per line"
 msgstr ""
 
+msgid "Number of packages to build simultaneously (0 = CPU count)"
+msgstr ""
+
 msgid "Number of pages to scan before the shared memory service goes to sleep"
 msgstr ""
 
@@ -39716,6 +39848,9 @@ msgstr ""
 msgid "Offensive fortunes only"
 msgstr ""
 
+msgid "Offer to read unread news via eselect when --ask is active"
+msgstr ""
+
 msgid "Offline migration"
 msgstr ""
 
@@ -39899,6 +40034,9 @@ msgstr ""
 msgid "Only connect if safe console handling is supported"
 msgstr ""
 
+msgid "Only consider rebuilt binaries with BUILD_TIME newer than TIMESTAMP"
+msgstr ""
+
 msgid "Only consider tags matching the given glob pattern"
 msgstr ""
 
@@ -39987,6 +40125,9 @@ msgid "Only expire unused working trees older than <time>"
 msgstr ""
 
 msgid "Only fail the build afterwards; allow all non-impacted builds to continue"
+msgstr ""
+
+msgid "Only fetch remote binary packages matching these atoms"
 msgstr ""
 
 msgid "Only fixate disk "
@@ -40383,6 +40524,9 @@ msgid "Only this package's library"
 msgstr ""
 
 msgid "Only uninstall the binary NAME"
+msgstr ""
+
+msgid "Only unmask and generate package.use settings without building anything"
 msgstr ""
 
 msgid "Only update the manifest"
@@ -43499,6 +43643,9 @@ msgstr ""
 msgid "Prefer lowest versions of dependencies"
 msgstr ""
 
+msgid "Prefer matching binary packages over newer unbuilt ebuilds"
+msgstr ""
+
 msgid "Prefer reading from other devices than these"
 msgstr ""
 
@@ -43848,6 +43995,12 @@ msgid "Prevent adding rpath for each used dynamic library"
 msgstr ""
 
 msgid "Prevent any configuration changes to domain until migration ends"
+msgstr ""
+
+msgid "Prevent autounmask from creating package.accept_keywords changes"
+msgstr ""
+
+msgid "Prevent autounmask from creating package.unmask or ** keyword changes"
 msgstr ""
 
 msgid "Prevent floating point registers from being used in any manner"
@@ -47396,6 +47549,9 @@ msgstr ""
 msgid "Pull in changes from another branch"
 msgstr ""
 
+msgid "Pull in test-conditional deps for matched packages even if test is not in FEATURES"
+msgstr ""
+
 msgid "Pull list of shunned references from server"
 msgstr ""
 
@@ -48467,6 +48623,18 @@ msgstr ""
 msgid "Rebuild modules installed in node_modules in current working directory"
 msgstr ""
 
+msgid "Rebuild packages when a new slot can satisfy := deps (default: y)"
+msgstr ""
+
+msgid "Rebuild packages when build-time deps are built from source"
+msgstr ""
+
+msgid "Rebuild packages when build-time deps are installed with a new revision"
+msgstr ""
+
+msgid "Rebuild packages when build-time deps are installed with a new version"
+msgstr ""
+
 msgid "Rebuild ports containing broken binaries"
 msgstr ""
 
@@ -48507,6 +48675,9 @@ msgid "Recognize Boost format strings (only language C++)"
 msgstr ""
 
 msgid "Recognize Qt format strings (only language C++)"
+msgstr ""
+
+msgid "Recompile a package if it is now pulled from a different repository"
 msgstr ""
 
 msgid "Recompile every Sass file, even if the CSS file is newer"
@@ -48731,6 +48902,9 @@ msgstr ""
 msgid "Redeploy artifact on Weblogic server(s) or cluster(s)"
 msgstr ""
 
+msgid "Redirect all build output to logs; display on failure"
+msgstr ""
+
 msgid "Redirect all messages into a file"
 msgstr ""
 
@@ -48905,6 +49079,9 @@ msgstr ""
 msgid "Regenerate library dependency metadata"
 msgstr ""
 
+msgid "Regenerate package manifests (prefer repoman manifest)"
+msgstr ""
+
 msgid "Regex flags: use `--help` instead of `-h` to see details"
 msgstr ""
 
@@ -49026,6 +49203,9 @@ msgid "Reinstall packages"
 msgstr ""
 
 msgid "Reinstall packages required by this package"
+msgstr ""
+
+msgid "Reinstall packages whose active USE flags changed since installation (ignores added/removed disabled flags)"
 msgstr ""
 
 msgid "Reinstall the app keeping its data"
@@ -49185,6 +49365,9 @@ msgid "Remote Path"
 msgstr ""
 
 msgid "Remote alias"
+msgstr ""
+
+msgid "Remote binary packages matching these atoms are not fetched"
 msgstr ""
 
 msgid "Remote branch ref used by `git push`"
@@ -49409,6 +49592,9 @@ msgstr ""
 msgid "Remove all but the given number of backups"
 msgstr ""
 
+msgid "Remove all but the most recently installed version in each slot"
+msgstr ""
+
 msgid "Remove all classes attributes"
 msgstr ""
 
@@ -49443,6 +49629,9 @@ msgid "Remove all gz files from cache"
 msgstr ""
 
 msgid "Remove all lines matching key"
+msgstr ""
+
+msgid "Remove all matching packages without checking dependencies"
 msgstr ""
 
 msgid "Remove all mutations"
@@ -49542,6 +49731,9 @@ msgid "Remove artifacts that cargo has generated in the past"
 msgstr ""
 
 msgid "Remove associated storage volumes"
+msgstr ""
+
+msgid "Remove atoms/sets from @world. Implied by uninstall actions (use --deselect=n to prevent)"
 msgstr ""
 
 msgid "Remove auto-generated configuration files left over by the daemon"
@@ -49769,6 +49961,9 @@ msgstr ""
 msgid "Remove matching variables"
 msgstr ""
 
+msgid "Remove merge-order constraint from --tree output for readability"
+msgstr ""
+
 msgid "Remove module"
 msgstr ""
 
@@ -49818,6 +50013,9 @@ msgid "Remove only ignored files"
 msgstr ""
 
 msgid "Remove only locks with specified repository"
+msgstr ""
+
+msgid "Remove orphaned dependencies (packages not in @world and not required by other packages)"
 msgstr ""
 
 msgid "Remove orphaned libraries (not required by installed packages)"
@@ -50136,6 +50334,9 @@ msgid "Removes a package from the require-dev section"
 msgstr ""
 
 msgid "Removes a remote"
+msgstr ""
+
+msgid "Removes all but the highest installed version of a package from your system"
 msgstr ""
 
 msgid "Removes all cache"
@@ -50477,6 +50678,9 @@ msgstr ""
 msgid "Replace include directories"
 msgstr ""
 
+msgid "Replace installed packages with binary packages that have been rebuilt"
+msgstr ""
+
 msgid "Replace non-graphic characters with '?'"
 msgstr ""
 
@@ -50484,6 +50688,12 @@ msgid "Replace only the last occurrence"
 msgstr ""
 
 msgid "Replace packages in the base layer"
+msgstr ""
+
+msgid "Replace packages whose ebuild SLOT metadata changed since they were built"
+msgstr ""
+
+msgid "Replace packages whose ebuild dependencies changed since they were built"
 msgstr ""
 
 msgid "Replace patch header"
@@ -50682,6 +50892,9 @@ msgid "Report on mode of file"
 msgstr ""
 
 msgid "Report outstanding replies"
+msgstr ""
+
+msgid "Report packages whose ebuild dependencies changed since installation"
 msgstr ""
 
 msgid "Report processor frequency and idle statistics"
@@ -51419,6 +51632,9 @@ msgstr ""
 msgid "Restow: delete and then stow again"
 msgstr ""
 
+msgid "Restrict --sync to specified submodule (rsync only); repeatable"
+msgstr ""
+
 msgid "Restrict access"
 msgstr ""
 
@@ -51507,6 +51723,9 @@ msgid "Resume previously canceled or interrupted scrub"
 msgstr ""
 
 msgid "Resume reactor from specified project"
+msgstr ""
+
+msgid "Resumes the most recent merge list that aborted due to an error"
 msgstr ""
 
 msgid "Resync package contents from source"
@@ -52040,6 +52259,9 @@ msgstr ""
 msgid "Root source tree"
 msgstr ""
 
+msgid "Root to use as --quickpkg-direct source (default: /)"
+msgstr ""
+
 msgid "Rotate log every kbytes, requires -f"
 msgstr ""
 
@@ -52557,6 +52779,9 @@ msgid "Run package manager within chroot"
 msgstr ""
 
 msgid "Run package manager within jail"
+msgstr ""
+
+msgid "Run package-specific actions after emerge (usually config setup)"
 msgstr ""
 
 msgid "Run patch phase of a port"
@@ -53691,6 +53916,9 @@ msgid "Search directory for makefile"
 msgstr ""
 
 msgid "Search documentation"
+msgstr ""
+
+msgid "Search ebuilds for <string>. Use `%<string>` for regex"
 msgstr ""
 
 msgid "Search files according to the specified search mask"
@@ -54959,6 +55187,9 @@ msgstr ""
 msgid "Set EDNS0 Max UDP packet size"
 msgstr ""
 
+msgid "Set EPREFIX"
+msgstr ""
+
 msgid "Set GDB's working directory"
 msgstr ""
 
@@ -54995,6 +55226,9 @@ msgstr ""
 msgid "Set NDOTS value"
 msgstr ""
 
+msgid "Set PORTAGE_CONFIGROOT"
+msgstr ""
+
 msgid "Set PTRACE_O_EXITKILL ptrace option to all tracee processes"
 msgstr ""
 
@@ -55014,6 +55248,9 @@ msgid "Set RAW writing mode"
 msgstr ""
 
 msgid "Set REQUESTER PAYS for operations"
+msgstr ""
+
+msgid "Set ROOT (target root filesystem)"
 msgstr ""
 
 msgid "Set Rails environment"
@@ -55038,6 +55275,9 @@ msgid "Set SMART data for a drive"
 msgstr ""
 
 msgid "Set SO_DEBUG socket option"
+msgstr ""
+
+msgid "Set SYSROOT (root for DEPEND build-time deps)"
 msgstr ""
 
 msgid "Set TAO (Track At Once) writing mode"
@@ -58334,9 +58574,6 @@ msgstr ""
 msgid "Show camera driver manual"
 msgstr ""
 
-msgid "Show changelog of pkg. Use with --pretend"
-msgstr ""
-
 msgid "Show changes between commits and working tree"
 msgstr ""
 
@@ -59843,6 +60080,9 @@ msgstr ""
 msgid "Show signatures and descriptions for the available functions"
 msgstr ""
 
+msgid "Show similar package names when a package is not found (default: y)"
+msgstr ""
+
 msgid "Show sizes in GiB, or GB with --si"
 msgstr ""
 
@@ -61346,6 +61586,9 @@ msgstr ""
 msgid "Skip package installation for this run"
 msgstr ""
 
+msgid "Skip packages already installed (same as --noreplace; use =n to force disable)"
+msgstr ""
+
 msgid "Skip pre/post hook scripts"
 msgstr ""
 
@@ -61625,6 +61868,9 @@ msgstr ""
 msgid "Sort files by name"
 msgstr ""
 
+msgid "Sort flag lists alphabetically"
+msgstr ""
+
 msgid "Sort languages based on column"
 msgstr ""
 
@@ -61773,6 +62019,9 @@ msgid "Source-only mode"
 msgstr ""
 
 msgid "Space or comma separated list of features to activate"
+msgstr ""
+
+msgid "Space-separated atoms to never install"
 msgstr ""
 
 msgid "Space-separated options to exclude from search"
@@ -65186,6 +65435,9 @@ msgstr ""
 msgid "Substitute %{var}% variables"
 msgstr ""
 
+msgid "Substitute installed-package deps with current ebuild deps during calculations (default: y)"
+msgstr ""
+
 msgid "Substitute one word for another"
 msgstr ""
 
@@ -65273,6 +65525,9 @@ msgstr ""
 msgid "Suppress --noImplicitAny errors for indexing objects lacking index signatures"
 msgstr ""
 
+msgid "Suppress ::repository in merge list; use numbers instead"
+msgstr ""
+
 msgid "Suppress SNAPSHOT updates"
 msgstr ""
 
@@ -65304,6 +65559,9 @@ msgid "Suppress any output"
 msgstr ""
 
 msgid "Suppress battery information"
+msgstr ""
+
+msgid "Suppress build log display on failure (show only die message and log path)"
 msgstr ""
 
 msgid "Suppress checkout"
@@ -65448,6 +65706,9 @@ msgid "Suppress the warning about missing MDC integrity protection"
 msgstr ""
 
 msgid "Suppress the warning about unsafe file and home directory (--homedir) permissions"
+msgstr ""
+
+msgid "Suppress the warning shown before --unmerge actions"
 msgstr ""
 
 msgid "Suppress thermal information"
@@ -66123,6 +66384,12 @@ msgid "Temporarily lock an active home area"
 msgstr ""
 
 msgid "Temporarily offline"
+msgstr ""
+
+msgid "Temporarily override ACCEPT_PROPERTIES (e.g. =-interactive)"
+msgstr ""
+
+msgid "Temporarily override ACCEPT_RESTRICT (e.g. =-bindist)"
 msgstr ""
 
 msgid "Temporary mount point property"
@@ -67601,6 +67868,9 @@ msgstr ""
 msgid "Treat keyboard as standard US keyboard"
 msgstr ""
 
+msgid "Treat matching packages as not installed and reinstall them"
+msgstr ""
+
 msgid "Treat newlines as hard line breaks"
 msgstr ""
 
@@ -67677,6 +67947,12 @@ msgid "Treated as MOZ_LOG_FILE=<file> environment variable, overrides it"
 msgstr ""
 
 msgid "Tree location"
+msgstr ""
+
+msgid "Trigger --complete-graph when USE or IUSE changes for an installed package (default: y)"
+msgstr ""
+
+msgid "Trigger --complete-graph when an installed package version changes (default: y)"
 msgstr ""
 
 msgid "Trigger DHCP reconfiguration of all connected clients"
@@ -68834,6 +69110,9 @@ msgstr ""
 msgid "Update packages"
 msgstr ""
 
+msgid "Update packages to best available version"
+msgstr ""
+
 msgid "Update parts of an existing network's configuration"
 msgstr ""
 
@@ -68859,6 +69138,9 @@ msgid "Update remote repositories"
 msgstr ""
 
 msgid "Update remote state from local state"
+msgstr ""
+
+msgid "Update repositories. Use without arguments to update all autosync repos"
 msgstr ""
 
 msgid "Update repository indexes"
@@ -70283,6 +70565,9 @@ msgstr ""
 msgid "Use dot character instead of braille"
 msgstr ""
 
+msgid "Use ebuilds for deps; binary packages only for explicitly named atoms"
+msgstr ""
+
 msgid "Use editor to modify kernel arguments"
 msgstr ""
 
@@ -70500,6 +70785,9 @@ msgid "Use input from pipe of emerge -pv"
 msgstr ""
 
 msgid "Use insecure TLS connection"
+msgstr ""
+
+msgid "Use installed packages directly as binary packages"
 msgstr ""
 
 msgid "Use instead of host if you want to address 255.255.255.255"
@@ -71207,6 +71495,9 @@ msgstr ""
 msgid "Use the dynamic section info when displaying symbols"
 msgstr ""
 
+msgid "Use the egencache-built search index (default: y)"
+msgstr ""
+
 msgid "Use the file's modification time as the time of import."
 msgstr ""
 
@@ -71490,6 +71781,9 @@ msgid "Use translations under given directory"
 msgstr ""
 
 msgid "Use uglier formatting"
+msgstr ""
+
+msgid "Use unbuilt ebuild metadata for visibility checks on built packages"
 msgstr ""
 
 msgid "Use unicode characters in the output"
@@ -72470,6 +72764,9 @@ msgstr ""
 msgid "Warn if variadic macros are used in pedantic mode"
 msgstr ""
 
+msgid "Warn on @world packages with no available ebuild (default: y)"
+msgstr ""
+
 msgid "Warn on lint"
 msgstr ""
 
@@ -73199,6 +73496,9 @@ msgstr ""
 msgid "Write attribute value"
 msgstr ""
 
+msgid "Write autounmask changes to config files (implied by --ask)"
+msgstr ""
+
 msgid "Write column names in results"
 msgstr ""
 
@@ -73251,6 +73551,9 @@ msgid "Write index to a file"
 msgstr ""
 
 msgid "Write index to specified file"
+msgstr ""
+
+msgid "Write keyword/mask changes using >= operators instead of ="
 msgstr ""
 
 msgid "Write line numbers for errors"

--- a/localization/po/pl.po
+++ b/localization/po/pl.po
@@ -5137,6 +5137,9 @@ msgstr ""
 msgid "Access repository settings"
 msgstr ""
 
+msgid "Account for library link-level deps during --depclean and --prune (default: y)"
+msgstr ""
+
 msgid "Account to be altered"
 msgstr ""
 
@@ -5923,6 +5926,9 @@ msgstr ""
 msgid "Add packages"
 msgstr ""
 
+msgid "Add packages to @world (inverse of --oneshot)"
+msgstr ""
+
 msgid "Add parts on top of the section hierarchy"
 msgstr ""
 
@@ -6583,10 +6589,19 @@ msgstr ""
 msgid "Allow automatically filling CAPTCHA"
 msgstr ""
 
+msgid "Allow autounmask to create package.license changes"
+msgstr ""
+
+msgid "Allow autounmask to create package.use changes (enabled by default)"
+msgstr ""
+
 msgid "Allow backspace and carriage return"
 msgstr ""
 
 msgid "Allow backspace, tab and carriage return"
+msgstr ""
+
+msgid "Allow backtracking after autounmask detects necessary changes"
 msgstr ""
 
 msgid "Allow binary files to be diffed"
@@ -7687,6 +7702,9 @@ msgstr ""
 msgid "Apply automated posting rules to modify txns"
 msgstr ""
 
+msgid "Apply autounmask changes and continue to execute command"
+msgstr ""
+
 msgid "Apply changes from a Differential diff"
 msgstr ""
 
@@ -7811,6 +7829,9 @@ msgid "Apply option to this zone"
 msgstr ""
 
 msgid "Apply options to a portion of the image [geometry]"
+msgstr ""
+
+msgid "Apply package moves when necessary (default: y; do not disable normally)"
 msgstr ""
 
 msgid "Apply packagefiles to the subproject"
@@ -8206,6 +8227,9 @@ msgstr ""
 msgid "Assume no to all questions"
 msgstr ""
 
+msgid "Assume packages may have implicit deps on @system (default: y)"
+msgstr ""
+
 msgid "Assume patches were created with old/new files swapped"
 msgstr ""
 
@@ -8342,6 +8366,9 @@ msgid "Assume yes when asked for confirmation"
 msgstr ""
 
 msgid "Assumes that structures should have 8 byte alignment"
+msgstr ""
+
+msgid "Atoms for which no binary packages should be built"
 msgstr ""
 
 msgid "Attach a USB device to the host"
@@ -8536,6 +8563,12 @@ msgstr ""
 msgid "Auto-confirm non-security prompts"
 msgstr ""
 
+msgid "Auto-detect regex in search strings (default: y)"
+msgstr ""
+
+msgid "Auto-enable --with-bdeps for installation actions (default: y)"
+msgstr ""
+
 msgid "Auto-gen package cache"
 msgstr ""
 
@@ -8663,6 +8696,9 @@ msgid "Automatically sync the repository"
 msgstr ""
 
 msgid "Automatically trust and import new repository signing keys"
+msgstr ""
+
+msgid "Automatically unmasks packages and generates package.use settings"
 msgstr ""
 
 msgid "Automatically update the packet display as packets are coming in"
@@ -9034,6 +9070,9 @@ msgstr ""
 msgid "Binary input mode"
 msgstr ""
 
+msgid "Binary package format to create"
+msgstr ""
+
 msgid "Binary-only mode, abort if no archive available"
 msgstr ""
 
@@ -9322,7 +9361,7 @@ msgstr ""
 msgid "Build a Windows executable"
 msgstr ""
 
-msgid "Build a binary pkg additionally"
+msgid "Build a binary package in addition to merging"
 msgstr ""
 
 msgid "Build a console executable"
@@ -10351,6 +10390,9 @@ msgstr ""
 msgid "Check and fix problems in the world file"
 msgstr ""
 
+msgid "Check and update the dependency cache of all ebuilds in repository"
+msgstr ""
+
 msgid "Check and wait until a group of devices of a filesystem is ready for mount"
 msgstr ""
 
@@ -11153,6 +11195,9 @@ msgid "Clean up cache directory"
 msgstr ""
 
 msgid "Clean up releases, stemcells, disks, etc."
+msgstr ""
+
+msgid "Clean up temp files after a build failure (useful with PORTAGE_TMPDIR on tmpfs)"
 msgstr ""
 
 msgid "Clean up the files that Cobertura Maven Plugin has created during instrumentation"
@@ -12514,6 +12559,9 @@ msgstr ""
 msgid "Consider case when comparing file names"
 msgstr ""
 
+msgid "Consider deep deps of all @world packages; bail if the operation would break any"
+msgstr ""
+
 msgid "Consider files as separate"
 msgstr ""
 
@@ -12617,6 +12665,9 @@ msgid "Continue after an error"
 msgstr ""
 
 msgid "Continue as much as possible after an error"
+msgstr ""
+
+msgid "Continue as much as possible after an error; recalculate deps for remaining packages"
 msgstr ""
 
 msgid "Continue conversation with given id"
@@ -12800,6 +12851,9 @@ msgid "Control whether GCC places uninitialized local variables into the \"bss\"
 msgstr ""
 
 msgid "Control whether RTC is in local time"
+msgstr ""
+
+msgid "Control whether build-time deps go into ROOT or /"
 msgstr ""
 
 msgid "Control whether color is used"
@@ -17341,6 +17395,9 @@ msgstr ""
 msgid "Display a help page"
 msgstr ""
 
+msgid "Display a list of available package sets"
+msgstr ""
+
 msgid "Display a list of speedtest.net servers sorted by distance"
 msgstr ""
 
@@ -17438,6 +17495,9 @@ msgid "Display all values currently available"
 msgstr ""
 
 msgid "Display an archive's list to console"
+msgstr ""
+
+msgid "Display ancillary information required for bug reports"
 msgstr ""
 
 msgid "Display answers as exclamation points and missing packets as dots"
@@ -18658,6 +18718,9 @@ msgstr ""
 msgid "Display toolbar or menubar"
 msgstr ""
 
+msgid "Display total of unread GLEP 42 news items"
+msgstr ""
+
 msgid "Display untracked files in columns"
 msgstr ""
 
@@ -19813,6 +19876,9 @@ msgstr ""
 msgid "Do not install files from given subprojects"
 msgstr ""
 
+msgid "Do not install from binary packages for live ebuilds"
+msgstr ""
+
 msgid "Do not install recommended packages"
 msgstr ""
 
@@ -20173,6 +20239,12 @@ msgstr ""
 msgid "Do not rebuild before running tests"
 msgstr ""
 
+msgid "Do not rebuild matching packages due to --rebuild"
+msgstr ""
+
+msgid "Do not rebuild packages that depend on matching packages due to --rebuild"
+msgstr ""
+
 msgid "Do not recalculate the effective rights mask"
 msgstr ""
 
@@ -20519,6 +20591,9 @@ msgid "Do not start ghostscript in safe mode"
 msgstr ""
 
 msgid "Do not start ghostscript with the -dQUIET option"
+msgstr ""
+
+msgid "Do not start new builds if load average is at least LOAD"
 msgstr ""
 
 msgid "Do not start the commit message editor"
@@ -30955,6 +31030,9 @@ msgstr ""
 msgid "Ignore 'Content-Length' header"
 msgstr ""
 
+msgid "Ignore @world deps; may break installed packages (use with --ask)"
+msgstr ""
+
 msgid "Ignore CD/DVD repositories"
 msgstr ""
 
@@ -31043,6 +31121,12 @@ msgid "Ignore any balance assertions"
 msgstr ""
 
 msgid "Ignore any saved configuration"
+msgstr ""
+
+msgid "Ignore binary packages whose USE flags differ from current config"
+msgstr ""
+
+msgid "Ignore binary packages whose ebuild dependencies changed since the build"
 msgstr ""
 
 msgid "Ignore bogus module names"
@@ -31207,6 +31291,9 @@ msgstr ""
 msgid "Ignore logical volume identity"
 msgstr ""
 
+msgid "Ignore matching binary packages"
+msgstr ""
+
 msgid "Ignore md5sum"
 msgstr ""
 
@@ -31247,6 +31334,9 @@ msgid "Ignore non-authenticated packages"
 msgstr ""
 
 msgid "Ignore non-existing files on receiving side"
+msgstr ""
+
+msgid "Ignore non-matching binary packages"
 msgstr ""
 
 msgid "Ignore nonexistent files"
@@ -31301,6 +31391,12 @@ msgid "Ignore safety checks"
 msgstr ""
 
 msgid "Ignore scissor lines"
+msgstr ""
+
+msgid "Ignore slot/sub-slot := operator deps recorded at build time (debug only)"
+msgstr ""
+
+msgid "Ignore soname dependencies of binary and installed packages (default: y)"
 msgstr ""
 
 msgid "Ignore spaces after function names"
@@ -31909,6 +32005,9 @@ msgstr ""
 msgid "Include inherited options"
 msgstr ""
 
+msgid "Include install-time deps when --onlydeps and --onlydeps-with-rdeps=n are used"
+msgstr ""
+
 msgid "Include installed pkgs with changed USE flags"
 msgstr ""
 
@@ -32009,6 +32108,9 @@ msgid "Include residual signal in text output"
 msgstr ""
 
 msgid "Include reverse dependencies in the output"
+msgstr ""
+
+msgid "Include run-time deps when using --onlydeps (default: y)"
 msgstr ""
 
 msgid "Include secret key comment packets when exporting secret keys"
@@ -33710,6 +33812,15 @@ msgid "Like --method=md5crypt"
 msgstr ""
 
 msgid "Like --reuse-message, but allow editing commit message"
+msgstr ""
+
+msgid "Like --search, but also matches package descriptions"
+msgstr ""
+
+msgid "Like --unmerge but with CLEAN_DELAY=0; can remove critical packages"
+msgstr ""
+
+msgid "Like --update but only for packages already installed"
 msgstr ""
 
 msgid "Like --write-batch but w/o updating dest"
@@ -35638,6 +35749,9 @@ msgstr ""
 msgid "List packages by provider"
 msgstr ""
 
+msgid "List packages causing slot rebuilds in emerge output (default: y)"
+msgstr ""
+
 msgid "List packages depending on"
 msgstr ""
 
@@ -37426,6 +37540,9 @@ msgstr ""
 msgid "Make zipfile as old as the latest entry"
 msgstr ""
 
+msgid "Makes --ask reject single Enter keypresses as answers"
+msgstr ""
+
 msgid "Makes COM type information in specified assemblies available to the project"
 msgstr ""
 
@@ -37927,6 +38044,9 @@ msgstr ""
 msgid "Match pattern against full command line"
 msgstr ""
 
+msgid "Match search strings approximately; auto-disabled for regex searches (default: y)"
+msgstr ""
+
 msgid "Match secondary date instead"
 msgstr ""
 
@@ -37955,6 +38075,9 @@ msgid "Max memory, as scaled integer (default KiB)"
 msgstr ""
 
 msgid "Max num of children"
+msgstr ""
+
+msgid "Max number of times to backtrack on dependency conflicts (default: 20)"
 msgstr ""
 
 msgid "Max objects per response"
@@ -38272,6 +38395,9 @@ msgstr ""
 msgid "Minimum drive buffer fill ratio for the ATAPI wait mode"
 msgstr ""
 
+msgid "Minimum free GiB in PORTAGE_TMPDIR before starting more jobs (default: 18)"
+msgstr ""
+
 msgid "Minimum height when --height is given in percent"
 msgstr ""
 
@@ -38294,6 +38420,9 @@ msgid "Minimum payload size for sweeping pings"
 msgstr ""
 
 msgid "Minimum port to listen to"
+msgstr ""
+
+msgid "Minimum similarity percentage for fuzzy search results (default: 80)"
 msgstr ""
 
 msgid "Minimum stability (empty or one of: stable, RC, beta, alpha, dev)"
@@ -39502,6 +39631,9 @@ msgstr ""
 msgid "Number of octets per line"
 msgstr ""
 
+msgid "Number of packages to build simultaneously (0 = CPU count)"
+msgstr ""
+
 msgid "Number of pages to scan before the shared memory service goes to sleep"
 msgstr ""
 
@@ -39709,6 +39841,9 @@ msgstr ""
 msgid "Offensive fortunes only"
 msgstr ""
 
+msgid "Offer to read unread news via eselect when --ask is active"
+msgstr ""
+
 msgid "Offline migration"
 msgstr ""
 
@@ -39892,6 +40027,9 @@ msgstr ""
 msgid "Only connect if safe console handling is supported"
 msgstr ""
 
+msgid "Only consider rebuilt binaries with BUILD_TIME newer than TIMESTAMP"
+msgstr ""
+
 msgid "Only consider tags matching the given glob pattern"
 msgstr ""
 
@@ -39980,6 +40118,9 @@ msgid "Only expire unused working trees older than <time>"
 msgstr ""
 
 msgid "Only fail the build afterwards; allow all non-impacted builds to continue"
+msgstr ""
+
+msgid "Only fetch remote binary packages matching these atoms"
 msgstr ""
 
 msgid "Only fixate disk "
@@ -40376,6 +40517,9 @@ msgid "Only this package's library"
 msgstr ""
 
 msgid "Only uninstall the binary NAME"
+msgstr ""
+
+msgid "Only unmask and generate package.use settings without building anything"
 msgstr ""
 
 msgid "Only update the manifest"
@@ -43492,6 +43636,9 @@ msgstr ""
 msgid "Prefer lowest versions of dependencies"
 msgstr ""
 
+msgid "Prefer matching binary packages over newer unbuilt ebuilds"
+msgstr ""
+
 msgid "Prefer reading from other devices than these"
 msgstr ""
 
@@ -43841,6 +43988,12 @@ msgid "Prevent adding rpath for each used dynamic library"
 msgstr ""
 
 msgid "Prevent any configuration changes to domain until migration ends"
+msgstr ""
+
+msgid "Prevent autounmask from creating package.accept_keywords changes"
+msgstr ""
+
+msgid "Prevent autounmask from creating package.unmask or ** keyword changes"
 msgstr ""
 
 msgid "Prevent floating point registers from being used in any manner"
@@ -47389,6 +47542,9 @@ msgstr ""
 msgid "Pull in changes from another branch"
 msgstr ""
 
+msgid "Pull in test-conditional deps for matched packages even if test is not in FEATURES"
+msgstr ""
+
 msgid "Pull list of shunned references from server"
 msgstr ""
 
@@ -48460,6 +48616,18 @@ msgstr ""
 msgid "Rebuild modules installed in node_modules in current working directory"
 msgstr ""
 
+msgid "Rebuild packages when a new slot can satisfy := deps (default: y)"
+msgstr ""
+
+msgid "Rebuild packages when build-time deps are built from source"
+msgstr ""
+
+msgid "Rebuild packages when build-time deps are installed with a new revision"
+msgstr ""
+
+msgid "Rebuild packages when build-time deps are installed with a new version"
+msgstr ""
+
 msgid "Rebuild ports containing broken binaries"
 msgstr ""
 
@@ -48500,6 +48668,9 @@ msgid "Recognize Boost format strings (only language C++)"
 msgstr ""
 
 msgid "Recognize Qt format strings (only language C++)"
+msgstr ""
+
+msgid "Recompile a package if it is now pulled from a different repository"
 msgstr ""
 
 msgid "Recompile every Sass file, even if the CSS file is newer"
@@ -48724,6 +48895,9 @@ msgstr ""
 msgid "Redeploy artifact on Weblogic server(s) or cluster(s)"
 msgstr ""
 
+msgid "Redirect all build output to logs; display on failure"
+msgstr ""
+
 msgid "Redirect all messages into a file"
 msgstr ""
 
@@ -48898,6 +49072,9 @@ msgstr ""
 msgid "Regenerate library dependency metadata"
 msgstr ""
 
+msgid "Regenerate package manifests (prefer repoman manifest)"
+msgstr ""
+
 msgid "Regex flags: use `--help` instead of `-h` to see details"
 msgstr ""
 
@@ -49019,6 +49196,9 @@ msgid "Reinstall packages"
 msgstr ""
 
 msgid "Reinstall packages required by this package"
+msgstr ""
+
+msgid "Reinstall packages whose active USE flags changed since installation (ignores added/removed disabled flags)"
 msgstr ""
 
 msgid "Reinstall the app keeping its data"
@@ -49178,6 +49358,9 @@ msgid "Remote Path"
 msgstr ""
 
 msgid "Remote alias"
+msgstr ""
+
+msgid "Remote binary packages matching these atoms are not fetched"
 msgstr ""
 
 msgid "Remote branch ref used by `git push`"
@@ -49402,6 +49585,9 @@ msgstr ""
 msgid "Remove all but the given number of backups"
 msgstr ""
 
+msgid "Remove all but the most recently installed version in each slot"
+msgstr ""
+
 msgid "Remove all classes attributes"
 msgstr ""
 
@@ -49436,6 +49622,9 @@ msgid "Remove all gz files from cache"
 msgstr ""
 
 msgid "Remove all lines matching key"
+msgstr ""
+
+msgid "Remove all matching packages without checking dependencies"
 msgstr ""
 
 msgid "Remove all mutations"
@@ -49535,6 +49724,9 @@ msgid "Remove artifacts that cargo has generated in the past"
 msgstr ""
 
 msgid "Remove associated storage volumes"
+msgstr ""
+
+msgid "Remove atoms/sets from @world. Implied by uninstall actions (use --deselect=n to prevent)"
 msgstr ""
 
 msgid "Remove auto-generated configuration files left over by the daemon"
@@ -49762,6 +49954,9 @@ msgstr ""
 msgid "Remove matching variables"
 msgstr ""
 
+msgid "Remove merge-order constraint from --tree output for readability"
+msgstr ""
+
 msgid "Remove module"
 msgstr ""
 
@@ -49811,6 +50006,9 @@ msgid "Remove only ignored files"
 msgstr ""
 
 msgid "Remove only locks with specified repository"
+msgstr ""
+
+msgid "Remove orphaned dependencies (packages not in @world and not required by other packages)"
 msgstr ""
 
 msgid "Remove orphaned libraries (not required by installed packages)"
@@ -50129,6 +50327,9 @@ msgid "Removes a package from the require-dev section"
 msgstr ""
 
 msgid "Removes a remote"
+msgstr ""
+
+msgid "Removes all but the highest installed version of a package from your system"
 msgstr ""
 
 msgid "Removes all cache"
@@ -50470,6 +50671,9 @@ msgstr ""
 msgid "Replace include directories"
 msgstr ""
 
+msgid "Replace installed packages with binary packages that have been rebuilt"
+msgstr ""
+
 msgid "Replace non-graphic characters with '?'"
 msgstr ""
 
@@ -50477,6 +50681,12 @@ msgid "Replace only the last occurrence"
 msgstr ""
 
 msgid "Replace packages in the base layer"
+msgstr ""
+
+msgid "Replace packages whose ebuild SLOT metadata changed since they were built"
+msgstr ""
+
+msgid "Replace packages whose ebuild dependencies changed since they were built"
 msgstr ""
 
 msgid "Replace patch header"
@@ -50675,6 +50885,9 @@ msgid "Report on mode of file"
 msgstr ""
 
 msgid "Report outstanding replies"
+msgstr ""
+
+msgid "Report packages whose ebuild dependencies changed since installation"
 msgstr ""
 
 msgid "Report processor frequency and idle statistics"
@@ -51412,6 +51625,9 @@ msgstr ""
 msgid "Restow: delete and then stow again"
 msgstr ""
 
+msgid "Restrict --sync to specified submodule (rsync only); repeatable"
+msgstr ""
+
 msgid "Restrict access"
 msgstr ""
 
@@ -51500,6 +51716,9 @@ msgid "Resume previously canceled or interrupted scrub"
 msgstr ""
 
 msgid "Resume reactor from specified project"
+msgstr ""
+
+msgid "Resumes the most recent merge list that aborted due to an error"
 msgstr ""
 
 msgid "Resync package contents from source"
@@ -52033,6 +52252,9 @@ msgstr ""
 msgid "Root source tree"
 msgstr ""
 
+msgid "Root to use as --quickpkg-direct source (default: /)"
+msgstr ""
+
 msgid "Rotate log every kbytes, requires -f"
 msgstr ""
 
@@ -52550,6 +52772,9 @@ msgid "Run package manager within chroot"
 msgstr ""
 
 msgid "Run package manager within jail"
+msgstr ""
+
+msgid "Run package-specific actions after emerge (usually config setup)"
 msgstr ""
 
 msgid "Run patch phase of a port"
@@ -53684,6 +53909,9 @@ msgid "Search directory for makefile"
 msgstr ""
 
 msgid "Search documentation"
+msgstr ""
+
+msgid "Search ebuilds for <string>. Use `%<string>` for regex"
 msgstr ""
 
 msgid "Search files according to the specified search mask"
@@ -54952,6 +55180,9 @@ msgstr ""
 msgid "Set EDNS0 Max UDP packet size"
 msgstr ""
 
+msgid "Set EPREFIX"
+msgstr ""
+
 msgid "Set GDB's working directory"
 msgstr ""
 
@@ -54988,6 +55219,9 @@ msgstr ""
 msgid "Set NDOTS value"
 msgstr ""
 
+msgid "Set PORTAGE_CONFIGROOT"
+msgstr ""
+
 msgid "Set PTRACE_O_EXITKILL ptrace option to all tracee processes"
 msgstr ""
 
@@ -55007,6 +55241,9 @@ msgid "Set RAW writing mode"
 msgstr ""
 
 msgid "Set REQUESTER PAYS for operations"
+msgstr ""
+
+msgid "Set ROOT (target root filesystem)"
 msgstr ""
 
 msgid "Set Rails environment"
@@ -55031,6 +55268,9 @@ msgid "Set SMART data for a drive"
 msgstr ""
 
 msgid "Set SO_DEBUG socket option"
+msgstr ""
+
+msgid "Set SYSROOT (root for DEPEND build-time deps)"
 msgstr ""
 
 msgid "Set TAO (Track At Once) writing mode"
@@ -58327,9 +58567,6 @@ msgstr ""
 msgid "Show camera driver manual"
 msgstr ""
 
-msgid "Show changelog of pkg. Use with --pretend"
-msgstr ""
-
 msgid "Show changes between commits and working tree"
 msgstr ""
 
@@ -59836,6 +60073,9 @@ msgstr ""
 msgid "Show signatures and descriptions for the available functions"
 msgstr ""
 
+msgid "Show similar package names when a package is not found (default: y)"
+msgstr ""
+
 msgid "Show sizes in GiB, or GB with --si"
 msgstr ""
 
@@ -61339,6 +61579,9 @@ msgstr ""
 msgid "Skip package installation for this run"
 msgstr ""
 
+msgid "Skip packages already installed (same as --noreplace; use =n to force disable)"
+msgstr ""
+
 msgid "Skip pre/post hook scripts"
 msgstr ""
 
@@ -61618,6 +61861,9 @@ msgstr ""
 msgid "Sort files by name"
 msgstr ""
 
+msgid "Sort flag lists alphabetically"
+msgstr ""
+
 msgid "Sort languages based on column"
 msgstr ""
 
@@ -61766,6 +62012,9 @@ msgid "Source-only mode"
 msgstr ""
 
 msgid "Space or comma separated list of features to activate"
+msgstr ""
+
+msgid "Space-separated atoms to never install"
 msgstr ""
 
 msgid "Space-separated options to exclude from search"
@@ -65179,6 +65428,9 @@ msgstr ""
 msgid "Substitute %{var}% variables"
 msgstr ""
 
+msgid "Substitute installed-package deps with current ebuild deps during calculations (default: y)"
+msgstr ""
+
 msgid "Substitute one word for another"
 msgstr ""
 
@@ -65266,6 +65518,9 @@ msgstr ""
 msgid "Suppress --noImplicitAny errors for indexing objects lacking index signatures"
 msgstr ""
 
+msgid "Suppress ::repository in merge list; use numbers instead"
+msgstr ""
+
 msgid "Suppress SNAPSHOT updates"
 msgstr ""
 
@@ -65297,6 +65552,9 @@ msgid "Suppress any output"
 msgstr ""
 
 msgid "Suppress battery information"
+msgstr ""
+
+msgid "Suppress build log display on failure (show only die message and log path)"
 msgstr ""
 
 msgid "Suppress checkout"
@@ -65441,6 +65699,9 @@ msgid "Suppress the warning about missing MDC integrity protection"
 msgstr ""
 
 msgid "Suppress the warning about unsafe file and home directory (--homedir) permissions"
+msgstr ""
+
+msgid "Suppress the warning shown before --unmerge actions"
 msgstr ""
 
 msgid "Suppress thermal information"
@@ -66116,6 +66377,12 @@ msgid "Temporarily lock an active home area"
 msgstr ""
 
 msgid "Temporarily offline"
+msgstr ""
+
+msgid "Temporarily override ACCEPT_PROPERTIES (e.g. =-interactive)"
+msgstr ""
+
+msgid "Temporarily override ACCEPT_RESTRICT (e.g. =-bindist)"
 msgstr ""
 
 msgid "Temporary mount point property"
@@ -67594,6 +67861,9 @@ msgstr ""
 msgid "Treat keyboard as standard US keyboard"
 msgstr ""
 
+msgid "Treat matching packages as not installed and reinstall them"
+msgstr ""
+
 msgid "Treat newlines as hard line breaks"
 msgstr ""
 
@@ -67670,6 +67940,12 @@ msgid "Treated as MOZ_LOG_FILE=<file> environment variable, overrides it"
 msgstr ""
 
 msgid "Tree location"
+msgstr ""
+
+msgid "Trigger --complete-graph when USE or IUSE changes for an installed package (default: y)"
+msgstr ""
+
+msgid "Trigger --complete-graph when an installed package version changes (default: y)"
 msgstr ""
 
 msgid "Trigger DHCP reconfiguration of all connected clients"
@@ -68827,6 +69103,9 @@ msgstr ""
 msgid "Update packages"
 msgstr ""
 
+msgid "Update packages to best available version"
+msgstr ""
+
 msgid "Update parts of an existing network's configuration"
 msgstr ""
 
@@ -68852,6 +69131,9 @@ msgid "Update remote repositories"
 msgstr ""
 
 msgid "Update remote state from local state"
+msgstr ""
+
+msgid "Update repositories. Use without arguments to update all autosync repos"
 msgstr ""
 
 msgid "Update repository indexes"
@@ -70276,6 +70558,9 @@ msgstr ""
 msgid "Use dot character instead of braille"
 msgstr ""
 
+msgid "Use ebuilds for deps; binary packages only for explicitly named atoms"
+msgstr ""
+
 msgid "Use editor to modify kernel arguments"
 msgstr ""
 
@@ -70493,6 +70778,9 @@ msgid "Use input from pipe of emerge -pv"
 msgstr ""
 
 msgid "Use insecure TLS connection"
+msgstr ""
+
+msgid "Use installed packages directly as binary packages"
 msgstr ""
 
 msgid "Use instead of host if you want to address 255.255.255.255"
@@ -71200,6 +71488,9 @@ msgstr ""
 msgid "Use the dynamic section info when displaying symbols"
 msgstr ""
 
+msgid "Use the egencache-built search index (default: y)"
+msgstr ""
+
 msgid "Use the file's modification time as the time of import."
 msgstr ""
 
@@ -71483,6 +71774,9 @@ msgid "Use translations under given directory"
 msgstr ""
 
 msgid "Use uglier formatting"
+msgstr ""
+
+msgid "Use unbuilt ebuild metadata for visibility checks on built packages"
 msgstr ""
 
 msgid "Use unicode characters in the output"
@@ -72463,6 +72757,9 @@ msgstr ""
 msgid "Warn if variadic macros are used in pedantic mode"
 msgstr ""
 
+msgid "Warn on @world packages with no available ebuild (default: y)"
+msgstr ""
+
 msgid "Warn on lint"
 msgstr ""
 
@@ -73192,6 +73489,9 @@ msgstr ""
 msgid "Write attribute value"
 msgstr ""
 
+msgid "Write autounmask changes to config files (implied by --ask)"
+msgstr ""
+
 msgid "Write column names in results"
 msgstr ""
 
@@ -73244,6 +73544,9 @@ msgid "Write index to a file"
 msgstr ""
 
 msgid "Write index to specified file"
+msgstr ""
+
+msgid "Write keyword/mask changes using >= operators instead of ="
 msgstr ""
 
 msgid "Write line numbers for errors"

--- a/localization/po/pt_BR.po
+++ b/localization/po/pt_BR.po
@@ -5142,6 +5142,9 @@ msgstr ""
 msgid "Access repository settings"
 msgstr ""
 
+msgid "Account for library link-level deps during --depclean and --prune (default: y)"
+msgstr ""
+
 msgid "Account to be altered"
 msgstr ""
 
@@ -5928,6 +5931,9 @@ msgstr ""
 msgid "Add packages"
 msgstr ""
 
+msgid "Add packages to @world (inverse of --oneshot)"
+msgstr ""
+
 msgid "Add parts on top of the section hierarchy"
 msgstr ""
 
@@ -6588,11 +6594,20 @@ msgstr ""
 msgid "Allow automatically filling CAPTCHA"
 msgstr ""
 
+msgid "Allow autounmask to create package.license changes"
+msgstr ""
+
+msgid "Allow autounmask to create package.use changes (enabled by default)"
+msgstr ""
+
 msgid "Allow backspace and carriage return"
 msgstr "Allow backspace and carriage return"
 
 msgid "Allow backspace, tab and carriage return"
 msgstr "Allow backspace, tab and carriage return"
+
+msgid "Allow backtracking after autounmask detects necessary changes"
+msgstr ""
 
 msgid "Allow binary files to be diffed"
 msgstr ""
@@ -7692,6 +7707,9 @@ msgstr ""
 msgid "Apply automated posting rules to modify txns"
 msgstr ""
 
+msgid "Apply autounmask changes and continue to execute command"
+msgstr ""
+
 msgid "Apply changes from a Differential diff"
 msgstr ""
 
@@ -7816,6 +7834,9 @@ msgid "Apply option to this zone"
 msgstr ""
 
 msgid "Apply options to a portion of the image [geometry]"
+msgstr ""
+
+msgid "Apply package moves when necessary (default: y; do not disable normally)"
 msgstr ""
 
 msgid "Apply packagefiles to the subproject"
@@ -8211,6 +8232,9 @@ msgstr "Assume no on most questions"
 msgid "Assume no to all questions"
 msgstr ""
 
+msgid "Assume packages may have implicit deps on @system (default: y)"
+msgstr ""
+
 msgid "Assume patches were created with old/new files swapped"
 msgstr ""
 
@@ -8347,6 +8371,9 @@ msgid "Assume yes when asked for confirmation"
 msgstr ""
 
 msgid "Assumes that structures should have 8 byte alignment"
+msgstr ""
+
+msgid "Atoms for which no binary packages should be built"
 msgstr ""
 
 msgid "Attach a USB device to the host"
@@ -8541,6 +8568,12 @@ msgstr ""
 msgid "Auto-confirm non-security prompts"
 msgstr ""
 
+msgid "Auto-detect regex in search strings (default: y)"
+msgstr ""
+
+msgid "Auto-enable --with-bdeps for installation actions (default: y)"
+msgstr ""
+
 msgid "Auto-gen package cache"
 msgstr ""
 
@@ -8668,6 +8701,9 @@ msgid "Automatically sync the repository"
 msgstr ""
 
 msgid "Automatically trust and import new repository signing keys"
+msgstr ""
+
+msgid "Automatically unmasks packages and generates package.use settings"
 msgstr ""
 
 msgid "Automatically update the packet display as packets are coming in"
@@ -9039,6 +9075,9 @@ msgstr ""
 msgid "Binary input mode"
 msgstr ""
 
+msgid "Binary package format to create"
+msgstr ""
+
 msgid "Binary-only mode, abort if no archive available"
 msgstr ""
 
@@ -9327,7 +9366,7 @@ msgstr ""
 msgid "Build a Windows executable"
 msgstr ""
 
-msgid "Build a binary pkg additionally"
+msgid "Build a binary package in addition to merging"
 msgstr ""
 
 msgid "Build a console executable"
@@ -10356,6 +10395,9 @@ msgstr ""
 msgid "Check and fix problems in the world file"
 msgstr ""
 
+msgid "Check and update the dependency cache of all ebuilds in repository"
+msgstr ""
+
 msgid "Check and wait until a group of devices of a filesystem is ready for mount"
 msgstr ""
 
@@ -11158,6 +11200,9 @@ msgid "Clean up cache directory"
 msgstr ""
 
 msgid "Clean up releases, stemcells, disks, etc."
+msgstr ""
+
+msgid "Clean up temp files after a build failure (useful with PORTAGE_TMPDIR on tmpfs)"
 msgstr ""
 
 msgid "Clean up the files that Cobertura Maven Plugin has created during instrumentation"
@@ -12519,6 +12564,9 @@ msgstr ""
 msgid "Consider case when comparing file names"
 msgstr ""
 
+msgid "Consider deep deps of all @world packages; bail if the operation would break any"
+msgstr ""
+
 msgid "Consider files as separate"
 msgstr ""
 
@@ -12622,6 +12670,9 @@ msgid "Continue after an error"
 msgstr "Continue after an error"
 
 msgid "Continue as much as possible after an error"
+msgstr ""
+
+msgid "Continue as much as possible after an error; recalculate deps for remaining packages"
 msgstr ""
 
 msgid "Continue conversation with given id"
@@ -12805,6 +12856,9 @@ msgid "Control whether GCC places uninitialized local variables into the \"bss\"
 msgstr ""
 
 msgid "Control whether RTC is in local time"
+msgstr ""
+
+msgid "Control whether build-time deps go into ROOT or /"
 msgstr ""
 
 msgid "Control whether color is used"
@@ -17346,6 +17400,9 @@ msgstr ""
 msgid "Display a help page"
 msgstr ""
 
+msgid "Display a list of available package sets"
+msgstr ""
+
 msgid "Display a list of speedtest.net servers sorted by distance"
 msgstr ""
 
@@ -17443,6 +17500,9 @@ msgid "Display all values currently available"
 msgstr ""
 
 msgid "Display an archive's list to console"
+msgstr ""
+
+msgid "Display ancillary information required for bug reports"
 msgstr ""
 
 msgid "Display answers as exclamation points and missing packets as dots"
@@ -18663,6 +18723,9 @@ msgstr ""
 msgid "Display toolbar or menubar"
 msgstr ""
 
+msgid "Display total of unread GLEP 42 news items"
+msgstr ""
+
 msgid "Display untracked files in columns"
 msgstr ""
 
@@ -19818,6 +19881,9 @@ msgstr ""
 msgid "Do not install files from given subprojects"
 msgstr ""
 
+msgid "Do not install from binary packages for live ebuilds"
+msgstr ""
+
 msgid "Do not install recommended packages"
 msgstr ""
 
@@ -20178,6 +20244,12 @@ msgstr ""
 msgid "Do not rebuild before running tests"
 msgstr ""
 
+msgid "Do not rebuild matching packages due to --rebuild"
+msgstr ""
+
+msgid "Do not rebuild packages that depend on matching packages due to --rebuild"
+msgstr ""
+
 msgid "Do not recalculate the effective rights mask"
 msgstr ""
 
@@ -20524,6 +20596,9 @@ msgid "Do not start ghostscript in safe mode"
 msgstr ""
 
 msgid "Do not start ghostscript with the -dQUIET option"
+msgstr ""
+
+msgid "Do not start new builds if load average is at least LOAD"
 msgstr ""
 
 msgid "Do not start the commit message editor"
@@ -30960,6 +31035,9 @@ msgstr ""
 msgid "Ignore 'Content-Length' header"
 msgstr "Ignore “Content-Length” header"
 
+msgid "Ignore @world deps; may break installed packages (use with --ask)"
+msgstr ""
+
 msgid "Ignore CD/DVD repositories"
 msgstr ""
 
@@ -31048,6 +31126,12 @@ msgid "Ignore any balance assertions"
 msgstr ""
 
 msgid "Ignore any saved configuration"
+msgstr ""
+
+msgid "Ignore binary packages whose USE flags differ from current config"
+msgstr ""
+
+msgid "Ignore binary packages whose ebuild dependencies changed since the build"
 msgstr ""
 
 msgid "Ignore bogus module names"
@@ -31212,6 +31296,9 @@ msgstr ""
 msgid "Ignore logical volume identity"
 msgstr ""
 
+msgid "Ignore matching binary packages"
+msgstr ""
+
 msgid "Ignore md5sum"
 msgstr ""
 
@@ -31252,6 +31339,9 @@ msgid "Ignore non-authenticated packages"
 msgstr ""
 
 msgid "Ignore non-existing files on receiving side"
+msgstr ""
+
+msgid "Ignore non-matching binary packages"
 msgstr ""
 
 msgid "Ignore nonexistent files"
@@ -31306,6 +31396,12 @@ msgid "Ignore safety checks"
 msgstr ""
 
 msgid "Ignore scissor lines"
+msgstr ""
+
+msgid "Ignore slot/sub-slot := operator deps recorded at build time (debug only)"
+msgstr ""
+
+msgid "Ignore soname dependencies of binary and installed packages (default: y)"
 msgstr ""
 
 msgid "Ignore spaces after function names"
@@ -31914,6 +32010,9 @@ msgstr ""
 msgid "Include inherited options"
 msgstr ""
 
+msgid "Include install-time deps when --onlydeps and --onlydeps-with-rdeps=n are used"
+msgstr ""
+
 msgid "Include installed pkgs with changed USE flags"
 msgstr ""
 
@@ -32014,6 +32113,9 @@ msgid "Include residual signal in text output"
 msgstr ""
 
 msgid "Include reverse dependencies in the output"
+msgstr ""
+
+msgid "Include run-time deps when using --onlydeps (default: y)"
 msgstr ""
 
 msgid "Include secret key comment packets when exporting secret keys"
@@ -33715,6 +33817,15 @@ msgid "Like --method=md5crypt"
 msgstr ""
 
 msgid "Like --reuse-message, but allow editing commit message"
+msgstr ""
+
+msgid "Like --search, but also matches package descriptions"
+msgstr ""
+
+msgid "Like --unmerge but with CLEAN_DELAY=0; can remove critical packages"
+msgstr ""
+
+msgid "Like --update but only for packages already installed"
 msgstr ""
 
 msgid "Like --write-batch but w/o updating dest"
@@ -35643,6 +35754,9 @@ msgstr ""
 msgid "List packages by provider"
 msgstr ""
 
+msgid "List packages causing slot rebuilds in emerge output (default: y)"
+msgstr ""
+
 msgid "List packages depending on"
 msgstr ""
 
@@ -37431,6 +37545,9 @@ msgstr ""
 msgid "Make zipfile as old as the latest entry"
 msgstr "Make zipfile as old as the latest entry"
 
+msgid "Makes --ask reject single Enter keypresses as answers"
+msgstr ""
+
 msgid "Makes COM type information in specified assemblies available to the project"
 msgstr ""
 
@@ -37932,6 +38049,9 @@ msgstr ""
 msgid "Match pattern against full command line"
 msgstr ""
 
+msgid "Match search strings approximately; auto-disabled for regex searches (default: y)"
+msgstr ""
+
 msgid "Match secondary date instead"
 msgstr ""
 
@@ -37960,6 +38080,9 @@ msgid "Max memory, as scaled integer (default KiB)"
 msgstr ""
 
 msgid "Max num of children"
+msgstr ""
+
+msgid "Max number of times to backtrack on dependency conflicts (default: 20)"
 msgstr ""
 
 msgid "Max objects per response"
@@ -38277,6 +38400,9 @@ msgstr ""
 msgid "Minimum drive buffer fill ratio for the ATAPI wait mode"
 msgstr ""
 
+msgid "Minimum free GiB in PORTAGE_TMPDIR before starting more jobs (default: 18)"
+msgstr ""
+
 msgid "Minimum height when --height is given in percent"
 msgstr ""
 
@@ -38299,6 +38425,9 @@ msgid "Minimum payload size for sweeping pings"
 msgstr ""
 
 msgid "Minimum port to listen to"
+msgstr ""
+
+msgid "Minimum similarity percentage for fuzzy search results (default: 80)"
 msgstr ""
 
 msgid "Minimum stability (empty or one of: stable, RC, beta, alpha, dev)"
@@ -39507,6 +39636,9 @@ msgstr ""
 msgid "Number of octets per line"
 msgstr ""
 
+msgid "Number of packages to build simultaneously (0 = CPU count)"
+msgstr ""
+
 msgid "Number of pages to scan before the shared memory service goes to sleep"
 msgstr ""
 
@@ -39714,6 +39846,9 @@ msgstr ""
 msgid "Offensive fortunes only"
 msgstr ""
 
+msgid "Offer to read unread news via eselect when --ask is active"
+msgstr ""
+
 msgid "Offline migration"
 msgstr ""
 
@@ -39897,6 +40032,9 @@ msgstr "Only check if sorted"
 msgid "Only connect if safe console handling is supported"
 msgstr ""
 
+msgid "Only consider rebuilt binaries with BUILD_TIME newer than TIMESTAMP"
+msgstr ""
+
 msgid "Only consider tags matching the given glob pattern"
 msgstr ""
 
@@ -39985,6 +40123,9 @@ msgid "Only expire unused working trees older than <time>"
 msgstr ""
 
 msgid "Only fail the build afterwards; allow all non-impacted builds to continue"
+msgstr ""
+
+msgid "Only fetch remote binary packages matching these atoms"
 msgstr ""
 
 msgid "Only fixate disk "
@@ -40381,6 +40522,9 @@ msgid "Only this package's library"
 msgstr ""
 
 msgid "Only uninstall the binary NAME"
+msgstr ""
+
+msgid "Only unmask and generate package.use settings without building anything"
 msgstr ""
 
 msgid "Only update the manifest"
@@ -43497,6 +43641,9 @@ msgstr ""
 msgid "Prefer lowest versions of dependencies"
 msgstr ""
 
+msgid "Prefer matching binary packages over newer unbuilt ebuilds"
+msgstr ""
+
 msgid "Prefer reading from other devices than these"
 msgstr ""
 
@@ -43846,6 +43993,12 @@ msgid "Prevent adding rpath for each used dynamic library"
 msgstr ""
 
 msgid "Prevent any configuration changes to domain until migration ends"
+msgstr ""
+
+msgid "Prevent autounmask from creating package.accept_keywords changes"
+msgstr ""
+
+msgid "Prevent autounmask from creating package.unmask or ** keyword changes"
 msgstr ""
 
 msgid "Prevent floating point registers from being used in any manner"
@@ -47394,6 +47547,9 @@ msgstr ""
 msgid "Pull in changes from another branch"
 msgstr ""
 
+msgid "Pull in test-conditional deps for matched packages even if test is not in FEATURES"
+msgstr ""
+
 msgid "Pull list of shunned references from server"
 msgstr ""
 
@@ -48465,6 +48621,18 @@ msgstr ""
 msgid "Rebuild modules installed in node_modules in current working directory"
 msgstr ""
 
+msgid "Rebuild packages when a new slot can satisfy := deps (default: y)"
+msgstr ""
+
+msgid "Rebuild packages when build-time deps are built from source"
+msgstr ""
+
+msgid "Rebuild packages when build-time deps are installed with a new revision"
+msgstr ""
+
+msgid "Rebuild packages when build-time deps are installed with a new version"
+msgstr ""
+
 msgid "Rebuild ports containing broken binaries"
 msgstr ""
 
@@ -48505,6 +48673,9 @@ msgid "Recognize Boost format strings (only language C++)"
 msgstr ""
 
 msgid "Recognize Qt format strings (only language C++)"
+msgstr ""
+
+msgid "Recompile a package if it is now pulled from a different repository"
 msgstr ""
 
 msgid "Recompile every Sass file, even if the CSS file is newer"
@@ -48729,6 +48900,9 @@ msgstr ""
 msgid "Redeploy artifact on Weblogic server(s) or cluster(s)"
 msgstr ""
 
+msgid "Redirect all build output to logs; display on failure"
+msgstr ""
+
 msgid "Redirect all messages into a file"
 msgstr ""
 
@@ -48903,6 +49077,9 @@ msgstr ""
 msgid "Regenerate library dependency metadata"
 msgstr ""
 
+msgid "Regenerate package manifests (prefer repoman manifest)"
+msgstr ""
+
 msgid "Regex flags: use `--help` instead of `-h` to see details"
 msgstr ""
 
@@ -49024,6 +49201,9 @@ msgid "Reinstall packages"
 msgstr ""
 
 msgid "Reinstall packages required by this package"
+msgstr ""
+
+msgid "Reinstall packages whose active USE flags changed since installation (ignores added/removed disabled flags)"
 msgstr ""
 
 msgid "Reinstall the app keeping its data"
@@ -49183,6 +49363,9 @@ msgid "Remote Path"
 msgstr ""
 
 msgid "Remote alias"
+msgstr ""
+
+msgid "Remote binary packages matching these atoms are not fetched"
 msgstr ""
 
 msgid "Remote branch ref used by `git push`"
@@ -49407,6 +49590,9 @@ msgstr ""
 msgid "Remove all but the given number of backups"
 msgstr ""
 
+msgid "Remove all but the most recently installed version in each slot"
+msgstr ""
+
 msgid "Remove all classes attributes"
 msgstr ""
 
@@ -49441,6 +49627,9 @@ msgid "Remove all gz files from cache"
 msgstr ""
 
 msgid "Remove all lines matching key"
+msgstr ""
+
+msgid "Remove all matching packages without checking dependencies"
 msgstr ""
 
 msgid "Remove all mutations"
@@ -49540,6 +49729,9 @@ msgid "Remove artifacts that cargo has generated in the past"
 msgstr ""
 
 msgid "Remove associated storage volumes"
+msgstr ""
+
+msgid "Remove atoms/sets from @world. Implied by uninstall actions (use --deselect=n to prevent)"
 msgstr ""
 
 msgid "Remove auto-generated configuration files left over by the daemon"
@@ -49767,6 +49959,9 @@ msgstr ""
 msgid "Remove matching variables"
 msgstr ""
 
+msgid "Remove merge-order constraint from --tree output for readability"
+msgstr ""
+
 msgid "Remove module"
 msgstr ""
 
@@ -49816,6 +50011,9 @@ msgid "Remove only ignored files"
 msgstr ""
 
 msgid "Remove only locks with specified repository"
+msgstr ""
+
+msgid "Remove orphaned dependencies (packages not in @world and not required by other packages)"
 msgstr ""
 
 msgid "Remove orphaned libraries (not required by installed packages)"
@@ -50134,6 +50332,9 @@ msgid "Removes a package from the require-dev section"
 msgstr ""
 
 msgid "Removes a remote"
+msgstr ""
+
+msgid "Removes all but the highest installed version of a package from your system"
 msgstr ""
 
 msgid "Removes all cache"
@@ -50475,6 +50676,9 @@ msgstr ""
 msgid "Replace include directories"
 msgstr ""
 
+msgid "Replace installed packages with binary packages that have been rebuilt"
+msgstr ""
+
 msgid "Replace non-graphic characters with '?'"
 msgstr "Mostra caracteres não imprimíveis com '?'"
 
@@ -50482,6 +50686,12 @@ msgid "Replace only the last occurrence"
 msgstr ""
 
 msgid "Replace packages in the base layer"
+msgstr ""
+
+msgid "Replace packages whose ebuild SLOT metadata changed since they were built"
+msgstr ""
+
+msgid "Replace packages whose ebuild dependencies changed since they were built"
 msgstr ""
 
 msgid "Replace patch header"
@@ -50680,6 +50890,9 @@ msgid "Report on mode of file"
 msgstr ""
 
 msgid "Report outstanding replies"
+msgstr ""
+
+msgid "Report packages whose ebuild dependencies changed since installation"
 msgstr ""
 
 msgid "Report processor frequency and idle statistics"
@@ -51417,6 +51630,9 @@ msgstr ""
 msgid "Restow: delete and then stow again"
 msgstr ""
 
+msgid "Restrict --sync to specified submodule (rsync only); repeatable"
+msgstr ""
+
 msgid "Restrict access"
 msgstr ""
 
@@ -51505,6 +51721,9 @@ msgid "Resume previously canceled or interrupted scrub"
 msgstr ""
 
 msgid "Resume reactor from specified project"
+msgstr ""
+
+msgid "Resumes the most recent merge list that aborted due to an error"
 msgstr ""
 
 msgid "Resync package contents from source"
@@ -52038,6 +52257,9 @@ msgstr ""
 msgid "Root source tree"
 msgstr ""
 
+msgid "Root to use as --quickpkg-direct source (default: /)"
+msgstr ""
+
 msgid "Rotate log every kbytes, requires -f"
 msgstr ""
 
@@ -52555,6 +52777,9 @@ msgid "Run package manager within chroot"
 msgstr ""
 
 msgid "Run package manager within jail"
+msgstr ""
+
+msgid "Run package-specific actions after emerge (usually config setup)"
 msgstr ""
 
 msgid "Run patch phase of a port"
@@ -53689,6 +53914,9 @@ msgid "Search directory for makefile"
 msgstr ""
 
 msgid "Search documentation"
+msgstr ""
+
+msgid "Search ebuilds for <string>. Use `%<string>` for regex"
 msgstr ""
 
 msgid "Search files according to the specified search mask"
@@ -54957,6 +55185,9 @@ msgstr ""
 msgid "Set EDNS0 Max UDP packet size"
 msgstr ""
 
+msgid "Set EPREFIX"
+msgstr ""
+
 msgid "Set GDB's working directory"
 msgstr ""
 
@@ -54993,6 +55224,9 @@ msgstr ""
 msgid "Set NDOTS value"
 msgstr ""
 
+msgid "Set PORTAGE_CONFIGROOT"
+msgstr ""
+
 msgid "Set PTRACE_O_EXITKILL ptrace option to all tracee processes"
 msgstr ""
 
@@ -55012,6 +55246,9 @@ msgid "Set RAW writing mode"
 msgstr ""
 
 msgid "Set REQUESTER PAYS for operations"
+msgstr ""
+
+msgid "Set ROOT (target root filesystem)"
 msgstr ""
 
 msgid "Set Rails environment"
@@ -55036,6 +55273,9 @@ msgid "Set SMART data for a drive"
 msgstr ""
 
 msgid "Set SO_DEBUG socket option"
+msgstr ""
+
+msgid "Set SYSROOT (root for DEPEND build-time deps)"
 msgstr ""
 
 msgid "Set TAO (Track At Once) writing mode"
@@ -58332,9 +58572,6 @@ msgstr ""
 msgid "Show camera driver manual"
 msgstr ""
 
-msgid "Show changelog of pkg. Use with --pretend"
-msgstr ""
-
 msgid "Show changes between commits and working tree"
 msgstr ""
 
@@ -59841,6 +60078,9 @@ msgstr ""
 msgid "Show signatures and descriptions for the available functions"
 msgstr ""
 
+msgid "Show similar package names when a package is not found (default: y)"
+msgstr ""
+
 msgid "Show sizes in GiB, or GB with --si"
 msgstr ""
 
@@ -61344,6 +61584,9 @@ msgstr ""
 msgid "Skip package installation for this run"
 msgstr ""
 
+msgid "Skip packages already installed (same as --noreplace; use =n to force disable)"
+msgstr ""
+
 msgid "Skip pre/post hook scripts"
 msgstr ""
 
@@ -61623,6 +61866,9 @@ msgstr ""
 msgid "Sort files by name"
 msgstr ""
 
+msgid "Sort flag lists alphabetically"
+msgstr ""
+
 msgid "Sort languages based on column"
 msgstr ""
 
@@ -61771,6 +62017,9 @@ msgid "Source-only mode"
 msgstr ""
 
 msgid "Space or comma separated list of features to activate"
+msgstr ""
+
+msgid "Space-separated atoms to never install"
 msgstr ""
 
 msgid "Space-separated options to exclude from search"
@@ -65184,6 +65433,9 @@ msgstr ""
 msgid "Substitute %{var}% variables"
 msgstr ""
 
+msgid "Substitute installed-package deps with current ebuild deps during calculations (default: y)"
+msgstr ""
+
 msgid "Substitute one word for another"
 msgstr "Substitue uma palavra por outra"
 
@@ -65271,6 +65523,9 @@ msgstr ""
 msgid "Suppress --noImplicitAny errors for indexing objects lacking index signatures"
 msgstr ""
 
+msgid "Suppress ::repository in merge list; use numbers instead"
+msgstr ""
+
 msgid "Suppress SNAPSHOT updates"
 msgstr ""
 
@@ -65302,6 +65557,9 @@ msgid "Suppress any output"
 msgstr ""
 
 msgid "Suppress battery information"
+msgstr ""
+
+msgid "Suppress build log display on failure (show only die message and log path)"
 msgstr ""
 
 msgid "Suppress checkout"
@@ -65447,6 +65705,9 @@ msgstr "Suppress the warning about missing MDC integrity protection"
 
 msgid "Suppress the warning about unsafe file and home directory (--homedir) permissions"
 msgstr "Suppress the warning about unsafe file and home directory (--homedir) permissions"
+
+msgid "Suppress the warning shown before --unmerge actions"
+msgstr ""
 
 msgid "Suppress thermal information"
 msgstr ""
@@ -66121,6 +66382,12 @@ msgid "Temporarily lock an active home area"
 msgstr ""
 
 msgid "Temporarily offline"
+msgstr ""
+
+msgid "Temporarily override ACCEPT_PROPERTIES (e.g. =-interactive)"
+msgstr ""
+
+msgid "Temporarily override ACCEPT_RESTRICT (e.g. =-bindist)"
 msgstr ""
 
 msgid "Temporary mount point property"
@@ -67599,6 +67866,9 @@ msgstr ""
 msgid "Treat keyboard as standard US keyboard"
 msgstr ""
 
+msgid "Treat matching packages as not installed and reinstall them"
+msgstr ""
+
 msgid "Treat newlines as hard line breaks"
 msgstr ""
 
@@ -67675,6 +67945,12 @@ msgid "Treated as MOZ_LOG_FILE=<file> environment variable, overrides it"
 msgstr ""
 
 msgid "Tree location"
+msgstr ""
+
+msgid "Trigger --complete-graph when USE or IUSE changes for an installed package (default: y)"
+msgstr ""
+
+msgid "Trigger --complete-graph when an installed package version changes (default: y)"
 msgstr ""
 
 msgid "Trigger DHCP reconfiguration of all connected clients"
@@ -68832,6 +69108,9 @@ msgstr ""
 msgid "Update packages"
 msgstr ""
 
+msgid "Update packages to best available version"
+msgstr ""
+
 msgid "Update parts of an existing network's configuration"
 msgstr ""
 
@@ -68857,6 +69136,9 @@ msgid "Update remote repositories"
 msgstr ""
 
 msgid "Update remote state from local state"
+msgstr ""
+
+msgid "Update repositories. Use without arguments to update all autosync repos"
 msgstr ""
 
 msgid "Update repository indexes"
@@ -70281,6 +70563,9 @@ msgstr ""
 msgid "Use dot character instead of braille"
 msgstr ""
 
+msgid "Use ebuilds for deps; binary packages only for explicitly named atoms"
+msgstr ""
+
 msgid "Use editor to modify kernel arguments"
 msgstr ""
 
@@ -70498,6 +70783,9 @@ msgid "Use input from pipe of emerge -pv"
 msgstr ""
 
 msgid "Use insecure TLS connection"
+msgstr ""
+
+msgid "Use installed packages directly as binary packages"
 msgstr ""
 
 msgid "Use instead of host if you want to address 255.255.255.255"
@@ -71205,6 +71493,9 @@ msgstr ""
 msgid "Use the dynamic section info when displaying symbols"
 msgstr ""
 
+msgid "Use the egencache-built search index (default: y)"
+msgstr ""
+
 msgid "Use the file's modification time as the time of import."
 msgstr ""
 
@@ -71488,6 +71779,9 @@ msgid "Use translations under given directory"
 msgstr ""
 
 msgid "Use uglier formatting"
+msgstr ""
+
+msgid "Use unbuilt ebuild metadata for visibility checks on built packages"
 msgstr ""
 
 msgid "Use unicode characters in the output"
@@ -72468,6 +72762,9 @@ msgstr ""
 msgid "Warn if variadic macros are used in pedantic mode"
 msgstr ""
 
+msgid "Warn on @world packages with no available ebuild (default: y)"
+msgstr ""
+
 msgid "Warn on lint"
 msgstr ""
 
@@ -73197,6 +73494,9 @@ msgstr "Write attribute subpackets to the specified file descriptor"
 msgid "Write attribute value"
 msgstr ""
 
+msgid "Write autounmask changes to config files (implied by --ask)"
+msgstr ""
+
 msgid "Write column names in results"
 msgstr ""
 
@@ -73249,6 +73549,9 @@ msgid "Write index to a file"
 msgstr ""
 
 msgid "Write index to specified file"
+msgstr ""
+
+msgid "Write keyword/mask changes using >= operators instead of ="
 msgstr ""
 
 msgid "Write line numbers for errors"

--- a/localization/po/sv.po
+++ b/localization/po/sv.po
@@ -5138,6 +5138,9 @@ msgstr "Hitta konfigurationsfil via skalet"
 msgid "Access repository settings"
 msgstr ""
 
+msgid "Account for library link-level deps during --depclean and --prune (default: y)"
+msgstr ""
+
 msgid "Account to be altered"
 msgstr ""
 
@@ -5924,6 +5927,9 @@ msgstr ""
 msgid "Add packages"
 msgstr ""
 
+msgid "Add packages to @world (inverse of --oneshot)"
+msgstr ""
+
 msgid "Add parts on top of the section hierarchy"
 msgstr ""
 
@@ -6584,11 +6590,20 @@ msgstr ""
 msgid "Allow automatically filling CAPTCHA"
 msgstr ""
 
+msgid "Allow autounmask to create package.license changes"
+msgstr ""
+
+msgid "Allow autounmask to create package.use changes (enabled by default)"
+msgstr ""
+
 msgid "Allow backspace and carriage return"
 msgstr "Tillåt backsteg och vagnretur"
 
 msgid "Allow backspace, tab and carriage return"
 msgstr "Tillåt backsteg, tabb och vagnretur"
+
+msgid "Allow backtracking after autounmask detects necessary changes"
+msgstr ""
 
 msgid "Allow binary files to be diffed"
 msgstr ""
@@ -7688,6 +7703,9 @@ msgstr ""
 msgid "Apply automated posting rules to modify txns"
 msgstr ""
 
+msgid "Apply autounmask changes and continue to execute command"
+msgstr ""
+
 msgid "Apply changes from a Differential diff"
 msgstr ""
 
@@ -7812,6 +7830,9 @@ msgid "Apply option to this zone"
 msgstr ""
 
 msgid "Apply options to a portion of the image [geometry]"
+msgstr ""
+
+msgid "Apply package moves when necessary (default: y; do not disable normally)"
 msgstr ""
 
 msgid "Apply packagefiles to the subproject"
@@ -8207,6 +8228,9 @@ msgstr "Anta nej på de flesta frågor"
 msgid "Assume no to all questions"
 msgstr "Anta nej på alla frågor"
 
+msgid "Assume packages may have implicit deps on @system (default: y)"
+msgstr ""
+
 msgid "Assume patches were created with old/new files swapped"
 msgstr ""
 
@@ -8343,6 +8367,9 @@ msgid "Assume yes when asked for confirmation"
 msgstr ""
 
 msgid "Assumes that structures should have 8 byte alignment"
+msgstr ""
+
+msgid "Atoms for which no binary packages should be built"
 msgstr ""
 
 msgid "Attach a USB device to the host"
@@ -8537,6 +8564,12 @@ msgstr ""
 msgid "Auto-confirm non-security prompts"
 msgstr ""
 
+msgid "Auto-detect regex in search strings (default: y)"
+msgstr ""
+
+msgid "Auto-enable --with-bdeps for installation actions (default: y)"
+msgstr ""
+
 msgid "Auto-gen package cache"
 msgstr "Autogenerera paketcache"
 
@@ -8664,6 +8697,9 @@ msgid "Automatically sync the repository"
 msgstr ""
 
 msgid "Automatically trust and import new repository signing keys"
+msgstr ""
+
+msgid "Automatically unmasks packages and generates package.use settings"
 msgstr ""
 
 msgid "Automatically update the packet display as packets are coming in"
@@ -9035,6 +9071,9 @@ msgstr ""
 msgid "Binary input mode"
 msgstr ""
 
+msgid "Binary package format to create"
+msgstr ""
+
 msgid "Binary-only mode, abort if no archive available"
 msgstr ""
 
@@ -9323,7 +9362,7 @@ msgstr ""
 msgid "Build a Windows executable"
 msgstr ""
 
-msgid "Build a binary pkg additionally"
+msgid "Build a binary package in addition to merging"
 msgstr ""
 
 msgid "Build a console executable"
@@ -10352,6 +10391,9 @@ msgstr ""
 msgid "Check and fix problems in the world file"
 msgstr ""
 
+msgid "Check and update the dependency cache of all ebuilds in repository"
+msgstr ""
+
 msgid "Check and wait until a group of devices of a filesystem is ready for mount"
 msgstr ""
 
@@ -11154,6 +11196,9 @@ msgid "Clean up cache directory"
 msgstr ""
 
 msgid "Clean up releases, stemcells, disks, etc."
+msgstr ""
+
+msgid "Clean up temp files after a build failure (useful with PORTAGE_TMPDIR on tmpfs)"
 msgstr ""
 
 msgid "Clean up the files that Cobertura Maven Plugin has created during instrumentation"
@@ -12515,6 +12560,9 @@ msgstr ""
 msgid "Consider case when comparing file names"
 msgstr "Skilj på skiftläge på filnamn"
 
+msgid "Consider deep deps of all @world packages; bail if the operation would break any"
+msgstr ""
+
 msgid "Consider files as separate"
 msgstr "Betrakta filer separat"
 
@@ -12618,6 +12666,9 @@ msgid "Continue after an error"
 msgstr "Fortsätt vid fel"
 
 msgid "Continue as much as possible after an error"
+msgstr ""
+
+msgid "Continue as much as possible after an error; recalculate deps for remaining packages"
 msgstr ""
 
 msgid "Continue conversation with given id"
@@ -12801,6 +12852,9 @@ msgid "Control whether GCC places uninitialized local variables into the \"bss\"
 msgstr ""
 
 msgid "Control whether RTC is in local time"
+msgstr ""
+
+msgid "Control whether build-time deps go into ROOT or /"
 msgstr ""
 
 msgid "Control whether color is used"
@@ -17342,6 +17396,9 @@ msgstr ""
 msgid "Display a help page"
 msgstr ""
 
+msgid "Display a list of available package sets"
+msgstr ""
+
 msgid "Display a list of speedtest.net servers sorted by distance"
 msgstr ""
 
@@ -17439,6 +17496,9 @@ msgid "Display all values currently available"
 msgstr ""
 
 msgid "Display an archive's list to console"
+msgstr ""
+
+msgid "Display ancillary information required for bug reports"
 msgstr ""
 
 msgid "Display answers as exclamation points and missing packets as dots"
@@ -18659,6 +18719,9 @@ msgstr ""
 msgid "Display toolbar or menubar"
 msgstr ""
 
+msgid "Display total of unread GLEP 42 news items"
+msgstr ""
+
 msgid "Display untracked files in columns"
 msgstr ""
 
@@ -19814,6 +19877,9 @@ msgstr ""
 msgid "Do not install files from given subprojects"
 msgstr ""
 
+msgid "Do not install from binary packages for live ebuilds"
+msgstr ""
+
 msgid "Do not install recommended packages"
 msgstr ""
 
@@ -20174,6 +20240,12 @@ msgstr ""
 msgid "Do not rebuild before running tests"
 msgstr ""
 
+msgid "Do not rebuild matching packages due to --rebuild"
+msgstr ""
+
+msgid "Do not rebuild packages that depend on matching packages due to --rebuild"
+msgstr ""
+
 msgid "Do not recalculate the effective rights mask"
 msgstr ""
 
@@ -20520,6 +20592,9 @@ msgid "Do not start ghostscript in safe mode"
 msgstr ""
 
 msgid "Do not start ghostscript with the -dQUIET option"
+msgstr ""
+
+msgid "Do not start new builds if load average is at least LOAD"
 msgstr ""
 
 msgid "Do not start the commit message editor"
@@ -30956,6 +31031,9 @@ msgstr ""
 msgid "Ignore 'Content-Length' header"
 msgstr "Ignorera 'Content-Length' huvud"
 
+msgid "Ignore @world deps; may break installed packages (use with --ask)"
+msgstr ""
+
 msgid "Ignore CD/DVD repositories"
 msgstr ""
 
@@ -31044,6 +31122,12 @@ msgid "Ignore any balance assertions"
 msgstr ""
 
 msgid "Ignore any saved configuration"
+msgstr ""
+
+msgid "Ignore binary packages whose USE flags differ from current config"
+msgstr ""
+
+msgid "Ignore binary packages whose ebuild dependencies changed since the build"
 msgstr ""
 
 msgid "Ignore bogus module names"
@@ -31208,6 +31292,9 @@ msgstr ""
 msgid "Ignore logical volume identity"
 msgstr ""
 
+msgid "Ignore matching binary packages"
+msgstr ""
+
 msgid "Ignore md5sum"
 msgstr ""
 
@@ -31248,6 +31335,9 @@ msgid "Ignore non-authenticated packages"
 msgstr "Ignorera oautentiserande paket"
 
 msgid "Ignore non-existing files on receiving side"
+msgstr ""
+
+msgid "Ignore non-matching binary packages"
 msgstr ""
 
 msgid "Ignore nonexistent files"
@@ -31302,6 +31392,12 @@ msgid "Ignore safety checks"
 msgstr ""
 
 msgid "Ignore scissor lines"
+msgstr ""
+
+msgid "Ignore slot/sub-slot := operator deps recorded at build time (debug only)"
+msgstr ""
+
+msgid "Ignore soname dependencies of binary and installed packages (default: y)"
 msgstr ""
 
 msgid "Ignore spaces after function names"
@@ -31910,6 +32006,9 @@ msgstr ""
 msgid "Include inherited options"
 msgstr ""
 
+msgid "Include install-time deps when --onlydeps and --onlydeps-with-rdeps=n are used"
+msgstr ""
+
 msgid "Include installed pkgs with changed USE flags"
 msgstr ""
 
@@ -32010,6 +32109,9 @@ msgid "Include residual signal in text output"
 msgstr ""
 
 msgid "Include reverse dependencies in the output"
+msgstr ""
+
+msgid "Include run-time deps when using --onlydeps (default: y)"
 msgstr ""
 
 msgid "Include secret key comment packets when exporting secret keys"
@@ -33711,6 +33813,15 @@ msgid "Like --method=md5crypt"
 msgstr ""
 
 msgid "Like --reuse-message, but allow editing commit message"
+msgstr ""
+
+msgid "Like --search, but also matches package descriptions"
+msgstr ""
+
+msgid "Like --unmerge but with CLEAN_DELAY=0; can remove critical packages"
+msgstr ""
+
+msgid "Like --update but only for packages already installed"
 msgstr ""
 
 msgid "Like --write-batch but w/o updating dest"
@@ -35639,6 +35750,9 @@ msgstr ""
 msgid "List packages by provider"
 msgstr ""
 
+msgid "List packages causing slot rebuilds in emerge output (default: y)"
+msgstr ""
+
 msgid "List packages depending on"
 msgstr "Visa paket som beror på"
 
@@ -37427,6 +37541,9 @@ msgstr ""
 msgid "Make zipfile as old as the latest entry"
 msgstr "Sätt filens ändringsdatum till ändringsdatum av senaste fil"
 
+msgid "Makes --ask reject single Enter keypresses as answers"
+msgstr ""
+
 msgid "Makes COM type information in specified assemblies available to the project"
 msgstr ""
 
@@ -37928,6 +38045,9 @@ msgstr ""
 msgid "Match pattern against full command line"
 msgstr ""
 
+msgid "Match search strings approximately; auto-disabled for regex searches (default: y)"
+msgstr ""
+
 msgid "Match secondary date instead"
 msgstr ""
 
@@ -37956,6 +38076,9 @@ msgid "Max memory, as scaled integer (default KiB)"
 msgstr ""
 
 msgid "Max num of children"
+msgstr ""
+
+msgid "Max number of times to backtrack on dependency conflicts (default: 20)"
 msgstr ""
 
 msgid "Max objects per response"
@@ -38273,6 +38396,9 @@ msgstr ""
 msgid "Minimum drive buffer fill ratio for the ATAPI wait mode"
 msgstr ""
 
+msgid "Minimum free GiB in PORTAGE_TMPDIR before starting more jobs (default: 18)"
+msgstr ""
+
 msgid "Minimum height when --height is given in percent"
 msgstr ""
 
@@ -38296,6 +38422,9 @@ msgstr ""
 
 msgid "Minimum port to listen to"
 msgstr "Lägsta portnummer att lyssna på"
+
+msgid "Minimum similarity percentage for fuzzy search results (default: 80)"
+msgstr ""
 
 msgid "Minimum stability (empty or one of: stable, RC, beta, alpha, dev)"
 msgstr ""
@@ -39503,6 +39632,9 @@ msgstr ""
 msgid "Number of octets per line"
 msgstr ""
 
+msgid "Number of packages to build simultaneously (0 = CPU count)"
+msgstr ""
+
 msgid "Number of pages to scan before the shared memory service goes to sleep"
 msgstr ""
 
@@ -39710,6 +39842,9 @@ msgstr ""
 msgid "Offensive fortunes only"
 msgstr ""
 
+msgid "Offer to read unread news via eselect when --ask is active"
+msgstr ""
+
 msgid "Offline migration"
 msgstr ""
 
@@ -39893,6 +40028,9 @@ msgstr "Verifiera bara sortering"
 msgid "Only connect if safe console handling is supported"
 msgstr ""
 
+msgid "Only consider rebuilt binaries with BUILD_TIME newer than TIMESTAMP"
+msgstr ""
+
 msgid "Only consider tags matching the given glob pattern"
 msgstr ""
 
@@ -39981,6 +40119,9 @@ msgid "Only expire unused working trees older than <time>"
 msgstr ""
 
 msgid "Only fail the build afterwards; allow all non-impacted builds to continue"
+msgstr ""
+
+msgid "Only fetch remote binary packages matching these atoms"
 msgstr ""
 
 msgid "Only fixate disk "
@@ -40377,6 +40518,9 @@ msgid "Only this package's library"
 msgstr ""
 
 msgid "Only uninstall the binary NAME"
+msgstr ""
+
+msgid "Only unmask and generate package.use settings without building anything"
 msgstr ""
 
 msgid "Only update the manifest"
@@ -43493,6 +43637,9 @@ msgstr ""
 msgid "Prefer lowest versions of dependencies"
 msgstr ""
 
+msgid "Prefer matching binary packages over newer unbuilt ebuilds"
+msgstr ""
+
 msgid "Prefer reading from other devices than these"
 msgstr ""
 
@@ -43842,6 +43989,12 @@ msgid "Prevent adding rpath for each used dynamic library"
 msgstr ""
 
 msgid "Prevent any configuration changes to domain until migration ends"
+msgstr ""
+
+msgid "Prevent autounmask from creating package.accept_keywords changes"
+msgstr ""
+
+msgid "Prevent autounmask from creating package.unmask or ** keyword changes"
 msgstr ""
 
 msgid "Prevent floating point registers from being used in any manner"
@@ -47390,6 +47543,9 @@ msgstr ""
 msgid "Pull in changes from another branch"
 msgstr ""
 
+msgid "Pull in test-conditional deps for matched packages even if test is not in FEATURES"
+msgstr ""
+
 msgid "Pull list of shunned references from server"
 msgstr ""
 
@@ -48461,6 +48617,18 @@ msgstr ""
 msgid "Rebuild modules installed in node_modules in current working directory"
 msgstr ""
 
+msgid "Rebuild packages when a new slot can satisfy := deps (default: y)"
+msgstr ""
+
+msgid "Rebuild packages when build-time deps are built from source"
+msgstr ""
+
+msgid "Rebuild packages when build-time deps are installed with a new revision"
+msgstr ""
+
+msgid "Rebuild packages when build-time deps are installed with a new version"
+msgstr ""
+
 msgid "Rebuild ports containing broken binaries"
 msgstr ""
 
@@ -48501,6 +48669,9 @@ msgid "Recognize Boost format strings (only language C++)"
 msgstr ""
 
 msgid "Recognize Qt format strings (only language C++)"
+msgstr ""
+
+msgid "Recompile a package if it is now pulled from a different repository"
 msgstr ""
 
 msgid "Recompile every Sass file, even if the CSS file is newer"
@@ -48725,6 +48896,9 @@ msgstr "Omdefinera variabel"
 msgid "Redeploy artifact on Weblogic server(s) or cluster(s)"
 msgstr ""
 
+msgid "Redirect all build output to logs; display on failure"
+msgstr ""
+
 msgid "Redirect all messages into a file"
 msgstr ""
 
@@ -48899,6 +49073,9 @@ msgstr ""
 msgid "Regenerate library dependency metadata"
 msgstr ""
 
+msgid "Regenerate package manifests (prefer repoman manifest)"
+msgstr ""
+
 msgid "Regex flags: use `--help` instead of `-h` to see details"
 msgstr ""
 
@@ -49020,6 +49197,9 @@ msgid "Reinstall packages"
 msgstr ""
 
 msgid "Reinstall packages required by this package"
+msgstr ""
+
+msgid "Reinstall packages whose active USE flags changed since installation (ignores added/removed disabled flags)"
 msgstr ""
 
 msgid "Reinstall the app keeping its data"
@@ -49179,6 +49359,9 @@ msgid "Remote Path"
 msgstr ""
 
 msgid "Remote alias"
+msgstr ""
+
+msgid "Remote binary packages matching these atoms are not fetched"
 msgstr ""
 
 msgid "Remote branch ref used by `git push`"
@@ -49403,6 +49586,9 @@ msgstr ""
 msgid "Remove all but the given number of backups"
 msgstr ""
 
+msgid "Remove all but the most recently installed version in each slot"
+msgstr ""
+
 msgid "Remove all classes attributes"
 msgstr ""
 
@@ -49437,6 +49623,9 @@ msgid "Remove all gz files from cache"
 msgstr "Ta bort alla gz-filer från cache"
 
 msgid "Remove all lines matching key"
+msgstr ""
+
+msgid "Remove all matching packages without checking dependencies"
 msgstr ""
 
 msgid "Remove all mutations"
@@ -49536,6 +49725,9 @@ msgid "Remove artifacts that cargo has generated in the past"
 msgstr ""
 
 msgid "Remove associated storage volumes"
+msgstr ""
+
+msgid "Remove atoms/sets from @world. Implied by uninstall actions (use --deselect=n to prevent)"
 msgstr ""
 
 msgid "Remove auto-generated configuration files left over by the daemon"
@@ -49763,6 +49955,9 @@ msgstr ""
 msgid "Remove matching variables"
 msgstr ""
 
+msgid "Remove merge-order constraint from --tree output for readability"
+msgstr ""
+
 msgid "Remove module"
 msgstr ""
 
@@ -49812,6 +50007,9 @@ msgid "Remove only ignored files"
 msgstr ""
 
 msgid "Remove only locks with specified repository"
+msgstr ""
+
+msgid "Remove orphaned dependencies (packages not in @world and not required by other packages)"
 msgstr ""
 
 msgid "Remove orphaned libraries (not required by installed packages)"
@@ -50130,6 +50328,9 @@ msgid "Removes a package from the require-dev section"
 msgstr ""
 
 msgid "Removes a remote"
+msgstr ""
+
+msgid "Removes all but the highest installed version of a package from your system"
 msgstr ""
 
 msgid "Removes all cache"
@@ -50471,6 +50672,9 @@ msgstr ""
 msgid "Replace include directories"
 msgstr "Ersätt inkluderingskataloger"
 
+msgid "Replace installed packages with binary packages that have been rebuilt"
+msgstr ""
+
 msgid "Replace non-graphic characters with '?'"
 msgstr "Ersätt ickegrafiska tecken med '?'"
 
@@ -50478,6 +50682,12 @@ msgid "Replace only the last occurrence"
 msgstr ""
 
 msgid "Replace packages in the base layer"
+msgstr ""
+
+msgid "Replace packages whose ebuild SLOT metadata changed since they were built"
+msgstr ""
+
+msgid "Replace packages whose ebuild dependencies changed since they were built"
 msgstr ""
 
 msgid "Replace patch header"
@@ -50676,6 +50886,9 @@ msgid "Report on mode of file"
 msgstr ""
 
 msgid "Report outstanding replies"
+msgstr ""
+
+msgid "Report packages whose ebuild dependencies changed since installation"
 msgstr ""
 
 msgid "Report processor frequency and idle statistics"
@@ -51413,6 +51626,9 @@ msgstr ""
 msgid "Restow: delete and then stow again"
 msgstr ""
 
+msgid "Restrict --sync to specified submodule (rsync only); repeatable"
+msgstr ""
+
 msgid "Restrict access"
 msgstr ""
 
@@ -51501,6 +51717,9 @@ msgid "Resume previously canceled or interrupted scrub"
 msgstr ""
 
 msgid "Resume reactor from specified project"
+msgstr ""
+
+msgid "Resumes the most recent merge list that aborted due to an error"
 msgstr ""
 
 msgid "Resync package contents from source"
@@ -52034,6 +52253,9 @@ msgstr ""
 msgid "Root source tree"
 msgstr "Rotkällträd"
 
+msgid "Root to use as --quickpkg-direct source (default: /)"
+msgstr ""
+
 msgid "Rotate log every kbytes, requires -f"
 msgstr ""
 
@@ -52551,6 +52773,9 @@ msgid "Run package manager within chroot"
 msgstr ""
 
 msgid "Run package manager within jail"
+msgstr ""
+
+msgid "Run package-specific actions after emerge (usually config setup)"
 msgstr ""
 
 msgid "Run patch phase of a port"
@@ -53685,6 +53910,9 @@ msgid "Search directory for makefile"
 msgstr "Sökkatalog för make-fil"
 
 msgid "Search documentation"
+msgstr ""
+
+msgid "Search ebuilds for <string>. Use `%<string>` for regex"
 msgstr ""
 
 msgid "Search files according to the specified search mask"
@@ -54953,6 +55181,9 @@ msgstr ""
 msgid "Set EDNS0 Max UDP packet size"
 msgstr ""
 
+msgid "Set EPREFIX"
+msgstr ""
+
 msgid "Set GDB's working directory"
 msgstr ""
 
@@ -54989,6 +55220,9 @@ msgstr ""
 msgid "Set NDOTS value"
 msgstr ""
 
+msgid "Set PORTAGE_CONFIGROOT"
+msgstr ""
+
 msgid "Set PTRACE_O_EXITKILL ptrace option to all tracee processes"
 msgstr ""
 
@@ -55008,6 +55242,9 @@ msgid "Set RAW writing mode"
 msgstr ""
 
 msgid "Set REQUESTER PAYS for operations"
+msgstr ""
+
+msgid "Set ROOT (target root filesystem)"
 msgstr ""
 
 msgid "Set Rails environment"
@@ -55032,6 +55269,9 @@ msgid "Set SMART data for a drive"
 msgstr ""
 
 msgid "Set SO_DEBUG socket option"
+msgstr ""
+
+msgid "Set SYSROOT (root for DEPEND build-time deps)"
 msgstr ""
 
 msgid "Set TAO (Track At Once) writing mode"
@@ -58328,9 +58568,6 @@ msgstr ""
 msgid "Show camera driver manual"
 msgstr ""
 
-msgid "Show changelog of pkg. Use with --pretend"
-msgstr ""
-
 msgid "Show changes between commits and working tree"
 msgstr ""
 
@@ -59837,6 +60074,9 @@ msgstr ""
 msgid "Show signatures and descriptions for the available functions"
 msgstr ""
 
+msgid "Show similar package names when a package is not found (default: y)"
+msgstr ""
+
 msgid "Show sizes in GiB, or GB with --si"
 msgstr ""
 
@@ -61340,6 +61580,9 @@ msgstr ""
 msgid "Skip package installation for this run"
 msgstr ""
 
+msgid "Skip packages already installed (same as --noreplace; use =n to force disable)"
+msgstr ""
+
 msgid "Skip pre/post hook scripts"
 msgstr ""
 
@@ -61619,6 +61862,9 @@ msgstr ""
 msgid "Sort files by name"
 msgstr ""
 
+msgid "Sort flag lists alphabetically"
+msgstr ""
+
 msgid "Sort languages based on column"
 msgstr ""
 
@@ -61767,6 +62013,9 @@ msgid "Source-only mode"
 msgstr ""
 
 msgid "Space or comma separated list of features to activate"
+msgstr ""
+
+msgid "Space-separated atoms to never install"
 msgstr ""
 
 msgid "Space-separated options to exclude from search"
@@ -65180,6 +65429,9 @@ msgstr ""
 msgid "Substitute %{var}% variables"
 msgstr ""
 
+msgid "Substitute installed-package deps with current ebuild deps during calculations (default: y)"
+msgstr ""
+
 msgid "Substitute one word for another"
 msgstr ""
 
@@ -65267,6 +65519,9 @@ msgstr ""
 msgid "Suppress --noImplicitAny errors for indexing objects lacking index signatures"
 msgstr ""
 
+msgid "Suppress ::repository in merge list; use numbers instead"
+msgstr ""
+
 msgid "Suppress SNAPSHOT updates"
 msgstr ""
 
@@ -65298,6 +65553,9 @@ msgid "Suppress any output"
 msgstr ""
 
 msgid "Suppress battery information"
+msgstr ""
+
+msgid "Suppress build log display on failure (show only die message and log path)"
 msgstr ""
 
 msgid "Suppress checkout"
@@ -65443,6 +65701,9 @@ msgstr "Undertryck varningen om saknat MDCintegritetsskydd"
 
 msgid "Suppress the warning about unsafe file and home directory (--homedir) permissions"
 msgstr "Undertryck varningen om osäkra fil- och hemkatalogrättigheter (--homedir) "
+
+msgid "Suppress the warning shown before --unmerge actions"
+msgstr ""
 
 msgid "Suppress thermal information"
 msgstr ""
@@ -66117,6 +66378,12 @@ msgid "Temporarily lock an active home area"
 msgstr ""
 
 msgid "Temporarily offline"
+msgstr ""
+
+msgid "Temporarily override ACCEPT_PROPERTIES (e.g. =-interactive)"
+msgstr ""
+
+msgid "Temporarily override ACCEPT_RESTRICT (e.g. =-bindist)"
 msgstr ""
 
 msgid "Temporary mount point property"
@@ -67595,6 +67862,9 @@ msgstr ""
 msgid "Treat keyboard as standard US keyboard"
 msgstr ""
 
+msgid "Treat matching packages as not installed and reinstall them"
+msgstr ""
+
 msgid "Treat newlines as hard line breaks"
 msgstr ""
 
@@ -67671,6 +67941,12 @@ msgid "Treated as MOZ_LOG_FILE=<file> environment variable, overrides it"
 msgstr ""
 
 msgid "Tree location"
+msgstr ""
+
+msgid "Trigger --complete-graph when USE or IUSE changes for an installed package (default: y)"
+msgstr ""
+
+msgid "Trigger --complete-graph when an installed package version changes (default: y)"
 msgstr ""
 
 msgid "Trigger DHCP reconfiguration of all connected clients"
@@ -68828,6 +69104,9 @@ msgstr ""
 msgid "Update packages"
 msgstr ""
 
+msgid "Update packages to best available version"
+msgstr ""
+
 msgid "Update parts of an existing network's configuration"
 msgstr ""
 
@@ -68853,6 +69132,9 @@ msgid "Update remote repositories"
 msgstr ""
 
 msgid "Update remote state from local state"
+msgstr ""
+
+msgid "Update repositories. Use without arguments to update all autosync repos"
 msgstr ""
 
 msgid "Update repository indexes"
@@ -70277,6 +70559,9 @@ msgstr ""
 msgid "Use dot character instead of braille"
 msgstr ""
 
+msgid "Use ebuilds for deps; binary packages only for explicitly named atoms"
+msgstr ""
+
 msgid "Use editor to modify kernel arguments"
 msgstr ""
 
@@ -70494,6 +70779,9 @@ msgid "Use input from pipe of emerge -pv"
 msgstr ""
 
 msgid "Use insecure TLS connection"
+msgstr ""
+
+msgid "Use installed packages directly as binary packages"
 msgstr ""
 
 msgid "Use instead of host if you want to address 255.255.255.255"
@@ -71201,6 +71489,9 @@ msgstr ""
 msgid "Use the dynamic section info when displaying symbols"
 msgstr ""
 
+msgid "Use the egencache-built search index (default: y)"
+msgstr ""
+
 msgid "Use the file's modification time as the time of import."
 msgstr ""
 
@@ -71484,6 +71775,9 @@ msgid "Use translations under given directory"
 msgstr ""
 
 msgid "Use uglier formatting"
+msgstr ""
+
+msgid "Use unbuilt ebuild metadata for visibility checks on built packages"
 msgstr ""
 
 msgid "Use unicode characters in the output"
@@ -72464,6 +72758,9 @@ msgstr ""
 msgid "Warn if variadic macros are used in pedantic mode"
 msgstr ""
 
+msgid "Warn on @world packages with no available ebuild (default: y)"
+msgstr ""
+
 msgid "Warn on lint"
 msgstr ""
 
@@ -73193,6 +73490,9 @@ msgstr "Skriv attributunderpaket till angiven filidentifierare"
 msgid "Write attribute value"
 msgstr ""
 
+msgid "Write autounmask changes to config files (implied by --ask)"
+msgstr ""
+
 msgid "Write column names in results"
 msgstr ""
 
@@ -73245,6 +73545,9 @@ msgid "Write index to a file"
 msgstr ""
 
 msgid "Write index to specified file"
+msgstr ""
+
+msgid "Write keyword/mask changes using >= operators instead of ="
 msgstr ""
 
 msgid "Write line numbers for errors"

--- a/localization/po/zh_CN.po
+++ b/localization/po/zh_CN.po
@@ -5162,6 +5162,9 @@ msgstr ""
 msgid "Access repository settings"
 msgstr ""
 
+msgid "Account for library link-level deps during --depclean and --prune (default: y)"
+msgstr ""
+
 msgid "Account to be altered"
 msgstr ""
 
@@ -5948,6 +5951,9 @@ msgstr ""
 msgid "Add packages"
 msgstr ""
 
+msgid "Add packages to @world (inverse of --oneshot)"
+msgstr ""
+
 msgid "Add parts on top of the section hierarchy"
 msgstr ""
 
@@ -6608,10 +6614,19 @@ msgstr ""
 msgid "Allow automatically filling CAPTCHA"
 msgstr ""
 
+msgid "Allow autounmask to create package.license changes"
+msgstr ""
+
+msgid "Allow autounmask to create package.use changes (enabled by default)"
+msgstr ""
+
 msgid "Allow backspace and carriage return"
 msgstr ""
 
 msgid "Allow backspace, tab and carriage return"
+msgstr ""
+
+msgid "Allow backtracking after autounmask detects necessary changes"
 msgstr ""
 
 msgid "Allow binary files to be diffed"
@@ -7712,6 +7727,9 @@ msgstr ""
 msgid "Apply automated posting rules to modify txns"
 msgstr ""
 
+msgid "Apply autounmask changes and continue to execute command"
+msgstr ""
+
 msgid "Apply changes from a Differential diff"
 msgstr ""
 
@@ -7836,6 +7854,9 @@ msgid "Apply option to this zone"
 msgstr ""
 
 msgid "Apply options to a portion of the image [geometry]"
+msgstr ""
+
+msgid "Apply package moves when necessary (default: y; do not disable normally)"
 msgstr ""
 
 msgid "Apply packagefiles to the subproject"
@@ -8231,6 +8252,9 @@ msgstr ""
 msgid "Assume no to all questions"
 msgstr ""
 
+msgid "Assume packages may have implicit deps on @system (default: y)"
+msgstr ""
+
 msgid "Assume patches were created with old/new files swapped"
 msgstr ""
 
@@ -8367,6 +8391,9 @@ msgid "Assume yes when asked for confirmation"
 msgstr ""
 
 msgid "Assumes that structures should have 8 byte alignment"
+msgstr ""
+
+msgid "Atoms for which no binary packages should be built"
 msgstr ""
 
 msgid "Attach a USB device to the host"
@@ -8561,6 +8588,12 @@ msgstr ""
 msgid "Auto-confirm non-security prompts"
 msgstr ""
 
+msgid "Auto-detect regex in search strings (default: y)"
+msgstr ""
+
+msgid "Auto-enable --with-bdeps for installation actions (default: y)"
+msgstr ""
+
 msgid "Auto-gen package cache"
 msgstr ""
 
@@ -8688,6 +8721,9 @@ msgid "Automatically sync the repository"
 msgstr ""
 
 msgid "Automatically trust and import new repository signing keys"
+msgstr ""
+
+msgid "Automatically unmasks packages and generates package.use settings"
 msgstr ""
 
 msgid "Automatically update the packet display as packets are coming in"
@@ -9059,6 +9095,9 @@ msgstr ""
 msgid "Binary input mode"
 msgstr ""
 
+msgid "Binary package format to create"
+msgstr ""
+
 msgid "Binary-only mode, abort if no archive available"
 msgstr ""
 
@@ -9347,7 +9386,7 @@ msgstr ""
 msgid "Build a Windows executable"
 msgstr ""
 
-msgid "Build a binary pkg additionally"
+msgid "Build a binary package in addition to merging"
 msgstr ""
 
 msgid "Build a console executable"
@@ -10376,6 +10415,9 @@ msgstr ""
 msgid "Check and fix problems in the world file"
 msgstr ""
 
+msgid "Check and update the dependency cache of all ebuilds in repository"
+msgstr ""
+
 msgid "Check and wait until a group of devices of a filesystem is ready for mount"
 msgstr ""
 
@@ -11178,6 +11220,9 @@ msgid "Clean up cache directory"
 msgstr ""
 
 msgid "Clean up releases, stemcells, disks, etc."
+msgstr ""
+
+msgid "Clean up temp files after a build failure (useful with PORTAGE_TMPDIR on tmpfs)"
 msgstr ""
 
 msgid "Clean up the files that Cobertura Maven Plugin has created during instrumentation"
@@ -12539,6 +12584,9 @@ msgstr ""
 msgid "Consider case when comparing file names"
 msgstr ""
 
+msgid "Consider deep deps of all @world packages; bail if the operation would break any"
+msgstr ""
+
 msgid "Consider files as separate"
 msgstr ""
 
@@ -12642,6 +12690,9 @@ msgid "Continue after an error"
 msgstr ""
 
 msgid "Continue as much as possible after an error"
+msgstr ""
+
+msgid "Continue as much as possible after an error; recalculate deps for remaining packages"
 msgstr ""
 
 msgid "Continue conversation with given id"
@@ -12825,6 +12876,9 @@ msgid "Control whether GCC places uninitialized local variables into the \"bss\"
 msgstr ""
 
 msgid "Control whether RTC is in local time"
+msgstr ""
+
+msgid "Control whether build-time deps go into ROOT or /"
 msgstr ""
 
 msgid "Control whether color is used"
@@ -17366,6 +17420,9 @@ msgstr ""
 msgid "Display a help page"
 msgstr ""
 
+msgid "Display a list of available package sets"
+msgstr ""
+
 msgid "Display a list of speedtest.net servers sorted by distance"
 msgstr ""
 
@@ -17463,6 +17520,9 @@ msgid "Display all values currently available"
 msgstr ""
 
 msgid "Display an archive's list to console"
+msgstr ""
+
+msgid "Display ancillary information required for bug reports"
 msgstr ""
 
 msgid "Display answers as exclamation points and missing packets as dots"
@@ -18683,6 +18743,9 @@ msgstr ""
 msgid "Display toolbar or menubar"
 msgstr ""
 
+msgid "Display total of unread GLEP 42 news items"
+msgstr ""
+
 msgid "Display untracked files in columns"
 msgstr ""
 
@@ -19838,6 +19901,9 @@ msgstr ""
 msgid "Do not install files from given subprojects"
 msgstr ""
 
+msgid "Do not install from binary packages for live ebuilds"
+msgstr ""
+
 msgid "Do not install recommended packages"
 msgstr ""
 
@@ -20198,6 +20264,12 @@ msgstr ""
 msgid "Do not rebuild before running tests"
 msgstr ""
 
+msgid "Do not rebuild matching packages due to --rebuild"
+msgstr ""
+
+msgid "Do not rebuild packages that depend on matching packages due to --rebuild"
+msgstr ""
+
 msgid "Do not recalculate the effective rights mask"
 msgstr ""
 
@@ -20544,6 +20616,9 @@ msgid "Do not start ghostscript in safe mode"
 msgstr ""
 
 msgid "Do not start ghostscript with the -dQUIET option"
+msgstr ""
+
+msgid "Do not start new builds if load average is at least LOAD"
 msgstr ""
 
 msgid "Do not start the commit message editor"
@@ -30980,6 +31055,9 @@ msgstr ""
 msgid "Ignore 'Content-Length' header"
 msgstr ""
 
+msgid "Ignore @world deps; may break installed packages (use with --ask)"
+msgstr ""
+
 msgid "Ignore CD/DVD repositories"
 msgstr ""
 
@@ -31068,6 +31146,12 @@ msgid "Ignore any balance assertions"
 msgstr ""
 
 msgid "Ignore any saved configuration"
+msgstr ""
+
+msgid "Ignore binary packages whose USE flags differ from current config"
+msgstr ""
+
+msgid "Ignore binary packages whose ebuild dependencies changed since the build"
 msgstr ""
 
 msgid "Ignore bogus module names"
@@ -31232,6 +31316,9 @@ msgstr ""
 msgid "Ignore logical volume identity"
 msgstr ""
 
+msgid "Ignore matching binary packages"
+msgstr ""
+
 msgid "Ignore md5sum"
 msgstr ""
 
@@ -31272,6 +31359,9 @@ msgid "Ignore non-authenticated packages"
 msgstr ""
 
 msgid "Ignore non-existing files on receiving side"
+msgstr ""
+
+msgid "Ignore non-matching binary packages"
 msgstr ""
 
 msgid "Ignore nonexistent files"
@@ -31326,6 +31416,12 @@ msgid "Ignore safety checks"
 msgstr ""
 
 msgid "Ignore scissor lines"
+msgstr ""
+
+msgid "Ignore slot/sub-slot := operator deps recorded at build time (debug only)"
+msgstr ""
+
+msgid "Ignore soname dependencies of binary and installed packages (default: y)"
 msgstr ""
 
 msgid "Ignore spaces after function names"
@@ -31934,6 +32030,9 @@ msgstr ""
 msgid "Include inherited options"
 msgstr ""
 
+msgid "Include install-time deps when --onlydeps and --onlydeps-with-rdeps=n are used"
+msgstr ""
+
 msgid "Include installed pkgs with changed USE flags"
 msgstr ""
 
@@ -32034,6 +32133,9 @@ msgid "Include residual signal in text output"
 msgstr ""
 
 msgid "Include reverse dependencies in the output"
+msgstr ""
+
+msgid "Include run-time deps when using --onlydeps (default: y)"
 msgstr ""
 
 msgid "Include secret key comment packets when exporting secret keys"
@@ -33735,6 +33837,15 @@ msgid "Like --method=md5crypt"
 msgstr ""
 
 msgid "Like --reuse-message, but allow editing commit message"
+msgstr ""
+
+msgid "Like --search, but also matches package descriptions"
+msgstr ""
+
+msgid "Like --unmerge but with CLEAN_DELAY=0; can remove critical packages"
+msgstr ""
+
+msgid "Like --update but only for packages already installed"
 msgstr ""
 
 msgid "Like --write-batch but w/o updating dest"
@@ -35663,6 +35774,9 @@ msgstr ""
 msgid "List packages by provider"
 msgstr ""
 
+msgid "List packages causing slot rebuilds in emerge output (default: y)"
+msgstr ""
+
 msgid "List packages depending on"
 msgstr ""
 
@@ -37451,6 +37565,9 @@ msgstr ""
 msgid "Make zipfile as old as the latest entry"
 msgstr ""
 
+msgid "Makes --ask reject single Enter keypresses as answers"
+msgstr ""
+
 msgid "Makes COM type information in specified assemblies available to the project"
 msgstr ""
 
@@ -37952,6 +38069,9 @@ msgstr ""
 msgid "Match pattern against full command line"
 msgstr ""
 
+msgid "Match search strings approximately; auto-disabled for regex searches (default: y)"
+msgstr ""
+
 msgid "Match secondary date instead"
 msgstr ""
 
@@ -37980,6 +38100,9 @@ msgid "Max memory, as scaled integer (default KiB)"
 msgstr ""
 
 msgid "Max num of children"
+msgstr ""
+
+msgid "Max number of times to backtrack on dependency conflicts (default: 20)"
 msgstr ""
 
 msgid "Max objects per response"
@@ -38297,6 +38420,9 @@ msgstr ""
 msgid "Minimum drive buffer fill ratio for the ATAPI wait mode"
 msgstr ""
 
+msgid "Minimum free GiB in PORTAGE_TMPDIR before starting more jobs (default: 18)"
+msgstr ""
+
 msgid "Minimum height when --height is given in percent"
 msgstr ""
 
@@ -38319,6 +38445,9 @@ msgid "Minimum payload size for sweeping pings"
 msgstr ""
 
 msgid "Minimum port to listen to"
+msgstr ""
+
+msgid "Minimum similarity percentage for fuzzy search results (default: 80)"
 msgstr ""
 
 msgid "Minimum stability (empty or one of: stable, RC, beta, alpha, dev)"
@@ -39527,6 +39656,9 @@ msgstr ""
 msgid "Number of octets per line"
 msgstr ""
 
+msgid "Number of packages to build simultaneously (0 = CPU count)"
+msgstr ""
+
 msgid "Number of pages to scan before the shared memory service goes to sleep"
 msgstr ""
 
@@ -39734,6 +39866,9 @@ msgstr ""
 msgid "Offensive fortunes only"
 msgstr ""
 
+msgid "Offer to read unread news via eselect when --ask is active"
+msgstr ""
+
 msgid "Offline migration"
 msgstr ""
 
@@ -39917,6 +40052,9 @@ msgstr ""
 msgid "Only connect if safe console handling is supported"
 msgstr ""
 
+msgid "Only consider rebuilt binaries with BUILD_TIME newer than TIMESTAMP"
+msgstr ""
+
 msgid "Only consider tags matching the given glob pattern"
 msgstr ""
 
@@ -40005,6 +40143,9 @@ msgid "Only expire unused working trees older than <time>"
 msgstr ""
 
 msgid "Only fail the build afterwards; allow all non-impacted builds to continue"
+msgstr ""
+
+msgid "Only fetch remote binary packages matching these atoms"
 msgstr ""
 
 msgid "Only fixate disk "
@@ -40401,6 +40542,9 @@ msgid "Only this package's library"
 msgstr ""
 
 msgid "Only uninstall the binary NAME"
+msgstr ""
+
+msgid "Only unmask and generate package.use settings without building anything"
 msgstr ""
 
 msgid "Only update the manifest"
@@ -43517,6 +43661,9 @@ msgstr ""
 msgid "Prefer lowest versions of dependencies"
 msgstr ""
 
+msgid "Prefer matching binary packages over newer unbuilt ebuilds"
+msgstr ""
+
 msgid "Prefer reading from other devices than these"
 msgstr ""
 
@@ -43866,6 +44013,12 @@ msgid "Prevent adding rpath for each used dynamic library"
 msgstr ""
 
 msgid "Prevent any configuration changes to domain until migration ends"
+msgstr ""
+
+msgid "Prevent autounmask from creating package.accept_keywords changes"
+msgstr ""
+
+msgid "Prevent autounmask from creating package.unmask or ** keyword changes"
 msgstr ""
 
 msgid "Prevent floating point registers from being used in any manner"
@@ -47414,6 +47567,9 @@ msgstr ""
 msgid "Pull in changes from another branch"
 msgstr ""
 
+msgid "Pull in test-conditional deps for matched packages even if test is not in FEATURES"
+msgstr ""
+
 msgid "Pull list of shunned references from server"
 msgstr ""
 
@@ -48485,6 +48641,18 @@ msgstr ""
 msgid "Rebuild modules installed in node_modules in current working directory"
 msgstr ""
 
+msgid "Rebuild packages when a new slot can satisfy := deps (default: y)"
+msgstr ""
+
+msgid "Rebuild packages when build-time deps are built from source"
+msgstr ""
+
+msgid "Rebuild packages when build-time deps are installed with a new revision"
+msgstr ""
+
+msgid "Rebuild packages when build-time deps are installed with a new version"
+msgstr ""
+
 msgid "Rebuild ports containing broken binaries"
 msgstr ""
 
@@ -48525,6 +48693,9 @@ msgid "Recognize Boost format strings (only language C++)"
 msgstr ""
 
 msgid "Recognize Qt format strings (only language C++)"
+msgstr ""
+
+msgid "Recompile a package if it is now pulled from a different repository"
 msgstr ""
 
 msgid "Recompile every Sass file, even if the CSS file is newer"
@@ -48749,6 +48920,9 @@ msgstr ""
 msgid "Redeploy artifact on Weblogic server(s) or cluster(s)"
 msgstr ""
 
+msgid "Redirect all build output to logs; display on failure"
+msgstr ""
+
 msgid "Redirect all messages into a file"
 msgstr ""
 
@@ -48923,6 +49097,9 @@ msgstr ""
 msgid "Regenerate library dependency metadata"
 msgstr ""
 
+msgid "Regenerate package manifests (prefer repoman manifest)"
+msgstr ""
+
 msgid "Regex flags: use `--help` instead of `-h` to see details"
 msgstr ""
 
@@ -49044,6 +49221,9 @@ msgid "Reinstall packages"
 msgstr ""
 
 msgid "Reinstall packages required by this package"
+msgstr ""
+
+msgid "Reinstall packages whose active USE flags changed since installation (ignores added/removed disabled flags)"
 msgstr ""
 
 msgid "Reinstall the app keeping its data"
@@ -49203,6 +49383,9 @@ msgid "Remote Path"
 msgstr ""
 
 msgid "Remote alias"
+msgstr ""
+
+msgid "Remote binary packages matching these atoms are not fetched"
 msgstr ""
 
 msgid "Remote branch ref used by `git push`"
@@ -49427,6 +49610,9 @@ msgstr ""
 msgid "Remove all but the given number of backups"
 msgstr ""
 
+msgid "Remove all but the most recently installed version in each slot"
+msgstr ""
+
 msgid "Remove all classes attributes"
 msgstr ""
 
@@ -49461,6 +49647,9 @@ msgid "Remove all gz files from cache"
 msgstr ""
 
 msgid "Remove all lines matching key"
+msgstr ""
+
+msgid "Remove all matching packages without checking dependencies"
 msgstr ""
 
 msgid "Remove all mutations"
@@ -49560,6 +49749,9 @@ msgid "Remove artifacts that cargo has generated in the past"
 msgstr ""
 
 msgid "Remove associated storage volumes"
+msgstr ""
+
+msgid "Remove atoms/sets from @world. Implied by uninstall actions (use --deselect=n to prevent)"
 msgstr ""
 
 msgid "Remove auto-generated configuration files left over by the daemon"
@@ -49787,6 +49979,9 @@ msgstr ""
 msgid "Remove matching variables"
 msgstr ""
 
+msgid "Remove merge-order constraint from --tree output for readability"
+msgstr ""
+
 msgid "Remove module"
 msgstr ""
 
@@ -49836,6 +50031,9 @@ msgid "Remove only ignored files"
 msgstr ""
 
 msgid "Remove only locks with specified repository"
+msgstr ""
+
+msgid "Remove orphaned dependencies (packages not in @world and not required by other packages)"
 msgstr ""
 
 msgid "Remove orphaned libraries (not required by installed packages)"
@@ -50154,6 +50352,9 @@ msgid "Removes a package from the require-dev section"
 msgstr ""
 
 msgid "Removes a remote"
+msgstr ""
+
+msgid "Removes all but the highest installed version of a package from your system"
 msgstr ""
 
 msgid "Removes all cache"
@@ -50495,6 +50696,9 @@ msgstr ""
 msgid "Replace include directories"
 msgstr ""
 
+msgid "Replace installed packages with binary packages that have been rebuilt"
+msgstr ""
+
 msgid "Replace non-graphic characters with '?'"
 msgstr ""
 
@@ -50502,6 +50706,12 @@ msgid "Replace only the last occurrence"
 msgstr ""
 
 msgid "Replace packages in the base layer"
+msgstr ""
+
+msgid "Replace packages whose ebuild SLOT metadata changed since they were built"
+msgstr ""
+
+msgid "Replace packages whose ebuild dependencies changed since they were built"
 msgstr ""
 
 msgid "Replace patch header"
@@ -50700,6 +50910,9 @@ msgid "Report on mode of file"
 msgstr ""
 
 msgid "Report outstanding replies"
+msgstr ""
+
+msgid "Report packages whose ebuild dependencies changed since installation"
 msgstr ""
 
 msgid "Report processor frequency and idle statistics"
@@ -51437,6 +51650,9 @@ msgstr ""
 msgid "Restow: delete and then stow again"
 msgstr ""
 
+msgid "Restrict --sync to specified submodule (rsync only); repeatable"
+msgstr ""
+
 msgid "Restrict access"
 msgstr ""
 
@@ -51525,6 +51741,9 @@ msgid "Resume previously canceled or interrupted scrub"
 msgstr ""
 
 msgid "Resume reactor from specified project"
+msgstr ""
+
+msgid "Resumes the most recent merge list that aborted due to an error"
 msgstr ""
 
 msgid "Resync package contents from source"
@@ -52058,6 +52277,9 @@ msgstr ""
 msgid "Root source tree"
 msgstr ""
 
+msgid "Root to use as --quickpkg-direct source (default: /)"
+msgstr ""
+
 msgid "Rotate log every kbytes, requires -f"
 msgstr ""
 
@@ -52575,6 +52797,9 @@ msgid "Run package manager within chroot"
 msgstr ""
 
 msgid "Run package manager within jail"
+msgstr ""
+
+msgid "Run package-specific actions after emerge (usually config setup)"
 msgstr ""
 
 msgid "Run patch phase of a port"
@@ -53709,6 +53934,9 @@ msgid "Search directory for makefile"
 msgstr ""
 
 msgid "Search documentation"
+msgstr ""
+
+msgid "Search ebuilds for <string>. Use `%<string>` for regex"
 msgstr ""
 
 msgid "Search files according to the specified search mask"
@@ -54977,6 +55205,9 @@ msgstr ""
 msgid "Set EDNS0 Max UDP packet size"
 msgstr ""
 
+msgid "Set EPREFIX"
+msgstr ""
+
 msgid "Set GDB's working directory"
 msgstr ""
 
@@ -55013,6 +55244,9 @@ msgstr ""
 msgid "Set NDOTS value"
 msgstr ""
 
+msgid "Set PORTAGE_CONFIGROOT"
+msgstr ""
+
 msgid "Set PTRACE_O_EXITKILL ptrace option to all tracee processes"
 msgstr ""
 
@@ -55032,6 +55266,9 @@ msgid "Set RAW writing mode"
 msgstr ""
 
 msgid "Set REQUESTER PAYS for operations"
+msgstr ""
+
+msgid "Set ROOT (target root filesystem)"
 msgstr ""
 
 msgid "Set Rails environment"
@@ -55056,6 +55293,9 @@ msgid "Set SMART data for a drive"
 msgstr ""
 
 msgid "Set SO_DEBUG socket option"
+msgstr ""
+
+msgid "Set SYSROOT (root for DEPEND build-time deps)"
 msgstr ""
 
 msgid "Set TAO (Track At Once) writing mode"
@@ -58352,9 +58592,6 @@ msgstr ""
 msgid "Show camera driver manual"
 msgstr ""
 
-msgid "Show changelog of pkg. Use with --pretend"
-msgstr ""
-
 msgid "Show changes between commits and working tree"
 msgstr ""
 
@@ -59861,6 +60098,9 @@ msgstr ""
 msgid "Show signatures and descriptions for the available functions"
 msgstr ""
 
+msgid "Show similar package names when a package is not found (default: y)"
+msgstr ""
+
 msgid "Show sizes in GiB, or GB with --si"
 msgstr ""
 
@@ -61364,6 +61604,9 @@ msgstr ""
 msgid "Skip package installation for this run"
 msgstr ""
 
+msgid "Skip packages already installed (same as --noreplace; use =n to force disable)"
+msgstr ""
+
 msgid "Skip pre/post hook scripts"
 msgstr ""
 
@@ -61643,6 +61886,9 @@ msgstr ""
 msgid "Sort files by name"
 msgstr ""
 
+msgid "Sort flag lists alphabetically"
+msgstr ""
+
 msgid "Sort languages based on column"
 msgstr ""
 
@@ -61791,6 +62037,9 @@ msgid "Source-only mode"
 msgstr ""
 
 msgid "Space or comma separated list of features to activate"
+msgstr ""
+
+msgid "Space-separated atoms to never install"
 msgstr ""
 
 msgid "Space-separated options to exclude from search"
@@ -65204,6 +65453,9 @@ msgstr ""
 msgid "Substitute %{var}% variables"
 msgstr ""
 
+msgid "Substitute installed-package deps with current ebuild deps during calculations (default: y)"
+msgstr ""
+
 msgid "Substitute one word for another"
 msgstr ""
 
@@ -65291,6 +65543,9 @@ msgstr ""
 msgid "Suppress --noImplicitAny errors for indexing objects lacking index signatures"
 msgstr ""
 
+msgid "Suppress ::repository in merge list; use numbers instead"
+msgstr ""
+
 msgid "Suppress SNAPSHOT updates"
 msgstr ""
 
@@ -65322,6 +65577,9 @@ msgid "Suppress any output"
 msgstr ""
 
 msgid "Suppress battery information"
+msgstr ""
+
+msgid "Suppress build log display on failure (show only die message and log path)"
 msgstr ""
 
 msgid "Suppress checkout"
@@ -65466,6 +65724,9 @@ msgid "Suppress the warning about missing MDC integrity protection"
 msgstr ""
 
 msgid "Suppress the warning about unsafe file and home directory (--homedir) permissions"
+msgstr ""
+
+msgid "Suppress the warning shown before --unmerge actions"
 msgstr ""
 
 msgid "Suppress thermal information"
@@ -66141,6 +66402,12 @@ msgid "Temporarily lock an active home area"
 msgstr ""
 
 msgid "Temporarily offline"
+msgstr ""
+
+msgid "Temporarily override ACCEPT_PROPERTIES (e.g. =-interactive)"
+msgstr ""
+
+msgid "Temporarily override ACCEPT_RESTRICT (e.g. =-bindist)"
 msgstr ""
 
 msgid "Temporary mount point property"
@@ -67619,6 +67886,9 @@ msgstr ""
 msgid "Treat keyboard as standard US keyboard"
 msgstr ""
 
+msgid "Treat matching packages as not installed and reinstall them"
+msgstr ""
+
 msgid "Treat newlines as hard line breaks"
 msgstr ""
 
@@ -67695,6 +67965,12 @@ msgid "Treated as MOZ_LOG_FILE=<file> environment variable, overrides it"
 msgstr ""
 
 msgid "Tree location"
+msgstr ""
+
+msgid "Trigger --complete-graph when USE or IUSE changes for an installed package (default: y)"
+msgstr ""
+
+msgid "Trigger --complete-graph when an installed package version changes (default: y)"
 msgstr ""
 
 msgid "Trigger DHCP reconfiguration of all connected clients"
@@ -68852,6 +69128,9 @@ msgstr ""
 msgid "Update packages"
 msgstr ""
 
+msgid "Update packages to best available version"
+msgstr ""
+
 msgid "Update parts of an existing network's configuration"
 msgstr ""
 
@@ -68877,6 +69156,9 @@ msgid "Update remote repositories"
 msgstr ""
 
 msgid "Update remote state from local state"
+msgstr ""
+
+msgid "Update repositories. Use without arguments to update all autosync repos"
 msgstr ""
 
 msgid "Update repository indexes"
@@ -70301,6 +70583,9 @@ msgstr ""
 msgid "Use dot character instead of braille"
 msgstr ""
 
+msgid "Use ebuilds for deps; binary packages only for explicitly named atoms"
+msgstr ""
+
 msgid "Use editor to modify kernel arguments"
 msgstr ""
 
@@ -70518,6 +70803,9 @@ msgid "Use input from pipe of emerge -pv"
 msgstr ""
 
 msgid "Use insecure TLS connection"
+msgstr ""
+
+msgid "Use installed packages directly as binary packages"
 msgstr ""
 
 msgid "Use instead of host if you want to address 255.255.255.255"
@@ -71225,6 +71513,9 @@ msgstr ""
 msgid "Use the dynamic section info when displaying symbols"
 msgstr ""
 
+msgid "Use the egencache-built search index (default: y)"
+msgstr ""
+
 msgid "Use the file's modification time as the time of import."
 msgstr ""
 
@@ -71508,6 +71799,9 @@ msgid "Use translations under given directory"
 msgstr ""
 
 msgid "Use uglier formatting"
+msgstr ""
+
+msgid "Use unbuilt ebuild metadata for visibility checks on built packages"
 msgstr ""
 
 msgid "Use unicode characters in the output"
@@ -72488,6 +72782,9 @@ msgstr ""
 msgid "Warn if variadic macros are used in pedantic mode"
 msgstr ""
 
+msgid "Warn on @world packages with no available ebuild (default: y)"
+msgstr ""
+
 msgid "Warn on lint"
 msgstr ""
 
@@ -73217,6 +73514,9 @@ msgstr ""
 msgid "Write attribute value"
 msgstr ""
 
+msgid "Write autounmask changes to config files (implied by --ask)"
+msgstr ""
+
 msgid "Write column names in results"
 msgstr ""
 
@@ -73269,6 +73569,9 @@ msgid "Write index to a file"
 msgstr ""
 
 msgid "Write index to specified file"
+msgstr ""
+
+msgid "Write keyword/mask changes using >= operators instead of ="
 msgstr ""
 
 msgid "Write line numbers for errors"

--- a/localization/po/zh_TW.po
+++ b/localization/po/zh_TW.po
@@ -5139,6 +5139,9 @@ msgstr ""
 msgid "Access repository settings"
 msgstr ""
 
+msgid "Account for library link-level deps during --depclean and --prune (default: y)"
+msgstr ""
+
 msgid "Account to be altered"
 msgstr ""
 
@@ -5925,6 +5928,9 @@ msgstr ""
 msgid "Add packages"
 msgstr ""
 
+msgid "Add packages to @world (inverse of --oneshot)"
+msgstr ""
+
 msgid "Add parts on top of the section hierarchy"
 msgstr ""
 
@@ -6585,10 +6591,19 @@ msgstr ""
 msgid "Allow automatically filling CAPTCHA"
 msgstr ""
 
+msgid "Allow autounmask to create package.license changes"
+msgstr ""
+
+msgid "Allow autounmask to create package.use changes (enabled by default)"
+msgstr ""
+
 msgid "Allow backspace and carriage return"
 msgstr ""
 
 msgid "Allow backspace, tab and carriage return"
+msgstr ""
+
+msgid "Allow backtracking after autounmask detects necessary changes"
 msgstr ""
 
 msgid "Allow binary files to be diffed"
@@ -7689,6 +7704,9 @@ msgstr ""
 msgid "Apply automated posting rules to modify txns"
 msgstr ""
 
+msgid "Apply autounmask changes and continue to execute command"
+msgstr ""
+
 msgid "Apply changes from a Differential diff"
 msgstr ""
 
@@ -7813,6 +7831,9 @@ msgid "Apply option to this zone"
 msgstr ""
 
 msgid "Apply options to a portion of the image [geometry]"
+msgstr ""
+
+msgid "Apply package moves when necessary (default: y; do not disable normally)"
 msgstr ""
 
 msgid "Apply packagefiles to the subproject"
@@ -8208,6 +8229,9 @@ msgstr ""
 msgid "Assume no to all questions"
 msgstr ""
 
+msgid "Assume packages may have implicit deps on @system (default: y)"
+msgstr ""
+
 msgid "Assume patches were created with old/new files swapped"
 msgstr ""
 
@@ -8344,6 +8368,9 @@ msgid "Assume yes when asked for confirmation"
 msgstr ""
 
 msgid "Assumes that structures should have 8 byte alignment"
+msgstr ""
+
+msgid "Atoms for which no binary packages should be built"
 msgstr ""
 
 msgid "Attach a USB device to the host"
@@ -8538,6 +8565,12 @@ msgstr ""
 msgid "Auto-confirm non-security prompts"
 msgstr ""
 
+msgid "Auto-detect regex in search strings (default: y)"
+msgstr ""
+
+msgid "Auto-enable --with-bdeps for installation actions (default: y)"
+msgstr ""
+
 msgid "Auto-gen package cache"
 msgstr ""
 
@@ -8665,6 +8698,9 @@ msgid "Automatically sync the repository"
 msgstr ""
 
 msgid "Automatically trust and import new repository signing keys"
+msgstr ""
+
+msgid "Automatically unmasks packages and generates package.use settings"
 msgstr ""
 
 msgid "Automatically update the packet display as packets are coming in"
@@ -9036,6 +9072,9 @@ msgstr ""
 msgid "Binary input mode"
 msgstr ""
 
+msgid "Binary package format to create"
+msgstr ""
+
 msgid "Binary-only mode, abort if no archive available"
 msgstr ""
 
@@ -9324,7 +9363,7 @@ msgstr ""
 msgid "Build a Windows executable"
 msgstr ""
 
-msgid "Build a binary pkg additionally"
+msgid "Build a binary package in addition to merging"
 msgstr ""
 
 msgid "Build a console executable"
@@ -10353,6 +10392,9 @@ msgstr ""
 msgid "Check and fix problems in the world file"
 msgstr ""
 
+msgid "Check and update the dependency cache of all ebuilds in repository"
+msgstr ""
+
 msgid "Check and wait until a group of devices of a filesystem is ready for mount"
 msgstr ""
 
@@ -11155,6 +11197,9 @@ msgid "Clean up cache directory"
 msgstr ""
 
 msgid "Clean up releases, stemcells, disks, etc."
+msgstr ""
+
+msgid "Clean up temp files after a build failure (useful with PORTAGE_TMPDIR on tmpfs)"
 msgstr ""
 
 msgid "Clean up the files that Cobertura Maven Plugin has created during instrumentation"
@@ -12516,6 +12561,9 @@ msgstr ""
 msgid "Consider case when comparing file names"
 msgstr ""
 
+msgid "Consider deep deps of all @world packages; bail if the operation would break any"
+msgstr ""
+
 msgid "Consider files as separate"
 msgstr ""
 
@@ -12619,6 +12667,9 @@ msgid "Continue after an error"
 msgstr ""
 
 msgid "Continue as much as possible after an error"
+msgstr ""
+
+msgid "Continue as much as possible after an error; recalculate deps for remaining packages"
 msgstr ""
 
 msgid "Continue conversation with given id"
@@ -12802,6 +12853,9 @@ msgid "Control whether GCC places uninitialized local variables into the \"bss\"
 msgstr ""
 
 msgid "Control whether RTC is in local time"
+msgstr ""
+
+msgid "Control whether build-time deps go into ROOT or /"
 msgstr ""
 
 msgid "Control whether color is used"
@@ -17343,6 +17397,9 @@ msgstr ""
 msgid "Display a help page"
 msgstr ""
 
+msgid "Display a list of available package sets"
+msgstr ""
+
 msgid "Display a list of speedtest.net servers sorted by distance"
 msgstr ""
 
@@ -17440,6 +17497,9 @@ msgid "Display all values currently available"
 msgstr ""
 
 msgid "Display an archive's list to console"
+msgstr ""
+
+msgid "Display ancillary information required for bug reports"
 msgstr ""
 
 msgid "Display answers as exclamation points and missing packets as dots"
@@ -18660,6 +18720,9 @@ msgstr ""
 msgid "Display toolbar or menubar"
 msgstr ""
 
+msgid "Display total of unread GLEP 42 news items"
+msgstr ""
+
 msgid "Display untracked files in columns"
 msgstr ""
 
@@ -19815,6 +19878,9 @@ msgstr ""
 msgid "Do not install files from given subprojects"
 msgstr ""
 
+msgid "Do not install from binary packages for live ebuilds"
+msgstr ""
+
 msgid "Do not install recommended packages"
 msgstr ""
 
@@ -20175,6 +20241,12 @@ msgstr ""
 msgid "Do not rebuild before running tests"
 msgstr ""
 
+msgid "Do not rebuild matching packages due to --rebuild"
+msgstr ""
+
+msgid "Do not rebuild packages that depend on matching packages due to --rebuild"
+msgstr ""
+
 msgid "Do not recalculate the effective rights mask"
 msgstr ""
 
@@ -20521,6 +20593,9 @@ msgid "Do not start ghostscript in safe mode"
 msgstr ""
 
 msgid "Do not start ghostscript with the -dQUIET option"
+msgstr ""
+
+msgid "Do not start new builds if load average is at least LOAD"
 msgstr ""
 
 msgid "Do not start the commit message editor"
@@ -30957,6 +31032,9 @@ msgstr ""
 msgid "Ignore 'Content-Length' header"
 msgstr ""
 
+msgid "Ignore @world deps; may break installed packages (use with --ask)"
+msgstr ""
+
 msgid "Ignore CD/DVD repositories"
 msgstr ""
 
@@ -31045,6 +31123,12 @@ msgid "Ignore any balance assertions"
 msgstr ""
 
 msgid "Ignore any saved configuration"
+msgstr ""
+
+msgid "Ignore binary packages whose USE flags differ from current config"
+msgstr ""
+
+msgid "Ignore binary packages whose ebuild dependencies changed since the build"
 msgstr ""
 
 msgid "Ignore bogus module names"
@@ -31209,6 +31293,9 @@ msgstr ""
 msgid "Ignore logical volume identity"
 msgstr ""
 
+msgid "Ignore matching binary packages"
+msgstr ""
+
 msgid "Ignore md5sum"
 msgstr ""
 
@@ -31249,6 +31336,9 @@ msgid "Ignore non-authenticated packages"
 msgstr ""
 
 msgid "Ignore non-existing files on receiving side"
+msgstr ""
+
+msgid "Ignore non-matching binary packages"
 msgstr ""
 
 msgid "Ignore nonexistent files"
@@ -31303,6 +31393,12 @@ msgid "Ignore safety checks"
 msgstr ""
 
 msgid "Ignore scissor lines"
+msgstr ""
+
+msgid "Ignore slot/sub-slot := operator deps recorded at build time (debug only)"
+msgstr ""
+
+msgid "Ignore soname dependencies of binary and installed packages (default: y)"
 msgstr ""
 
 msgid "Ignore spaces after function names"
@@ -31911,6 +32007,9 @@ msgstr ""
 msgid "Include inherited options"
 msgstr ""
 
+msgid "Include install-time deps when --onlydeps and --onlydeps-with-rdeps=n are used"
+msgstr ""
+
 msgid "Include installed pkgs with changed USE flags"
 msgstr ""
 
@@ -32011,6 +32110,9 @@ msgid "Include residual signal in text output"
 msgstr ""
 
 msgid "Include reverse dependencies in the output"
+msgstr ""
+
+msgid "Include run-time deps when using --onlydeps (default: y)"
 msgstr ""
 
 msgid "Include secret key comment packets when exporting secret keys"
@@ -33712,6 +33814,15 @@ msgid "Like --method=md5crypt"
 msgstr ""
 
 msgid "Like --reuse-message, but allow editing commit message"
+msgstr ""
+
+msgid "Like --search, but also matches package descriptions"
+msgstr ""
+
+msgid "Like --unmerge but with CLEAN_DELAY=0; can remove critical packages"
+msgstr ""
+
+msgid "Like --update but only for packages already installed"
 msgstr ""
 
 msgid "Like --write-batch but w/o updating dest"
@@ -35640,6 +35751,9 @@ msgstr ""
 msgid "List packages by provider"
 msgstr ""
 
+msgid "List packages causing slot rebuilds in emerge output (default: y)"
+msgstr ""
+
 msgid "List packages depending on"
 msgstr ""
 
@@ -37428,6 +37542,9 @@ msgstr ""
 msgid "Make zipfile as old as the latest entry"
 msgstr ""
 
+msgid "Makes --ask reject single Enter keypresses as answers"
+msgstr ""
+
 msgid "Makes COM type information in specified assemblies available to the project"
 msgstr ""
 
@@ -37929,6 +38046,9 @@ msgstr ""
 msgid "Match pattern against full command line"
 msgstr ""
 
+msgid "Match search strings approximately; auto-disabled for regex searches (default: y)"
+msgstr ""
+
 msgid "Match secondary date instead"
 msgstr ""
 
@@ -37957,6 +38077,9 @@ msgid "Max memory, as scaled integer (default KiB)"
 msgstr ""
 
 msgid "Max num of children"
+msgstr ""
+
+msgid "Max number of times to backtrack on dependency conflicts (default: 20)"
 msgstr ""
 
 msgid "Max objects per response"
@@ -38274,6 +38397,9 @@ msgstr ""
 msgid "Minimum drive buffer fill ratio for the ATAPI wait mode"
 msgstr ""
 
+msgid "Minimum free GiB in PORTAGE_TMPDIR before starting more jobs (default: 18)"
+msgstr ""
+
 msgid "Minimum height when --height is given in percent"
 msgstr ""
 
@@ -38296,6 +38422,9 @@ msgid "Minimum payload size for sweeping pings"
 msgstr ""
 
 msgid "Minimum port to listen to"
+msgstr ""
+
+msgid "Minimum similarity percentage for fuzzy search results (default: 80)"
 msgstr ""
 
 msgid "Minimum stability (empty or one of: stable, RC, beta, alpha, dev)"
@@ -39504,6 +39633,9 @@ msgstr ""
 msgid "Number of octets per line"
 msgstr ""
 
+msgid "Number of packages to build simultaneously (0 = CPU count)"
+msgstr ""
+
 msgid "Number of pages to scan before the shared memory service goes to sleep"
 msgstr ""
 
@@ -39711,6 +39843,9 @@ msgstr ""
 msgid "Offensive fortunes only"
 msgstr ""
 
+msgid "Offer to read unread news via eselect when --ask is active"
+msgstr ""
+
 msgid "Offline migration"
 msgstr ""
 
@@ -39894,6 +40029,9 @@ msgstr ""
 msgid "Only connect if safe console handling is supported"
 msgstr ""
 
+msgid "Only consider rebuilt binaries with BUILD_TIME newer than TIMESTAMP"
+msgstr ""
+
 msgid "Only consider tags matching the given glob pattern"
 msgstr ""
 
@@ -39982,6 +40120,9 @@ msgid "Only expire unused working trees older than <time>"
 msgstr ""
 
 msgid "Only fail the build afterwards; allow all non-impacted builds to continue"
+msgstr ""
+
+msgid "Only fetch remote binary packages matching these atoms"
 msgstr ""
 
 msgid "Only fixate disk "
@@ -40378,6 +40519,9 @@ msgid "Only this package's library"
 msgstr ""
 
 msgid "Only uninstall the binary NAME"
+msgstr ""
+
+msgid "Only unmask and generate package.use settings without building anything"
 msgstr ""
 
 msgid "Only update the manifest"
@@ -43494,6 +43638,9 @@ msgstr ""
 msgid "Prefer lowest versions of dependencies"
 msgstr ""
 
+msgid "Prefer matching binary packages over newer unbuilt ebuilds"
+msgstr ""
+
 msgid "Prefer reading from other devices than these"
 msgstr ""
 
@@ -43843,6 +43990,12 @@ msgid "Prevent adding rpath for each used dynamic library"
 msgstr ""
 
 msgid "Prevent any configuration changes to domain until migration ends"
+msgstr ""
+
+msgid "Prevent autounmask from creating package.accept_keywords changes"
+msgstr ""
+
+msgid "Prevent autounmask from creating package.unmask or ** keyword changes"
 msgstr ""
 
 msgid "Prevent floating point registers from being used in any manner"
@@ -47391,6 +47544,9 @@ msgstr ""
 msgid "Pull in changes from another branch"
 msgstr ""
 
+msgid "Pull in test-conditional deps for matched packages even if test is not in FEATURES"
+msgstr ""
+
 msgid "Pull list of shunned references from server"
 msgstr ""
 
@@ -48462,6 +48618,18 @@ msgstr ""
 msgid "Rebuild modules installed in node_modules in current working directory"
 msgstr ""
 
+msgid "Rebuild packages when a new slot can satisfy := deps (default: y)"
+msgstr ""
+
+msgid "Rebuild packages when build-time deps are built from source"
+msgstr ""
+
+msgid "Rebuild packages when build-time deps are installed with a new revision"
+msgstr ""
+
+msgid "Rebuild packages when build-time deps are installed with a new version"
+msgstr ""
+
 msgid "Rebuild ports containing broken binaries"
 msgstr ""
 
@@ -48502,6 +48670,9 @@ msgid "Recognize Boost format strings (only language C++)"
 msgstr ""
 
 msgid "Recognize Qt format strings (only language C++)"
+msgstr ""
+
+msgid "Recompile a package if it is now pulled from a different repository"
 msgstr ""
 
 msgid "Recompile every Sass file, even if the CSS file is newer"
@@ -48726,6 +48897,9 @@ msgstr ""
 msgid "Redeploy artifact on Weblogic server(s) or cluster(s)"
 msgstr ""
 
+msgid "Redirect all build output to logs; display on failure"
+msgstr ""
+
 msgid "Redirect all messages into a file"
 msgstr ""
 
@@ -48900,6 +49074,9 @@ msgstr ""
 msgid "Regenerate library dependency metadata"
 msgstr ""
 
+msgid "Regenerate package manifests (prefer repoman manifest)"
+msgstr ""
+
 msgid "Regex flags: use `--help` instead of `-h` to see details"
 msgstr ""
 
@@ -49021,6 +49198,9 @@ msgid "Reinstall packages"
 msgstr ""
 
 msgid "Reinstall packages required by this package"
+msgstr ""
+
+msgid "Reinstall packages whose active USE flags changed since installation (ignores added/removed disabled flags)"
 msgstr ""
 
 msgid "Reinstall the app keeping its data"
@@ -49180,6 +49360,9 @@ msgid "Remote Path"
 msgstr ""
 
 msgid "Remote alias"
+msgstr ""
+
+msgid "Remote binary packages matching these atoms are not fetched"
 msgstr ""
 
 msgid "Remote branch ref used by `git push`"
@@ -49404,6 +49587,9 @@ msgstr ""
 msgid "Remove all but the given number of backups"
 msgstr ""
 
+msgid "Remove all but the most recently installed version in each slot"
+msgstr ""
+
 msgid "Remove all classes attributes"
 msgstr ""
 
@@ -49438,6 +49624,9 @@ msgid "Remove all gz files from cache"
 msgstr ""
 
 msgid "Remove all lines matching key"
+msgstr ""
+
+msgid "Remove all matching packages without checking dependencies"
 msgstr ""
 
 msgid "Remove all mutations"
@@ -49537,6 +49726,9 @@ msgid "Remove artifacts that cargo has generated in the past"
 msgstr ""
 
 msgid "Remove associated storage volumes"
+msgstr ""
+
+msgid "Remove atoms/sets from @world. Implied by uninstall actions (use --deselect=n to prevent)"
 msgstr ""
 
 msgid "Remove auto-generated configuration files left over by the daemon"
@@ -49764,6 +49956,9 @@ msgstr ""
 msgid "Remove matching variables"
 msgstr ""
 
+msgid "Remove merge-order constraint from --tree output for readability"
+msgstr ""
+
 msgid "Remove module"
 msgstr ""
 
@@ -49813,6 +50008,9 @@ msgid "Remove only ignored files"
 msgstr ""
 
 msgid "Remove only locks with specified repository"
+msgstr ""
+
+msgid "Remove orphaned dependencies (packages not in @world and not required by other packages)"
 msgstr ""
 
 msgid "Remove orphaned libraries (not required by installed packages)"
@@ -50131,6 +50329,9 @@ msgid "Removes a package from the require-dev section"
 msgstr ""
 
 msgid "Removes a remote"
+msgstr ""
+
+msgid "Removes all but the highest installed version of a package from your system"
 msgstr ""
 
 msgid "Removes all cache"
@@ -50472,6 +50673,9 @@ msgstr ""
 msgid "Replace include directories"
 msgstr ""
 
+msgid "Replace installed packages with binary packages that have been rebuilt"
+msgstr ""
+
 msgid "Replace non-graphic characters with '?'"
 msgstr ""
 
@@ -50479,6 +50683,12 @@ msgid "Replace only the last occurrence"
 msgstr ""
 
 msgid "Replace packages in the base layer"
+msgstr ""
+
+msgid "Replace packages whose ebuild SLOT metadata changed since they were built"
+msgstr ""
+
+msgid "Replace packages whose ebuild dependencies changed since they were built"
 msgstr ""
 
 msgid "Replace patch header"
@@ -50677,6 +50887,9 @@ msgid "Report on mode of file"
 msgstr ""
 
 msgid "Report outstanding replies"
+msgstr ""
+
+msgid "Report packages whose ebuild dependencies changed since installation"
 msgstr ""
 
 msgid "Report processor frequency and idle statistics"
@@ -51414,6 +51627,9 @@ msgstr ""
 msgid "Restow: delete and then stow again"
 msgstr ""
 
+msgid "Restrict --sync to specified submodule (rsync only); repeatable"
+msgstr ""
+
 msgid "Restrict access"
 msgstr ""
 
@@ -51502,6 +51718,9 @@ msgid "Resume previously canceled or interrupted scrub"
 msgstr ""
 
 msgid "Resume reactor from specified project"
+msgstr ""
+
+msgid "Resumes the most recent merge list that aborted due to an error"
 msgstr ""
 
 msgid "Resync package contents from source"
@@ -52035,6 +52254,9 @@ msgstr ""
 msgid "Root source tree"
 msgstr ""
 
+msgid "Root to use as --quickpkg-direct source (default: /)"
+msgstr ""
+
 msgid "Rotate log every kbytes, requires -f"
 msgstr ""
 
@@ -52552,6 +52774,9 @@ msgid "Run package manager within chroot"
 msgstr ""
 
 msgid "Run package manager within jail"
+msgstr ""
+
+msgid "Run package-specific actions after emerge (usually config setup)"
 msgstr ""
 
 msgid "Run patch phase of a port"
@@ -53686,6 +53911,9 @@ msgid "Search directory for makefile"
 msgstr ""
 
 msgid "Search documentation"
+msgstr ""
+
+msgid "Search ebuilds for <string>. Use `%<string>` for regex"
 msgstr ""
 
 msgid "Search files according to the specified search mask"
@@ -54954,6 +55182,9 @@ msgstr ""
 msgid "Set EDNS0 Max UDP packet size"
 msgstr ""
 
+msgid "Set EPREFIX"
+msgstr ""
+
 msgid "Set GDB's working directory"
 msgstr ""
 
@@ -54990,6 +55221,9 @@ msgstr ""
 msgid "Set NDOTS value"
 msgstr ""
 
+msgid "Set PORTAGE_CONFIGROOT"
+msgstr ""
+
 msgid "Set PTRACE_O_EXITKILL ptrace option to all tracee processes"
 msgstr ""
 
@@ -55009,6 +55243,9 @@ msgid "Set RAW writing mode"
 msgstr ""
 
 msgid "Set REQUESTER PAYS for operations"
+msgstr ""
+
+msgid "Set ROOT (target root filesystem)"
 msgstr ""
 
 msgid "Set Rails environment"
@@ -55033,6 +55270,9 @@ msgid "Set SMART data for a drive"
 msgstr ""
 
 msgid "Set SO_DEBUG socket option"
+msgstr ""
+
+msgid "Set SYSROOT (root for DEPEND build-time deps)"
 msgstr ""
 
 msgid "Set TAO (Track At Once) writing mode"
@@ -58329,9 +58569,6 @@ msgstr ""
 msgid "Show camera driver manual"
 msgstr ""
 
-msgid "Show changelog of pkg. Use with --pretend"
-msgstr ""
-
 msgid "Show changes between commits and working tree"
 msgstr ""
 
@@ -59838,6 +60075,9 @@ msgstr ""
 msgid "Show signatures and descriptions for the available functions"
 msgstr ""
 
+msgid "Show similar package names when a package is not found (default: y)"
+msgstr ""
+
 msgid "Show sizes in GiB, or GB with --si"
 msgstr ""
 
@@ -61341,6 +61581,9 @@ msgstr ""
 msgid "Skip package installation for this run"
 msgstr ""
 
+msgid "Skip packages already installed (same as --noreplace; use =n to force disable)"
+msgstr ""
+
 msgid "Skip pre/post hook scripts"
 msgstr ""
 
@@ -61620,6 +61863,9 @@ msgstr ""
 msgid "Sort files by name"
 msgstr ""
 
+msgid "Sort flag lists alphabetically"
+msgstr ""
+
 msgid "Sort languages based on column"
 msgstr ""
 
@@ -61768,6 +62014,9 @@ msgid "Source-only mode"
 msgstr ""
 
 msgid "Space or comma separated list of features to activate"
+msgstr ""
+
+msgid "Space-separated atoms to never install"
 msgstr ""
 
 msgid "Space-separated options to exclude from search"
@@ -65181,6 +65430,9 @@ msgstr ""
 msgid "Substitute %{var}% variables"
 msgstr ""
 
+msgid "Substitute installed-package deps with current ebuild deps during calculations (default: y)"
+msgstr ""
+
 msgid "Substitute one word for another"
 msgstr ""
 
@@ -65268,6 +65520,9 @@ msgstr ""
 msgid "Suppress --noImplicitAny errors for indexing objects lacking index signatures"
 msgstr ""
 
+msgid "Suppress ::repository in merge list; use numbers instead"
+msgstr ""
+
 msgid "Suppress SNAPSHOT updates"
 msgstr ""
 
@@ -65299,6 +65554,9 @@ msgid "Suppress any output"
 msgstr ""
 
 msgid "Suppress battery information"
+msgstr ""
+
+msgid "Suppress build log display on failure (show only die message and log path)"
 msgstr ""
 
 msgid "Suppress checkout"
@@ -65443,6 +65701,9 @@ msgid "Suppress the warning about missing MDC integrity protection"
 msgstr ""
 
 msgid "Suppress the warning about unsafe file and home directory (--homedir) permissions"
+msgstr ""
+
+msgid "Suppress the warning shown before --unmerge actions"
 msgstr ""
 
 msgid "Suppress thermal information"
@@ -66118,6 +66379,12 @@ msgid "Temporarily lock an active home area"
 msgstr ""
 
 msgid "Temporarily offline"
+msgstr ""
+
+msgid "Temporarily override ACCEPT_PROPERTIES (e.g. =-interactive)"
+msgstr ""
+
+msgid "Temporarily override ACCEPT_RESTRICT (e.g. =-bindist)"
 msgstr ""
 
 msgid "Temporary mount point property"
@@ -67596,6 +67863,9 @@ msgstr ""
 msgid "Treat keyboard as standard US keyboard"
 msgstr ""
 
+msgid "Treat matching packages as not installed and reinstall them"
+msgstr ""
+
 msgid "Treat newlines as hard line breaks"
 msgstr ""
 
@@ -67672,6 +67942,12 @@ msgid "Treated as MOZ_LOG_FILE=<file> environment variable, overrides it"
 msgstr ""
 
 msgid "Tree location"
+msgstr ""
+
+msgid "Trigger --complete-graph when USE or IUSE changes for an installed package (default: y)"
+msgstr ""
+
+msgid "Trigger --complete-graph when an installed package version changes (default: y)"
 msgstr ""
 
 msgid "Trigger DHCP reconfiguration of all connected clients"
@@ -68829,6 +69105,9 @@ msgstr ""
 msgid "Update packages"
 msgstr ""
 
+msgid "Update packages to best available version"
+msgstr ""
+
 msgid "Update parts of an existing network's configuration"
 msgstr ""
 
@@ -68854,6 +69133,9 @@ msgid "Update remote repositories"
 msgstr ""
 
 msgid "Update remote state from local state"
+msgstr ""
+
+msgid "Update repositories. Use without arguments to update all autosync repos"
 msgstr ""
 
 msgid "Update repository indexes"
@@ -70278,6 +70560,9 @@ msgstr ""
 msgid "Use dot character instead of braille"
 msgstr ""
 
+msgid "Use ebuilds for deps; binary packages only for explicitly named atoms"
+msgstr ""
+
 msgid "Use editor to modify kernel arguments"
 msgstr ""
 
@@ -70495,6 +70780,9 @@ msgid "Use input from pipe of emerge -pv"
 msgstr ""
 
 msgid "Use insecure TLS connection"
+msgstr ""
+
+msgid "Use installed packages directly as binary packages"
 msgstr ""
 
 msgid "Use instead of host if you want to address 255.255.255.255"
@@ -71202,6 +71490,9 @@ msgstr ""
 msgid "Use the dynamic section info when displaying symbols"
 msgstr ""
 
+msgid "Use the egencache-built search index (default: y)"
+msgstr ""
+
 msgid "Use the file's modification time as the time of import."
 msgstr ""
 
@@ -71485,6 +71776,9 @@ msgid "Use translations under given directory"
 msgstr ""
 
 msgid "Use uglier formatting"
+msgstr ""
+
+msgid "Use unbuilt ebuild metadata for visibility checks on built packages"
 msgstr ""
 
 msgid "Use unicode characters in the output"
@@ -72465,6 +72759,9 @@ msgstr ""
 msgid "Warn if variadic macros are used in pedantic mode"
 msgstr ""
 
+msgid "Warn on @world packages with no available ebuild (default: y)"
+msgstr ""
+
 msgid "Warn on lint"
 msgstr ""
 
@@ -73194,6 +73491,9 @@ msgstr ""
 msgid "Write attribute value"
 msgstr ""
 
+msgid "Write autounmask changes to config files (implied by --ask)"
+msgstr ""
+
 msgid "Write column names in results"
 msgstr ""
 
@@ -73246,6 +73546,9 @@ msgid "Write index to a file"
 msgstr ""
 
 msgid "Write index to specified file"
+msgstr ""
+
+msgid "Write keyword/mask changes using >= operators instead of ="
 msgstr ""
 
 msgid "Write line numbers for errors"

--- a/share/completions/emerge.fish
+++ b/share/completions/emerge.fish
@@ -54,123 +54,145 @@ complete -c emerge -xa "(__fish_emerge_possible_args)"
 #########################
 # Actions               #
 #########################
-complete -c emerge -l check-news
-complete -c emerge -l clean
-complete -c emerge -l config
-complete -c emerge -s c -l depclean
-complete -c emerge -l deselect
-complete -c emerge -s h -l help
-complete -c emerge -l info
-complete -c emerge -l list-sets
+complete -c emerge -l check-news -d "Display total of unread GLEP 42 news items"
+complete -c emerge -l clean -d "Remove all but the most recently installed version in each slot"
+complete -c emerge -l config -d "Run package-specific actions after emerge (usually config setup)"
+complete -c emerge -s c -l depclean -d "Remove orphaned dependencies (packages not in @world and not required by other packages)"
+complete -c emerge -s W -l deselect -a 'y n' -d "Remove atoms/sets from @world. Implied by uninstall actions (use --deselect=n to prevent)"
+complete -c emerge -s h -l help -d "Display help information"
+complete -c emerge -l info -d "Display ancillary information required for bug reports"
+complete -c emerge -l list-sets -d "Display a list of available package sets"
 complete -c emerge -l metadata
-complete -c emerge -s P -l prune
-complete -c emerge -l regen
-complete -c emerge -s r -l resume
-complete -c emerge -s s -l search
-complete -c emerge -s S -l searchdesc
-complete -c emerge -l sync
-complete -c emerge -s C -l unmerge
-complete -c emerge -s V -l version
+complete -c emerge -s P -l prune -d "Removes all but the highest installed version of a package from your system"
+complete -c emerge -l regen -d "Check and update the dependency cache of all ebuilds in repository"
+complete -c emerge -s r -l resume -d "Resumes the most recent merge list that aborted due to an error"
+complete -c emerge -s s -l search -d "Search ebuilds for <string>. Use `%<string>` for regex"
+complete -c emerge -s S -l searchdesc -d "Like --search, but also matches package descriptions"
+complete -c emerge -l sync -d "Update repositories. Use without arguments to update all autosync repos"
+complete -c emerge -s C -l unmerge -d "Remove all matching packages without checking dependencies"
+complete -c emerge -s V -l version -d "Display version number"
 
 #########################
 # Options               #
 #########################
-complete -c emerge -s A -l alert -d "Add a terminal bell character ('\a') to all interactive prompts"
-#complete -c emerge      -l alphabetical -d "Sort flag lists alphabetically"
-complete -c emerge -s a -l ask -d "Prompt the user before performing the merge"
-# ask-enter-invalid
-# autounmask
-# autounmask-backtrack <yn>
-# autounmask-continue
-# autounmask-only
-# autounmask-unrestricted-atoms
-# autounmask-keep-keywords
-# autounmask-keep-masks
-# autounmask-write
-complete -c emerge -l backtrack
-complete -c emerge -s b -l buildpkg -d "Build a binary pkg additionally"
-# buildpkg-exclude
+complete -c emerge -l accept-properties -d "Temporarily override ACCEPT_PROPERTIES (e.g. =-interactive)"
+complete -c emerge -l accept-restrict -d "Temporarily override ACCEPT_RESTRICT (e.g. =-bindist)"
+complete -c emerge -s A -l alert -a 'y n' -d "Add a terminal bell character ('\a') to all interactive prompts"
+complete -c emerge -l alphabetical -d "Sort flag lists alphabetically"
+complete -c emerge -s a -l ask -a 'y n' -d "Prompt the user before performing the merge"
+complete -c emerge -l ask-enter-invalid -d "Makes --ask reject single Enter keypresses as answers"
+complete -c emerge -l autounmask -a 'y n' -d "Automatically unmasks packages and generates package.use settings"
+complete -c emerge -l autounmask-backtrack -xa 'y n' -d "Allow backtracking after autounmask detects necessary changes"
+complete -c emerge -l autounmask-continue -a 'y n' -d "Apply autounmask changes and continue to execute command"
+complete -c emerge -l autounmask-only -a 'y n' -d "Only unmask and generate package.use settings without building anything"
+complete -c emerge -l autounmask-unrestricted-atoms -a 'y n' -d "Write keyword/mask changes using >= operators instead of ="
+complete -c emerge -l autounmask-keep-keywords -a 'y n' -d "Prevent autounmask from creating package.accept_keywords changes"
+complete -c emerge -l autounmask-keep-masks -a 'y n' -d "Prevent autounmask from creating package.unmask or ** keyword changes"
+complete -c emerge -l autounmask-license -xa 'y n' -d "Allow autounmask to create package.license changes"
+complete -c emerge -l autounmask-use -xa 'y n' -d "Allow autounmask to create package.use changes (enabled by default)"
+complete -c emerge -l autounmask-write -a 'y n' -d "Write autounmask changes to config files (implied by --ask)"
+complete -c emerge -l backtrack -d "Max number of times to backtrack on dependency conflicts (default: 20)"
+complete -c emerge -l binpkg-changed-deps -a 'y n' -d "Ignore binary packages whose ebuild dependencies changed since the build"
+complete -c emerge -l binpkg-respect-use -a 'y n' -d "Ignore binary packages whose USE flags differ from current config"
+complete -c emerge -s b -l buildpkg -a 'y n' -d "Build a binary package in addition to merging"
+complete -c emerge -l buildpkg-exclude -d "Atoms for which no binary packages should be built"
 complete -c emerge -s B -l buildpkgonly -d "Only build a binary pkg"
-# changed-deps
-complete -c emerge -s U -l changed-use
-complete -c emerge -s l -l changelog -d "Show changelog of pkg. Use with --pretend"
+complete -c emerge -l changed-deps -a 'y n' -d "Replace packages whose ebuild dependencies changed since they were built"
+complete -c emerge -l changed-deps-report -a 'y n' -d "Report packages whose ebuild dependencies changed since installation"
+complete -c emerge -l changed-slot -a 'y n' -d "Replace packages whose ebuild SLOT metadata changed since they were built"
+complete -c emerge -s U -l changed-use -d "Reinstall packages whose active USE flags changed since installation (ignores added/removed disabled flags)"
 complete -c emerge -l color -d "Colorized output" \
     -xa "y n"
 complete -c emerge -l columns -d "Align output. Use with --pretend"
-complete -c emerge -l complete-graph
-# complete-graph-if-new-use <yn>
-# complete-graph-if-new-ver <yn>
-# config-root DIR
+complete -c emerge -l complete-graph -a 'y n' -d "Consider deep deps of all @world packages; bail if the operation would break any"
+complete -c emerge -l complete-graph-if-new-use -xa 'y n' -d "Trigger --complete-graph when USE or IUSE changes for an installed package (default: y)"
+complete -c emerge -l complete-graph-if-new-ver -xa 'y n' -d "Trigger --complete-graph when an installed package version changes (default: y)"
+complete -c emerge -l config-root -d "Set PORTAGE_CONFIGROOT"
 complete -c emerge -s d -l debug -d "Run in debug mode"
 complete -c emerge -s D -l deep -d "Consider the whole dependency tree"
-# depclean-lib-check
-# digest
-# dynamic-deps <yn>
+complete -c emerge -l depclean-lib-check -a 'y n' -d "Account for library link-level deps during --depclean and --prune (default: y)"
+complete -c emerge -l digest -d "Regenerate package manifests (prefer repoman manifest)"
+complete -c emerge -l dynamic-deps -xa 'y n' -d "Substitute installed-package deps with current ebuild deps during calculations (default: y)"
 complete -c emerge -s e -l emptytree -d "Reinstall all world pkgs"
-# exclude ATOMS
-complete -c emerge -l exclude
-# fail-clean
+complete -c emerge -s X -l exclude -d "Space-separated atoms to never install"
+complete -c emerge -l fail-clean -a 'y n' -d "Clean up temp files after a build failure (useful with PORTAGE_TMPDIR on tmpfs)"
 complete -c emerge -s f -l fetchonly -d "Only download the pkgs but don't install them"
 complete -c emerge -s F -l fetch-all-uri -d "Same as --fetchonly and grab all potential files"
-# fuzzy-search
-complete -c emerge -s g -l getbinpkg -d "Download infos from each binary pkg. Implies -k"
-complete -c emerge -s G -l getbinpkgonly -d "As -g but don't use local infos"
+complete -c emerge -l fuzzy-search -a 'y n' -d "Match search strings approximately; auto-disabled for regex searches (default: y)"
+complete -c emerge -s g -l getbinpkg -a 'y n' -d "Download infos from each binary pkg. Implies -k"
+complete -c emerge -s G -l getbinpkgonly -a 'y n' -d "As -g but don't use local infos"
+complete -c emerge -l getbinpkg-exclude -d "Remote binary packages matching these atoms are not fetched"
+complete -c emerge -l getbinpkg-include -d "Only fetch remote binary packages matching these atoms"
 complete -c emerge -l ignore-default-opts -d "Ignore EMERGE_DEFAULT_OPTS"
-# ignore-build-slot-operator-deps <yn>
-# ignore-soname-deps <yn>
-complete -c emerge -l jobs
-complete -c emerge -l keep-going
-# load-average
-# misspell-suggestion
-# newrepo
+complete -c emerge -l ignore-built-slot-operator-deps -xa 'y n' -d "Ignore slot/sub-slot := operator deps recorded at build time (debug only)"
+complete -c emerge -l ignore-soname-deps -xa 'y n' -d "Ignore soname dependencies of binary and installed packages (default: y)"
+complete -c emerge -l ignore-world -a 'y n' -d "Ignore @world deps; may break installed packages (use with --ask)"
+complete -c emerge -l implicit-system-deps -xa 'y n' -d "Assume packages may have implicit deps on @system (default: y)"
+complete -c emerge -s j -l jobs -d "Number of packages to build simultaneously (0 = CPU count)"
+complete -c emerge -l jobs-tmpdir-require-free-gb -d "Minimum free GiB in PORTAGE_TMPDIR before starting more jobs (default: 18)"
+complete -c emerge -l keep-going -a 'y n' -d "Continue as much as possible after an error; recalculate deps for remaining packages"
+complete -c emerge -s l -l load-average -d "Do not start new builds if load average is at least LOAD"
+complete -c emerge -l misspell-suggestions -xa 'y n' -d "Show similar package names when a package is not found (default: y)"
+complete -c emerge -l newrepo -d "Recompile a package if it is now pulled from a different repository"
 complete -c emerge -s N -l newuse -d "Include installed pkgs with changed USE flags"
+complete -c emerge -l nobindeps -d "Use ebuilds for deps; binary packages only for explicitly named atoms"
 complete -c emerge -l noconfmem -d "Disregard merge records"
 complete -c emerge -s O -l nodeps -d "Don't merge dependencies"
 complete -c emerge -s n -l noreplace -d "Skip already installed pkgs"
 complete -c emerge -l nospinner -d "Disable the spinner"
-# usepkg-exclude ATOMS
-# rebuild-exclude ATOMS
-# rebuild-ignore ATOMS
+complete -c emerge -l usepkg-exclude -d "Ignore matching binary packages"
+complete -c emerge -l usepkg-exclude-live -a 'y n' -d "Do not install from binary packages for live ebuilds"
+complete -c emerge -l usepkg-include -d "Ignore non-matching binary packages"
+complete -c emerge -l useoldpkg-atoms -d "Prefer matching binary packages over newer unbuilt ebuilds"
+complete -c emerge -l rebuild-exclude -d "Do not rebuild matching packages due to --rebuild"
+complete -c emerge -l rebuild-ignore -d "Do not rebuild packages that depend on matching packages due to --rebuild"
 complete -c emerge -s 1 -l oneshot -d "Don't add pkgs to world"
 complete -c emerge -s o -l onlydeps -d "Only merge dependencies"
-# onlydeps-with-rdeps <yn>
-# package-moves
-# pkg-format
-# prefix DIR
+complete -c emerge -l onlydeps-with-rdeps -xa 'y n' -d "Include run-time deps when using --onlydeps (default: y)"
+complete -c emerge -l onlydeps-with-ideps -xa 'y n' -d "Include install-time deps when --onlydeps and --onlydeps-with-rdeps=n are used"
+complete -c emerge -l package-moves -a 'y n' -d "Apply package moves when necessary (default: y; do not disable normally)"
+complete -c emerge -l pkg-format -xa 'tar rpm' -d "Binary package format to create"
+complete -c emerge -l prefix -d "Set EPREFIX"
+complete -c emerge -l quickpkg-direct -a 'y n' -d "Use installed packages directly as binary packages"
+complete -c emerge -l quickpkg-direct-root -d "Root to use as --quickpkg-direct source (default: /)"
 complete -c emerge -s p -l pretend -d "Display what would be done without doing it"
-complete -c emerge -s q -l quiet -d "Use a condensed output"
-# quiet-build
-# quiet-fail
-# quiet-repo-display
-# quiet-unmerge-warn
-# rage-clean
-# read-news
-# rebuild-if-new-slot
-# rebuild-if-new-rev
-# rebuild-if-new-ver
-# rebuild-if-unbuilt
-# rebuild-binaries
-# rebuild-binaries-timestamp TIMESTAMP
-# reinstall changed-use
-# reinstall-atoms ATOMS
-# root-deps
-# search-index
-# search-similarity PERCENTAGE
-complete -c emerge -s w -l select
-# selective
+complete -c emerge -s q -l quiet -a 'y n' -d "Use a condensed output"
+complete -c emerge -l quiet-build -a 'y n' -d "Redirect all build output to logs; display on failure"
+complete -c emerge -l quiet-fail -a 'y n' -d "Suppress build log display on failure (show only die message and log path)"
+complete -c emerge -l quiet-repo-display -d "Suppress ::repository in merge list; use numbers instead"
+complete -c emerge -l quiet-unmerge-warn -d "Suppress the warning shown before --unmerge actions"
+complete -c emerge -l rage-clean -d "Like --unmerge but with CLEAN_DELAY=0; can remove critical packages"
+complete -c emerge -l read-news -a 'y n' -d "Offer to read unread news via eselect when --ask is active"
+complete -c emerge -l rebuild-if-new-slot -a 'y n' -d "Rebuild packages when a new slot can satisfy := deps (default: y)"
+complete -c emerge -l rebuild-if-new-rev -a 'y n' -d "Rebuild packages when build-time deps are installed with a new revision"
+complete -c emerge -l rebuild-if-new-ver -a 'y n' -d "Rebuild packages when build-time deps are installed with a new version"
+complete -c emerge -l rebuild-if-unbuilt -a 'y n' -d "Rebuild packages when build-time deps are built from source"
+complete -c emerge -l rebuilt-binaries -a 'y n' -d "Replace installed packages with binary packages that have been rebuilt"
+complete -c emerge -l rebuilt-binaries-timestamp -d "Only consider rebuilt binaries with BUILD_TIME newer than TIMESTAMP"
+complete -c emerge -l regex-search-auto -xa 'y n' -d "Auto-detect regex in search strings (default: y)"
+# reinstall changed-use (alias for --changed-use)
+complete -c emerge -l reinstall-atoms -d "Treat matching packages as not installed and reinstall them"
+complete -c emerge -l root -d "Set ROOT (target root filesystem)"
+complete -c emerge -l root-deps -d "Control whether build-time deps go into ROOT or /"
+complete -c emerge -l sysroot -d "Set SYSROOT (root for DEPEND build-time deps)"
+complete -c emerge -l search-index -xa 'y n' -d "Use the egencache-built search index (default: y)"
+complete -c emerge -l search-similarity -d "Minimum similarity percentage for fuzzy search results (default: 80)"
+complete -c emerge -s w -l select -a 'y n' -d "Add packages to @world (inverse of --oneshot)"
+complete -c emerge -l selective -a 'y n' -d "Skip packages already installed (same as --noreplace; use =n to force disable)"
 complete -c emerge -l skipfirst -d "Remove first pkg in resume list. Use with --resume"
-# sync-module <glsa|news|profiles>
+complete -c emerge -l sync-submodule -xa 'glsa news profiles' -d "Restrict --sync to specified submodule (rsync only); repeatable"
 complete -c emerge -s t -l tree -d "Show the dependency tree"
-# unordered-display
-complete -c emerge -s u -l update
-# use-ebuild-visibility
-# useoldpkg-atoms ATOMS
-complete -c emerge -s k -l usepkg -d "Use binary pkg if available"
-complete -c emerge -s K -l usepkgonly -d "Only use binary pkgs"
-complete -c emerge -s v -l verbose -d "Run in verbose mode"
+complete -c emerge -l unordered-display -d "Remove merge-order constraint from --tree output for readability"
+complete -c emerge -s u -l update -d "Update packages to best available version"
+complete -c emerge -l update-if-installed -d "Like --update but only for packages already installed"
+complete -c emerge -l use-ebuild-visibility -a 'y n' -d "Use unbuilt ebuild metadata for visibility checks on built packages"
+complete -c emerge -s k -l usepkg -a 'y n' -d "Use binary pkg if available"
+complete -c emerge -s K -l usepkgonly -a 'y n' -d "Only use binary pkgs"
+complete -c emerge -s v -l verbose -a 'y n' -d "Run in verbose mode"
 complete -c emerge -l verbose-conflicts -d "Verbose slot conflicts"
-# verbose-slot-rebuilds
+complete -c emerge -l verbose-missing-ebuilds -a 'y n' -d "Warn on @world packages with no available ebuild (default: y)"
+complete -c emerge -l verbose-slot-rebuilds -a 'y n' -d "List packages causing slot rebuilds in emerge output (default: y)"
 complete -c emerge -l with-bdeps -d "Pull in build time dependencies" \
     -xa "y n"
-# with-bdeps-auto <yn>
-# with-test-bdeps
+complete -c emerge -l with-bdeps-auto -xa 'y n' -d "Auto-enable --with-bdeps for installation actions (default: y)"
+complete -c emerge -l with-test-deps -a 'y n' -d "Pull in test-conditional deps for matched packages even if test is not in FEATURES"


### PR DESCRIPTION
Add missing options, descriptions, y/n completions, and correct short flags throughout. Drop --changelog (removed from portage). Fix several wrong option names in stubs (--ignore-built-slot-operator-deps, --rebuilt-binaries, --sync-submodule, etc.). Use -xa for mandatory boolean args and -a for optional ones.