### PR TITLE
fix: trim spaces around commas in nested brace expansion

### DIFF
--- a/src/expand.rs
+++ b/src/expand.rs
@@ -854,9 +854,15 @@ fn expand_braces(
             let item_len = pos - item_begin;
             let item = input[item_begin..pos].to_owned();
             let mut item = trim(item, Some(wstr::from_char_slice(&[BRACE_SPACE, '\0'])));
-            for c in item.as_char_slice_mut() {
-                if *c == BRACE_SPACE {
-                    *c = ' ';
+            // Only convert BRACE_SPACE back to regular space if there are no more
+            // nested braces to expand. Otherwise the inner expansion would see a
+            // regular space and fail to trim it from the item edges (#12794).
+            let has_nested_braces = item.contains(BRACE_BEGIN) || item.contains(BRACE_END);
+            if !has_nested_braces {
+                for c in item.as_char_slice_mut() {
+                    if *c == BRACE_SPACE {
+                        *c = ' ';
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary

When brace expansion contains nested brace pairs, spaces after commas
inside the inner braces were not being stripped.

For example:
```
echo foo-{bar, baz-{far, faz}}
```

**Before**: `foo-bar foo-baz-far foo-baz- faz` (extra space in last token)  
**After**:  `foo-bar foo-baz-far foo-baz-faz`

**Root cause**: `expand_braces()` was converting `BRACE_SPACE` placeholder
characters to regular `' '` before recursing into nested pairs. When the
inner expansion called `trim()` on its items to strip edge whitespace,
the already-converted regular spaces were not recognized as trimmable.

**Fix**: Defer the `BRACE_SPACE` → `' '` conversion until no more nested
braces remain in the item, preserving the marker for recursive passes.

## Test plan

- All 175 existing Rust unit tests pass
- All existing brace expansion test cases verified
- `echo foo-{bar, baz-{far, faz}}` → `foo-bar foo-baz-far foo-baz-faz`
- `echo foo-{bar, baz-{far ,faz}}` → `foo-bar foo-baz-far foo-baz-faz`
- `echo foo-{1,2{3,4}}` → `foo-1 foo-23 foo-24` (unchanged)
- Multi-line whitespace in braces still preserved

## Related issue

Fixes #12794