### PR TITLE
completions/pgrep: Add missing options

### DIFF
--- a/localization/po/de.po
+++ b/localization/po/de.po
@@ -20994,6 +20994,9 @@ msgstr ""
 msgid "Do not write anything"
 msgstr "Nichts schreiben"
 
+msgid "Do not write anything to standard output"
+msgstr ""
+
 msgid "Do not write column names in results"
 msgstr ""
 
@@ -36279,6 +36282,9 @@ msgstr ""
 msgid "List the files that are supplied by the named package"
 msgstr ""
 
+msgid "List the full command line as well as the process ID"
+msgstr ""
+
 msgid "List the host and all running local containers"
 msgstr ""
 
@@ -41677,6 +41683,9 @@ msgid "Output system directory"
 msgstr ""
 
 msgid "Output the build plan in JSON (unstable)"
+msgstr ""
+
+msgid "Output the command line in shell-quoted form"
 msgstr ""
 
 msgid "Output the content of specified files or URLs"

--- a/localization/po/es.po
+++ b/localization/po/es.po
@@ -20994,6 +20994,9 @@ msgstr ""
 msgid "Do not write anything"
 msgstr ""
 
+msgid "Do not write anything to standard output"
+msgstr ""
+
 msgid "Do not write column names in results"
 msgstr ""
 
@@ -36279,6 +36282,9 @@ msgstr ""
 msgid "List the files that are supplied by the named package"
 msgstr ""
 
+msgid "List the full command line as well as the process ID"
+msgstr ""
+
 msgid "List the host and all running local containers"
 msgstr ""
 
@@ -41677,6 +41683,9 @@ msgid "Output system directory"
 msgstr ""
 
 msgid "Output the build plan in JSON (unstable)"
+msgstr ""
+
+msgid "Output the command line in shell-quoted form"
 msgstr ""
 
 msgid "Output the content of specified files or URLs"

--- a/localization/po/fr.po
+++ b/localization/po/fr.po
@@ -21123,6 +21123,9 @@ msgstr "Ne pas écrire de fichier ~/.fehbg"
 msgid "Do not write anything"
 msgstr "Ne rien écrire"
 
+msgid "Do not write anything to standard output"
+msgstr ""
+
 msgid "Do not write column names in results"
 msgstr ""
 
@@ -36408,6 +36411,9 @@ msgstr ""
 msgid "List the files that are supplied by the named package"
 msgstr ""
 
+msgid "List the full command line as well as the process ID"
+msgstr ""
+
 msgid "List the host and all running local containers"
 msgstr ""
 
@@ -41806,6 +41812,9 @@ msgid "Output system directory"
 msgstr ""
 
 msgid "Output the build plan in JSON (unstable)"
+msgstr ""
+
+msgid "Output the command line in shell-quoted form"
 msgstr ""
 
 msgid "Output the content of specified files or URLs"

--- a/localization/po/ja_JP.po
+++ b/localization/po/ja_JP.po
@@ -20997,6 +20997,9 @@ msgstr ""
 msgid "Do not write anything"
 msgstr ""
 
+msgid "Do not write anything to standard output"
+msgstr ""
+
 msgid "Do not write column names in results"
 msgstr ""
 
@@ -36282,6 +36285,9 @@ msgstr ""
 msgid "List the files that are supplied by the named package"
 msgstr ""
 
+msgid "List the full command line as well as the process ID"
+msgstr ""
+
 msgid "List the host and all running local containers"
 msgstr ""
 
@@ -41680,6 +41686,9 @@ msgid "Output system directory"
 msgstr ""
 
 msgid "Output the build plan in JSON (unstable)"
+msgstr ""
+
+msgid "Output the command line in shell-quoted form"
 msgstr ""
 
 msgid "Output the content of specified files or URLs"

--- a/localization/po/pl.po
+++ b/localization/po/pl.po
@@ -20990,6 +20990,9 @@ msgstr ""
 msgid "Do not write anything"
 msgstr ""
 
+msgid "Do not write anything to standard output"
+msgstr ""
+
 msgid "Do not write column names in results"
 msgstr ""
 
@@ -36275,6 +36278,9 @@ msgstr ""
 msgid "List the files that are supplied by the named package"
 msgstr ""
 
+msgid "List the full command line as well as the process ID"
+msgstr ""
+
 msgid "List the host and all running local containers"
 msgstr ""
 
@@ -41673,6 +41679,9 @@ msgid "Output system directory"
 msgstr ""
 
 msgid "Output the build plan in JSON (unstable)"
+msgstr ""
+
+msgid "Output the command line in shell-quoted form"
 msgstr ""
 
 msgid "Output the content of specified files or URLs"

--- a/localization/po/pt_BR.po
+++ b/localization/po/pt_BR.po
@@ -20995,6 +20995,9 @@ msgstr ""
 msgid "Do not write anything"
 msgstr ""
 
