### PR TITLE
completions/adb: update adb command parsing

### DIFF
--- a/localization/po/de.po
+++ b/localization/po/de.po
@@ -12717,9 +12717,6 @@ msgstr ""
 msgid "Continuously display system-wide disk manipulation activity"
 msgstr ""
 
-msgid "Continuously print the device status"
-msgstr ""
-
 msgid "Control Unicode features"
 msgstr ""
 
@@ -25882,6 +25879,9 @@ msgid "Exit ibus-daemon"
 msgstr ""
 
 msgid "Exit if command has a non-zero exit"
+msgstr ""
+
+msgid "Exit if stdout is closed"
 msgstr ""
 
 msgid "Exit if the size is exceeded"
@@ -52290,9 +52290,6 @@ msgstr ""
 msgid "Run Node with the hook already setup"
 msgstr ""
 
-msgid "Run PPP over USB"
-msgstr "PPP über USB ausführen"
-
 msgid "Run PROG after connect"
 msgstr ""
 
@@ -55076,6 +55073,9 @@ msgstr ""
 
 msgid "Server mode"
 msgstr "Server-Modus"
+
+msgid "Server only connects to one USB device"
+msgstr ""
 
 msgid "Server option"
 msgstr ""

--- a/localization/po/es.po
+++ b/localization/po/es.po
@@ -12717,9 +12717,6 @@ msgstr ""
 msgid "Continuously display system-wide disk manipulation activity"
 msgstr ""
 
-msgid "Continuously print the device status"
-msgstr ""
-
 msgid "Control Unicode features"
 msgstr ""
 
@@ -25882,6 +25879,9 @@ msgid "Exit ibus-daemon"
 msgstr ""
 
 msgid "Exit if command has a non-zero exit"
+msgstr ""
+
+msgid "Exit if stdout is closed"
 msgstr ""
 
 msgid "Exit if the size is exceeded"
@@ -52290,9 +52290,6 @@ msgstr ""
 msgid "Run Node with the hook already setup"
 msgstr ""
 
-msgid "Run PPP over USB"
-msgstr ""
-
 msgid "Run PROG after connect"
 msgstr ""
 
@@ -55075,6 +55072,9 @@ msgid "Serve time even when not synced"
 msgstr ""
 
 msgid "Server mode"
+msgstr ""
+
+msgid "Server only connects to one USB device"
 msgstr ""
 
 msgid "Server option"

--- a/localization/po/fr.po
+++ b/localization/po/fr.po
@@ -12846,9 +12846,6 @@ msgstr ""
 msgid "Continuously display system-wide disk manipulation activity"
 msgstr "Afficher en continu les activités du système sur le disque"
 
-msgid "Continuously print the device status"
-msgstr "Afficher en permanence l’état du périphérique"
-
 msgid "Control Unicode features"
 msgstr ""
 
@@ -26012,6 +26009,9 @@ msgstr ""
 
 msgid "Exit if command has a non-zero exit"
 msgstr "Quitter en cas de code de retour non nul"
+
+msgid "Exit if stdout is closed"
+msgstr ""
 
 msgid "Exit if the size is exceeded"
 msgstr "Quitter si la taille est dépassée"
@@ -52419,9 +52419,6 @@ msgstr ""
 msgid "Run Node with the hook already setup"
 msgstr ""
 
-msgid "Run PPP over USB"
-msgstr "Exécuter PPP sur USB"
-
 msgid "Run PROG after connect"
 msgstr ""
 
@@ -55205,6 +55202,9 @@ msgstr ""
 
 msgid "Server mode"
 msgstr "Mode serveur"
+
+msgid "Server only connects to one USB device"
+msgstr ""
 
 msgid "Server option"
 msgstr ""

--- a/localization/po/ja_JP.po
+++ b/localization/po/ja_JP.po
@@ -12720,9 +12720,6 @@ msgstr ""
 msgid "Continuously display system-wide disk manipulation activity"
 msgstr ""
 
-msgid "Continuously print the device status"
-msgstr ""
-
 msgid "Control Unicode features"
 msgstr ""
 
@@ -25885,6 +25882,9 @@ msgid "Exit ibus-daemon"
 msgstr ""
 
 msgid "Exit if command has a non-zero exit"
+msgstr ""
+
+msgid "Exit if stdout is closed"
 msgstr ""
 
 msgid "Exit if the size is exceeded"
@@ -52293,9 +52293,6 @@ msgstr ""
 msgid "Run Node with the hook already setup"
 msgstr ""
 
-msgid "Run PPP over USB"
-msgstr ""
-
 msgid "Run PROG after connect"
 msgstr ""
 
@@ -55078,6 +55075,9 @@ msgid "Serve time even when not synced"
 msgstr ""
 
 msgid "Server mode"
+msgstr ""
+
+msgid "Server only connects to one USB device"
 msgstr ""
 
 msgid "Server option"

--- a/localization/po/pl.po
+++ b/localization/po/pl.po
@@ -12713,9 +12713,6 @@ msgstr ""
 msgid "Continuously display system-wide disk manipulation activity"
 msgstr ""
 
-msgid "Continuously print the device status"
-msgstr ""
-
 msgid "Control Unicode features"
 msgstr ""
 
@@ -25878,6 +25875,9 @@ msgid "Exit ibus-daemon"
 msgstr ""
 
 msgid "Exit if command has a non-zero exit"
+msgstr ""
+
+msgid "Exit if stdout is closed"
 msgstr ""
 
 msgid "Exit if the size is exceeded"
@@ -52286,9 +52286,6 @@ msgstr ""
 msgid "Run Node with the hook already setup"
 msgstr ""
 
-msgid "Run PPP over USB"
-msgstr ""
-
 msgid "Run PROG after connect"
 msgstr ""
 
