### PR TITLE
completion/dotslash: add completion for `dotslash`

### DIFF
--- a/localization/po/de.po
+++ b/localization/po/de.po
@@ -12267,7 +12267,13 @@ msgstr ""
 msgid "Compute the best common ancestors of all supplied commits"
 msgstr ""
 
+msgid "Compute the blake3 hash of a file"
+msgstr ""
+
 msgid "Compute the password using the given method"
+msgstr ""
+
+msgid "Compute the sha256 hash of a file"
 msgstr ""
 
 msgid "Computes public key given a private key"
@@ -15244,6 +15250,9 @@ msgid "Delete subvolumes beneath each subvolume recursively"
 msgstr ""
 
 msgid "Delete tag"
+msgstr ""
+
+msgid "Delete the cache directory"
 msgstr ""
 
 msgid "Delete the feature branch in the remote after landing it"
@@ -26457,6 +26466,9 @@ msgstr ""
 msgid "Fetch from multiple remotes"
 msgstr ""
 
+msgid "Fetch given URL, generate JSON template with size and hash filled in"
+msgstr ""
+
 msgid "Fetch history leading to the given revision"
 msgstr ""
 
@@ -26474,6 +26486,9 @@ msgstr "Quellpaket über Standardeingabe lesen"
 
 msgid "Fetch source packages"
 msgstr "Quellpakete abrufen"
+
+msgid "Fetch the artifact, print its path instead of running it"
+msgstr ""
 
 msgid "Fetches all files from SRC_URI"
 msgstr ""
@@ -42393,6 +42408,9 @@ msgstr ""
 msgid "Parsable list format"
 msgstr ""
 
+msgid "Parse a DotSlash file and print it as JSON"
+msgstr ""
+
 msgid "Parse a JJTree grammar file (*.jjt) and transform it to source files and a JavaCC grammar file"
 msgstr ""
 
@@ -46056,6 +46074,9 @@ msgstr ""
 msgid "Print the URL for the upstream"
 msgstr ""
 
+msgid "Print the cache directory"
+msgstr ""
+
 msgid "Print the command line on the standard error output before executing it"
 msgstr ""
 
@@ -46108,6 +46129,9 @@ msgid "Print the description of a key"
 msgstr ""
 
 msgid "Print the domain's hostname"
+msgstr ""
+
+msgid "Print the dotslash version"
 msgstr ""
 
 msgid "Print the dput configuration"
@@ -46600,6 +46624,9 @@ msgid "Print what is done"
 msgstr ""
 
 msgid "Print what would be done"
+msgstr ""
+
+msgid "Print where the artifact would be cached, without fetching it"
 msgstr ""
 
 msgid "Print whether the current working directory is in the .git directory"
@@ -52516,6 +52543,9 @@ msgid "Run a command with Wine-related environment variables set"
 msgstr ""
 
 msgid "Run a defined package script"
+msgstr ""
+
+msgid "Run a dotslash subcommand"
 msgstr ""
 
 msgid "Run a faster version of the benchmarks in headless mode"
@@ -66738,6 +66768,12 @@ msgstr ""
 msgid "Test if bundle has been given no subcommand"
 msgstr ""
 
+msgid "Test if completing a dotslash subcommand, immediately following a --"
+msgstr ""
+
+msgid "Test if completing the argument of any of the given subcommands"
+msgstr ""
+
 msgid "Test if given subcommand is used"
 msgstr ""
 
@@ -66772,6 +66808,9 @@ msgid "Test if snap command should have files as potential completion"
 msgstr ""
 
 msgid "Test if snap has yet to be given the subcommand"
+msgstr ""
+
+msgid "Test if the dotslash subcommand form is being used"
 msgstr ""
 
 msgid "Test if there is a subcommand given"

--- a/localization/po/es.po
+++ b/localization/po/es.po
@@ -12267,7 +12267,13 @@ msgstr ""
 msgid "Compute the best common ancestors of all supplied commits"
 msgstr ""
 
+msgid "Compute the blake3 hash of a file"
+msgstr ""
+
 msgid "Compute the password using the given method"
+msgstr ""
+
+msgid "Compute the sha256 hash of a file"
 msgstr ""
 
 msgid "Computes public key given a private key"
@@ -15244,6 +15250,9 @@ msgid "Delete subvolumes beneath each subvolume recursively"
 msgstr ""
 
 msgid "Delete tag"
+msgstr ""
+
+msgid "Delete the cache directory"
 msgstr ""
 
 msgid "Delete the feature branch in the remote after landing it"
@@ -26457,6 +26466,9 @@ msgstr ""
 msgid "Fetch from multiple remotes"
 msgstr ""
 
+msgid "Fetch given URL, generate JSON template with size and hash filled in"
+msgstr ""
+
 msgid "Fetch history leading to the given revision"
 msgstr ""
 