+msgid "Do not write anything to standard output"
+msgstr ""
+
 msgid "Do not write column names in results"
 msgstr ""
 
@@ -36280,6 +36283,9 @@ msgstr ""
 msgid "List the files that are supplied by the named package"
 msgstr ""
 
+msgid "List the full command line as well as the process ID"
+msgstr ""
+
 msgid "List the host and all running local containers"
 msgstr ""
 
@@ -41678,6 +41684,9 @@ msgid "Output system directory"
 msgstr ""
 
 msgid "Output the build plan in JSON (unstable)"
+msgstr ""
+
+msgid "Output the command line in shell-quoted form"
 msgstr ""
 
 msgid "Output the content of specified files or URLs"

--- a/localization/po/sv.po
+++ b/localization/po/sv.po
@@ -20991,6 +20991,9 @@ msgstr ""
 msgid "Do not write anything"
 msgstr "Skriv ingenting"
 
+msgid "Do not write anything to standard output"
+msgstr ""
+
 msgid "Do not write column names in results"
 msgstr ""
 
@@ -36276,6 +36279,9 @@ msgstr ""
 msgid "List the files that are supplied by the named package"
 msgstr ""
 
+msgid "List the full command line as well as the process ID"
+msgstr ""
+
 msgid "List the host and all running local containers"
 msgstr ""
 
@@ -41674,6 +41680,9 @@ msgid "Output system directory"
 msgstr ""
 
 msgid "Output the build plan in JSON (unstable)"
+msgstr ""
+
+msgid "Output the command line in shell-quoted form"
 msgstr ""
 
 msgid "Output the content of specified files or URLs"

--- a/localization/po/zh_CN.po
+++ b/localization/po/zh_CN.po
@@ -21015,6 +21015,9 @@ msgstr ""
 msgid "Do not write anything"
 msgstr ""
 
+msgid "Do not write anything to standard output"
+msgstr ""
+
 msgid "Do not write column names in results"
 msgstr ""
 
@@ -36300,6 +36303,9 @@ msgstr ""
 msgid "List the files that are supplied by the named package"
 msgstr ""
 
+msgid "List the full command line as well as the process ID"
+msgstr ""
+
 msgid "List the host and all running local containers"
 msgstr ""
 
@@ -41698,6 +41704,9 @@ msgid "Output system directory"
 msgstr ""
 
 msgid "Output the build plan in JSON (unstable)"
+msgstr ""
+
+msgid "Output the command line in shell-quoted form"
 msgstr ""
 
 msgid "Output the content of specified files or URLs"

--- a/localization/po/zh_TW.po
+++ b/localization/po/zh_TW.po
@@ -20992,6 +20992,9 @@ msgstr ""
 msgid "Do not write anything"
 msgstr ""
 
+msgid "Do not write anything to standard output"
+msgstr ""
+
 msgid "Do not write column names in results"
 msgstr ""
 
@@ -36277,6 +36280,9 @@ msgstr ""
 msgid "List the files that are supplied by the named package"
 msgstr ""
 
+msgid "List the full command line as well as the process ID"
+msgstr ""
+
 msgid "List the host and all running local containers"
 msgstr ""
 
@@ -41675,6 +41681,9 @@ msgid "Output system directory"
 msgstr ""
 
 msgid "Output the build plan in JSON (unstable)"
+msgstr ""
+
+msgid "Output the command line in shell-quoted form"
 msgstr ""
 
 msgid "Output the content of specified files or URLs"

--- a/share/completions/pgrep.fish
+++ b/share/completions/pgrep.fish
@@ -1,3 +1,12 @@
 __fish_complete_pgrep pgrep
-complete -c pgrep -s d -r -d 'Output delimiter'
-complete -c pgrep -s l -d 'List the process name as well as the process ID'
+
+if pgrep --help >/dev/null 2>/dev/null
+    complete -c pgrep -s d -l delimiter -r -d 'Output delimiter'
+    complete -c pgrep -s l -l list-name -d 'List the process name as well as the process ID'
+    complete -c pgrep -s a -l list-full -d 'List the full command line as well as the process ID'
+    complete -c pgrep -s Q -l shell-quote -d 'Output the command line in shell-quoted form'
+    complete -c pgrep -l quiet -d 'Do not write anything to standard output'
+else # non GNU
+    complete -c pgrep -s d -r -d 'Output delimiter'
+    complete -c pgrep -s l -d 'List the process name as well as the process ID'
+end


### PR DESCRIPTION
- Add missing -a/–list-full, -Q/–shell-quote and –quiet, which are pgrep only;
- Add long flags for -d and -l.

---

## TODOs:
<!-- Check off what what has been done so far. -->
- [ ] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->