@@ -55071,6 +55068,9 @@ msgid "Serve time even when not synced"
 msgstr ""
 
 msgid "Server mode"
+msgstr ""
+
+msgid "Server only connects to one USB device"
 msgstr ""
 
 msgid "Server option"

--- a/localization/po/pt_BR.po
+++ b/localization/po/pt_BR.po
@@ -12718,9 +12718,6 @@ msgstr ""
 msgid "Continuously display system-wide disk manipulation activity"
 msgstr ""
 
-msgid "Continuously print the device status"
-msgstr ""
-
 msgid "Control Unicode features"
 msgstr ""
 
@@ -25883,6 +25880,9 @@ msgid "Exit ibus-daemon"
 msgstr ""
 
 msgid "Exit if command has a non-zero exit"
+msgstr ""
+
+msgid "Exit if stdout is closed"
 msgstr ""
 
 msgid "Exit if the size is exceeded"
@@ -52291,9 +52291,6 @@ msgstr ""
 msgid "Run Node with the hook already setup"
 msgstr ""
 
-msgid "Run PPP over USB"
-msgstr ""
-
 msgid "Run PROG after connect"
 msgstr ""
 
@@ -55077,6 +55074,9 @@ msgstr ""
 
 msgid "Server mode"
 msgstr "Server mode"
+
+msgid "Server only connects to one USB device"
+msgstr ""
 
 msgid "Server option"
 msgstr ""

--- a/localization/po/sv.po
+++ b/localization/po/sv.po
@@ -12714,9 +12714,6 @@ msgstr ""
 msgid "Continuously display system-wide disk manipulation activity"
 msgstr ""
 
-msgid "Continuously print the device status"
-msgstr ""
-
 msgid "Control Unicode features"
 msgstr ""
 
@@ -25879,6 +25876,9 @@ msgid "Exit ibus-daemon"
 msgstr ""
 
 msgid "Exit if command has a non-zero exit"
+msgstr ""
+
+msgid "Exit if stdout is closed"
 msgstr ""
 
 msgid "Exit if the size is exceeded"
@@ -52287,9 +52287,6 @@ msgstr ""
 msgid "Run Node with the hook already setup"
 msgstr ""
 
-msgid "Run PPP over USB"
-msgstr ""
-
 msgid "Run PROG after connect"
 msgstr ""
 
@@ -55073,6 +55070,9 @@ msgstr ""
 
 msgid "Server mode"
 msgstr "Serverläge"
+
+msgid "Server only connects to one USB device"
+msgstr ""
 
 msgid "Server option"
 msgstr ""

--- a/localization/po/zh_CN.po
+++ b/localization/po/zh_CN.po
@@ -12738,9 +12738,6 @@ msgstr ""
 msgid "Continuously display system-wide disk manipulation activity"
 msgstr ""
 
-msgid "Continuously print the device status"
-msgstr ""
-
 msgid "Control Unicode features"
 msgstr ""
 
@@ -25903,6 +25900,9 @@ msgid "Exit ibus-daemon"
 msgstr ""
 
 msgid "Exit if command has a non-zero exit"
+msgstr ""
+
+msgid "Exit if stdout is closed"
 msgstr ""
 
 msgid "Exit if the size is exceeded"
@@ -52311,9 +52311,6 @@ msgstr ""
 msgid "Run Node with the hook already setup"
 msgstr ""
 
-msgid "Run PPP over USB"
-msgstr ""
-
 msgid "Run PROG after connect"
 msgstr ""
 
@@ -55096,6 +55093,9 @@ msgid "Serve time even when not synced"
 msgstr ""
 
 msgid "Server mode"
+msgstr ""
+
+msgid "Server only connects to one USB device"
 msgstr ""
 
 msgid "Server option"

--- a/localization/po/zh_TW.po
+++ b/localization/po/zh_TW.po
@@ -12715,9 +12715,6 @@ msgstr ""
 msgid "Continuously display system-wide disk manipulation activity"
 msgstr ""
 
-msgid "Continuously print the device status"
-msgstr ""
-
 msgid "Control Unicode features"
 msgstr ""
 
@@ -25880,6 +25877,9 @@ msgid "Exit ibus-daemon"
 msgstr ""
 
 msgid "Exit if command has a non-zero exit"
+msgstr ""
+
+msgid "Exit if stdout is closed"
 msgstr ""
 
 msgid "Exit if the size is exceeded"
@@ -52288,9 +52288,6 @@ msgstr ""
 msgid "Run Node with the hook already setup"
 msgstr ""
 
-msgid "Run PPP over USB"
-msgstr ""
-
 msgid "Run PROG after connect"
 msgstr ""
 
@@ -55073,6 +55070,9 @@ msgid "Serve time even when not synced"
 msgstr ""
 
 msgid "Server mode"
+msgstr ""
+
+msgid "Server only connects to one USB device"
 msgstr ""
 
 msgid "Server option"

--- a/share/completions/adb.fish
+++ b/share/completions/adb.fish
@@ -9,7 +9,7 @@ function __fish_adb_parse_global_prefix
         set -l token $tokens[1]
         set -e tokens[1]
         switch $token
-            case -s -t -H -P -L
+            case -s -t -H -P -L --one-device
                 if set -q tokens[1]
                     test "$mode" = forwarded-options
                     and printf '%s\n' $token $tokens[1]
@@ -18,7 +18,7 @@ function __fish_adb_parse_global_prefix
             case -d -e
                 test "$mode" = forwarded-options
                 and printf '%s\n' $token
-            case -a
+            case -a --exit-on-write-error
                 # Global option without an argument that does not affect shell queries.
             case '-*'
                 if string match -qr '^-([HP].+|s[0-9]|t[0-9]+$)' -- $token