@@ -26473,6 +26485,9 @@ msgid "Fetch source package from STDIN"
 msgstr ""
 
 msgid "Fetch source packages"
+msgstr ""
+
+msgid "Fetch the artifact, print its path instead of running it"
 msgstr ""
 
 msgid "Fetches all files from SRC_URI"
@@ -42393,6 +42408,9 @@ msgstr ""
 msgid "Parsable list format"
 msgstr ""
 
+msgid "Parse a DotSlash file and print it as JSON"
+msgstr ""
+
 msgid "Parse a JJTree grammar file (*.jjt) and transform it to source files and a JavaCC grammar file"
 msgstr ""
 
@@ -46056,6 +46074,9 @@ msgstr ""
 msgid "Print the URL for the upstream"
 msgstr ""
 
+msgid "Print the cache directory"
+msgstr ""
+
 msgid "Print the command line on the standard error output before executing it"
 msgstr ""
 
@@ -46108,6 +46129,9 @@ msgid "Print the description of a key"
 msgstr ""
 
 msgid "Print the domain's hostname"
+msgstr ""
+
+msgid "Print the dotslash version"
 msgstr ""
 
 msgid "Print the dput configuration"
@@ -46600,6 +46624,9 @@ msgid "Print what is done"
 msgstr ""
 
 msgid "Print what would be done"
+msgstr ""
+
+msgid "Print where the artifact would be cached, without fetching it"
 msgstr ""
 
 msgid "Print whether the current working directory is in the .git directory"
@@ -52516,6 +52543,9 @@ msgid "Run a command with Wine-related environment variables set"
 msgstr ""
 
 msgid "Run a defined package script"
+msgstr ""
+
+msgid "Run a dotslash subcommand"
 msgstr ""
 
 msgid "Run a faster version of the benchmarks in headless mode"
@@ -66738,6 +66768,12 @@ msgstr ""
 msgid "Test if bundle has been given no subcommand"
 msgstr ""
 
+msgid "Test if completing a dotslash subcommand, immediately following a --"
+msgstr ""
+
+msgid "Test if completing the argument of any of the given subcommands"
+msgstr ""
+
 msgid "Test if given subcommand is used"
 msgstr ""
 
@@ -66772,6 +66808,9 @@ msgid "Test if snap command should have files as potential completion"
 msgstr ""
 
 msgid "Test if snap has yet to be given the subcommand"
+msgstr ""
+
+msgid "Test if the dotslash subcommand form is being used"
 msgstr ""
 
 msgid "Test if there is a subcommand given"

--- a/localization/po/fr.po
+++ b/localization/po/fr.po
@@ -12396,7 +12396,13 @@ msgstr ""
 msgid "Compute the best common ancestors of all supplied commits"
 msgstr ""
 
+msgid "Compute the blake3 hash of a file"
+msgstr ""
+
 msgid "Compute the password using the given method"
+msgstr ""
+
+msgid "Compute the sha256 hash of a file"
 msgstr ""
 
 msgid "Computes public key given a private key"
@@ -15373,6 +15379,9 @@ msgid "Delete subvolumes beneath each subvolume recursively"
 msgstr ""
 
 msgid "Delete tag"
+msgstr ""
+
+msgid "Delete the cache directory"
 msgstr ""
 
 msgid "Delete the feature branch in the remote after landing it"
@@ -26586,6 +26595,9 @@ msgstr "Rapatrier et fusionner depuis un autre dépôt ou une branche locale"
 msgid "Fetch from multiple remotes"
 msgstr ""
 
+msgid "Fetch given URL, generate JSON template with size and hash filled in"
+msgstr ""
+
 msgid "Fetch history leading to the given revision"
 msgstr ""
 
@@ -26603,6 +26615,9 @@ msgstr "Récupérer le paquet source depuis l’entrée standard"
 
 msgid "Fetch source packages"
 msgstr "Récupérer les paquets sources"
+
+msgid "Fetch the artifact, print its path instead of running it"
+msgstr ""
 
 msgid "Fetches all files from SRC_URI"
 msgstr ""
@@ -42522,6 +42537,9 @@ msgstr ""
 msgid "Parsable list format"
 msgstr ""
 
+msgid "Parse a DotSlash file and print it as JSON"
+msgstr ""
+
 msgid "Parse a JJTree grammar file (*.jjt) and transform it to source files and a JavaCC grammar file"
 msgstr ""
 
@@ -46185,6 +46203,9 @@ msgstr "Afficher les URI"
 msgid "Print the URL for the upstream"
 msgstr ""
 
+msgid "Print the cache directory"
+msgstr ""
+
 msgid "Print the command line on the standard error output before executing it"
 msgstr ""
 
@@ -46237,6 +46258,9 @@ msgid "Print the description of a key"
 msgstr "Afficher la description d’une clé"
 
 msgid "Print the domain's hostname"
+msgstr ""
+
+msgid "Print the dotslash version"
 msgstr ""
 
 msgid "Print the dput configuration"
