### PR TITLE
Add completions for `git history fixup`

### DIFF
--- a/share/completions/git.fish
+++ b/share/completions/git.fish
@@ -1688,14 +1688,17 @@ complete -f -c git -n '__fish_git_using_command grep' -l no-index -d 'Search fil
 complete -f -c git -n '__fish_git_using_command grep' -l recurse-submodules -d 'Recursively search in each submodule'
 
 ### history
-set -l git_history_commands reword split
+set -l git_history_commands fixup reword split
 complete -f -c git -n __fish_git_needs_command -a history -d 'Rewrite history'
+complete -f -c git -n "__fish_git_using_command history" -n "not __fish_seen_subcommand_from $git_history_commands" -a fixup -d 'Fixup a commit'
 complete -f -c git -n "__fish_git_using_command history" -n "not __fish_seen_subcommand_from $git_history_commands" -a reword -d 'Rewrite a commit message'
 complete -f -c git -n "__fish_git_using_command history" -n "not __fish_seen_subcommand_from $git_history_commands" -a split -d 'Split up a commit'
 
-complete -f -c git -n '__fish_git_using_command history' -n '__fish_seen_subcommand_from reword split' -l dry-run -d 'Do not update references'
-complete -x -c git -n '__fish_git_using_command history' -n '__fish_seen_subcommand_from reword split' -l update-refs -a 'branches head'
-complete -x -c git -n '__fish_git_using_command history' -n '__fish_seen_subcommand_from reword' -ka '(__fish_git_recent_commits)'
+complete -f -c git -n '__fish_git_using_command history' -n '__fish_seen_subcommand_from fixup reword split' -l dry-run -d 'Do not update references'
+complete -x -c git -n '__fish_git_using_command history' -n '__fish_seen_subcommand_from fixup reword split' -l update-refs -a 'branches head'
+complete -x -c git -n '__fish_git_using_command history' -n '__fish_seen_subcommand_from fixup reword' -ka '(__fish_git_recent_commits)'
+complete -f -c git -n '__fish_git_using_command history' -n '__fish_seen_subcommand_from fixup' -l reedit-message -d 'Open editor to modify commit message'
+complete -x -c git -n '__fish_git_using_command history' -n '__fish_seen_subcommand_from fixup' -l empty -a 'drop keep abort'
 complete -x -c git -n '__fish_git_using_command history' -n '__fish_seen_subcommand_from split' -n 'not contains -- -- (commandline -xpc)' -ka '(__fish_git_recent_commits)'
 complete -F -c git -n '__fish_git_using_command history' -n '__fish_seen_subcommand_from split' -n 'contains -- -- (commandline -xpc)'
 


### PR DESCRIPTION
This subcommand was added in git v2.55:

https://gitlab.com/git-scm/git/-/blob/e9019fcafe0040228b8631c30f97ae1adb61bcdc/Documentation/RelNotes/2.55.0.adoc

Full documentation here:

https://git-scm.com/docs/git-history

## TODOs:
<!-- Check off what what has been done so far. -->
- [ ] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