@@ -126,10 +126,12 @@ complete -n __fish_adb_needs_command -c adb -o a -d 'Listen on all network inter
 complete -n __fish_adb_needs_command -c adb -o d -d 'Use first USB device'
 complete -n __fish_adb_needs_command -c adb -o e -d 'Use first TCP/IP device'
 complete -n __fish_adb_needs_command -c adb -o s -x -a "(__fish_adb_get_devices)" -d 'Use device with given serial'
-complete -n __fish_adb_needs_command -c adb -o t -d 'Use device with given transport id'
-complete -n __fish_adb_needs_command -c adb -o H -d 'Name of adb server host'
-complete -n __fish_adb_needs_command -c adb -o P -d 'Port of adb server'
-complete -n __fish_adb_needs_command -c adb -o L -d 'Listen on given socket for adb server'
+complete -n __fish_adb_needs_command -c adb -o t -x -d 'Use device with given transport id'
+complete -n __fish_adb_needs_command -c adb -o H -x -d 'Name of adb server host'
+complete -n __fish_adb_needs_command -c adb -o P -x -d 'Port of adb server'
+complete -n __fish_adb_needs_command -c adb -o L -r -d 'Listen on given socket for adb server'
+complete -n __fish_adb_needs_command -c adb -l one-device -x -a "(__fish_adb_get_devices)" -d 'Server only connects to one USB device'
+complete -n __fish_adb_needs_command -c adb -l exit-on-write-error -d 'Exit if stdout is closed'
 
 # Commands
 complete -f -n __fish_adb_needs_command -c adb -a connect -d 'Connect to device'
@@ -158,12 +160,10 @@ complete -f -n __fish_adb_needs_command -c adb -a reboot -d 'Reboots the device,
 complete -f -n __fish_adb_needs_command -c adb -a get-state -d 'Prints state of the device'
 complete -f -n __fish_adb_needs_command -c adb -a get-serialno -d 'Prints serial number of the device'
 complete -f -n __fish_adb_needs_command -c adb -a get-devpath -d 'Prints device path'
-complete -f -n __fish_adb_needs_command -c adb -a status-window -d 'Continuously print the device status'
 complete -f -n __fish_adb_needs_command -c adb -a root -d 'Restart the adbd daemon with root permissions'
 complete -f -n __fish_adb_needs_command -c adb -a unroot -d 'Restart the adbd daemon without root permissions'
 complete -f -n __fish_adb_needs_command -c adb -a usb -d 'Restart the adbd daemon listening on USB'
 complete -f -n __fish_adb_needs_command -c adb -a tcpip -d 'Restart the adbd daemon listening on TCP'
-complete -f -n __fish_adb_needs_command -c adb -a ppp -d 'Run PPP over USB'
 complete -f -n __fish_adb_needs_command -c adb -a sideload -d 'Sideloads the given package'
 complete -f -n __fish_adb_needs_command -c adb -a reconnect -d 'Kick current connection from host side and make it reconnect.'
 complete -f -n __fish_adb_needs_command -c adb -a exec-out -d 'Execute a command on the device and send its stdout back'
@@ -189,7 +189,7 @@ complete -n '__fish_adb_using_command devices' -c adb -s l -d 'Also list device 
 complete -n '__fish_adb_using_command disconnect' -c adb -x -a "(__fish_adb_get_tcpip_devices)" -d 'Device to disconnect'
 
 # backup
-complete -n '__fish_adb_using_command backup' -c adb -s f -d 'File to write backup data to'
+complete -n '__fish_adb_using_command backup' -c adb -s f -r -d 'File to write backup data to'
 complete -n '__fish_adb_using_command backup' -c adb -o apk -d 'Enable backup of the .apks themselves'
 complete -n '__fish_adb_using_command backup' -c adb -o noapk -d 'Disable backup of the .apks themselves (default)'
 complete -n '__fish_adb_using_command backup' -c adb -o obb -d 'Enable backup of any installed apk expansion'
@@ -237,7 +237,7 @@ complete -n '__fish_adb_using_command logcat' -c adb -s v -l format -d 'Sets log
 complete -n '__fish_adb_using_command logcat' -c adb -s D -l dividers -d 'Print dividers between each log buffer'
 complete -n '__fish_adb_using_command logcat' -c adb -s B -l binary -d 'Output the log in binary'
 # outfile files
-complete -n '__fish_adb_using_command logcat' -c adb -s f -l file -d 'Log to file instead of stdout'
+complete -n '__fish_adb_using_command logcat' -c adb -s f -l file -r -d 'Log to file instead of stdout'
 complete -n '__fish_adb_using_command logcat' -c adb -s r -l rotate-kbytes -d 'Rotate log every kbytes, requires -f'
 complete -n '__fish_adb_using_command logcat' -c adb -s n -l rotate-count -d 'Sets number of rotated logs to keep, default 4'
 complete -n '__fish_adb_using_command logcat' -c adb -l id -d 'If the given signature for logging changes, clear the associated files'

--- a/share/completions/adb.fish
+++ b/share/completions/adb.fish
@@ -1,12 +1,58 @@
 # Completions for Android adb command
 