@@ -46729,6 +46753,9 @@ msgid "Print what is done"
 msgstr ""
 
 msgid "Print what would be done"
+msgstr ""
+
+msgid "Print where the artifact would be cached, without fetching it"
 msgstr ""
 
 msgid "Print whether the current working directory is in the .git directory"
@@ -52645,6 +52672,9 @@ msgid "Run a command with Wine-related environment variables set"
 msgstr ""
 
 msgid "Run a defined package script"
+msgstr ""
+
+msgid "Run a dotslash subcommand"
 msgstr ""
 
 msgid "Run a faster version of the benchmarks in headless mode"
@@ -66867,6 +66897,12 @@ msgstr "Vérifier si bundle s’est fait donner une sous-commande spécifique"
 msgid "Test if bundle has been given no subcommand"
 msgstr "Vérifier si bundle ne s’est encore fait donner aucune sous-commande"
 
+msgid "Test if completing a dotslash subcommand, immediately following a --"
+msgstr ""
+
+msgid "Test if completing the argument of any of the given subcommands"
+msgstr ""
+
 msgid "Test if given subcommand is used"
 msgstr "Vérifier si la sous-commande spécifiée est utilisée"
 
@@ -66901,6 +66937,9 @@ msgid "Test if snap command should have files as potential completion"
 msgstr ""
 
 msgid "Test if snap has yet to be given the subcommand"
+msgstr ""
+
+msgid "Test if the dotslash subcommand form is being used"
 msgstr ""
 
 msgid "Test if there is a subcommand given"

--- a/localization/po/ja_JP.po
+++ b/localization/po/ja_JP.po
@@ -12270,7 +12270,13 @@ msgstr ""
 msgid "Compute the best common ancestors of all supplied commits"
 msgstr ""
 
+msgid "Compute the blake3 hash of a file"
+msgstr ""
+
 msgid "Compute the password using the given method"
+msgstr ""
+
+msgid "Compute the sha256 hash of a file"
 msgstr ""
 
 msgid "Computes public key given a private key"
@@ -15247,6 +15253,9 @@ msgid "Delete subvolumes beneath each subvolume recursively"
 msgstr ""
 
 msgid "Delete tag"
+msgstr ""
+
+msgid "Delete the cache directory"
 msgstr ""
 
 msgid "Delete the feature branch in the remote after landing it"
@@ -26460,6 +26469,9 @@ msgstr ""
 msgid "Fetch from multiple remotes"
 msgstr ""
 
+msgid "Fetch given URL, generate JSON template with size and hash filled in"
+msgstr ""
+
 msgid "Fetch history leading to the given revision"
 msgstr ""
 
@@ -26476,6 +26488,9 @@ msgid "Fetch source package from STDIN"
 msgstr ""
 
 msgid "Fetch source packages"
+msgstr ""
+
+msgid "Fetch the artifact, print its path instead of running it"
 msgstr ""
 
 msgid "Fetches all files from SRC_URI"
@@ -42396,6 +42411,9 @@ msgstr ""
 msgid "Parsable list format"
 msgstr ""
 
+msgid "Parse a DotSlash file and print it as JSON"
+msgstr ""
+
 msgid "Parse a JJTree grammar file (*.jjt) and transform it to source files and a JavaCC grammar file"
 msgstr ""
 
@@ -46059,6 +46077,9 @@ msgstr ""
 msgid "Print the URL for the upstream"
 msgstr ""
 
+msgid "Print the cache directory"
+msgstr ""
+
 msgid "Print the command line on the standard error output before executing it"
 msgstr ""
 
@@ -46111,6 +46132,9 @@ msgid "Print the description of a key"
 msgstr ""
 
 msgid "Print the domain's hostname"
+msgstr ""
+
+msgid "Print the dotslash version"
 msgstr ""
 
 msgid "Print the dput configuration"
@@ -46603,6 +46627,9 @@ msgid "Print what is done"
 msgstr ""
 
 msgid "Print what would be done"
+msgstr ""
+
+msgid "Print where the artifact would be cached, without fetching it"
 msgstr ""
 
 msgid "Print whether the current working directory is in the .git directory"
@@ -52519,6 +52546,9 @@ msgid "Run a command with Wine-related environment variables set"
 msgstr ""
 
 msgid "Run a defined package script"
+msgstr ""
+
+msgid "Run a dotslash subcommand"
 msgstr ""
 
 msgid "Run a faster version of the benchmarks in headless mode"
@@ -66741,6 +66771,12 @@ msgstr ""
 msgid "Test if bundle has been given no subcommand"
 msgstr ""
 
+msgid "Test if completing a dotslash subcommand, immediately following a --"
+msgstr ""
+
+msgid "Test if completing the argument of any of the given subcommands"
+msgstr ""
+
 msgid "Test if given subcommand is used"
 msgstr ""
 
