### PR TITLE
fix: correct non paged file previews

### DIFF
--- a/share/functions/__fish_preview_current_file.fish
+++ b/share/functions/__fish_preview_current_file.fish
@@ -28,7 +28,6 @@ function __fish_preview_current_file --description "Open the file at the cursor 
     $prefix -l files $file || return # Bail if $file does not tokenize.
 
     if set -q files[1] && test -f $files[1]
-        $pager $files
-        commandline -f repaint
+        __fish_echo $pager $files
     end
 end


### PR DESCRIPTION
the previous code worked just fine for pagers that invariably utilize the alternate buffer. but otherwise the output from the previewer would write over lines of the prompt. using `__fish_echo` means cases like plain old cat, or less with the -F (aka. --quit-if-one-screen) option (which is typically used by bat under the hood) work as well.