-function __fish_adb_no_subcommand -d 'Test if adb has yet to be given the subcommand'
-    for i in (commandline -xpc)
-        if contains -- $i connect disconnect devices push pull sync shell emu logcat install uninstall jdwp forward bugreport backup restore version help start-server kill-server remount reboot get-state get-serialno get-devpath status-window root usb tcpip ppp sideload reconnect unroot exec-out
-            return 1
+function __fish_adb_parse_global_prefix
+    set -l mode $argv[1]
+    set -l tokens (commandline -pxc)
+    set -e tokens[1]
+
+    while set -q tokens[1]
+        set -l token $tokens[1]
+        set -e tokens[1]
+        switch $token
+            case -s -t -H -P -L
+                if set -q tokens[1]
+                    test "$mode" = forwarded-options
+                    and printf '%s\n' $token $tokens[1]
+                    set -e tokens[1]
+                end
+            case -d -e
+                test "$mode" = forwarded-options
+                and printf '%s\n' $token
+            case -a
+                # Global option without an argument that does not affect shell queries.
+            case '-*'
+                if string match -qr '^-([HP].+|s[0-9]|t[0-9]+$)' -- $token
+                    test "$mode" = forwarded-options
+                    and printf '%s\n' $token
+                else
+                    test "$mode" = command
+                    and echo $token
+                    return 0
+                end
+            case '*'
+                test "$mode" = command
+                and echo $token
+                return 0
         end
     end
+
+    return 1
+end
+
+function __fish_adb_using_command
+    set -l command (__fish_adb_parse_global_prefix command)
+    test -n "$command"; and contains -- $command $argv
+end
+
+function __fish_adb_needs_command -d 'Test if adb has yet to be given the subcommand'
+    __fish_adb_parse_global_prefix command >/dev/null
+    and return 1
     return 0
+end
+
+function __fish_adb_seen_shell_command
+    __fish_adb_using_command shell exec-out
+    and __fish_seen_subcommand_from $argv
 end
 
 function __fish_adb_get_devices -d 'Run adb devices and parse output'
@@ -23,33 +69,9 @@ function __fish_adb_get_tcpip_devices -d 'Get list of devices connected via TCP/
 end
 
 function __fish_adb_run_command -d 'Runs adb with any -s parameters already given on the command line'
-    set -l sopt
-    set -l sopt_is_next
-    set -l cmd (commandline -pxc)
-    set -e cmd[1]
-    for i in $cmd
-        if test -n "$sopt_is_next"
-            set sopt -s $i
-            break
-        else
-            switch $i
-                case -s
-                    set sopt_is_next 1
-            end
-        end
-    end
-
-    # If no -s option, see if there's a -d or -e instead
-    if test -z "$sopt"
-        if contains -- -d $cmd
-            set sopt -d
-        else if contains -- -e $cmd
-            set sopt -e
-        end
-    end
-
+    set -l adb_opts (__fish_adb_parse_global_prefix forwarded-options)
     # adb returns CRLF (seemingly) so strip CRs
-    adb $sopt shell $argv | string replace -a \r ''
+    adb $adb_opts shell $argv | string replace -a \r ''
 end
 
 function __fish_adb_list_packages
@@ -100,142 +122,142 @@ function __fish_adb_list_properties
 end
 
 # Generic options, must come before command
-complete -n __fish_adb_no_subcommand -c adb -o a -d 'Listen on all network interfaces'
-complete -n __fish_adb_no_subcommand -c adb -o d -d 'Use first USB device'
-complete -n __fish_adb_no_subcommand -c adb -o e -d 'Use first TCP/IP device'
-complete -n __fish_adb_no_subcommand -c adb -o s -x -a "(__fish_adb_get_devices)" -d 'Use device with given serial'
-complete -n __fish_adb_no_subcommand -c adb -o t -d 'Use device with given transport id'
-complete -n __fish_adb_no_subcommand -c adb -o H -d 'Name of adb server host'
-complete -n __fish_adb_no_subcommand -c adb -o P -d 'Port of adb server'
-complete -n __fish_adb_no_subcommand -c adb -o L -d 'Listen on given socket for adb server'
+complete -n __fish_adb_needs_command -c adb -o a -d 'Listen on all network interfaces'
+complete -n __fish_adb_needs_command -c adb -o d -d 'Use first USB device'
+complete -n __fish_adb_needs_command -c adb -o e -d 'Use first TCP/IP device'
+complete -n __fish_adb_needs_command -c adb -o s -x -a "(__fish_adb_get_devices)" -d 'Use device with given serial'
+complete -n __fish_adb_needs_command -c adb -o t -d 'Use device with given transport id'
+complete -n __fish_adb_needs_command -c adb -o H -d 'Name of adb server host'
+complete -n __fish_adb_needs_command -c adb -o P -d 'Port of adb server'
+complete -n __fish_adb_needs_command -c adb -o L -d 'Listen on given socket for adb server'
 
 # Commands
