### PR TITLE
 Improve escape prefix detection in `parse_util`

### DIFF
--- a/src/parse_util.rs
+++ b/src/parse_util.rs
@@ -1331,8 +1331,8 @@ pub fn detect_errors_in_argument(
                     if src.len() == 2
                         && src[0] == '\\'
                         && (src[1] == 'c'
-                            || src[1].to_lowercase().eq(['u'])
-                            || src[1].to_lowercase().eq(['x']))
+                            || src[1].eq_ignore_ascii_case(&'u')
+                            || src[1].eq_ignore_ascii_case(&'x'))
                     {
                         append_syntax_error!(
                             out_errors,


### PR DESCRIPTION
## Objective

* Make the comparison clearer and more direct for ASCII escape markers.
* Removes the extra lowercase iterator logic while preserving the same parser behavior.