### PR TITLE
docs(set_color): fix copy-paste error with `-rSTATE` flag

### DIFF
--- a/doc_src/cmds/set_color.rst
+++ b/doc_src/cmds/set_color.rst
@@ -62,7 +62,7 @@ The following options are available:
 **-i** or **--italics**, or **-iSTATE** or **--italics=STATE**
     Sets italics mode. The state can be **on** (default), or **off**.
 
-**-r** or **--reverse**, or **-iSTATE** or **--reverse=STATE**
+**-r** or **--reverse**, or **-rSTATE** or **--reverse=STATE**
     Sets reverse mode. The state can be **on** (default), or **off**.
 
 **-s** or **--strikethrough**, or **-sSTATE** or **--strikethrough=STATE**


### PR DESCRIPTION
Just a minimal change to the manpage for `set_color` because I noticed a little error that seemed unintentional ^^