-complete -f -n __fish_adb_no_subcommand -c adb -a connect -d 'Connect to device'
-complete -f -n __fish_adb_no_subcommand -c adb -a disconnect -d 'Disconnect from device'
-complete -f -n __fish_adb_no_subcommand -c adb -a devices -d 'List all connected devices'
-complete -f -n __fish_adb_no_subcommand -c adb -a push -d 'Copy file to device'
-complete -f -n __fish_adb_no_subcommand -c adb -a pull -d 'Copy file from device'
-complete -f -n __fish_adb_no_subcommand -c adb -a sync -d 'Copy host->device only if changed'
-complete -f -n __fish_adb_no_subcommand -c adb -a shell -d 'Run remote shell [command]'
-complete -f -n __fish_adb_no_subcommand -c adb -a emu -d 'Run emulator console command'
-complete -f -n __fish_adb_no_subcommand -c adb -a logcat -d 'View device log'
-complete -f -n __fish_adb_no_subcommand -c adb -a install -d 'Install package'
-complete -f -n __fish_adb_no_subcommand -c adb -a uninstall -d 'Uninstall package'
-complete -f -n __fish_adb_no_subcommand -c adb -a jdwp -d 'List PIDs of processes hosting a JDWP transport'
-complete -f -n __fish_adb_no_subcommand -c adb -a forward -d 'Port forwarding'
-complete -f -n __fish_adb_no_subcommand -c adb -a bugreport -d 'Return bugreport information'
-complete -f -n __fish_adb_no_subcommand -c adb -a backup -d 'Perform device backup'
-complete -f -n __fish_adb_no_subcommand -c adb -a restore -d 'Restore device from backup'
-complete -f -n __fish_adb_no_subcommand -c adb -a version -d 'Show adb version'
-complete -f -n __fish_adb_no_subcommand -c adb -a help -d 'Show adb help'
-complete -f -n __fish_adb_no_subcommand -c adb -a wait-for-device -d 'Block until device is online'
-complete -f -n __fish_adb_no_subcommand -c adb -a start-server -d 'Ensure that there is a server running'
-complete -f -n __fish_adb_no_subcommand -c adb -a kill-server -d 'Kill the server if it is running'
-complete -f -n __fish_adb_no_subcommand -c adb -a remount -d 'Remounts the /system partition on the device read-write'
-complete -f -n __fish_adb_no_subcommand -c adb -a reboot -d 'Reboots the device, optionally into the bootloader or recovery program'
-complete -f -n __fish_adb_no_subcommand -c adb -a get-state -d 'Prints state of the device'
-complete -f -n __fish_adb_no_subcommand -c adb -a get-serialno -d 'Prints serial number of the device'
-complete -f -n __fish_adb_no_subcommand -c adb -a get-devpath -d 'Prints device path'
-complete -f -n __fish_adb_no_subcommand -c adb -a status-window -d 'Continuously print the device status'
-complete -f -n __fish_adb_no_subcommand -c adb -a root -d 'Restart the adbd daemon with root permissions'
-complete -f -n __fish_adb_no_subcommand -c adb -a unroot -d 'Restart the adbd daemon without root permissions'
-complete -f -n __fish_adb_no_subcommand -c adb -a usb -d 'Restart the adbd daemon listening on USB'
-complete -f -n __fish_adb_no_subcommand -c adb -a tcpip -d 'Restart the adbd daemon listening on TCP'
-complete -f -n __fish_adb_no_subcommand -c adb -a ppp -d 'Run PPP over USB'
-complete -f -n __fish_adb_no_subcommand -c adb -a sideload -d 'Sideloads the given package'
-complete -f -n __fish_adb_no_subcommand -c adb -a reconnect -d 'Kick current connection from host side and make it reconnect.'
-complete -f -n __fish_adb_no_subcommand -c adb -a exec-out -d 'Execute a command on the device and send its stdout back'
+complete -f -n __fish_adb_needs_command -c adb -a connect -d 'Connect to device'
+complete -f -n __fish_adb_needs_command -c adb -a disconnect -d 'Disconnect from device'
+complete -f -n __fish_adb_needs_command -c adb -a devices -d 'List all connected devices'
+complete -f -n __fish_adb_needs_command -c adb -a push -d 'Copy file to device'
+complete -f -n __fish_adb_needs_command -c adb -a pull -d 'Copy file from device'
+complete -f -n __fish_adb_needs_command -c adb -a sync -d 'Copy host->device only if changed'
+complete -f -n __fish_adb_needs_command -c adb -a shell -d 'Run remote shell [command]'
+complete -f -n __fish_adb_needs_command -c adb -a emu -d 'Run emulator console command'
+complete -f -n __fish_adb_needs_command -c adb -a logcat -d 'View device log'
+complete -f -n __fish_adb_needs_command -c adb -a install -d 'Install package'
+complete -f -n __fish_adb_needs_command -c adb -a uninstall -d 'Uninstall package'
+complete -f -n __fish_adb_needs_command -c adb -a jdwp -d 'List PIDs of processes hosting a JDWP transport'
+complete -f -n __fish_adb_needs_command -c adb -a forward -d 'Port forwarding'
+complete -f -n __fish_adb_needs_command -c adb -a bugreport -d 'Return bugreport information'
+complete -f -n __fish_adb_needs_command -c adb -a backup -d 'Perform device backup'
+complete -f -n __fish_adb_needs_command -c adb -a restore -d 'Restore device from backup'
+complete -f -n __fish_adb_needs_command -c adb -a version -d 'Show adb version'
+complete -f -n __fish_adb_needs_command -c adb -a help -d 'Show adb help'
+complete -f -n __fish_adb_needs_command -c adb -a wait-for-device -d 'Block until device is online'
+complete -f -n __fish_adb_needs_command -c adb -a start-server -d 'Ensure that there is a server running'
+complete -f -n __fish_adb_needs_command -c adb -a kill-server -d 'Kill the server if it is running'
+complete -f -n __fish_adb_needs_command -c adb -a remount -d 'Remounts the /system partition on the device read-write'
+complete -f -n __fish_adb_needs_command -c adb -a reboot -d 'Reboots the device, optionally into the bootloader or recovery program'
+complete -f -n __fish_adb_needs_command -c adb -a get-state -d 'Prints state of the device'
+complete -f -n __fish_adb_needs_command -c adb -a get-serialno -d 'Prints serial number of the device'
+complete -f -n __fish_adb_needs_command -c adb -a get-devpath -d 'Prints device path'
+complete -f -n __fish_adb_needs_command -c adb -a status-window -d 'Continuously print the device status'
+complete -f -n __fish_adb_needs_command -c adb -a root -d 'Restart the adbd daemon with root permissions'
+complete -f -n __fish_adb_needs_command -c adb -a unroot -d 'Restart the adbd daemon without root permissions'
+complete -f -n __fish_adb_needs_command -c adb -a usb -d 'Restart the adbd daemon listening on USB'
+complete -f -n __fish_adb_needs_command -c adb -a tcpip -d 'Restart the adbd daemon listening on TCP'
+complete -f -n __fish_adb_needs_command -c adb -a ppp -d 'Run PPP over USB'
+complete -f -n __fish_adb_needs_command -c adb -a sideload -d 'Sideloads the given package'
+complete -f -n __fish_adb_needs_command -c adb -a reconnect -d 'Kick current connection from host side and make it reconnect.'
+complete -f -n __fish_adb_needs_command -c adb -a exec-out -d 'Execute a command on the device and send its stdout back'
 
 # install options