@@ -66775,6 +66811,9 @@ msgid "Test if snap command should have files as potential completion"
 msgstr ""
 
 msgid "Test if snap has yet to be given the subcommand"
+msgstr ""
+
+msgid "Test if the dotslash subcommand form is being used"
 msgstr ""
 
 msgid "Test if there is a subcommand given"

--- a/localization/po/pl.po
+++ b/localization/po/pl.po
@@ -12263,7 +12263,13 @@ msgstr ""
 msgid "Compute the best common ancestors of all supplied commits"
 msgstr ""
 
+msgid "Compute the blake3 hash of a file"
+msgstr ""
+
 msgid "Compute the password using the given method"
+msgstr ""
+
+msgid "Compute the sha256 hash of a file"
 msgstr ""
 
 msgid "Computes public key given a private key"
@@ -15240,6 +15246,9 @@ msgid "Delete subvolumes beneath each subvolume recursively"
 msgstr ""
 
 msgid "Delete tag"
+msgstr ""
+
+msgid "Delete the cache directory"
 msgstr ""
 
 msgid "Delete the feature branch in the remote after landing it"
@@ -26453,6 +26462,9 @@ msgstr ""
 msgid "Fetch from multiple remotes"
 msgstr ""
 
+msgid "Fetch given URL, generate JSON template with size and hash filled in"
+msgstr ""
+
 msgid "Fetch history leading to the given revision"
 msgstr ""
 
@@ -26469,6 +26481,9 @@ msgid "Fetch source package from STDIN"
 msgstr ""
 
 msgid "Fetch source packages"
+msgstr ""
+
+msgid "Fetch the artifact, print its path instead of running it"
 msgstr ""
 
 msgid "Fetches all files from SRC_URI"
@@ -42389,6 +42404,9 @@ msgstr ""
 msgid "Parsable list format"
 msgstr ""
 
+msgid "Parse a DotSlash file and print it as JSON"
+msgstr ""
+
 msgid "Parse a JJTree grammar file (*.jjt) and transform it to source files and a JavaCC grammar file"
 msgstr ""
 
@@ -46052,6 +46070,9 @@ msgstr ""
 msgid "Print the URL for the upstream"
 msgstr ""
 
+msgid "Print the cache directory"
+msgstr ""
+
 msgid "Print the command line on the standard error output before executing it"
 msgstr ""
 
@@ -46104,6 +46125,9 @@ msgid "Print the description of a key"
 msgstr ""
 
 msgid "Print the domain's hostname"
+msgstr ""
+
+msgid "Print the dotslash version"
 msgstr ""
 
 msgid "Print the dput configuration"
@@ -46596,6 +46620,9 @@ msgid "Print what is done"
 msgstr ""
 
 msgid "Print what would be done"
+msgstr ""
+
+msgid "Print where the artifact would be cached, without fetching it"
 msgstr ""
 
 msgid "Print whether the current working directory is in the .git directory"
@@ -52512,6 +52539,9 @@ msgid "Run a command with Wine-related environment variables set"
 msgstr ""
 
 msgid "Run a defined package script"
+msgstr ""
+
+msgid "Run a dotslash subcommand"
 msgstr ""
 
 msgid "Run a faster version of the benchmarks in headless mode"
@@ -66734,6 +66764,12 @@ msgstr ""
 msgid "Test if bundle has been given no subcommand"
 msgstr ""
 
+msgid "Test if completing a dotslash subcommand, immediately following a --"
+msgstr ""
+
+msgid "Test if completing the argument of any of the given subcommands"
+msgstr ""
+
 msgid "Test if given subcommand is used"
 msgstr ""
 
@@ -66768,6 +66804,9 @@ msgid "Test if snap command should have files as potential completion"
 msgstr ""
 
 msgid "Test if snap has yet to be given the subcommand"
+msgstr ""
+
+msgid "Test if the dotslash subcommand form is being used"
 msgstr ""
 
 msgid "Test if there is a subcommand given"

--- a/localization/po/pt_BR.po
+++ b/localization/po/pt_BR.po
@@ -12268,7 +12268,13 @@ msgstr ""
 msgid "Compute the best common ancestors of all supplied commits"
 msgstr ""
 
+msgid "Compute the blake3 hash of a file"
+msgstr ""
+
 msgid "Compute the password using the given method"
+msgstr ""
+
+msgid "Compute the sha256 hash of a file"
 msgstr ""
 
 msgid "Computes public key given a private key"
@@ -15245,6 +15251,9 @@ msgid "Delete subvolumes beneath each subvolume recursively"
 msgstr ""
 
 msgid "Delete tag"
+msgstr ""
+
+msgid "Delete the cache directory"
 msgstr ""
 
 msgid "Delete the feature branch in the remote after landing it"
@@ -26458,6 +26467,9 @@ msgstr ""
 msgid "Fetch from multiple remotes"
 msgstr ""
 
