### PR TITLE
Add `fish_darcs_prompt`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Interactive improvements
 ------------------------
 - Builtin and function commands can now be colored separately via new variables :envvar:`fish_color_builtin` and :envvar:`fish_color_function` (:issue:`12837`).
 - On non-macOS platforms, :kbd:`alt-backspace`, :kbd:`alt-left` and :kbd:`alt-right` operate on words again instead of tokens (:issue:`12122`) eliminating cross-platform differences in input handling.
+- Add ``fish_darcs_prompt`` for `Darcs <https://darcs.net/>`_ repository status.
 
 Regression fixes:
 -----------------

--- a/doc_src/cmds/fish_darcs_prompt.rst
+++ b/doc_src/cmds/fish_darcs_prompt.rst
@@ -1,0 +1,56 @@
+fish_darcs_prompt - output Darcs information for use in a prompt
+================================================================
+
+Synopsis
+--------
+
+.. synopsis::
+
+    fish_darcs_prompt
+
+::
+
+     function fish_prompt
+          printf '%s' $PWD (fish_darcs_prompt) ' $ '
+     end
+
+Description
+-----------
+
+The ``fish_darcs_prompt`` function displays information about the current Darcs repository, if any.
+
+`Darcs <https://darcs.net/>`_ must be installed.
+
+The prompt always shows the VCS name (configurable via ``$fish_prompt_darcs_name``, default ``darcs``) as there are no branches/channels; it can be unset to remove it entirely. If the repository has unrecorded changes, status counts are shown for each change type:
+
+- ``$fish_color_darcs_normal``, default ``green`` (the prompt label color)
+- ``$fish_color_darcs_rebasing``, default ``yellow`` (used when a rebase is in progress)
+
+The logo color can be referenced via ``$__darcs_logo_color`` for themes that want the exact Darcs branding::
+
+    set fish_color_darcs_normal $__darcs_logo_color
+
+The Darcs status symbols:
+
+- ``$fish_prompt_darcs_status_added``, default ``+``
+- ``$fish_prompt_darcs_status_modified``, default ``*``
+- ``$fish_prompt_darcs_status_removed``, default ``-``
+- ``$fish_prompt_darcs_status_moved``, default ``→``
+- ``$fish_prompt_darcs_status_untracked``, default ``…``
+- ``$fish_prompt_darcs_status_conflict``, default ``!``
+
+Colors for these symbols can be set with the corresponding variables (``$fish_color_darcs_added`` & so on), which are unset by default so the terminal’s foreground color is used.
+
+``$fish_prompt_darcs_status_order`` can be used to change the order the status symbols appear in. It defaults to ``added removed modified moved conflict untracked``.
+
+See also :doc:`fish_vcs_prompt <fish_vcs_prompt>`, which will call all supported version control prompt functions, including Git, Mercurial, & Darcs.
+
+Example
+-------
+
+A simple prompt that displays darcs info::
+
+    function fish_prompt
+        ...
+        printf '%s %s$' $PWD (fish_darcs_prompt)
+    end

--- a/doc_src/cmds/fish_vcs_prompt.rst
+++ b/doc_src/cmds/fish_vcs_prompt.rst
@@ -23,6 +23,7 @@ It calls out to VCS-specific functions. The currently supported systems are:
 
 - :doc:`fish_git_prompt <fish_git_prompt>`
 - :doc:`fish_hg_prompt <fish_hg_prompt>`
+- :doc:`fish_darcs_prompt <fish_darcs_prompt>`
 - :doc:`fish_svn_prompt <fish_svn_prompt>`
 
 If a VCS isn't installed, the respective function does nothing.

--- a/localization/po/de.po
+++ b/localization/po/de.po
@@ -3108,6 +3108,9 @@ msgstr ""
 msgid "Print/set the line the cursor is on"
 msgstr ""
 
+msgid "Prompt function for Darcs"
+msgstr ""
+
 msgid "Prompt function for Git"
 msgstr ""
 

--- a/localization/po/es.po
+++ b/localization/po/es.po
@@ -3108,6 +3108,9 @@ msgstr ""
 msgid "Print/set the line the cursor is on"
 msgstr ""
 
+msgid "Prompt function for Darcs"
+msgstr ""
+
 msgid "Prompt function for Git"
 msgstr ""
 

--- a/localization/po/fr.po
+++ b/localization/po/fr.po
@@ -3237,6 +3237,9 @@ msgstr ""
 msgid "Print/set the line the cursor is on"
 msgstr ""
 
+msgid "Prompt function for Darcs"
+msgstr ""
+
 msgid "Prompt function for Git"
 msgstr ""
 

--- a/localization/po/ja_JP.po
+++ b/localization/po/ja_JP.po
@@ -3111,6 +3111,9 @@ msgstr "カーソルがある列を表示・設定"
 msgid "Print/set the line the cursor is on"
 msgstr "カーソルがある行を表示・設定"
 
+msgid "Prompt function for Darcs"
+msgstr ""
+
 msgid "Prompt function for Git"
 msgstr "Git 用のプロンプト関数"
 

--- a/localization/po/pl.po
+++ b/localization/po/pl.po
@@ -3104,6 +3104,9 @@ msgstr ""
 msgid "Print/set the line the cursor is on"
 msgstr ""
 
+msgid "Prompt function for Darcs"
+msgstr ""
+
 msgid "Prompt function for Git"
 msgstr ""
 

--- a/localization/po/pt_BR.po
+++ b/localization/po/pt_BR.po
@@ -3109,6 +3109,9 @@ msgstr ""
 msgid "Print/set the line the cursor is on"
 msgstr ""
 
+msgid "Prompt function for Darcs"
+msgstr ""
+
 msgid "Prompt function for Git"
 msgstr ""
 