-complete -n '__fish_seen_subcommand_from install' -c adb -s l -d 'Forward-lock the app'
-complete -n '__fish_seen_subcommand_from install' -c adb -s r -d 'Reinstall the app keeping its data'
-complete -n '__fish_seen_subcommand_from install' -c adb -s s -d 'Install on SD card instead of internal storage'
-complete -n '__fish_seen_subcommand_from install' -c adb -l algo -d 'Algorithm name'
-complete -n '__fish_seen_subcommand_from install' -c adb -l key -d 'Hex-encoded key'
-complete -n '__fish_seen_subcommand_from install' -c adb -l iv -d 'Hex-encoded iv'
-complete -n '__fish_seen_subcommand_from install' -c adb -ka '(__fish_complete_suffix .apk)'
+complete -n '__fish_adb_using_command install' -c adb -s l -d 'Forward-lock the app'
+complete -n '__fish_adb_using_command install' -c adb -s r -d 'Reinstall the app keeping its data'
+complete -n '__fish_adb_using_command install' -c adb -s s -d 'Install on SD card instead of internal storage'
+complete -n '__fish_adb_using_command install' -c adb -l algo -d 'Algorithm name'
+complete -n '__fish_adb_using_command install' -c adb -l key -d 'Hex-encoded key'
+complete -n '__fish_adb_using_command install' -c adb -l iv -d 'Hex-encoded iv'
+complete -n '__fish_adb_using_command install' -c adb -ka '(__fish_complete_suffix .apk)'
 
 # uninstall
-complete -n '__fish_seen_subcommand_from uninstall' -c adb -s k -d 'Keep the data and cache directories'
-complete -n '__fish_seen_subcommand_from uninstall' -c adb -f -a "(__fish_adb_list_uninstallable_packages)"
+complete -n '__fish_adb_using_command uninstall' -c adb -s k -d 'Keep the data and cache directories'
+complete -n '__fish_adb_using_command uninstall' -c adb -f -a "(__fish_adb_list_uninstallable_packages)"
 
 # devices
-complete -n '__fish_seen_subcommand_from devices' -c adb -f
-complete -n '__fish_seen_subcommand_from devices' -c adb -s l -d 'Also list device qualifiers'
+complete -n '__fish_adb_using_command devices' -c adb -f
+complete -n '__fish_adb_using_command devices' -c adb -s l -d 'Also list device qualifiers'
 
 # disconnect
-complete -n '__fish_seen_subcommand_from disconnect' -c adb -x -a "(__fish_adb_get_tcpip_devices)" -d 'Device to disconnect'
+complete -n '__fish_adb_using_command disconnect' -c adb -x -a "(__fish_adb_get_tcpip_devices)" -d 'Device to disconnect'
 
 # backup
-complete -n '__fish_seen_subcommand_from backup' -c adb -s f -d 'File to write backup data to'
-complete -n '__fish_seen_subcommand_from backup' -c adb -o apk -d 'Enable backup of the .apks themselves'
-complete -n '__fish_seen_subcommand_from backup' -c adb -o noapk -d 'Disable backup of the .apks themselves (default)'
-complete -n '__fish_seen_subcommand_from backup' -c adb -o obb -d 'Enable backup of any installed apk expansion'
-complete -n '__fish_seen_subcommand_from backup' -c adb -o noobb -d 'Disable backup of any installed apk expansion (default)'
-complete -n '__fish_seen_subcommand_from backup' -c adb -o shared -d 'Enable backup of the device\'s shared storage / SD card contents'
-complete -n '__fish_seen_subcommand_from backup' -c adb -o noshared -d 'Disable backup of the device\'s shared storage / SD card contents (default)'
-complete -n '__fish_seen_subcommand_from backup' -c adb -o all -d 'Back up all installed applications'
-complete -n '__fish_seen_subcommand_from backup' -c adb -o system -d 'Include system applications in -all (default)'
-complete -n '__fish_seen_subcommand_from backup' -c adb -o nosystem -d 'Exclude system applications in -all'
-complete -n '__fish_seen_subcommand_from backup' -c adb -f -a "(__fish_adb_list_packages)" -d 'Package(s) to backup'
+complete -n '__fish_adb_using_command backup' -c adb -s f -d 'File to write backup data to'
+complete -n '__fish_adb_using_command backup' -c adb -o apk -d 'Enable backup of the .apks themselves'
+complete -n '__fish_adb_using_command backup' -c adb -o noapk -d 'Disable backup of the .apks themselves (default)'
+complete -n '__fish_adb_using_command backup' -c adb -o obb -d 'Enable backup of any installed apk expansion'
+complete -n '__fish_adb_using_command backup' -c adb -o noobb -d 'Disable backup of any installed apk expansion (default)'
+complete -n '__fish_adb_using_command backup' -c adb -o shared -d 'Enable backup of the device\'s shared storage / SD card contents'
+complete -n '__fish_adb_using_command backup' -c adb -o noshared -d 'Disable backup of the device\'s shared storage / SD card contents (default)'
+complete -n '__fish_adb_using_command backup' -c adb -o all -d 'Back up all installed applications'
+complete -n '__fish_adb_using_command backup' -c adb -o system -d 'Include system applications in -all (default)'
+complete -n '__fish_adb_using_command backup' -c adb -o nosystem -d 'Exclude system applications in -all'
+complete -n '__fish_adb_using_command backup' -c adb -f -a "(__fish_adb_list_packages)" -d 'Package(s) to backup'
 
 # reboot
