### PR TITLE
completions/guile: update against guile/guild 3.0.11

### DIFF
--- a/localization/po/de.po
+++ b/localization/po/de.po
@@ -25326,6 +25326,9 @@ msgstr ""
 msgid "Evaluate expr on nvim server specified with --server"
 msgstr ""
 
+msgid "Evaluate expression EXPR and exit"
+msgstr ""
+
 msgid "Evaluate indexing information for path"
 msgstr ""
 
@@ -36720,6 +36723,12 @@ msgstr ""
 msgid "Load settings from all system configuration files"
 msgstr ""
 
+msgid "Load source code from FILE"
+msgstr ""
+
+msgid "Load source code from FILE and exit"
+msgstr ""
+
 msgid "Load stylesheet from Nmap.Org"
 msgstr ""
 
@@ -47137,6 +47146,9 @@ msgid "Profile stack usage"
 msgstr "Profilstackauslastung"
 
 msgid "Profile startup execution time"
+msgstr ""
+
+msgid "Profile using statprof and show results in STYLE"
 msgstr ""
 
 msgid "Profiles the given file or expression with fprof"
@@ -63801,9 +63813,6 @@ msgstr ""
 msgid "Specify the code page for source code files"
 msgstr ""
 
-msgid "Specify the code to run"
-msgstr ""
-
 msgid "Specify the codepage used to read source files"
 msgstr ""
 
@@ -64081,12 +64090,6 @@ msgid "Specify the rsync to run on remote machine"
 msgstr ""
 
 msgid "Specify the scope of the search"
-msgstr ""
-
-msgid "Specify the script to load"
-msgstr ""
-
-msgid "Specify the script to run"
 msgstr ""
 
 msgid "Specify the selection in a view"

--- a/localization/po/es.po
+++ b/localization/po/es.po
@@ -25326,6 +25326,9 @@ msgstr ""
 msgid "Evaluate expr on nvim server specified with --server"
 msgstr ""
 
+msgid "Evaluate expression EXPR and exit"
+msgstr ""
+
 msgid "Evaluate indexing information for path"
 msgstr ""
 
@@ -36720,6 +36723,12 @@ msgstr ""
 msgid "Load settings from all system configuration files"
 msgstr ""
 
+msgid "Load source code from FILE"
+msgstr ""
+
+msgid "Load source code from FILE and exit"
+msgstr ""
+
 msgid "Load stylesheet from Nmap.Org"
 msgstr ""
 
@@ -47137,6 +47146,9 @@ msgid "Profile stack usage"
 msgstr ""
 
 msgid "Profile startup execution time"
+msgstr ""
+
+msgid "Profile using statprof and show results in STYLE"
 msgstr ""
 
 msgid "Profiles the given file or expression with fprof"
@@ -63801,9 +63813,6 @@ msgstr ""
 msgid "Specify the code page for source code files"
 msgstr ""
 
-msgid "Specify the code to run"
-msgstr ""
-
 msgid "Specify the codepage used to read source files"
 msgstr ""
 
@@ -64081,12 +64090,6 @@ msgid "Specify the rsync to run on remote machine"
 msgstr ""
 
 msgid "Specify the scope of the search"
-msgstr ""
-
-msgid "Specify the script to load"
-msgstr ""
-
-msgid "Specify the script to run"
 msgstr ""
 
 msgid "Specify the selection in a view"

--- a/localization/po/fr.po
+++ b/localization/po/fr.po
@@ -25455,6 +25455,9 @@ msgstr "Évaluer l’expression spécifiée sur un serveur Vim"
 msgid "Evaluate expr on nvim server specified with --server"
 msgstr ""
 
+msgid "Evaluate expression EXPR and exit"
+msgstr ""
+
 msgid "Evaluate indexing information for path"
 msgstr ""
 
@@ -36849,6 +36852,12 @@ msgstr ""
 msgid "Load settings from all system configuration files"
 msgstr ""
 
+msgid "Load source code from FILE"
+msgstr ""
+
+msgid "Load source code from FILE and exit"
+msgstr ""
+
 msgid "Load stylesheet from Nmap.Org"
 msgstr ""
 
@@ -47266,6 +47275,9 @@ msgid "Profile stack usage"
 msgstr ""
 
 msgid "Profile startup execution time"
+msgstr ""
+
+msgid "Profile using statprof and show results in STYLE"
 msgstr ""
 
 msgid "Profiles the given file or expression with fprof"
@@ -63930,9 +63942,6 @@ msgstr ""
 msgid "Specify the code page for source code files"
 msgstr ""
 
-msgid "Specify the code to run"
-msgstr ""
-
 msgid "Specify the codepage used to read source files"
 msgstr ""
 