--- a/localization/po/sv.po
+++ b/localization/po/sv.po
@@ -3105,6 +3105,9 @@ msgstr ""
 msgid "Print/set the line the cursor is on"
 msgstr ""
 
+msgid "Prompt function for Darcs"
+msgstr ""
+
 msgid "Prompt function for Git"
 msgstr ""
 

--- a/localization/po/zh_CN.po
+++ b/localization/po/zh_CN.po
@@ -3129,6 +3129,9 @@ msgstr "打印/设置光标所在的列"
 msgid "Print/set the line the cursor is on"
 msgstr "打印/设置光标所在的行"
 
+msgid "Prompt function for Darcs"
+msgstr ""
+
 msgid "Prompt function for Git"
 msgstr "Git 的提示函数"
 

--- a/localization/po/zh_TW.po
+++ b/localization/po/zh_TW.po
@@ -3104,6 +3104,9 @@ msgstr "印出／設定游標所在的欄"
 msgid "Print/set the line the cursor is on"
 msgstr "印出／設定游標所在的行"
 
+msgid "Prompt function for Darcs"
+msgstr ""
+
 msgid "Prompt function for Git"
 msgstr "Git 的提示函式"
 

--- a/share/functions/fish_darcs_prompt.fish
+++ b/share/functions/fish_darcs_prompt.fish
@@ -1,0 +1,93 @@
+# Based on the Darc hub ``darcs-fish`` repositories of raichoo & toastal
+
+# For a Darcs-themed prompt try:
+# set fish_color_darcs_normal $__darcs_logo_color
+set -g __darcs_logo_color 72ff01
+# Basic green preferred to clash less with terminal emulator theming
+set -g fish_color_darcs_normal green
+set -g fish_color_darcs_rebasing yellow
+# Conflicts are a critical state that should be resolved
+set -g fish_color_darcs_conflict red
+
+# Darcs doesn’t have branches/channels so just showing the VCS name is more
+# consistent with having text as other VCS prompts do
+set -g fish_prompt_darcs_name darcs
+set -g fish_prompt_darcs_status_added '+'
+set -g fish_prompt_darcs_status_removed -
+set -g fish_prompt_darcs_status_modified '*'
+set -g fish_prompt_darcs_status_moved '→'
+set -g fish_prompt_darcs_status_conflict '!'
+set -g fish_prompt_darcs_status_untracked '…'
+
+set -g fish_prompt_darcs_status_order added removed modified moved conflict untracked
+
+function fish_darcs_prompt --description "Prompt function for Darcs"
+    # No Darcs, no prompt
+    command -sq darcs || return 1
+    # The _darcs metadata directory, must be exist
+    darcs show repo >/dev/null 2>&1 || return 1
+
+    set -l added 0
+    set -l modified 0
+    set -l removed 0
+    set -l moved 0
+    set -l untracked 0
+    set -l conflict 0
+
+    for state_line in (darcs status --machine-readable 2>&1)
+        set -l parts (string split ' ' -- "$state_line")
+        switch $parts[1]
+            case Rebase
+                set rebase $parts[4]
+            case A
+                set added (math "$added + 1")
+            case M
+                set modified (math "$modified + 1")
+            case R
+                set removed (math "$removed + 1")
+            case F
+                set moved (math "$moved + 1")
+            case a
+                set untracked (math "$untracked + 1")
+            case '!'
+                set conflict (math "$conflict + 1")
+        end
+    end
+
+    set_color normal
+    echo -n '('
+    if set -q rebase
+        set_color $fish_color_darcs_rebasing
+    else if test "$conflict" -gt 0
+        set_color $fish_color_darcs_conflict
+    else
+        set_color $fish_color_darcs_normal
+    end
+    echo -n $fish_prompt_darcs_name
+    set_color normal
+    if set -q rebase
+        echo -n "[$rebase]"
+    end
+
+    set -l sep
+    if string length -q -- "$fish_prompt_darcs_name"
+        set sep '|'
+    end
+    for stat in $fish_prompt_darcs_status_order
+        set -l count $$stat
+        if test "$count" -gt 0
+            echo -n "$sep"
+            set -l color_var fish_color_darcs_$stat
+            if set -q $color_var
+                set_color $$color_var
+            end
+            echo -n "$count"
+            set -l symbol_var fish_prompt_darcs_status_$stat
+            echo -n "$$symbol_var"
+            set_color normal
+            set sep /
+        end
+    end
+    set_color normal
+    echo -n ')'
+end

--- a/share/functions/fish_vcs_prompt.fish
+++ b/share/functions/fish_vcs_prompt.fish
@@ -4,6 +4,7 @@ function fish_vcs_prompt --description "Print all vcs prompts"
     fish_jj_prompt $argv
     or fish_git_prompt $argv
     or fish_hg_prompt $argv
+    or fish_darcs_prompt $argv
     # The svn and fossil prompts are disabled by default because they can be quite slow.
     # To enable them uncomment them.
     # You can also only use them in specific directories by checking $PWD.

--- a/share/help_sections
+++ b/share/help_sections
@@ -39,6 +39,7 @@ cmds/fish_clipboard_copy
 cmds/fish_clipboard_paste
 cmds/fish_command_not_found
 cmds/fish_config
+cmds/fish_darcs_prompt
 cmds/fish_default_key_bindings
 cmds/fish_delta
 cmds/fish_git_prompt


### PR DESCRIPTION
Improves on the prompts floating around the internet (which I forked a long time ago)—specifically copied the ability to reorder statuses from the other VCSs, added `!` for showing that there are merge conflicts (in red), rebases being yellow instead of red to differentiate.

Fixes #12825

## TODOs:
<!-- Check off what what has been done so far. -->
- [x] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
