### PR TITLE
Remove extraneous dash in `path basename` description

### DIFF
--- a/doc_src/cmds/path.rst
+++ b/doc_src/cmds/path.rst
@@ -57,7 +57,7 @@ The following subcommands are available.
 
 ``path basename`` returns the last path component of the given path, by removing the directory prefix and removing trailing slashes. In other words, it is the part that is not the dirname. For files you might call it the "filename".
 
-If the ``-E`` or ``---no-extension`` option is used and the base name contained a period, the path is returned with the extension (or the last extension) removed, i.e. the "filename" without an extension (akin to calling ``path change-extension "" (path basename $path)``).
+If the ``-E`` or ``--no-extension`` option is used and the base name contained a period, the path is returned with the extension (or the last extension) removed, i.e. the "filename" without an extension (akin to calling ``path change-extension "" (path basename $path)``).
 
 It returns 0 if there was a basename, i.e. if the path wasn't empty or just slashes.
 


### PR DESCRIPTION
Noticed a triple dash in `doc_src/cmds/path.rst`. Running that command prints an error, so I presume it's meant to be a double dash.

## TODOs:
<!-- Check off what what has been done so far. -->
- [x] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>` -- Not needed
- [x] Changes to fish usage are reflected in user documentation/manpages. -- Not needed 
- [x] Tests have been added for regressions fixed -- Not needed
- [x] User-visible changes noted in CHANGELOG.rst -- Don't think it's needed? <!-- Usually skipped for changes to completions -->