@@ -64210,12 +64219,6 @@ msgid "Specify the rsync to run on remote machine"
 msgstr "Spécifier le chemin de l’exécutable rsync sur la destination"
 
 msgid "Specify the scope of the search"
-msgstr ""
-
-msgid "Specify the script to load"
-msgstr ""
-
-msgid "Specify the script to run"
 msgstr ""
 
 msgid "Specify the selection in a view"

--- a/localization/po/ja_JP.po
+++ b/localization/po/ja_JP.po
@@ -25329,6 +25329,9 @@ msgstr ""
 msgid "Evaluate expr on nvim server specified with --server"
 msgstr ""
 
+msgid "Evaluate expression EXPR and exit"
+msgstr ""
+
 msgid "Evaluate indexing information for path"
 msgstr ""
 
@@ -36723,6 +36726,12 @@ msgstr ""
 msgid "Load settings from all system configuration files"
 msgstr ""
 
+msgid "Load source code from FILE"
+msgstr ""
+
+msgid "Load source code from FILE and exit"
+msgstr ""
+
 msgid "Load stylesheet from Nmap.Org"
 msgstr ""
 
@@ -47140,6 +47149,9 @@ msgid "Profile stack usage"
 msgstr ""
 
 msgid "Profile startup execution time"
+msgstr ""
+
+msgid "Profile using statprof and show results in STYLE"
 msgstr ""
 
 msgid "Profiles the given file or expression with fprof"
@@ -63804,9 +63816,6 @@ msgstr ""
 msgid "Specify the code page for source code files"
 msgstr ""
 
-msgid "Specify the code to run"
-msgstr ""
-
 msgid "Specify the codepage used to read source files"
 msgstr ""
 
@@ -64084,12 +64093,6 @@ msgid "Specify the rsync to run on remote machine"
 msgstr ""
 
 msgid "Specify the scope of the search"
-msgstr ""
-
-msgid "Specify the script to load"
-msgstr ""
-
-msgid "Specify the script to run"
 msgstr ""
 
 msgid "Specify the selection in a view"

--- a/localization/po/pl.po
+++ b/localization/po/pl.po
@@ -25322,6 +25322,9 @@ msgstr ""
 msgid "Evaluate expr on nvim server specified with --server"
 msgstr ""
 
+msgid "Evaluate expression EXPR and exit"
+msgstr ""
+
 msgid "Evaluate indexing information for path"
 msgstr ""
 
@@ -36716,6 +36719,12 @@ msgstr ""
 msgid "Load settings from all system configuration files"
 msgstr ""
 
+msgid "Load source code from FILE"
+msgstr ""
+
+msgid "Load source code from FILE and exit"
+msgstr ""
+
 msgid "Load stylesheet from Nmap.Org"
 msgstr ""
 
@@ -47133,6 +47142,9 @@ msgid "Profile stack usage"
 msgstr ""
 
 msgid "Profile startup execution time"
+msgstr ""
+
+msgid "Profile using statprof and show results in STYLE"
 msgstr ""
 
 msgid "Profiles the given file or expression with fprof"
@@ -63797,9 +63809,6 @@ msgstr ""
 msgid "Specify the code page for source code files"
 msgstr ""
 
-msgid "Specify the code to run"
-msgstr ""
-
 msgid "Specify the codepage used to read source files"
 msgstr ""
 
@@ -64077,12 +64086,6 @@ msgid "Specify the rsync to run on remote machine"
 msgstr ""
 
 msgid "Specify the scope of the search"
-msgstr ""
-
-msgid "Specify the script to load"
-msgstr ""
-
-msgid "Specify the script to run"
 msgstr ""
 
 msgid "Specify the selection in a view"

--- a/localization/po/pt_BR.po
+++ b/localization/po/pt_BR.po
@@ -25327,6 +25327,9 @@ msgstr ""
 msgid "Evaluate expr on nvim server specified with --server"
 msgstr ""
 
+msgid "Evaluate expression EXPR and exit"
+msgstr ""
+
 msgid "Evaluate indexing information for path"
 msgstr ""
 
@@ -36721,6 +36724,12 @@ msgstr ""
 msgid "Load settings from all system configuration files"
 msgstr ""
 
+msgid "Load source code from FILE"
+msgstr ""
+
+msgid "Load source code from FILE and exit"
+msgstr ""
+
 msgid "Load stylesheet from Nmap.Org"
 msgstr ""
 
@@ -47138,6 +47147,9 @@ msgid "Profile stack usage"
 msgstr ""
 
 msgid "Profile startup execution time"
+msgstr ""
+
+msgid "Profile using statprof and show results in STYLE"
 msgstr ""
 
 msgid "Profiles the given file or expression with fprof"
@@ -63802,9 +63814,6 @@ msgstr ""
 msgid "Specify the code page for source code files"
 msgstr ""
 
