### PR TITLE
fix: use command -q man in __fish_print_help

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 fish ?.?.? (released ???)
 =========================
 
+Interactive improvements
+------------------------
+- ``__fish_print_help`` now checks for the external ``man`` command with ``command -q man`` instead of ``type -q man``, so a user-defined ``man`` function no longer makes ``--help`` fail when no real ``man`` binary is installed (:issue:`12886`).
+
 fish 4.8.1 (released July 14, 2026)
 ===================================
 

--- a/share/functions/__fish_print_help.fish
+++ b/share/functions/__fish_print_help.fish
@@ -1,6 +1,6 @@
 # localization: skip(private)
 function __fish_print_help --description "Print help for the specified fish function or builtin"
-    if not type -q man
+    if not command -q man
         fish_command_not_found man
         return 1
     end


### PR DESCRIPTION
## TODOs:
- [x] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst

`__fish_print_help` used `type -q man` before calling `command man`. If a user defines a `man` function but has no external `man` binary, the type check passes and help then fails (e.g. `string --help`).

Switch to `command -q man`, same as `share/completions/man.fish`.

Fixes #12886