### PR TITLE
fs: Fix compilation with time64-enabled libc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ fluent-ftl-tools = { git = "https://codeberg.org/danielrainer/fluent-ftl-tools",
 fluent-syntax = { git = "https://github.com/danielrainer/fluent-rs", rev = "cf712bced280b217b6307edabc2089b3e57204ab" }
 ignore = "0.4.25"
 itertools = "0.14.0"
-libc = "0.2.177"
+libc = "0.2.183"
 # lru pulls in hashbrown by default, which uses a faster (though less DoS resistant) hashing algo.
 # disabling default features uses the stdlib instead, but it doubles the time to rewrite the history
 # files as of 22 April 2024.

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -326,15 +326,12 @@ where
         #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             use libc::timespec;
-            let mut time = timespec {
-                tv_sec: 0,
-                tv_nsec: 0,
-            };
+            let mut time = timespec::default();
             if unsafe { libc::clock_gettime(libc::CLOCK_REALTIME, &mut time) } == 0 {
                 let times = [
-                    timespec {
-                        tv_sec: 0,
-                        tv_nsec: libc::UTIME_OMIT, // don't change atime,
+                    libc::timespec {
+                        tv_nsec: libc::UTIME_OMIT,
+                        ..Default::default()
                     },
                     time,
                 ];


### PR DESCRIPTION
On 32-bit targets with time64 enabled in the libc crate, for example via the `CARGO_CFG_LIBC_UNSTABLE_MUSL_V1_2_3` environment variable on a 32-bit musl target, the timespec struct has a few private padding fields.

Therefore, compilation will fail when attempting to construct a timespec through struct-initialization. We can use the `Default` implementation that is available since libc 0.2.183 instead.



## TODOs:
<!-- Check off what what has been done so far. -->
- [ ] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