-msgid "Specify the code to run"
-msgstr ""
-
 msgid "Specify the codepage used to read source files"
 msgstr ""
 
@@ -64082,12 +64091,6 @@ msgid "Specify the rsync to run on remote machine"
 msgstr ""
 
 msgid "Specify the scope of the search"
-msgstr ""
-
-msgid "Specify the script to load"
-msgstr ""
-
-msgid "Specify the script to run"
 msgstr ""
 
 msgid "Specify the selection in a view"

--- a/localization/po/sv.po
+++ b/localization/po/sv.po
@@ -25323,6 +25323,9 @@ msgstr ""
 msgid "Evaluate expr on nvim server specified with --server"
 msgstr ""
 
+msgid "Evaluate expression EXPR and exit"
+msgstr ""
+
 msgid "Evaluate indexing information for path"
 msgstr ""
 
@@ -36717,6 +36720,12 @@ msgstr ""
 msgid "Load settings from all system configuration files"
 msgstr ""
 
+msgid "Load source code from FILE"
+msgstr ""
+
+msgid "Load source code from FILE and exit"
+msgstr ""
+
 msgid "Load stylesheet from Nmap.Org"
 msgstr ""
 
@@ -47134,6 +47143,9 @@ msgid "Profile stack usage"
 msgstr "Profilera stackanvändning"
 
 msgid "Profile startup execution time"
+msgstr ""
+
+msgid "Profile using statprof and show results in STYLE"
 msgstr ""
 
 msgid "Profiles the given file or expression with fprof"
@@ -63798,9 +63810,6 @@ msgstr ""
 msgid "Specify the code page for source code files"
 msgstr ""
 
-msgid "Specify the code to run"
-msgstr ""
-
 msgid "Specify the codepage used to read source files"
 msgstr ""
 
@@ -64078,12 +64087,6 @@ msgid "Specify the rsync to run on remote machine"
 msgstr ""
 
 msgid "Specify the scope of the search"
-msgstr ""
-
-msgid "Specify the script to load"
-msgstr ""
-
-msgid "Specify the script to run"
 msgstr ""
 
 msgid "Specify the selection in a view"

--- a/localization/po/zh_CN.po
+++ b/localization/po/zh_CN.po
@@ -25347,6 +25347,9 @@ msgstr ""
 msgid "Evaluate expr on nvim server specified with --server"
 msgstr ""
 
+msgid "Evaluate expression EXPR and exit"
+msgstr ""
+
 msgid "Evaluate indexing information for path"
 msgstr ""
 
@@ -36741,6 +36744,12 @@ msgstr ""
 msgid "Load settings from all system configuration files"
 msgstr ""
 
+msgid "Load source code from FILE"
+msgstr ""
+
+msgid "Load source code from FILE and exit"
+msgstr ""
+
 msgid "Load stylesheet from Nmap.Org"
 msgstr ""
 
@@ -47158,6 +47167,9 @@ msgid "Profile stack usage"
 msgstr ""
 
 msgid "Profile startup execution time"
+msgstr ""
+
+msgid "Profile using statprof and show results in STYLE"
 msgstr ""
 
 msgid "Profiles the given file or expression with fprof"
@@ -63822,9 +63834,6 @@ msgstr ""
 msgid "Specify the code page for source code files"
 msgstr ""
 
-msgid "Specify the code to run"
-msgstr ""
-
 msgid "Specify the codepage used to read source files"
 msgstr ""
 
@@ -64102,12 +64111,6 @@ msgid "Specify the rsync to run on remote machine"
 msgstr ""
 
 msgid "Specify the scope of the search"
-msgstr ""
-
-msgid "Specify the script to load"
-msgstr ""
-
-msgid "Specify the script to run"
 msgstr ""
 
 msgid "Specify the selection in a view"

--- a/localization/po/zh_TW.po
+++ b/localization/po/zh_TW.po
@@ -25324,6 +25324,9 @@ msgstr ""
 msgid "Evaluate expr on nvim server specified with --server"
 msgstr ""
 
+msgid "Evaluate expression EXPR and exit"
+msgstr ""
+
 msgid "Evaluate indexing information for path"
 msgstr ""
 
@@ -36718,6 +36721,12 @@ msgstr ""
 msgid "Load settings from all system configuration files"
 msgstr ""
 
+msgid "Load source code from FILE"
+msgstr ""
+
+msgid "Load source code from FILE and exit"
+msgstr ""
+
 msgid "Load stylesheet from Nmap.Org"
 msgstr ""
 
@@ -47135,6 +47144,9 @@ msgid "Profile stack usage"
 msgstr ""
 
 msgid "Profile startup execution time"
+msgstr ""
+
+msgid "Profile using statprof and show results in STYLE"
 msgstr ""
 
 msgid "Profiles the given file or expression with fprof"