+msgid "Fetch given URL, generate JSON template with size and hash filled in"
+msgstr ""
+
 msgid "Fetch history leading to the given revision"
 msgstr ""
 
@@ -26474,6 +26486,9 @@ msgid "Fetch source package from STDIN"
 msgstr ""
 
 msgid "Fetch source packages"
+msgstr ""
+
+msgid "Fetch the artifact, print its path instead of running it"
 msgstr ""
 
 msgid "Fetches all files from SRC_URI"
@@ -42394,6 +42409,9 @@ msgstr ""
 msgid "Parsable list format"
 msgstr ""
 
+msgid "Parse a DotSlash file and print it as JSON"
+msgstr ""
+
 msgid "Parse a JJTree grammar file (*.jjt) and transform it to source files and a JavaCC grammar file"
 msgstr ""
 
@@ -46057,6 +46075,9 @@ msgstr ""
 msgid "Print the URL for the upstream"
 msgstr ""
 
+msgid "Print the cache directory"
+msgstr ""
+
 msgid "Print the command line on the standard error output before executing it"
 msgstr "Print the command line on the standard error output before executing it"
 
@@ -46109,6 +46130,9 @@ msgid "Print the description of a key"
 msgstr ""
 
 msgid "Print the domain's hostname"
+msgstr ""
+
+msgid "Print the dotslash version"
 msgstr ""
 
 msgid "Print the dput configuration"
@@ -46601,6 +46625,9 @@ msgid "Print what is done"
 msgstr ""
 
 msgid "Print what would be done"
+msgstr ""
+
+msgid "Print where the artifact would be cached, without fetching it"
 msgstr ""
 
 msgid "Print whether the current working directory is in the .git directory"
@@ -52517,6 +52544,9 @@ msgid "Run a command with Wine-related environment variables set"
 msgstr ""
 
 msgid "Run a defined package script"
+msgstr ""
+
+msgid "Run a dotslash subcommand"
 msgstr ""
 
 msgid "Run a faster version of the benchmarks in headless mode"
@@ -66739,6 +66769,12 @@ msgstr ""
 msgid "Test if bundle has been given no subcommand"
 msgstr ""
 
+msgid "Test if completing a dotslash subcommand, immediately following a --"
+msgstr ""
+
+msgid "Test if completing the argument of any of the given subcommands"
+msgstr ""
+
 msgid "Test if given subcommand is used"
 msgstr ""
 
@@ -66773,6 +66809,9 @@ msgid "Test if snap command should have files as potential completion"
 msgstr ""
 
 msgid "Test if snap has yet to be given the subcommand"
+msgstr ""
+
+msgid "Test if the dotslash subcommand form is being used"
 msgstr ""
 
 msgid "Test if there is a subcommand given"

--- a/localization/po/sv.po
+++ b/localization/po/sv.po
@@ -12264,7 +12264,13 @@ msgstr ""
 msgid "Compute the best common ancestors of all supplied commits"
 msgstr ""
 
+msgid "Compute the blake3 hash of a file"
+msgstr ""
+
 msgid "Compute the password using the given method"
+msgstr ""
+
+msgid "Compute the sha256 hash of a file"
 msgstr ""
 
 msgid "Computes public key given a private key"
@@ -15241,6 +15247,9 @@ msgid "Delete subvolumes beneath each subvolume recursively"
 msgstr ""
 
 msgid "Delete tag"
+msgstr ""
+
+msgid "Delete the cache directory"
 msgstr ""
 
 msgid "Delete the feature branch in the remote after landing it"
@@ -26454,6 +26463,9 @@ msgstr ""
 msgid "Fetch from multiple remotes"
 msgstr ""
 
+msgid "Fetch given URL, generate JSON template with size and hash filled in"
+msgstr ""
+
 msgid "Fetch history leading to the given revision"
 msgstr ""
 
@@ -26471,6 +26483,9 @@ msgstr "Hämta källkodspaket från standard in"
 
 msgid "Fetch source packages"
 msgstr "Hämta källkodspaket"
+
+msgid "Fetch the artifact, print its path instead of running it"
+msgstr ""
 
 msgid "Fetches all files from SRC_URI"
 msgstr ""
@@ -42390,6 +42405,9 @@ msgstr ""
 msgid "Parsable list format"
 msgstr ""
 
+msgid "Parse a DotSlash file and print it as JSON"
+msgstr ""
+
 msgid "Parse a JJTree grammar file (*.jjt) and transform it to source files and a JavaCC grammar file"
 msgstr ""
 
@@ -46053,6 +46071,9 @@ msgstr ""
 msgid "Print the URL for the upstream"
 msgstr ""
 
+msgid "Print the cache directory"
+msgstr ""
+
 msgid "Print the command line on the standard error output before executing it"
 msgstr "Skriv ut kommandoraden på standard fel före exekvering"
 
