### PR TITLE
Don't expand command substitutions when completing command name

### DIFF
--- a/src/complete.rs
+++ b/src/complete.rs
@@ -1004,7 +1004,10 @@ impl<'ctx, 'parser> Completer<'ctx, 'parser> {
     }
 
     fn completion_expand_flags(&self) -> ExpandFlags {
-        self.expand_flags() | ExpandFlags::FOR_COMPLETIONS | ExpandFlags::PRESERVE_HOME_TILDES
+        self.expand_flags()
+            | ExpandFlags::FAIL_ON_CMDSUBST
+            | ExpandFlags::FOR_COMPLETIONS
+            | ExpandFlags::PRESERVE_HOME_TILDES
     }
 
     /// If command to complete is short enough, substitute the description with the whatis information
@@ -1607,7 +1610,7 @@ impl<'ctx, 'parser> Completer<'ctx, 'parser> {
         if self.ctx.check_cancel() {
             return;
         }
-        let mut flags = self.completion_expand_flags() | ExpandFlags::FAIL_ON_CMDSUBST;
+        let mut flags = self.completion_expand_flags();
         if !do_file {
             flags |= ExpandFlags::SKIP_WILDCARDS;
         }

--- a/src/complete.rs
+++ b/src/complete.rs
@@ -968,10 +968,7 @@ impl<'ctx, 'parser> Completer<'ctx, 'parser> {
         let mut tmp = wc_escaped.to_owned();
         if !expand_one(
             &mut tmp,
-            self.expand_flags()
-                | extra_expand_flags
-                | ExpandFlags::FAIL_ON_CMDSUBST
-                | ExpandFlags::SKIP_WILDCARDS,
+            self.expand_flags() | extra_expand_flags | ExpandFlags::SKIP_WILDCARDS,
             self.ctx,
             None,
         ) {
@@ -997,17 +994,14 @@ impl<'ctx, 'parser> Completer<'ctx, 'parser> {
 
     fn expand_flags(&self) -> ExpandFlags {
         let mut result = ExpandFlags::empty();
-        result.set(ExpandFlags::FAIL_ON_CMDSUBST, self.flags.autosuggestion);
+        result.set(ExpandFlags::FAIL_ON_CMDSUBST, true);
         result.set(ExpandFlags::FUZZY_MATCH, self.flags.fuzzy_match);
         result.set(ExpandFlags::GEN_DESCRIPTIONS, self.flags.descriptions);
         result
     }
 
     fn completion_expand_flags(&self) -> ExpandFlags {
-        self.expand_flags()
-            | ExpandFlags::FAIL_ON_CMDSUBST
-            | ExpandFlags::FOR_COMPLETIONS
-            | ExpandFlags::PRESERVE_HOME_TILDES
+        self.expand_flags() | ExpandFlags::FOR_COMPLETIONS | ExpandFlags::PRESERVE_HOME_TILDES
     }
 
     /// If command to complete is short enough, substitute the description with the whatis information

--- a/tests/checks/complete.fish
+++ b/tests/checks/complete.fish
@@ -494,6 +494,7 @@ HOME=$path_to_cat/.. complete -C '~/cat '
 
 # Do not expand command substitutions.
 complete -C '(echo cat) ' | string match +pet
+complete -C '(echo $PWD)/'
 # Give up if we expand to multiple arguments (we'd need to handle the arguments).
 complete -C '{cat,arg1,arg2} ' | string match +pet
 # Don't expand wildcards though we could.


### PR DESCRIPTION
As reported in https://github.com/fish-shell/fish-shell/issues/5575#issuecomment-1912920305, when pressing tab with the cursor at the command token, we expand command substitutions in the command token

	$ complete -C '(echo $PWD)/'
	(echo $PWD)/benchmarks/ directory
	(echo $PWD)/build/ directory
	...

I'm not sure if this is intended behavior.

All other completion requests (i.e. for arguments etc.) suppress expansion of all command substitutions on the command line.
In particular,

	$ complete -C'(echo /bin)/git '

already does not get custom completions, so the benefit of completing the command name seems relatively small, and the risk of doing something the user doesn't like is quite small but non-zero.

Disable expansion of command substitution when completing commands.
