### PR TITLE
Handle expanded closing brackets in slice indices

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,10 @@ Interactive improvements
 ------------------------
 - Builtin and function commands can now be colored separately via new variables :envvar:`fish_color_builtin` and :envvar:`fish_color_function` (:issue:`12837`).
 
+Scripting improvements
+----------------------
+- Expanded variable values containing ``]`` are no longer treated as closing array index brackets (:issue:`12819`).
+
 Regression fixes:
 -----------------
 - ``abbr --position=anywhere`` completions are no longer offered in argument position, to avoid cluttering the completion pager (:issue:`12838`).

--- a/crates/widestring/src/lib.rs
+++ b/crates/widestring/src/lib.rs
@@ -97,9 +97,11 @@ pub const INTERNAL_SEPARATOR: char = char_offset(EXPAND_RESERVED_BASE, 8);
 /// Character representing an empty variable expansion. Only used transitively while expanding
 /// variables.
 pub const VARIABLE_EXPAND_EMPTY: char = char_offset(EXPAND_RESERVED_BASE, 9);
+/// Character representing the boundary around a transitive expansion.
+pub const EXPANSION_BOUNDARY: char = char_offset(EXPAND_RESERVED_BASE, 10);
 
 const _: () = assert!(
-    EXPAND_RESERVED_END as u32 > VARIABLE_EXPAND_EMPTY as u32,
+    EXPAND_RESERVED_END as u32 > EXPANSION_BOUNDARY as u32,
     "Characters used in expansions must stay within private use area"
 );
 

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -32,7 +32,7 @@ use fish_util::wcsfilecmp_glob;
 use fish_wcstringutil::{join_strings, trim};
 use fish_widestring::{
     ANY_CHAR, ANY_STRING, ANY_STRING_RECURSIVE, BRACE_BEGIN, BRACE_END, BRACE_SEP, BRACE_SPACE,
-    HOME_DIRECTORY, INTERNAL_SEPARATOR, PROCESS_EXPAND_SELF, VARIABLE_EXPAND,
+    EXPANSION_BOUNDARY, HOME_DIRECTORY, INTERNAL_SEPARATOR, PROCESS_EXPAND_SELF, VARIABLE_EXPAND,
     VARIABLE_EXPAND_EMPTY, VARIABLE_EXPAND_SINGLE, osstr2wcstring,
 };
 use nix::unistd::{User, getpid};
@@ -385,6 +385,20 @@ enum ParseSliceError {
     InvalidIndex,
 }
 
+fn skip_slice_separators(input: &wstr, pos: &mut usize, in_expansion: &mut bool, whitespace: bool) {
+    loop {
+        match input.char_at(*pos) {
+            c if whitespace && c.is_whitespace() => *pos += 1,
+            INTERNAL_SEPARATOR => *pos += 1,
+            EXPANSION_BOUNDARY => {
+                *in_expansion = !*in_expansion;
+                *pos += 1;
+            }
+            _ => break,
+        }
+    }
+}
+
 /// Parse an array slicing specification Returns 0 on success. If a parse error occurs, returns the
 /// index of the bad token. Note that 0 can never be a bad index because the string always starts
 /// with [.
