### PR TITLE
fix: exclude broadcast hosts from completions

### DIFF
--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -11,12 +11,7 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
     begin
         test -r /etc/hosts && read -z </etc/hosts | string replace -r '#.*$' ''
         or type -q getent && getent hosts 2>/dev/null
-    end |
-        # Ignore own IP addresses (127.*, 0.0[.0[.0]], ::1), non-host IPs (fe00::*, ff00::*),
-        # and leading/trailing whitespace. Split results on whitespace to handle multiple aliases for
-        # one IP.
-        string replace -irf '^\s*?(?!(?:0\.|127\.|ff0|fe0|::1))\S+\s*(.*?)\s*$' '$1' |
-        string split ' '
+    end | __fish_print_hostnames_from_hosts
 
     # Print nfs servers from /etc/fstab
     if test -r /etc/fstab
@@ -140,4 +135,15 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
         string split ',' | string replace -r '\[?([^\]]+).*' '$1'
 
     return 0
+end
+
+function __fish_print_hostnames_from_hosts -d "Extract hostnames from hosts file entries"
+    # Ignore own IP addresses (127.*, 0.0[.0[.0]], ::1), broadcast addresses (255.255.255.255),
+    # non-host IPs (fe00::*, ff00::*), and leading/trailing whitespace. Split results on whitespace
+    # to handle multiple aliases for one IP.
+    read -lz entries
+    set entries (string split \n -- $entries)
+    set -l host_entries (string match -reiv '^\s*(?:0\.|127\.|255\.255\.255\.255|ff0|fe0|::1)' -- $entries)
+    set -l hostnames (string replace -r '^\s*\S+\s*' '' -- $host_entries)
+    string split ' ' -- $hostnames
 end

--- a/share/functions/__fish_print_hostnames.fish
+++ b/share/functions/__fish_print_hostnames.fish
@@ -8,10 +8,12 @@ function __fish_print_hostnames -d "Print a list of known hostnames"
     # order is now reversed and `getent hosts` is only used if the hosts file is not found at
     # `/etc/hosts` for portability reasons.
 
-    begin
-        test -r /etc/hosts && read -z </etc/hosts | string replace -r '#.*$' ''
-        or type -q getent && getent hosts 2>/dev/null
-    end | __fish_print_hostnames_from_hosts
+    __fish_print_hostnames_from_hosts (
+        begin
+            test -r /etc/hosts && read -z </etc/hosts | string replace -r '#.*$' ''
+            or type -q getent && getent hosts 2>/dev/null
+        end
+    )
 
     # Print nfs servers from /etc/fstab
     if test -r /etc/fstab
@@ -141,9 +143,7 @@ function __fish_print_hostnames_from_hosts -d "Extract hostnames from hosts file
     # Ignore own IP addresses (127.*, 0.0[.0[.0]], ::1), broadcast addresses (255.255.255.255),
     # non-host IPs (fe00::*, ff00::*), and leading/trailing whitespace. Split results on whitespace
     # to handle multiple aliases for one IP.
-    read -lz entries
-    set entries (string split \n -- $entries)
-    set -l host_entries (string match -reiv '^\s*(?:0\.|127\.|255\.255\.255\.255|ff0|fe0|::1)' -- $entries)
+    set -l host_entries (string match -reiv '^\s*(?:0\.|127\.|255\.255\.255\.255|ff0|fe0|::1)' -- $argv)
     set -l hostnames (string replace -r '^\s*\S+\s*' '' -- $host_entries)
     string split ' ' -- $hostnames
 end

--- a/tests/checks/hostnames.fish
+++ b/tests/checks/hostnames.fish
@@ -1,0 +1,14 @@
+# RUN: %fish %s
+
+# Load the source-tree function explicitly so this test can exercise the hosts-file filter
+# without depending on the machine's real /etc/hosts.
+set -l workspace_root (path resolve -- (status dirname)/../../)
+source $workspace_root/share/functions/__fish_print_hostnames.fish
+
+printf '%s\n' \
+    '127.0.0.1 localhost' \
+    '0.0.0.0 blocked' \
+    '255.255.255.255 broadcasthost' \
+    '192.0.2.1 example.test alias.test' | __fish_print_hostnames_from_hosts
+# CHECK: example.test
+# CHECK: alias.test

--- a/tests/checks/hostnames.fish
+++ b/tests/checks/hostnames.fish
@@ -5,10 +5,10 @@
 set -l workspace_root (path resolve -- (status dirname)/../../)
 source $workspace_root/share/functions/__fish_print_hostnames.fish
 
-printf '%s\n' \
+__fish_print_hostnames_from_hosts \
     '127.0.0.1 localhost' \
     '0.0.0.0 blocked' \
     '255.255.255.255 broadcasthost' \
-    '192.0.2.1 example.test alias.test' | __fish_print_hostnames_from_hosts
+    '192.0.2.1 example.test alias.test'
 # CHECK: example.test
 # CHECK: alias.test


### PR DESCRIPTION
## Summary
- exclude the IPv4 limited-broadcast address (`255.255.255.255`) from hostname completions
- isolate `/etc/hosts` parsing so the filtering behavior has a focused regression test

## Root cause
macOS includes `255.255.255.255 broadcasthost` in its default hosts file. The existing filter excluded loopback, unspecified, and multicast/reserved addresses, but not the limited-broadcast address, so `broadcasthost` appeared in SSH and other hostname completions.

Fixes #12845

## Validation
- `python3 tests/test_driver.py target/debug tests/checks/hostnames.fish`
- `target/debug/fish -n share/functions/__fish_print_hostnames.fish tests/checks/hostnames.fish`
- `target/debug/fish_indent --check share/functions/__fish_print_hostnames.fish tests/checks/hostnames.fish`
- `cargo fmt --check`