@@ -46105,6 +46126,9 @@ msgid "Print the description of a key"
 msgstr ""
 
 msgid "Print the domain's hostname"
+msgstr ""
+
+msgid "Print the dotslash version"
 msgstr ""
 
 msgid "Print the dput configuration"
@@ -46597,6 +46621,9 @@ msgid "Print what is done"
 msgstr ""
 
 msgid "Print what would be done"
+msgstr ""
+
+msgid "Print where the artifact would be cached, without fetching it"
 msgstr ""
 
 msgid "Print whether the current working directory is in the .git directory"
@@ -52513,6 +52540,9 @@ msgid "Run a command with Wine-related environment variables set"
 msgstr ""
 
 msgid "Run a defined package script"
+msgstr ""
+
+msgid "Run a dotslash subcommand"
 msgstr ""
 
 msgid "Run a faster version of the benchmarks in headless mode"
@@ -66735,6 +66765,12 @@ msgstr ""
 msgid "Test if bundle has been given no subcommand"
 msgstr ""
 
+msgid "Test if completing a dotslash subcommand, immediately following a --"
+msgstr ""
+
+msgid "Test if completing the argument of any of the given subcommands"
+msgstr ""
+
 msgid "Test if given subcommand is used"
 msgstr ""
 
@@ -66769,6 +66805,9 @@ msgid "Test if snap command should have files as potential completion"
 msgstr ""
 
 msgid "Test if snap has yet to be given the subcommand"
+msgstr ""
+
+msgid "Test if the dotslash subcommand form is being used"
 msgstr ""
 
 msgid "Test if there is a subcommand given"

--- a/localization/po/zh_CN.po
+++ b/localization/po/zh_CN.po
@@ -12288,7 +12288,13 @@ msgstr ""
 msgid "Compute the best common ancestors of all supplied commits"
 msgstr ""
 
+msgid "Compute the blake3 hash of a file"
+msgstr ""
+
 msgid "Compute the password using the given method"
+msgstr ""
+
+msgid "Compute the sha256 hash of a file"
 msgstr ""
 
 msgid "Computes public key given a private key"
@@ -15265,6 +15271,9 @@ msgid "Delete subvolumes beneath each subvolume recursively"
 msgstr ""
 
 msgid "Delete tag"
+msgstr ""
+
+msgid "Delete the cache directory"
 msgstr ""
 
 msgid "Delete the feature branch in the remote after landing it"
@@ -26478,6 +26487,9 @@ msgstr ""
 msgid "Fetch from multiple remotes"
 msgstr ""
 
+msgid "Fetch given URL, generate JSON template with size and hash filled in"
+msgstr ""
+
 msgid "Fetch history leading to the given revision"
 msgstr ""
 
@@ -26494,6 +26506,9 @@ msgid "Fetch source package from STDIN"
 msgstr ""
 
 msgid "Fetch source packages"
+msgstr ""
+
+msgid "Fetch the artifact, print its path instead of running it"
 msgstr ""
 
 msgid "Fetches all files from SRC_URI"
@@ -42414,6 +42429,9 @@ msgstr ""
 msgid "Parsable list format"
 msgstr ""
 
+msgid "Parse a DotSlash file and print it as JSON"
+msgstr ""
+
 msgid "Parse a JJTree grammar file (*.jjt) and transform it to source files and a JavaCC grammar file"
 msgstr ""
 
@@ -46077,6 +46095,9 @@ msgstr ""
 msgid "Print the URL for the upstream"
 msgstr ""
 
+msgid "Print the cache directory"
+msgstr ""
+
 msgid "Print the command line on the standard error output before executing it"
 msgstr ""
 
@@ -46129,6 +46150,9 @@ msgid "Print the description of a key"
 msgstr ""
 
 msgid "Print the domain's hostname"
+msgstr ""
+
+msgid "Print the dotslash version"
 msgstr ""
 
 msgid "Print the dput configuration"
@@ -46621,6 +46645,9 @@ msgid "Print what is done"
 msgstr ""
 
 msgid "Print what would be done"
+msgstr ""
+
+msgid "Print where the artifact would be cached, without fetching it"
 msgstr ""
 
 msgid "Print whether the current working directory is in the .git directory"
@@ -52537,6 +52564,9 @@ msgid "Run a command with Wine-related environment variables set"
 msgstr ""
 
 msgid "Run a defined package script"
+msgstr ""
+
+msgid "Run a dotslash subcommand"
 msgstr ""
 
 msgid "Run a faster version of the benchmarks in headless mode"
@@ -66759,6 +66789,12 @@ msgstr ""
 msgid "Test if bundle has been given no subcommand"
 msgstr ""
 
+msgid "Test if completing a dotslash subcommand, immediately following a --"
+msgstr ""
+
+msgid "Test if completing the argument of any of the given subcommands"
+msgstr ""
+
 msgid "Test if given subcommand is used"
 msgstr ""
 
