### PR TITLE
Add option to disable history use for autosuggestions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ fish ?.?.? (released ???)
 Interactive improvements
 ------------------------
 - Builtin and function commands can now be colored separately via new variables :envvar:`fish_color_builtin` and :envvar:`fish_color_function` (:issue:`12837`).
+- History entries can now be excluded from autosuggestions by setting ``$fish_autosuggestion_include_history`` to 0.
 
 Regression fixes:
 -----------------

--- a/doc_src/language.rst
+++ b/doc_src/language.rst
@@ -1581,6 +1581,10 @@ You can change the settings of fish by changing the values of certain variables.
 
    controls if :ref:`autosuggestions` are enabled. Set it to 0 to disable, anything else to enable. By default they are on.
 
+.. envvar:: fish_autosuggestion_include_history
+
+   controls if history entries are used for autosuggestions. Set it to 0 to disable, anything else to enable. By default it is on.
+
 .. envvar:: fish_transient_prompt
 
    If this is set to 1, fish will redraw prompts with a ``--final-rendering`` argument before running a commandline, allowing you to change it before pushing it to the scrollback. This enables :ref:`transient prompts <transient-prompt>`.

--- a/src/env_dispatch.rs
+++ b/src/env_dispatch.rs
@@ -10,7 +10,7 @@ use crate::prelude::*;
 use crate::reader::{
     reader_change_cursor_end_mode, reader_change_cursor_selection_mode, reader_change_history,
     reader_current_data, reader_schedule_prompt_repaint, reader_set_autosuggestion_enabled,
-    reader_set_transient_prompt,
+    reader_set_autosuggestion_include_history, reader_set_transient_prompt,
 };
 use crate::screen::{IS_DUMB, ONLY_GRAYSCALE, screen_set_midnight_commander_hack};
 use crate::terminal::ColorSupport;
