### PR TITLE
Add back CI for Alpine, FreeBSD and Ubuntu-ARM64

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,10 @@ jobs:
           sudo -u fish-user -s env CI=1 ninja fish_run_tests
 
   ubuntu:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-latest-arm64]
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2, build_tools/update-dependencies.sh
     - uses: ./.github/actions/rust-toolchain@oldest-supported


### PR DESCRIPTION
Add back some CI coverage. FreeBSD and Alpine were removed recently:

- ff0afd14c25 (Remove Cirrus CI, 2026-05-28)
- f48166ff365 (update-dependencies: remove things used for Cirrus, 2026-05-29)
- dc9668c8a41 (Remove unused workflow to build docker images, 2026-05-30)

For BSD, use vmactions.
For Linux, use docker/docker_run_tests.sh.

In future, we should maybe use the docker approach for all Linux CI runners, to make it easy to run them locally?

Closes #12626