@@ -66793,6 +66829,9 @@ msgid "Test if snap command should have files as potential completion"
 msgstr ""
 
 msgid "Test if snap has yet to be given the subcommand"
+msgstr ""
+
+msgid "Test if the dotslash subcommand form is being used"
 msgstr ""
 
 msgid "Test if there is a subcommand given"

--- a/localization/po/zh_TW.po
+++ b/localization/po/zh_TW.po
@@ -12265,7 +12265,13 @@ msgstr ""
 msgid "Compute the best common ancestors of all supplied commits"
 msgstr ""
 
+msgid "Compute the blake3 hash of a file"
+msgstr ""
+
 msgid "Compute the password using the given method"
+msgstr ""
+
+msgid "Compute the sha256 hash of a file"
 msgstr ""
 
 msgid "Computes public key given a private key"
@@ -15242,6 +15248,9 @@ msgid "Delete subvolumes beneath each subvolume recursively"
 msgstr ""
 
 msgid "Delete tag"
+msgstr ""
+
+msgid "Delete the cache directory"
 msgstr ""
 
 msgid "Delete the feature branch in the remote after landing it"
@@ -26455,6 +26464,9 @@ msgstr ""
 msgid "Fetch from multiple remotes"
 msgstr ""
 
+msgid "Fetch given URL, generate JSON template with size and hash filled in"
+msgstr ""
+
 msgid "Fetch history leading to the given revision"
 msgstr ""
 
@@ -26471,6 +26483,9 @@ msgid "Fetch source package from STDIN"
 msgstr ""
 
 msgid "Fetch source packages"
+msgstr ""
+
+msgid "Fetch the artifact, print its path instead of running it"
 msgstr ""
 
 msgid "Fetches all files from SRC_URI"
@@ -42391,6 +42406,9 @@ msgstr ""
 msgid "Parsable list format"
 msgstr ""
 
+msgid "Parse a DotSlash file and print it as JSON"
+msgstr ""
+
 msgid "Parse a JJTree grammar file (*.jjt) and transform it to source files and a JavaCC grammar file"
 msgstr ""
 
@@ -46054,6 +46072,9 @@ msgstr ""
 msgid "Print the URL for the upstream"
 msgstr ""
 
+msgid "Print the cache directory"
+msgstr ""
+
 msgid "Print the command line on the standard error output before executing it"
 msgstr ""
 
@@ -46106,6 +46127,9 @@ msgid "Print the description of a key"
 msgstr ""
 
 msgid "Print the domain's hostname"
+msgstr ""
+
+msgid "Print the dotslash version"
 msgstr ""
 
 msgid "Print the dput configuration"
@@ -46598,6 +46622,9 @@ msgid "Print what is done"
 msgstr ""
 
 msgid "Print what would be done"
+msgstr ""
+
+msgid "Print where the artifact would be cached, without fetching it"
 msgstr ""
 
 msgid "Print whether the current working directory is in the .git directory"
@@ -52514,6 +52541,9 @@ msgid "Run a command with Wine-related environment variables set"
 msgstr ""
 
 msgid "Run a defined package script"
+msgstr ""
+
+msgid "Run a dotslash subcommand"
 msgstr ""
 
 msgid "Run a faster version of the benchmarks in headless mode"
@@ -66736,6 +66766,12 @@ msgstr ""
 msgid "Test if bundle has been given no subcommand"
 msgstr ""
 
+msgid "Test if completing a dotslash subcommand, immediately following a --"
+msgstr ""
+
+msgid "Test if completing the argument of any of the given subcommands"
+msgstr ""
+
 msgid "Test if given subcommand is used"
 msgstr ""
 
@@ -66770,6 +66806,9 @@ msgid "Test if snap command should have files as potential completion"
 msgstr ""
 
 msgid "Test if snap has yet to be given the subcommand"
+msgstr ""
+
+msgid "Test if the dotslash subcommand form is being used"
 msgstr ""
 
 msgid "Test if there is a subcommand given"

