### PR TITLE
Fix implicit cd showing help if directory name starts with "-h"

### DIFF
--- a/src/parse_execution.rs
+++ b/src/parse_execution.rs
@@ -784,7 +784,7 @@ impl ExecutionContext {
         let mut redirections = RedirectionSpecList::new();
         if use_implicit_cd {
             // Implicit cd is simple.
-            cmd_args = vec![L!("cd").to_owned(), cmd];
+            cmd_args = vec![L!("cd").to_owned(), L!("--").to_owned(), cmd];
 
             // If we have defined a wrapper around cd, use it, otherwise use the cd builtin.
             process_type = if function::exists(L!("cd"), ctx.parser()) {

--- a/tests/checks/cd.fish
+++ b/tests/checks/cd.fish
@@ -167,6 +167,14 @@ test $PWD = $base/-testdir
 echo $status
 #CHECK: 0
 
+# An implicit cd must also accept a directory name beginning with a hyphen.
+mkdir $base/-h
+cd $base
+-h/
+test $PWD = $base/-h
+echo $status
+#CHECK: 0
+
 # test a few error cases - nonexistent directory
 set -l old_cdpath $CDPATH
 set -l old_path $PWD


### PR DESCRIPTION
Says everything in the name. Added new test for that, local test runs were successful.

None of the template checkboxes were applicable.