-complete -n '__fish_seen_subcommand_from reboot' -c adb -x -a 'bootloader recovery fastboot'
+complete -n '__fish_adb_using_command reboot' -c adb -x -a 'bootloader recovery fastboot'
 
 # forward
-complete -n '__fish_seen_subcommand_from forward' -c adb -l list -d 'List all forward socket connections'
-complete -n '__fish_seen_subcommand_from forward' -c adb -l no-rebind -d 'Fails the forward if local is already forwarded'
-complete -n '__fish_seen_subcommand_from forward' -c adb -l remove -d 'Remove a specific forward socket connection'
-complete -n '__fish_seen_subcommand_from forward' -c adb -l remove-all -d 'Remove all forward socket connections'
+complete -n '__fish_adb_using_command forward' -c adb -l list -d 'List all forward socket connections'
+complete -n '__fish_adb_using_command forward' -c adb -l no-rebind -d 'Fails the forward if local is already forwarded'
+complete -n '__fish_adb_using_command forward' -c adb -l remove -d 'Remove a specific forward socket connection'
+complete -n '__fish_adb_using_command forward' -c adb -l remove-all -d 'Remove all forward socket connections'
 
 # sideload
-complete -n '__fish_seen_subcommand_from sideload' -c adb -k -xa '(__fish_complete_suffix .zip)'
+complete -n '__fish_adb_using_command sideload' -c adb -k -xa '(__fish_complete_suffix .zip)'
 
 # reconnect
-complete -n '__fish_seen_subcommand_from reconnect' -c adb -x -a device -d 'Kick current connection from device side and make it reconnect.'
+complete -n '__fish_adb_using_command reconnect' -c adb -x -a device -d 'Kick current connection from device side and make it reconnect.'
 
 # commands that accept listing device files
-complete -n '__fish_seen_subcommand_from exec-out' -c adb -f -a "(__fish_adb_list_files)" -d 'File on device'
-complete -n '__fish_seen_subcommand_from shell' -c adb -f -a "(__fish_adb_list_files)" -d 'File on device'
-complete -n '__fish_seen_subcommand_from pull' -c adb -F -a "(__fish_adb_list_files)" -d 'File on device'
-complete -n '__fish_seen_subcommand_from push' -c adb -ka "(__fish_adb_list_files)" -d 'File on device'
-complete -n '__fish_seen_subcommand_from push' -c adb -ka "(__fish_adb_list_local_files)"
+complete -n '__fish_adb_using_command exec-out' -c adb -f -a "(__fish_adb_list_files)" -d 'File on device'
+complete -n '__fish_adb_using_command shell' -c adb -f -a "(__fish_adb_list_files)" -d 'File on device'
+complete -n '__fish_adb_using_command pull' -c adb -F -a "(__fish_adb_list_files)" -d 'File on device'
+complete -n '__fish_adb_using_command push' -c adb -ka "(__fish_adb_list_files)" -d 'File on device'
+complete -n '__fish_adb_using_command push' -c adb -ka "(__fish_adb_list_local_files)"
 
 # logcat
-complete -n '__fish_seen_subcommand_from logcat' -c adb -f
+complete -n '__fish_adb_using_command logcat' -c adb -f
 # general options
-complete -n '__fish_seen_subcommand_from logcat' -c adb -s L -l last -d 'Dump logs from prior to last reboot from pstore'
-complete -n '__fish_seen_subcommand_from logcat' -c adb -s b -l buffer -d ' Request alternate ring buffer(s)' -xa '(__fish_append , main system radio events crash default all)'
-complete -n '__fish_seen_subcommand_from logcat' -c adb -s c -l clear -d 'Clear (flush) the entire log and exit'
-complete -n '__fish_seen_subcommand_from logcat' -c adb -s d -d 'Dump the log and then exit (don\'t block)'
-complete -n '__fish_seen_subcommand_from logcat' -c adb -l pid -d 'Only print the logs for the given PID'
-complete -n '__fish_seen_subcommand_from logcat' -c adb -l wrap -d 'Sleep for 2 hours or when buffer about to wrap whichever comes first'
+complete -n '__fish_adb_using_command logcat' -c adb -s L -l last -d 'Dump logs from prior to last reboot from pstore'
+complete -n '__fish_adb_using_command logcat' -c adb -s b -l buffer -d ' Request alternate ring buffer(s)' -xa '(__fish_append , main system radio events crash default all)'
+complete -n '__fish_adb_using_command logcat' -c adb -s c -l clear -d 'Clear (flush) the entire log and exit'
+complete -n '__fish_adb_using_command logcat' -c adb -s d -d 'Dump the log and then exit (don\'t block)'
+complete -n '__fish_adb_using_command logcat' -c adb -l pid -d 'Only print the logs for the given PID'
+complete -n '__fish_adb_using_command logcat' -c adb -l wrap -d 'Sleep for 2 hours or when buffer about to wrap whichever comes first'
 # formatting
-complete -n '__fish_seen_subcommand_from logcat' -c adb -s v -l format -d 'Sets log print format verb and adverbs' -xa ' brief help long process raw tag thread threadtime time color descriptive epoch monotonic printable uid usec UTC year zone'
-complete -n '__fish_seen_subcommand_from logcat' -c adb -s D -l dividers -d 'Print dividers between each log buffer'
-complete -n '__fish_seen_subcommand_from logcat' -c adb -s B -l binary -d 'Output the log in binary'
+complete -n '__fish_adb_using_command logcat' -c adb -s v -l format -d 'Sets log print format verb and adverbs' -xa ' brief help long process raw tag thread threadtime time color descriptive epoch monotonic printable uid usec UTC year zone'
+complete -n '__fish_adb_using_command logcat' -c adb -s D -l dividers -d 'Print dividers between each log buffer'
+complete -n '__fish_adb_using_command logcat' -c adb -s B -l binary -d 'Output the log in binary'
 # outfile files
