### PR TITLE
ci: remove redundant build step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,9 +166,6 @@ jobs:
       shell: cmd
       run: |
         "%MSYS2_LOCATION%\usr\bin\dash" /usr/bin/rebaseall -p -v
-    - name: cargo build
-      run: |
-        cargo build
     - name: tests
       env:
         FISH_CHECK_LINT: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,7 +166,7 @@ jobs:
       shell: cmd
       run: |
         "%MSYS2_LOCATION%\usr\bin\dash" /usr/bin/rebaseall -p -v
-    - name: tests
+    - name: check
       env:
         FISH_CHECK_LINT: false
       run: |


### PR DESCRIPTION
`cargo xtask check` already takes care of building, so there is no point in having a separate build step, especially because the build options used by `cargo xtask check` will trigger a rebuild of most of our code to handle extraction for localization.