@@ -63799,9 +63811,6 @@ msgstr ""
 msgid "Specify the code page for source code files"
 msgstr ""
 
-msgid "Specify the code to run"
-msgstr ""
-
 msgid "Specify the codepage used to read source files"
 msgstr ""
 
@@ -64079,12 +64088,6 @@ msgid "Specify the rsync to run on remote machine"
 msgstr ""
 
 msgid "Specify the scope of the search"
-msgstr ""
-
-msgid "Specify the script to load"
-msgstr ""
-
-msgid "Specify the script to run"
 msgstr ""
 
 msgid "Specify the selection in a view"

--- a/share/completions/guild.fish
+++ b/share/completions/guild.fish
@@ -18,6 +18,10 @@ set -l command guild
 complete -c $command -f
 
 set -l compile_condition '__fish_seen_subcommand_from compile'
+
+# compile takes FILE... as positional arguments
+complete -c $command -F -n $compile_condition
+
 complete -c $command -a 'compile\tCompile scripts' -n "not $compile_condition"
 
 complete -c $command -s h -l help -d 'Show help' -n $compile_condition
@@ -46,7 +50,7 @@ complete -c $command -s O -l optimize \
     -n $compile_condition
 
 for standard in 6 7
-    set -l option r$standard"rc"
+    set -l option r$standard"rs"
 
     complete -c $command -l $option \
         -d "Use $(string upper -- $option) compatible mode" \
@@ -59,7 +63,7 @@ complete -c $command -s f -l from \
     -n $compile_condition
 
 complete -c $command -s t -l to \
-    -a 'rtl\tdefault' \
+    -a 'bytecode\tdefault tree-il cps value' \
     -d 'Specify the language for an output' \
     -n $compile_condition
 

--- a/share/completions/guile.fish
+++ b/share/completions/guile.fish
@@ -43,7 +43,12 @@ function __fish_guile__complete_srfis
         98\t'Accessing environment variables' \
         105\t'Curly-infix expressions' \
         111\t'Boxes' \
-        119\t'Wisp: simpler indentation-sensitive Scheme'
+        119\t'Wisp: simpler indentation-sensitive Scheme' \
+        171\t'Transducers' \
+        197\t'Pipeline Operators' \
+        207\t'String-notated bytevectors' \
+        235\t'Combinators' \
+        244\t'Multiple-value Definitions'
 end
 
 function __fish_guile__complete_function_names
@@ -58,12 +63,11 @@ function __fish_guile__complete_function_names
 end
 
 set -l command guile
-complete -c $command -f
 
 complete -c $command -s h -l help -d 'Show help'
 complete -c $command -s v -l version -d 'Show version'
-complete -c $command -s s -F -r -d 'Specify the script to run'
-complete -c $command -s c -x -d 'Specify the code to run'
+complete -c $command -s s -F -r -d 'Load source code from FILE and exit'
+complete -c $command -s c -x -d 'Evaluate expression EXPR and exit'
 
 complete -c $command -s L -F -r \
     -d 'Specify the directory to prepend to module load path'
@@ -75,7 +79,7 @@ complete -c $command -s x -x \
     -a '.scm\tdefault' \
     -d 'Specify the extension to prepend to extension list'
 
-complete -c $command -s l -F -r -d 'Specify the script to load'
+complete -c $command -s l -F -r -d 'Load source code from FILE'
 
 complete -c $command -s e -x \
     -a '(__fish_guile__complete_function_names)' \
@@ -89,7 +93,7 @@ complete -c $command -l use-srfi \
     -d 'Specify the SRFI modules to load'
 
 for standard in 6 7
-    set -l option r$standard"rc"
+    set -l option r$standard"rs"
 
     complete -c $command -l $option \
         -d "Use $(string upper -- $option) compatible mode"
@@ -101,7 +105,7 @@ complete -c $command -s q -d "Don't load .guile file"
 
 complete -c $command -l listen \
     -a '37146\tdefault' \
-    -d 'Specify the port to list to'
+    -d 'Specify the port to listen on'
 
 complete -c $command -l auto-compile -d 'Compile scripts automatically'
 
@@ -109,6 +113,8 @@ complete -c $command -l fresh-auto-compile \
     -d 'Compile scripts automatically forcefully'
 
 complete -c $command -l no-auto-compile -d "Don't compile scripts automatically"
+
+complete -c $command -l statprof -d 'Profile using statprof and show results in STYLE'
 
 complete -c $command -l language \
     -a 'scheme\tdefault elisp ecmascript' \


### PR DESCRIPTION
Update the `guile` and `guild` completions to match the current Guile 3.0.11 `--help` output.

## TODOs:
<!-- Check off what what has been done so far. -->
- [ ] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