--- a/share/completions/dotslash.fish
+++ b/share/completions/dotslash.fish
@@ -1,0 +1,64 @@
+# DotSlash, https://dotslash-cli.com/
+#
+# DotSlash has an unusual CLI syntax. There are four possible kinds
+# of invocations:
+#    dotslash DOTSLASH_FILE [OPTIONS...]
+#    dotslash --help
+#    dotslash --version
+#    dotslash -- DOTSLASH_SUBCOMMAND [ARG]
+#
+# For the first of these, we leave fish's default file completion to
+# complete the DOTSLASH_FILE.  We don't attempt to deal with [OPTIONS...];
+# invocations that need those usually happen from a shebang rather than
+# from the command line.
+#
+# The remaining three kinds of invocations:
+complete -c dotslash -n __fish_is_first_arg -l help -d "Print usage"
+complete -c dotslash -n __fish_is_first_arg -l version -d "Print the dotslash version"
+complete -c dotslash -n __fish_is_first_arg -a -- -d "Run a dotslash subcommand"
+
+# The rest of the completions are dedicated to completing various
+# dotslash subcommands.
+
+function __fish_dotslash_needs_subcommand -d "Test if completing a dotslash subcommand, immediately following a --"
+    set -l tokens (commandline -pxc)
+    test (count $tokens) -eq 2; and test "$tokens[2]" = --
+end
+
+function __fish_dotslash_after_dashdash -d "Test if the dotslash subcommand form is being used"
+    set -l tokens (commandline -pxc)
+    test (count $tokens) -ge 2; and test "$tokens[2]" = --
+end
+
+function __fish_dotslash_arg_of_these_subcommands -d "Test if completing the argument of any of the given subcommands"
+    set -l tokens (commandline -pxc)
+    test (count $tokens) -eq 3
+    and test "$tokens[2]" = --
+    and contains -- $tokens[3] $argv
+end
+
+# Nothing after `dotslash --` is a file unless a subcommand below says so.
+complete -c dotslash -f -n __fish_dotslash_after_dashdash
+
+# Subcommands current as of DotSlash 0.5.9.
+complete -c dotslash -n __fish_dotslash_needs_subcommand -a b3sum -d "Compute the blake3 hash of a file"
+complete -c dotslash -n __fish_dotslash_needs_subcommand -a cache-dir -d "Print the cache directory"
+complete -c dotslash -n __fish_dotslash_needs_subcommand -a clean -d "Delete the cache directory"
+complete -c dotslash -n __fish_dotslash_needs_subcommand -a create-url-entry -d "Fetch given URL, generate JSON template with size and hash filled in"
+complete -c dotslash -n __fish_dotslash_needs_subcommand -a fetch -d "Fetch the artifact, print its path instead of running it"
+complete -c dotslash -n __fish_dotslash_needs_subcommand -a get-extracted-cache-path -d "Print where the artifact would be cached, without fetching it"
+complete -c dotslash -n __fish_dotslash_needs_subcommand -a parse -d "Parse a DotSlash file and print it as JSON"
+complete -c dotslash -n __fish_dotslash_needs_subcommand -a sha256 -d "Compute the sha256 hash of a file"
+
+# `version` and `help` commands are undocumented but work; `-- help` is the same as `--help`.
+complete -c dotslash -n __fish_dotslash_needs_subcommand -a help -d "Print usage"
+complete -c dotslash -n __fish_dotslash_needs_subcommand -a version -d "Print the dotslash version"
+
+# fetch, get-extracted-cache-path and parse take a DotSlash file; b3sum and
+# sha256 hash any file at all.
+set -l subcommands_taking_a_path b3sum fetch get-extracted-cache-path parse sha256
+complete -c dotslash -F -n "__fish_dotslash_arg_of_these_subcommands $subcommands_taking_a_path"
+
+# create-url-entry takes a URL, where we can't provide useful completions,
+# and the remaining subcommands take no arguments at all. So, nothing more to
+# do for those.


### PR DESCRIPTION
Dotslash is an odd duck among CLIs: a person rarely uses the `dotslash FILE` invokation; if they are typing `dotslash` they are probably reaching for `--version` or one of the `--` commands.

<https://dotslash-cli.com>

For reference,

```console
$ dotslash --help
usage: dotslash DOTSLASH_FILE [OPTIONS]

DOTSLASH_FILE must be a file that starts with `#!/usr/bin/env dotslash`
and contains a JSON body tells DotSlash how to fetch and run the
executable
that DOTSLASH_FILE represents.

All OPTIONS will be forwarded directly to the executable identified by
DOTSLASH_FILE.

Supported platform: macos-aarch64

Your DotSlash cache is: /opt/cache/dotslash

dotslash also has these special experimental commands:
  dotslash --help                   Print this message
  dotslash --version                Print the version of dotslash
  dotslash -- b3sum FILE            Compute blake3 hash
  dotslash -- clean                 Clean dotslash cache
  dotslash -- create-url-entry URL  Generate "http" provider entry
  dotslash -- cache-dir             Print path to the cache directory
  dotslash -- fetch DOTSLASH_FILE   Prepare for execution, but print exe path
                                    instead of executing
  dotslash -- get-extracted-cache-path DOTSLASH_FILE
                                    Print the path to the extracted artifact in
                                    the cache without running the binary
  dotslash -- parse DOTSLASH_FILE   Parse the dotslash file
  dotslash -- sha256 FILE           Compute sha256 sum of the file

Learn more at https://dotslash-cli.com

$ dotslash --version
DotSlash 0.5.9
```



## TODOs:
<!-- Check off what what has been done so far. -->
- [n/a] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [n/a] Changes to fish usage are reflected in user documentation/manpages.
- [n/a] Tests have been added for regressions fixed
- [n/a] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