@@ -74,6 +74,10 @@ static VAR_DISPATCH_TABLE: once_cell::sync::Lazy<VarDispatchTable> =
         table.add_anon(
             L!("fish_autosuggestion_enabled"),
             vars!(handle_autosuggestion_change),
+        );
+        table.add_anon(
+            L!("fish_autosuggestion_include_history"),
+            vars!(handle_autosuggestion_history_change),
         );
         table.add_anon(
             L!("fish_transient_prompt"),
@@ -271,6 +275,10 @@ pub fn handle_fish_cursor_end_mode_change(vars: &EnvStack) {
 
 fn handle_autosuggestion_change(vars: &EnvStack) {
     reader_set_autosuggestion_enabled(vars);
+}
+
+fn handle_autosuggestion_history_change(vars: &EnvStack) {
+    reader_set_autosuggestion_include_history(vars);
 }
 
 fn handle_transient_prompt_change(vars: &EnvStack) {

--- a/src/reader/reader.rs
+++ b/src/reader/reader.rs
@@ -473,6 +473,9 @@ pub struct ReaderConfig {
     /// Whether to allow autosuggestions.
     pub autosuggest_ok: bool,
 
+    /// Whether to include history in autosuggestions
+    pub autosuggestion_include_history: bool,
+
     /// Whether to reexecute prompt function before final rendering.
     pub transient_prompt: bool,
 
@@ -829,6 +832,11 @@ fn read_i(parser: &mut Parser) {
         syntax_check_ok: true,
         expand_abbrev_ok: true,
         autosuggest_ok: check_bool_var(parser.vars(), L!("fish_autosuggestion_enabled"), true),
+        autosuggestion_include_history: check_bool_var(
+            parser.vars(),
+            L!("fish_autosuggestion_include_history"),
+            true,
+        ),
         transient_prompt: check_bool_var(parser.vars(), L!("fish_transient_prompt"), false),
         ..Default::default()
     };
@@ -1119,6 +1127,17 @@ pub fn reader_set_autosuggestion_enabled(vars: &dyn Environment) {
         let enable = check_bool_var(vars, L!("fish_autosuggestion_enabled"), true);
         if data.conf.autosuggest_ok != enable {
             data.conf.autosuggest_ok = enable;
+            data.schedule_prompt_repaint();
+        }
+    }
+}
+
+/// Include or exclude history in autosuggestions
+pub fn reader_set_autosuggestion_include_history(vars: &dyn Environment) {
+    if let Some(data) = current_data() {
+        let enable = check_bool_var(vars, L!("fish_autosuggestion_include_history"), true);
+        if data.conf.autosuggestion_include_history != enable {
+            data.conf.autosuggestion_include_history = enable;
             data.schedule_prompt_repaint();
         }
     }
@@ -5302,6 +5321,7 @@ fn get_autosuggestion_performer(
     command_line: WString,
     cursor_pos: usize,
     history: Arc<History>,
+    include_history: bool,
 ) -> impl FnOnce() -> AutosuggestionResult + use<> {
     let generation_count = read_generation_count();
     let vars = parser.vars().snapshot();
@@ -5318,111 +5338,113 @@ fn get_autosuggestion_performer(
         let mut icase_history_result = None;
 
         let line_range = range_of_line_at_cursor(&command_line, cursor_pos);
-        // Search history for a matching item unless this line is not a continuation line or quoted.
-        for (search_type, range) in [
-            (SearchType::Prefix, 0..command_line.len()),
-            (SearchType::LinePrefix, line_range.clone()),
-        ] {
-            if range.is_empty() {
-                continue;
-            }
-            let search_string = &command_line[range.clone()];
-            if search_type == SearchType::LinePrefix {
-                let cursor_line_has_process_start = {
-                    let mut tokens = vec![];
-                    get_process_extent(&command_line, cursor_pos, Some(&mut tokens));
-                    range_of_line_at_cursor(
-                        &command_line,
-                        get_process_first_token_offset(&command_line, cursor_pos)
-                            .unwrap_or(cursor_pos),
-                    ) == range
-                };
-                if !cursor_line_has_process_start {
+        // Search history for a matching item unless this line is not a continuation line or quoted or history is disabled for autosuggestions.
+        if include_history {
+            for (search_type, range) in [
+                (SearchType::Prefix, 0..command_line.len()),
+                (SearchType::LinePrefix, line_range.clone()),
+            ] {
+                if range.is_empty() {
                     continue;
                 }
-            }
-            let mut searcher = HistorySearch::new_with(
-                history.clone(),
-                search_string.to_owned(),
-                search_type,
-                SearchFlags::IGNORE_CASE,
-                0,
-            );
-
-            while !ctx.check_cancel() && searcher.go_to_next_match(SearchDirection::Backward) {
-                let item = searcher.current_item();
-
-                let full = item.str();
-                let (suggested_range, icase) = if search_type == SearchType::Prefix {
-                    let mut suggested_range =
-                        full.starts_with(search_string).then_some(0..full.len());
-                    let mut icase = false;
-                    // Only check for a case-insensitive match if we haven't already found one
-                    if suggested_range.is_none() && icase_history_result.is_none() {
-                        icase = true;
-                        suggested_range =
-                            string_prefixes_string_case_insensitive(search_string, full)
-                                .then_some(0..full.len());
+                let search_string = &command_line[range.clone()];
+                if search_type == SearchType::LinePrefix {
+                    let cursor_line_has_process_start = {
+                        let mut tokens = vec![];
+                        get_process_extent(&command_line, cursor_pos, Some(&mut tokens));
+                        range_of_line_at_cursor(
+                            &command_line,
+                            get_process_first_token_offset(&command_line, cursor_pos)
+                                .unwrap_or(cursor_pos),
+                        ) == range
+                    };
+                    if !cursor_line_has_process_start {
+                        continue;
                     }
+                }
+                let mut searcher = HistorySearch::new_with(
+                    history.clone(),
+                    search_string.to_owned(),
+                    search_type,
+                    SearchFlags::IGNORE_CASE,
+                    0,
+                );
 
-                    (suggested_range, icase)
-                } else {
-                    // The history items may have multiple lines of text.
-                    // Only suggest the line that actually contains the search string.
-                    let newlines = full
-                        .char_indices()
-                        .filter_map(|(i, c)| (c == '\n').then_some(i));
-                    let line_ranges = std::iter::once(0)
-                        .chain(newlines.clone().map(|i| i + 1))
-                        .zip(newlines.chain(std::iter::once(full.char_count())))
-                        .map(|(start, end)| start..end);
+                while !ctx.check_cancel() && searcher.go_to_next_match(SearchDirection::Backward) {
+                    let item = searcher.current_item();
 
-                    let mut icase = false;
-                    let mut suggested_range = line_ranges
-                        .clone()
-                        .find(|range| full[range.clone()].starts_with(search_string));
+                    let full = item.str();
+                    let (suggested_range, icase) = if search_type == SearchType::Prefix {
+                        let mut suggested_range =
+                            full.starts_with(search_string).then_some(0..full.len());
+                        let mut icase = false;
+                        // Only check for a case-insensitive match if we haven't already found one
+                        if suggested_range.is_none() && icase_history_result.is_none() {
+                            icase = true;
+                            suggested_range =
+                                string_prefixes_string_case_insensitive(search_string, full)
+                                    .then_some(0..full.len());
+                        }
 
-                    // Only check for a case-insensitive match if we haven't already found one
-                    if suggested_range.is_none() && icase_history_result.is_none() {
-                        icase = true;
-                        suggested_range = line_ranges.into_iter().find(|range| {
-                            string_prefixes_string_case_insensitive(
-                                search_string,
-                                &full[range.clone()],
-                            )
-                        });
-                    }
-
-                    (suggested_range, icase)
-                };
-                let Some(suggested_range) = suggested_range else {
-                    assert!(
-                        icase_history_result.is_some(),
-                        "couldn't find line matching search {search_string:?} in history item {item:?} (did history search yield a bogus result?)"
-                    );
-                    continue;
-                };
-
-                if autosuggest_validate_from_history(
-                    full,
-                    suggested_range.clone(),
-                    item.get_required_paths(),
-                    &working_directory,
-                    ctx,
-                ) {
-                    // The command autosuggestion was handled specially, so we're done.
-                    let is_whole = suggested_range.len() == item.str().len();
-                    let result = AutosuggestionResult::new(
-                        command_line.clone(),
-                        range.clone(),
-                        full[suggested_range].into(),
-                        icase.then(|| searcher.canon_term().char_count()),
-                        is_whole,
-                    );
-                    if icase {
-                        icase_history_result = Some(result);
+                        (suggested_range, icase)
                     } else {
-                        return result;
+                        // The history items may have multiple lines of text.
+                        // Only suggest the line that actually contains the search string.
+                        let newlines = full
+                            .char_indices()
+                            .filter_map(|(i, c)| (c == '\n').then_some(i));
+                        let line_ranges = std::iter::once(0)
+                            .chain(newlines.clone().map(|i| i + 1))
+                            .zip(newlines.chain(std::iter::once(full.char_count())))
+                            .map(|(start, end)| start..end);
+
+                        let mut icase = false;
+                        let mut suggested_range = line_ranges
+                            .clone()
+                            .find(|range| full[range.clone()].starts_with(search_string));
+
+                        // Only check for a case-insensitive match if we haven't already found one
+                        if suggested_range.is_none() && icase_history_result.is_none() {
+                            icase = true;
+                            suggested_range = line_ranges.into_iter().find(|range| {
+                                string_prefixes_string_case_insensitive(
+                                    search_string,
+                                    &full[range.clone()],
+                                )
+                            });
+                        }
+
+                        (suggested_range, icase)
+                    };
+                    let Some(suggested_range) = suggested_range else {
+                        assert!(
+                            icase_history_result.is_some(),
+                            "couldn't find line matching search {search_string:?} in history item {item:?} (did history search yield a bogus result?)"
+                        );
+                        continue;
+                    };
+
+                    if autosuggest_validate_from_history(
+                        full,
+                        suggested_range.clone(),
+                        item.get_required_paths(),
+                        &working_directory,
+                        ctx,
+                    ) {
+                        // The command autosuggestion was handled specially, so we're done.
+                        let is_whole = suggested_range.len() == item.str().len();
+                        let result = AutosuggestionResult::new(
+                            command_line.clone(),
+                            range.clone(),
+                            full[suggested_range].into(),
+                            icase.then(|| searcher.canon_term().char_count()),
+                            is_whole,
+                        );
+                        if icase {
+                            icase_history_result = Some(result);
+                        } else {
+                            return result;
+                        }
                     }
                 }
             }
@@ -5598,6 +5620,7 @@ impl<'a> Reader<'a> {
             el.text().to_owned(),
             el.position(),
             self.history.clone(),
+            self.conf.autosuggestion_include_history,
         );
         self.debouncers.autosuggestions.perform(performer);
     }

--- a/tests/checks/tmux-autosuggestion-no-history.fish
+++ b/tests/checks/tmux-autosuggestion-no-history.fish
@@ -1,0 +1,27 @@
+#RUN: %fish %s
+#REQUIRES: command -v tmux
+
+isolated-tmux-start
+isolated-tmux send-keys 'echo unique_history_command' Enter C-l
+
+isolated-tmux send-keys 'echo uni'
+tmux-sleep
+isolated-tmux send-keys Tab
+isolated-tmux capture-pane -p
+# CHECK: prompt {{\d+}}> echo unique_history_command
+
+touch complete_test_file
+isolated-tmux send-keys C-u C-l ': complete_'
+tmux-sleep
+isolated-tmux send-keys Tab
+isolated-tmux capture-pane -p
+# CHECK: prompt {{\d+}}> : complete_test_file
+
+isolated-tmux send-keys C-u 'set -gx fish_autosuggestion_include_history 0' Enter C-l
+
+isolated-tmux send-keys 'echo uni'
+tmux-sleep
+isolated-tmux send-keys Tab
+isolated-tmux capture-pane -p
+# CHECK: prompt {{\d+}}> echo uni
+# CHECK-NOT: prompt {{\d+}}> echo unique_history_command


### PR DESCRIPTION
Added configuration to enable/disable the inclusion of history in autosuggestions



## TODOs:
<!-- Check off what what has been done so far. -->
- [ ] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
