### PR TITLE
fish_opt: correct flag: long(+`-`)only

### DIFF
--- a/share/completions/fish_opt.fish
+++ b/share/completions/fish_opt.fish
@@ -8,7 +8,7 @@ complete --command fish_opt --short-option h --long-option help --description 'S
 
 complete --command fish_opt --short-option s --long-option short --no-files --require-parameter --description 'Specify short option'
 complete --command fish_opt --short-option l --long-option long --no-files --require-parameter --description 'Specify long option'
-complete --command fish_opt --long-option longonly --description 'Use only long option'
+complete --command fish_opt --long-option long-only --description 'Use only long option'
 complete --command fish_opt --short-option o --long-option optional-val -n $CONDITION --description 'Don\'t require value'
 complete --command fish_opt --short-option r --long-option required-val -n $CONDITION --description 'Require value'
 complete --command fish_opt --short-option m --long-option multiple-vals --description 'Store all values'


### PR DESCRIPTION
The  `--longonly` option for [`fish_opt`](https://fishshell.com/docs/current/cmds/fish_opt.html "create an option specification for the argparse command") doesn't exist.

Though there is `--long-only`, but it is deprecated.  
> **--long-only**
>
>    Deprecated. …

— Documentation

Other references of `longonly` are in `argparse` that accepts [`#longonly`](https://github.com/fish-shell/fish-shell/blob/master/doc_src/cmds/argparse.rst#example-option_specs) as one of its arguments which causes the last integer value provided to be stored in `$_flag_longonly`.  
There is also documentation on `argparse`claiming that `argparse` supports an option: `longonly`, with no details on what it does. I have marked that part of the documentation as deprecated.

---
If we try using the `longonly` option from the completions:
```fish
❯ fish_opt --longonly
fish_opt: --longonly: unknown option
```
The completion has been updated so that it suggests `long-only` instead (with the `-`).

## TODOs:
<!-- Check off what what has been done so far. -->
- [x] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