-complete -n '__fish_seen_subcommand_from logcat' -c adb -s f -l file -d 'Log to file instead of stdout'
-complete -n '__fish_seen_subcommand_from logcat' -c adb -s r -l rotate-kbytes -d 'Rotate log every kbytes, requires -f'
-complete -n '__fish_seen_subcommand_from logcat' -c adb -s n -l rotate-count -d 'Sets number of rotated logs to keep, default 4'
-complete -n '__fish_seen_subcommand_from logcat' -c adb -l id -d 'If the given signature for logging changes, clear the associated files'
+complete -n '__fish_adb_using_command logcat' -c adb -s f -l file -d 'Log to file instead of stdout'
+complete -n '__fish_adb_using_command logcat' -c adb -s r -l rotate-kbytes -d 'Rotate log every kbytes, requires -f'
+complete -n '__fish_adb_using_command logcat' -c adb -s n -l rotate-count -d 'Sets number of rotated logs to keep, default 4'
+complete -n '__fish_adb_using_command logcat' -c adb -l id -d 'If the given signature for logging changes, clear the associated files'
 # logd control
-complete -n '__fish_seen_subcommand_from logcat' -c adb -s g -l buffer-size -d 'Get the size of the ring buffers within logd'
-complete -n '__fish_seen_subcommand_from logcat' -c adb -s G -l buffer-size -d 'Set size of a ring buffer in logd'
-complete -n '__fish_seen_subcommand_from logcat' -c adb -s S -l statistics -d 'Output statistics'
-complete -n '__fish_seen_subcommand_from logcat' -c adb -s p -l prune -d 'Print prune rules'
-complete -n '__fish_seen_subcommand_from logcat' -c adb -s P -l prune -d 'Set prune rules'
+complete -n '__fish_adb_using_command logcat' -c adb -s g -l buffer-size -d 'Get the size of the ring buffers within logd'
+complete -n '__fish_adb_using_command logcat' -c adb -s G -l buffer-size -d 'Set size of a ring buffer in logd'
+complete -n '__fish_adb_using_command logcat' -c adb -s S -l statistics -d 'Output statistics'
+complete -n '__fish_adb_using_command logcat' -c adb -s p -l prune -d 'Print prune rules'
+complete -n '__fish_adb_using_command logcat' -c adb -s P -l prune -d 'Set prune rules'
 # filtering
-complete -n '__fish_seen_subcommand_from logcat' -c adb -s s -d 'Set default filter to silent'
-complete -n '__fish_seen_subcommand_from logcat' -c adb -s e -l regex -d 'Only print lines where the log message matches'
-complete -n '__fish_seen_subcommand_from logcat' -c adb -s m -l max-count -d 'Quit after print <count> lines'
-complete -n '__fish_seen_subcommand_from logcat' -c adb -l print -d 'Print all message even if they do not matches, requires --regex and --max-count'
-complete -n '__fish_seen_subcommand_from logcat' -c adb -l uid -d 'Only display log messages from UIDs present in the comma separate list <uids>'
+complete -n '__fish_adb_using_command logcat' -c adb -s s -d 'Set default filter to silent'
+complete -n '__fish_adb_using_command logcat' -c adb -s e -l regex -d 'Only print lines where the log message matches'
+complete -n '__fish_adb_using_command logcat' -c adb -s m -l max-count -d 'Quit after print <count> lines'
+complete -n '__fish_adb_using_command logcat' -c adb -l print -d 'Print all message even if they do not matches, requires --regex and --max-count'
+complete -n '__fish_adb_using_command logcat' -c adb -l uid -d 'Only display log messages from UIDs present in the comma separate list <uids>'
 
 # commands that accept listing device binaries
-complete -n '__fish_seen_subcommand_from exec-out' -c adb -f -a "(__fish_adb_list_bin)" -d "Command on device"
-complete -n '__fish_seen_subcommand_from shell' -c adb -f -a "(__fish_adb_list_bin)" -d "Command on device"
+complete -n '__fish_adb_using_command exec-out' -c adb -f -a "(__fish_adb_list_bin)" -d "Command on device"
+complete -n '__fish_adb_using_command shell' -c adb -f -a "(__fish_adb_list_bin)" -d "Command on device"
 
 # setprop and getprop in shell
-complete -n '__fish_seen_subcommand_from setprop' -c adb -f -a "(__fish_adb_list_properties)" -d 'Property to set'
-complete -n '__fish_seen_subcommand_from getprop' -c adb -f -a "(__fish_adb_list_properties)" -d 'Property to get'
+complete -n '__fish_adb_seen_shell_command setprop' -c adb -f -a "(__fish_adb_list_properties)" -d 'Property to set'
+complete -n '__fish_adb_seen_shell_command getprop' -c adb -f -a "(__fish_adb_list_properties)" -d 'Property to get'


### PR DESCRIPTION
- completions/adb: handle global options before commands
- completions/adb: handle attached global options
- completions/adb: update adb global options

## Description

Update adb completions to better match current adb command parsing.

This preserves supported global options for dynamic shell-based completions, adds `--one-device` and `--exit-on-write-error`, and removes obsolete `status-window` and `ppp` command completions.

## TODOs:
<!-- Check off what what has been done so far. -->
- [ ] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->