@@ -395,12 +409,14 @@ fn parse_slice(
 ) -> Result<usize, (usize, ParseSliceError)> {
     let size = i64::try_from(array_size).unwrap();
     let mut pos = 1; // skip past the opening square bracket
+    let mut in_expansion = false;
 
     loop {
-        while input.char_at(pos).is_whitespace() || input.char_at(pos) == INTERNAL_SEPARATOR {
-            pos += 1;
-        }
+        skip_slice_separators(input, &mut pos, &mut in_expansion, true);
         if input.char_at(pos) == ']' {
+            if in_expansion {
+                return Err((pos, ParseSliceError::InvalidIndex));
+            }
             pos += 1;
             break;
         }
@@ -438,17 +454,10 @@ fn parse_slice(
         };
 
         let mut i1 = if tmp > -1 { tmp } else { size + tmp + 1 };
-        while input.char_at(pos) == INTERNAL_SEPARATOR {
-            pos += 1;
-        }
+        skip_slice_separators(input, &mut pos, &mut in_expansion, false);
         if input.char_at(pos) == '.' && input.char_at(pos + 1) == '.' {
             pos += 2;
-            while input.char_at(pos) == INTERNAL_SEPARATOR {
-                pos += 1;
-            }
-            while input.char_at(pos).is_whitespace() {
-                pos += 1; // Allow the space in "[.. ]".
-            }
+            skip_slice_separators(input, &mut pos, &mut in_expansion, true);
 
             // If we are at the last index range expression  then a missing end-index means the
             // range spans until the last item.
@@ -712,9 +721,11 @@ fn expand_variables(
             var.as_ref().unwrap().delimiter()
         };
         let mut res = instr[..varexp_char_idx].to_owned();
+        let mut add_expansion_boundary = false;
         if !res.is_empty() {
             if res.as_char_slice().last() != Some(&VARIABLE_EXPAND_SINGLE) {
-                res.push(INTERNAL_SEPARATOR);
+                res.push(EXPANSION_BOUNDARY);
+                add_expansion_boundary = true;
             } else if var_item_list.is_empty() || var_item_list[0].is_empty() {
                 // First expansion is empty, but we need to recursively expand.
                 res.push(VARIABLE_EXPAND_EMPTY);
@@ -723,6 +734,9 @@ fn expand_variables(
 
         // Append all entries in var_item_list, separated by the delimiter.
         res.push_utfstr(&join_strings(&var_item_list, delimit));
+        if add_expansion_boundary {
+            res.push(EXPANSION_BOUNDARY);
+        }
         res.push_utfstr(&instr[var_name_and_slice_stop..]);
         return expand_variables(res, out, varexp_char_idx, vars, errors);
     } else {
@@ -734,14 +748,19 @@ fn expand_variables(
                 }
             } else {
                 let mut new_in = instr[..varexp_char_idx].to_owned();
+                let mut add_expansion_boundary = false;
                 if !new_in.is_empty() {
                     if new_in.as_char_slice().last() != Some(&VARIABLE_EXPAND) {
-                        new_in.push(INTERNAL_SEPARATOR);
+                        new_in.push(EXPANSION_BOUNDARY);
+                        add_expansion_boundary = true;
                     } else if item.is_empty() {
                         new_in.push(VARIABLE_EXPAND_EMPTY);
                     }
                 }
                 new_in.push_utfstr(&item);
+                if add_expansion_boundary {
+                    new_in.push(EXPANSION_BOUNDARY);
+                }
                 new_in.push_utfstr(&instr[var_name_and_slice_stop..]);
                 let res = expand_variables(new_in, out, varexp_char_idx, vars, errors);
                 if res.result != ExpandResultCode::Ok {
@@ -1148,8 +1167,8 @@ fn expand_percent_self(input: &mut WString) {
 /// Remove any internal separators. Also optionally convert wildcard characters to regular
 /// equivalents. This is done to support skip_wildcards.
 fn remove_internal_separator(s: &mut WString, conv: bool) {
-    // Remove all instances of INTERNAL_SEPARATOR.
-    s.retain(|c| c != INTERNAL_SEPARATOR);
+    // Remove all transient expansion markers.
+    s.retain(|c| c != INTERNAL_SEPARATOR && c != EXPANSION_BOUNDARY);
 
     // If conv is true, replace all instances of ANY_STRING with '*',
     // ANY_STRING_RECURSIVE with '*'.

--- a/tests/checks/expansion.fish
+++ b/tests/checks/expansion.fish
@@ -246,6 +246,22 @@ echo $foo[d]
 #CHECKERR: echo $foo[d]
 #CHECKERR: ^
 
+# see https://github.com/fish-shell/fish-shell/issues/12819
+set -l close_bracket_index '1]'
+echo $foo[$close_bracket_index]
+#CHECKERR: {{.*}}expansion.fish (line {{\d+}}): Invalid index value
+#CHECKERR: echo $foo[$close_bracket_index]
+#CHECKERR: ^
+echo $foo["$close_bracket_index"]
+#CHECKERR: {{.*}}expansion.fish (line {{\d+}}): Invalid index value
+#CHECKERR: echo $foo["$close_bracket_index"]
+#CHECKERR: ^
+set -l close_bracket ']'
+echo "$foo[1$close_bracket"
+#CHECKERR: {{.*}}expansion.fish (line {{\d+}}): Invalid index value
+#CHECKERR: echo "$foo[1$close_bracket"
+#CHECKERR: ^
+
 echo ()[1]
 # No output
 echo ()[d]


### PR DESCRIPTION

## TODOs:
- [x] If addressing an issue, a commit message mentions `Fixes issue #12819`
- [x] Changes to fish usage are reflected in user documentation/manpages. (No manpage change needed; changelog entry added.)
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst

## Summary

Fixes issue #12819.

When a variable expanded inside an array index contained `]`, the slice parser could treat that character as the closing bracket and leave the real bracket as literal output. This wraps embedded variable expansions with a transient boundary marker so `parse_slice()` rejects a `]` that came from the expanded value while preserving normal numeric and range index expansion.

## Testing

- `$HOME/.cargo/bin/cargo build`
- `target/debug/fish -c 'set bar "1]"; set foo a b; echo $foo[$bar]' 2>&1`\n- `target/debug/fish -c 'set bar "1]"; set foo a b; echo $foo["$bar"]' 2>&1`\n- `target/debug/fish -c 'set bar "]"; set foo a b; echo "$foo[1$bar"' 2>&1`\n- `target/debug/fish -c 'set bar "1]"; set foo a b c d e f g h i j k l m n; echo "$foo[1$bar"' 2>&1`\n- `tests/test_driver.py target/debug tests/checks/expansion.fish`\n- `$HOME/.cargo/bin/cargo test -p fish-widestring`\n- `$HOME/.cargo/bin/cargo test -p fish --lib expand`\n- `$HOME/.cargo/bin/cargo fmt --check`\n\nFull `cargo xtask check` was not run locally.\n\nNote: I used Codex while preparing this change, and I reviewed the final diff and ran the listed checks locally.\n