### PR TITLE
history: don't ignore re-added history items after vacuum

### DIFF
--- a/src/history/file.rs
+++ b/src/history/file.rs
@@ -2,7 +2,8 @@
 
 use super::HistoryItem;
 use super::yaml_backend::{
-    decode_item_fish_2_0, escape_yaml_fish_2_0, offset_of_next_item_fish_2_0,
+    CREATION_TIMESTAMP_KEY, LAST_ADDED_TIMESTAMP_KEY, decode_item_fish_2_0, escape_yaml_fish_2_0,
+    offset_of_next_item_fish_2_0,
 };
 use crate::{
     flog::flog,
@@ -292,7 +293,22 @@ impl HistoryItem {
         writer.write_all(b"- cmd: ")?;
         writer.write_all(&cmd)?;
         writer.write_all(b"\n")?;
-        writeln!(writer, "  when: {}", time_to_seconds(self.timestamp()))?;
+        let last_added = self.last_added_timestamp();
+        let created = self.creation_timestamp();
+        writeln!(
+            writer,
+            "  {}: {}",
+            LAST_ADDED_TIMESTAMP_KEY,
+            time_to_seconds(last_added)
+        )?;
+        if created != last_added {
+            writeln!(
+                writer,
+                "  {}: {}",
+                CREATION_TIMESTAMP_KEY,
+                time_to_seconds(created)
+            )?;
+        }
 
         let paths = self.get_required_paths();
         if !paths.is_empty() {

--- a/src/history/history.rs
+++ b/src/history/history.rs
@@ -1774,6 +1774,7 @@ mod tests {
         tests::prelude::test_init,
     };
     use fish_build_helper::workspace_root;
+    use fish_tempfile::TempDir;
     use fish_wcstringutil::{string_prefixes_string, string_prefixes_string_case_insensitive};
     use fish_widestring::{osstr2wcstring, wcs2bytes};
     use rand::{RngExt as _, rngs::ThreadRng};
@@ -2115,33 +2116,90 @@ mod tests {
         hist.clear();
     }
 
+    struct Test {
+        history_name: &'static wstr,
+        _temp_dir: TempDir,
+        temp_dir_wcstring: WString,
+        next_unique_id: usize,
+    }
+    impl Test {
+        fn new(history_name: &'static wstr) -> Self {
+            // Place history in a temp directory.
+            let _temp_dir = fish_tempfile::new_dir().unwrap();
+            let temp_dir_wcstring = osstr2wcstring(_temp_dir.path());
+            Self {
+                history_name,
+                _temp_dir,
+                temp_dir_wcstring,
+                next_unique_id: 0,
+            }
+        }
+        fn create_history(&self) -> Arc<History> {
+            create_test_history(self.history_name, &self.temp_dir_wcstring)
+        }
+        fn trigger_vacuum(&mut self, hist: &History) {
+            for _i in 0..VACUUM_FREQUENCY {
+                hist.add_commandline(sprintf!("maybe vacuum %d", self.next_unique_id));
+                self.next_unique_id += 1;
+            }
+        }
+    }
+
     #[test]
     fn test_history_external_rewrites() {
-        // Place history in a temp directory.
-        let tmpdir = fish_tempfile::new_dir().unwrap();
-        let hist_dir = osstr2wcstring(tmpdir.path());
+        let mut test = Test::new(L!("interleave_test"));
 
         // Write some history to disk.
         {
-            let hist = write_history_entries(&hist_dir, VACUUM_FREQUENCY / 2, 0);
+            let hist = test.create_history();
+            test.trigger_vacuum(&hist);
             hist.add_commandline("needle".into());
             hist.save();
         }
         std::thread::sleep(Duration::from_secs(1));
 
         // Read history from disk.
-        let hist = create_test_history(L!("race_test"), &hist_dir);
+        let hist = test.create_history();
         assert_eq!(hist.item_at_index(1).unwrap().str(), "needle");
 
         // Add items until we rewrite the file.
         // In practice this might be done by another shell.
-        write_history_entries(&hist_dir, VACUUM_FREQUENCY, 0);
+        test.trigger_vacuum(&hist);
 
-        for i in 1.. {
-            if hist.item_at_index(i).unwrap().str() == "needle" {
-                break;
-            }
-        }
+        assert!(history_contains(&hist, L!("needle")));
+    }
+
+    #[test]
+    fn test_history_external_rewrite_read_back_with_correct_ordering() {
+        let mut test = Test::new(L!("interleave_test_2"));
+
+        // Write some history to disk.
+        let hist1 = test.create_history();
+        let item1 = L!("item 1");
+        let item2 = L!("item 2");
+        let item3 = L!("item 3");
+        hist1.add_commandline(item1.into());
+        hist1.add_commandline(item2.into());
+        hist1.add_commandline(item3.into());
+
+        std::thread::sleep(std::time::Duration::from_secs(1));
+
+        let hist2 = test.create_history();
+
+        hist1.add_commandline(item1.into());
+        hist1.add_commandline(item3.into());
+        hist1.add_commandline(item2.into());
+        test.trigger_vacuum(&hist1);
+
+        let trigger_reload = L!("trigger-reload");
+        hist2.add_commandline(trigger_reload.into());
+
+        assert_eq!(hist2.item_at_index(1).unwrap().str(), trigger_reload);
+        let skip = VACUUM_FREQUENCY;
+        assert_eq!(hist2.item_at_index(skip + 2).unwrap().str(), item2);
+        assert_eq!(hist2.item_at_index(skip + 3).unwrap().str(), item3);
+        assert_eq!(hist2.item_at_index(skip + 4).unwrap().str(), item1);
+        assert!(hist2.item_at_index(skip + 5).is_none());
     }
 
     #[test]

--- a/src/history/history.rs
+++ b/src/history/history.rs
@@ -259,18 +259,18 @@ impl HistoryItem {
 
     /// We can merge two items if they are the same command. We use the more recent timestamp, more
     /// recent identifier, and the longer list of required paths.
-    fn merge(&mut self, item: &HistoryItem) -> bool {
+    fn merge(&mut self, item: HistoryItem) -> Result<(), HistoryItem> {
         // We can only merge items if they agree on their text and persistence mode.
         if self.contents != item.contents || self.persist_mode != item.persist_mode {
-            return false;
+            return Err(item);
         }
 
         // Ok, merge this item.
         self.creation_timestamp = self.creation_timestamp.max(item.creation_timestamp);
         if self.required_paths.len() < item.required_paths.len() {
-            self.required_paths.clone_from(&item.required_paths);
+            self.required_paths = item.required_paths;
         }
-        true
+        Ok(())
     }
 }
 
@@ -380,14 +380,19 @@ impl HistoryImpl {
         }
 
         // Try merging with the last item.
-        if let Some(last) = self.new_items.last_mut() {
-            if last.merge(&item) {
-                // We merged, so we don't have to add anything. Maybe this item was pending, but it just got
-                // merged with an item that is not pending, so pending just becomes false.
-                self.has_pending_item = false;
-                return;
+        let item = if let Some(last) = self.new_items.last_mut() {
+            match last.merge(item) {
+                Ok(()) => {
+                    // We merged, so we don't have to add anything. Maybe this item was pending, but it just got
+                    // merged with an item that is not pending, so pending just becomes false.
+                    self.has_pending_item = false;
+                    return;
+                }
+                Err(item) => item,
             }
-        }
+        } else {
+            item
+        };
 
         // We have to add a new item.
         self.new_items.push(item);

--- a/src/history/history.rs
+++ b/src/history/history.rs
@@ -146,7 +146,7 @@ impl LruCacheExt for LruCache<WString, HistoryItem> {
         // and add it. Note that calling get_node promotes the node to the front.
         let key = item.str();
         if let Some(node) = self.get_mut(key) {
-            node.creation_timestamp = SystemTime::max(node.timestamp(), item.timestamp());
+            node.timestamps.update_last_added(item.timestamps);
             // What to do about paths here? Let's just ignore them.
         } else {
             self.put(key.to_owned(), item);
@@ -160,25 +160,39 @@ pub type PathList = Vec<WString>;
 pub struct HistoryItem {
     /// The actual contents of the entry.
     contents: WString,
-    /// Original creation time for the entry.
-    creation_timestamp: SystemTime,
+    /// Timestamps of creation of this history entry.
+    timestamps: Timestamps,
     /// Paths that we require to be valid for this item to be autosuggested.
     required_paths: Vec<WString>,
     /// Whether to write this item to disk.
     persist_mode: PersistenceMode,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub(super) struct Timestamps {
+    /// Time of most recent re-creation.
+    pub(super) last_added: SystemTime,
+    /// Original creation time for the entry.
+    pub(super) created: SystemTime,
+}
+
+impl Timestamps {
+    fn update_last_added(&mut self, new: Timestamps) {
+        self.last_added = self.last_added.max(new.last_added);
+    }
+}
+
 impl HistoryItem {
     /// Construct from a text, timestamp, and optional identifier.
     /// If `persist_mode` is not [`PersistenceMode::Disk`], then do not write this item to disk.
-    pub fn new(
+    pub(super) fn new(
         s: WString,
-        when: SystemTime,              /*=0*/
+        timestamps: Timestamps,
         persist_mode: PersistenceMode, /*=Disk*/
     ) -> Self {
         Self {
             contents: s,
-            creation_timestamp: when,
+            timestamps,
             required_paths: vec![],
             persist_mode,
         }
@@ -235,9 +249,14 @@ impl HistoryItem {
         }
     }
 
+    /// Returns the timestamp of when this history item was last added.
+    pub fn last_added_timestamp(&self) -> SystemTime {
+        self.timestamps.last_added
+    }
+
     /// Returns the timestamp for creating this history item.
-    pub fn timestamp(&self) -> SystemTime {
-        self.creation_timestamp
+    pub fn creation_timestamp(&self) -> SystemTime {
+        self.timestamps.created
     }
 
     /// Returns whether this item should be persisted (written to disk).
@@ -266,7 +285,7 @@ impl HistoryItem {
         }
 
         // Ok, merge this item.
-        self.creation_timestamp = self.creation_timestamp.max(item.creation_timestamp);
+        self.timestamps.update_last_added(item.timestamps);
         if self.required_paths.len() < item.required_paths.len() {
             self.required_paths = item.required_paths;
         }
@@ -409,22 +428,25 @@ impl HistoryImpl {
     }
 
     /// Returns a timestamp for new items - see the implementation for a subtlety.
-    fn timestamp_now(&self) -> SystemTime {
-        let mut when = SystemTime::now();
+    fn timestamps_as_of_now(&self) -> Timestamps {
+        let mut now = SystemTime::now();
         // Big hack: do not allow timestamps equal to our boundary date. This is because we include
         // items whose timestamps are equal to our boundary when reading old history, so we can catch
         // "just closed" items. But this means that we may interpret our own items, that we just wrote,
         // as old items, if we wrote them in the same second as our birthdate.
-        if when.duration_since(UNIX_EPOCH).ok().map(|d| d.as_secs())
+        if now.duration_since(UNIX_EPOCH).ok().map(|d| d.as_secs())
             == self
                 .boundary_timestamp
                 .duration_since(UNIX_EPOCH)
                 .ok()
                 .map(|d| d.as_secs())
         {
-            when += Duration::from_secs(1);
+            now += Duration::from_secs(1);
         }
-        when
+        Timestamps {
+            last_added: now,
+            created: now,
+        }
     }
 
     /// Loads old items if necessary.
@@ -533,7 +555,7 @@ impl HistoryImpl {
                 if let Some(&scope) = self.deleted_items.get(old_item.str()) {
                     // If old item is newer than session always erase if in deleted.
                     // If old item is older and in deleted items don't erase if added by clear_session.
-                    let delete = old_item.timestamp() > self.boundary_timestamp
+                    let delete = old_item.creation_timestamp() > self.boundary_timestamp
                         || scope == DeletionScope::AllSessions;
                     if delete {
                         continue;
@@ -558,7 +580,7 @@ impl HistoryImpl {
         // This is because we may have read "old" items with a later timestamp than our "new" items
         // This is the essential step that roughly orders items by history
         let mut items: Vec<_> = lru.into_iter().map(|(_key, item)| item).collect();
-        items.sort_by_key(HistoryItem::timestamp);
+        items.sort_by_key(HistoryItem::last_added_timestamp);
 
         /// Default buffer size for flushing to the history file.
         const HISTORY_OUTPUT_BUFFER_SIZE: usize = 64 * 1024;
@@ -876,7 +898,7 @@ impl HistoryImpl {
     fn populate_from_bash<R: BufRead>(&mut self, contents: R) {
         // Process the entire history file until EOF is observed.
         // Pretend all items were created at this time.
-        let when = self.timestamp_now();
+        let timestamps = self.timestamps_as_of_now();
         for line in contents.split(b'\n') {
             let Ok(line) = line else {
                 break;
@@ -885,7 +907,7 @@ impl HistoryImpl {
             // Add this line if it doesn't contain anything we know we can't handle.
             if should_import_bash_history_line(&wide_line) {
                 self.add(
-                    HistoryItem::new(wide_line, when, PersistenceMode::Disk),
+                    HistoryItem::new(wide_line, timestamps.clone(), PersistenceMode::Disk),
                     /*pending=*/ false,
                     /*do_save=*/ false,
                 );
@@ -982,7 +1004,7 @@ impl HistoryImpl {
     fn set_valid_file_paths(&mut self, valid_file_paths: Vec<WString>, snapshot: &HistoryItem) {
         // Look for an item with the given identifier. It is likely to be at the end of new_items.
         for item in self.new_items.iter_mut().rev() {
-            if item.creation_timestamp == snapshot.creation_timestamp
+            if item.last_added_timestamp() == snapshot.last_added_timestamp()
                 && item.contents == snapshot.contents
             {
                 // found it
@@ -1086,7 +1108,7 @@ fn format_history_record(
     color_enabled: bool,
 ) -> WString {
     let mut result = WString::new();
-    let seconds = time_to_seconds(item.timestamp());
+    let seconds = time_to_seconds(item.last_added_timestamp());
     // This warns for musl, but the warning is useless to us - there is nothing we can or should do.
     #[allow(deprecated)]
     let seconds = seconds as libc::time_t;
@@ -1176,8 +1198,8 @@ impl History {
 
     pub fn add_commandline(&self, s: WString) {
         let mut imp = self.imp();
-        let when = imp.timestamp_now();
-        let item = HistoryItem::new(s, when, PersistenceMode::Disk);
+        let timestamps = imp.timestamps_as_of_now();
+        let item = HistoryItem::new(s, timestamps, PersistenceMode::Disk);
         imp.add(item, false, true);
     }
 
@@ -1282,8 +1304,7 @@ impl History {
         let mut imp = self.imp();
 
         // Make our history item.
-        let when = imp.timestamp_now();
-        let item = HistoryItem::new(s.to_owned(), when, persist_mode);
+        let item = HistoryItem::new(s.to_owned(), imp.timestamps_as_of_now(), persist_mode);
         let to_disk = persist_mode == PersistenceMode::Disk;
 
         if wants_file_detection {
@@ -1774,7 +1795,7 @@ mod tests {
         common::ESCAPE_TEST_CHAR,
         env::{EnvMode, EnvSetMode, EnvStack},
         fs::{LockedFile, WriteMethod},
-        history::HistoryId,
+        history::{HistoryId, Timestamps},
         prelude::*,
         tests::prelude::test_init,
     };
@@ -1954,7 +1975,12 @@ mod tests {
                 .collect();
 
             // Record this item.
-            let mut item = HistoryItem::new(value, SystemTime::now(), PersistenceMode::Disk);
+            let now = SystemTime::now();
+            let timestamps = Timestamps {
+                last_added: now,
+                created: now,
+            };
+            let mut item = HistoryItem::new(value, timestamps, PersistenceMode::Disk);
             item.set_required_paths(paths);
             before.push_back(item.clone());
             history.add(item, false);
@@ -1974,7 +2000,7 @@ mod tests {
             let bef = &before[i];
             let aft = &after[i];
             assert_eq!(bef.str(), aft.str());
-            assert_eq!(bef.timestamp(), aft.timestamp());
+            assert_eq!(bef.timestamps, aft.timestamps);
             assert_eq!(bef.get_required_paths(), aft.get_required_paths());
         }
 
@@ -2205,6 +2231,35 @@ mod tests {
         assert_eq!(hist2.item_at_index(skip + 3).unwrap().str(), item3);
         assert_eq!(hist2.item_at_index(skip + 4).unwrap().str(), item1);
         assert!(hist2.item_at_index(skip + 5).is_none());
+    }
+
+    #[test]
+    fn test_history_external_rewrite_increases_last_added_timestamp() {
+        let mut test = Test::new(L!("interleave_test_3"));
+
+        // Write some history to disk.
+        let hist1 = test.create_history();
+        let needle = WString::from_str("needle");
+        hist1.add_commandline(needle.clone());
+        hist1.save();
+        assert!(history_contains(&hist1, &needle));
+        std::thread::sleep(Duration::from_secs(1));
+        let hist2 = test.create_history();
+        assert!(history_contains(&hist2, &needle));
+
+        // Increase needle's last-used timestamp.
+        std::thread::sleep(Duration::from_secs(1));
+        hist1.add_commandline("something to avoid merge() special case".into());
+        hist1.add_commandline(needle.clone());
+        test.trigger_vacuum(&hist1);
+
+        hist2.add_commandline("trigger-reload".into());
+        assert!(history_contains(&hist2, &needle));
+        let needle = hist2.item_at_index(2).unwrap();
+        assert!(needle.creation_timestamp() < needle.last_added_timestamp());
+        assert!(
+            needle.creation_timestamp() + Duration::from_secs(3) > needle.last_added_timestamp()
+        );
     }
 
     #[test]
@@ -2485,7 +2540,6 @@ mod tests {
         let test_history_imported_from_corrupted = create_test_history(name, &hist_dir);
         let expected: Vec<WString> = vec![
             "no_newline_at_end_of_file".into(),
-            "corrupt_prefix".into(),
             "this_command_is_ok".into(),
         ];
         assert_eq!(test_history_imported_from_corrupted.get_history(), expected);

--- a/src/history/yaml_backend.rs
+++ b/src/history/yaml_backend.rs
@@ -1,7 +1,7 @@
 //! Implementation of the YAML-like history file format.
 
 use super::{HistoryItem, PersistenceMode};
-use crate::flog::flog;
+use crate::{flog::flog, history::Timestamps};
 use fish_widestring::{bytes2wcstring, subslice_position};
 use std::{
     borrow::Cow,
@@ -12,6 +12,7 @@ use std::{
 //
 //   - cmd: ssh blah blah blah
 //     when: 2348237
+//     created_when: 2348238
 //     paths:
 //       - /path/to/something
 //       - /path/to/something_else
@@ -137,6 +138,9 @@ fn time_from_seconds(offset: i64) -> SystemTime {
     }
 }
 
+pub(super) const LAST_ADDED_TIMESTAMP_KEY: &str = "when";
+pub(super) const CREATION_TIMESTAMP_KEY: &str = "created_when";
+
 /// Decode an item via the fish 2.0 format.
 pub fn decode_item_fish_2_0(mut data: &[u8]) -> Option<HistoryItem> {
     let (advance, line) = read_line(data);
@@ -152,7 +156,8 @@ pub fn decode_item_fish_2_0(mut data: &[u8]) -> Option<HistoryItem> {
 
     // Read the remaining lines.
     let mut indent = None;
-    let mut when = UNIX_EPOCH;
+    let mut timestamp_last_added = None;
+    let mut timestamp_created = None;
     let mut paths = Vec::new();
     loop {
         let (advance, line) = read_line(data);
@@ -170,14 +175,18 @@ pub fn decode_item_fish_2_0(mut data: &[u8]) -> Option<HistoryItem> {
         // We are definitely going to consume this line.
         data = &data[advance..];
 
-        if *key == *b"when" {
-            // Parse an int from the timestamp. Should this fail, 0 is acceptable.
-            when = time_from_seconds(
-                std::str::from_utf8(&value)
-                    .ok()
-                    .and_then(|s| s.parse().ok())
-                    .unwrap_or(0),
-            );
+        let parse_timestamp_value = |value| {
+            std::str::from_utf8(value)
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .map(time_from_seconds)
+        };
+
+        if *key == *LAST_ADDED_TIMESTAMP_KEY.as_bytes() {
+            timestamp_last_added = parse_timestamp_value(&value);
+            timestamp_created = timestamp_created.or(timestamp_last_added);
+        } else if *key == *CREATION_TIMESTAMP_KEY.as_bytes() {
+            timestamp_created = parse_timestamp_value(&value);
         } else if *key == *b"paths" {
             // Read lines starting with " - " until we can't read any more.
             loop {
@@ -200,16 +209,21 @@ pub fn decode_item_fish_2_0(mut data: &[u8]) -> Option<HistoryItem> {
         }
     }
 
-    let mut result = HistoryItem::new(cmd, when, PersistenceMode::Disk);
+    let timestamps = Timestamps {
+        last_added: timestamp_last_added.unwrap_or(UNIX_EPOCH),
+        created: timestamp_created.unwrap_or(UNIX_EPOCH),
+    };
+    let mut result = HistoryItem::new(cmd, timestamps, PersistenceMode::Disk);
     result.set_required_paths(paths);
     Some(result)
 }
 
-/// Parse a timestamp line that looks like this: spaces, "when:", spaces, timestamp, newline
+/// Parse a timestamp line that looks like this: spaces, "$key:", spaces, timestamp, newline
 /// We know the string contains a newline, so stop when we reach it.
-fn parse_timestamp(s: &[u8]) -> Option<SystemTime> {
+fn parse_timestamp_line(key: &str, s: &[u8]) -> Option<SystemTime> {
     let s = trim_start(s);
-    let s = s.strip_prefix(b"when:")?;
+    let s = s.strip_prefix(key.as_bytes())?;
+    let s = s.strip_prefix(b":")?;
     let s = trim_start(s);
 
     let t = std::str::from_utf8(s).ok()?.parse().ok()?;
@@ -234,7 +248,7 @@ pub fn offset_of_next_item_fish_2_0(
     cutoff_timestamp: Option<SystemTime>,
 ) -> Option<usize> {
     let mut lines = complete_lines(&contents[*cursor..]).peekable();
-    while let Some(mut line) = lines.next() {
+    while let Some(line) = lines.next() {
         // Skip lines with a leading space, since these are in the interior of one of our items.
         if line.starts_with(b" ") {
             continue;
@@ -242,19 +256,6 @@ pub fn offset_of_next_item_fish_2_0(
 
         // Try to be a little YAML compatible. Skip lines with leading %, ---, or ...
         if line.starts_with(b"%") || line.starts_with(b"---") || line.starts_with(b"...") {
-            continue;
-        }
-
-        // Hackish: fish 1.x rewriting a fish 2.0 history file can produce lines with lots of
-        // leading "- cmd: - cmd: - cmd:". Trim all but one leading "- cmd:".
-        while line.starts_with(b"- cmd: - cmd: ") {
-            // Skip over just one of the - cmd. In the end there will be just one left.
-            line = line.strip_prefix(b"- cmd: ").unwrap();
-        }
-
-        // Hackish: fish 1.x rewriting a fish 2.0 history file can produce commands like "when:
-        // 123456". Ignore those.
-        if line.starts_with(b"- cmd:    when:") {
             continue;
         }
 
@@ -287,18 +288,22 @@ pub fn offset_of_next_item_fish_2_0(
             // changes. So we'll read all subsequent items.
             // Walk over lines that we think are interior. These lines are not null terminated, but
             // are guaranteed to contain a newline.
-            let mut timestamp = None;
+            let mut timestamp_created = None;
+            let mut timestamp_last_added = None;
             while let Some(interior_line) = lines.next_if(|l| l.starts_with(b" ")) {
                 // Try parsing a timestamp from this line. If we succeed, the loop will break.
-                timestamp = parse_timestamp(interior_line);
-                if timestamp.is_some() {
+                timestamp_created = timestamp_created
+                    .or_else(|| parse_timestamp_line(CREATION_TIMESTAMP_KEY, interior_line));
+                if timestamp_created.is_some() {
                     break;
                 }
+                timestamp_last_added = timestamp_last_added
+                    .or_else(|| parse_timestamp_line(LAST_ADDED_TIMESTAMP_KEY, interior_line));
             }
 
-            // Skip this item if the timestamp is past our cutoff.
-            if let Some(timestamp) = timestamp {
-                if timestamp > cutoff_timestamp {
+            // Skip this item if the creation timestamp is past our cutoff.
+            if let Some(timestamp_created) = timestamp_created.or(timestamp_last_added) {
+                if timestamp_created > cutoff_timestamp {
                     continue;
                 }
             }

--- a/src/history/yaml_backend.rs
+++ b/src/history/yaml_backend.rs
@@ -318,7 +318,7 @@ pub fn offset_of_next_item_fish_2_0(
             offset.try_into().unwrap()
         }
 
-        // Advance the cursor past the last line of this entry
+        // Advance the cursor past the first line of this entry
         *cursor = match lines.next() {
             Some(next_line) => unsafe { offset(contents, next_line) },
             None => contents.len(),

--- a/tests/history_sample_corrupt1
+++ b/tests/history_sample_corrupt1
@@ -1,5 +1,3 @@
 - cmd: this_command_is_ok
-- cmd: - cmd: - cmd: - cmd: - cmd: - cmd: - cmd: - cmd: - cmd: - cmd: - cmd: - cmd: - cmd: - cmd: - cmd:    when: 1396531614
-- cmd: - cmd: - cmd: - cmd: - cmd: - cmd: - cmd: - cmd: - cmd: - cmd: - cmd: - cmd: - cmd: - cmd: - cmd: - cmd: corrupt_prefix
 - cmd: no_newline_at_end_of_file
    when: 1403531898

--- a/tests/history_sample_fish_2_0
+++ b/tests/history_sample_fish_2_0
@@ -1,5 +1,6 @@
 - cmd: echo alpha
-   when: 1339717374
+   when:         1111111111
+   created_when: 1111122222
 - cmd: function foo\necho bar\nend
    when: 1339717377
 - cmd: echo this has\\\nbackslashes


### PR DESCRIPTION
As root-caused in https://github.com/fish-shell/fish-shell/issues/10300#issuecomment-4674848354, we sometimes temporarily forget about history items:

Steps:

	1. start fish1
	2. fish1: run "echo remember me"
	3. start fish2
	4. fish1: run "echo something else"
	5. fish1: run "echo remember me"
	6. fish1: run up to VACUUM_FREQUENCY commands, until vacuum happens
	   (can watch ~/.config/fish/${fish_history:-fish}_history)
	7. fish2: run "echo reload"

Now fish2 can't recall `echo remember me` anymore.

This is because when re-running that command, fish1 updates the command's history entry's `when` timestamp to something younger than fish2.  When fish2 reloads the history, it ignores history entries younger than itself (except for the entries created by itself).

Fix this by introducing a second timestamp called `created_when`, the immutable creation time.  Use this for determining the cutoff, fixing the above scenario.

Keep the `when` key for forward compatibility.  Keep its semantics (update it whenever we re-run a command; used for sorting); if we'd instead let `when` be the creation time, then old fish will sort wrongly commands that are run again in concurrent new fish. (If new fish vacuums again, it will correct the ordering automatically.)

While at it, remove some old forward compatibilty crutches, since I'm not sure they still work (specifically the one with `when`).

Alternatively, we could replace `created_when` with another monotonically increasing number, maybe an integer sequence, with the per-history next number stored on disk.  We only use it to compare against the boundary timestamp in `offset_of_next_item_fish_2_0()` and `rewrite_to_temporary_file()`.  I haven't explored this yet because `SystemTime` is easy and already used for "last added time".

Closes #10300
