### PR TITLE
completions/direnv: completions for `exec <DIR> <COMMAND>`, `export`, `hook`

### DIFF
--- a/share/completions/direnv.fish
+++ b/share/completions/direnv.fish
@@ -1,6 +1,6 @@
-set -l commands allow permit grant block deny revoke edit exec export fetchurl help hook prune reload status stdlib version
+set -l commands allow permit grant block deny disallow revoke edit exec export fetchurl help hook prune reload status stdlib version
 
-set -l with_file allow permit grant block deny revoke edit
+set -l with_file allow permit grant block deny disallow revoke edit
 
 complete -c direnv -f
 complete -c direnv -n "__fish_seen_subcommand_from $with_file" -F
@@ -8,7 +8,7 @@ complete -c direnv -n "__fish_seen_subcommand_from $with_file" -F
 complete -c direnv -n "not __fish_seen_subcommand_from $commands" \
     -a "allow permit grant" -d "Grant direnv permission to load the given .envrc or .env file"
 complete -c direnv -n "not __fish_seen_subcommand_from $commands" \
-    -a "block deny revoke" -d "Revoke the authorization of a given .envrc or .env file"
+    -a "block deny disallow revoke" -d "Revoke the authorization of a given .envrc or .env file"
 complete -c direnv -n "not __fish_seen_subcommand_from $commands" \
     -a edit -d "Open given file or current .envrc/.env in \$EDITOR and allow it to be loaded afterwards"
 complete -c direnv -n "not __fish_seen_subcommand_from $commands" \

--- a/share/completions/direnv.fish
+++ b/share/completions/direnv.fish
@@ -3,6 +3,7 @@ set -l commands allow permit grant block deny revoke edit exec fetchurl help hoo
 set -l with_file allow permit grant block deny revoke edit
 
 complete -c direnv -f
+complete -c direnv -n "__fish_seen_subcommand_from $with_file" -F
 
 complete -c direnv -n "not __fish_seen_subcommand_from $commands" \
     -a "allow permit grant" -d "Grant direnv permission to load the given .envrc or .env file"
@@ -28,8 +29,6 @@ complete -c direnv -n "not __fish_seen_subcommand_from $commands" \
     -a stdlib -d "Display the stdlib available in the .envrc execution context"
 complete -c direnv -n "not __fish_seen_subcommand_from $commands" \
     -a version -d "Print the version or check that direnv is at least given version"
-
-complete -c direnv -n "__fish_seen_subcommand_from $with_file" -F
 
 # Directory completions for the dir argument of `direnv exec DIR COMMAND [...ARGS]`
 complete -c direnv -n "__fish_seen_subcommand_from exec; and test (__fish_number_of_cmd_args_wo_opts) -eq 2" \

--- a/share/completions/direnv.fish
+++ b/share/completions/direnv.fish
@@ -1,4 +1,4 @@
-set -l commands allow permit grant block deny revoke edit exec fetchurl help hook prune reload status stdlib version
+set -l commands allow permit grant block deny revoke edit exec export fetchurl help hook prune reload status stdlib version
 
 set -l with_file allow permit grant block deny revoke edit
 
@@ -13,6 +13,8 @@ complete -c direnv -n "not __fish_seen_subcommand_from $commands" \
     -a edit -d "Open given file or current .envrc/.env in \$EDITOR and allow it to be loaded afterwards"
 complete -c direnv -n "not __fish_seen_subcommand_from $commands" \
     -a exec -d "Execute a command after loading the first .envrc or .env found in DIR"
+complete -c direnv -n "not __fish_seen_subcommand_from $commands" \
+    -a export -d "Load an .envrc/.env and print the diff in terms of exports"
 complete -c direnv -n "not __fish_seen_subcommand_from $commands" \
     -a fetchurl -d "Fetch a given URL into direnv's CAS"
 complete -c direnv -n "not __fish_seen_subcommand_from $commands" \
@@ -29,6 +31,15 @@ complete -c direnv -n "not __fish_seen_subcommand_from $commands" \
     -a stdlib -d "Display the stdlib available in the .envrc execution context"
 complete -c direnv -n "not __fish_seen_subcommand_from $commands" \
     -a version -d "Print the version or check that direnv is at least given version"
+
+# List of valid shells/export formats for `direnv export` and `direnv hook` current as of direnv 2.37.1
+# The combined list is from `direnv help`; the subset accepted by `hook` was tested empirically.
+set -l shells "bash zsh fish tcsh elvish pwsh murex"
+set -l additional_export_formats "gha gzenv json vim systemd"
+complete -c direnv -n "__fish_seen_subcommand_from hook; and test (__fish_number_of_cmd_args_wo_opts) -eq 2" \
+    -a "$shells" -d Shell
+complete -c direnv -n "__fish_seen_subcommand_from export; and test (__fish_number_of_cmd_args_wo_opts) -eq 2" \
+    -a "$shells $additional_export_formats" -d "Export format"
 
 # Directory completions for the dir argument of `direnv exec DIR COMMAND [...ARGS]`
 complete -c direnv -n "__fish_seen_subcommand_from exec; and test (__fish_number_of_cmd_args_wo_opts) -eq 2" \

--- a/share/completions/direnv.fish
+++ b/share/completions/direnv.fish
@@ -30,3 +30,23 @@ complete -c direnv -n "not __fish_seen_subcommand_from $commands" \
     -a version -d "Print the version or check that direnv is at least given version"
 
 complete -c direnv -n "__fish_seen_subcommand_from $with_file" -F
+
+# Directory completions for the dir argument of `direnv exec DIR COMMAND [...ARGS]`
+complete -c direnv -n "__fish_seen_subcommand_from exec; and test (__fish_number_of_cmd_args_wo_opts) -eq 2" \
+    -a "(__fish_complete_directories)" -d "Directory to load .envrc from"
+
+# Completions for the command or the args in `direnv exec DIR COMMAND [...ARGS]`
+#
+# Complete against the PATH direnv sets up inside its environment for
+# DIR. If direnv fails (DIR doesn't exist, its .envrc isn't allowed,
+# etc.), leave PATH alone and complete against the normal environment.
+function __fish_direnv_exec_complete
+    # `exec` is the first non-option token, DIR is the second.
+    set -l dir (__fish_nth_token 2)
+    if set --path -l dpath (direnv exec $dir (__fish_posix_shell) -c 'printf %s "$PATH"' 2>/dev/null)
+        set -fx PATH $dpath
+    end
+    __fish_complete_subcommand --fcs-skip=3
+end
+complete -c direnv -n "__fish_seen_subcommand_from exec; and test (__fish_number_of_cmd_args_wo_opts) -ge 3" \
+    -xa "(__fish_direnv_exec_complete)"


### PR DESCRIPTION
direnv environments often adjust the PATH, so the commands in `direnv exec` are completed with the PATH `direnv` would set.

There are also some minor additions/cleanups.



## TODOs:
- [n/a] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [n/a] Changes to fish usage are reflected in user documentation/manpages.
- [n/a] Tests have been added for regressions fixed
- [n/a] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
