### PR TITLE
completions/ps: add macOS options

### DIFF
--- a/share/completions/ps.fish
+++ b/share/completions/ps.fish
@@ -1,8 +1,11 @@
 # Completions for ps
 
 set -l gnu_linux 0
+set -l darwin 0
 if ps -V <&- >/dev/null 2>/dev/null
     set gnu_linux 1
+else if test (uname) = Darwin && test (command -v ps) = /bin/ps
+    set darwin 1
 end
 
 # Separate out GNU/Linux-only options from BSD-compatible options
@@ -41,6 +44,29 @@ if test "$gnu_linux" -eq 1
     complete -c ps -l no-headers -d 'Print no headers'
     complete -c ps -l ppid -d "Select by parent PID" -x -a "(__fish_stripprefix='^--ppid=' __fish_complete_list , __fish_complete_pids)"
     complete -c ps -l sort -d 'Specify sort order' -r
+else if test "$darwin" -eq 1
+    complete -c ps -s A -d "Select all processes"
+    complete -c ps -s a -d "Select processes for all users with a terminal"
+    complete -c ps -s C -d "Use raw CPU calculation"
+    complete -c ps -s c -d "Show executable name instead of full command line"
+    complete -c ps -s d -d "Select all processes except session leaders"
+    complete -c ps -s E -d "Show environment"
+    complete -c ps -s e -d "Select all processes"
+    complete -c ps -s f -d "Show full format"
+    complete -c ps -s g -d "Select by process group" -x -a "(__fish_stripprefix='^-\w*g' __fish_complete_list , __fish_complete_pids)"
+    complete -c ps -s h -d "Repeat headers on each page"
+    complete -c ps -s j -d "Jobs format"
+    complete -c ps -s l -d "Long format"
+    complete -c ps -s L -d "List available columns for -O/-o"
+    complete -c ps -s M -d "Show threads"
+    complete -c ps -s m -d "Sort by memory usage"
+    complete -c ps -s r -d "Sort by CPU usage"
+    complete -c ps -s S -d "Include child process times"
+    complete -c ps -s T -d "Select processes attached to standard input"
+    complete -c ps -s u -d "Select by user" -x -a "(__fish_stripprefix='^-\w*u' __fish_complete_list , __fish_complete_users)"
+    complete -c ps -s v -d "Virtual memory format"
+    complete -c ps -s X -d "Skip processes without a controlling terminal"
+    complete -c ps -s x -d "Include processes without a controlling terminal"
 else
     # Assume BSD options otherwise
     complete -c ps -s a -d "Select processes for all users"
@@ -79,7 +105,9 @@ if test $gnu_linux -eq 0
 end
 
 complete -c ps -s o -lformat$bsd_null -d "User defined format" -x
-complete -c ps -s Z -lcontext$bsd_null -d "Include security info"
+if test "$darwin" -eq 0
+    complete -c ps -s Z -lcontext$bsd_null -d "Include security info"
+end
 complete -c ps -s t -ltty$bsd_null -d "Select by tty" -r
 complete -c ps -s G -lgroup$bsd_null -d "Select by group" -x -a "(__fish_stripprefix='^(--group=|-\w*G)' __fish_complete_list , __fish_complete_groups)"
 complete -c ps -s U -luser$bsd_null -d "Select by user" -x -a "(__fish_stripprefix='^(--user=|-\w*U)' __fish_complete_list , __fish_complete_users)"

--- a/tests/checks/completion-ps.fish
+++ b/tests/checks/completion-ps.fish
@@ -1,0 +1,23 @@
+# RUN: %fish %s
+# REQUIRES: test "$(uname)" = Darwin
+# REQUIRES: test "$(command -v ps)" = /bin/ps
+
+set -l options (complete -C 'ps -' | string replace -r '\t.*' '')
+
+for option in -A -E -g
+    contains -- $option $options
+    and echo $option
+end
+
+for option in -H -J -N -Z
+    contains -- $option $options
+    or echo "no $option"
+end
+
+# CHECK: -A
+# CHECK: -E
+# CHECK: -g
+# CHECK: no -H
+# CHECK: no -J
+# CHECK: no -N
+# CHECK: no -Z


### PR DESCRIPTION
The native macOS `ps` currently receives the FreeBSD completion set. Detect `/bin/ps` on Darwin separately and register the options documented by macOS, including `-A`, `-E`, and `-g` while excluding unsupported FreeBSD options.

Adds a macOS-only completion regression check.

Fixes #12891.

## TODOs:
- [x] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
