### PR TITLE
wildcard: avoid stat()-ing non-matching symlinks during completion

### DIFF
--- a/src/wildcard.rs
+++ b/src/wildcard.rs
@@ -328,7 +328,15 @@ fn wildcard_test_flags_then_complete(
     // and we don't need to do anything else, just return it.
     // This is a common case for cd completions, and removes the `stat` entirely in case the system
     // supports it.
-    if entry.is_dir() && !executables_only && !expand_flags.contains(ExpandFlags::GEN_DESCRIPTIONS)
+    //
+    // Use is_dir_fast() rather than is_dir() here: for a symlink, d_type can't tell us the target's
+    // type, so is_dir() would fall back to a stat() that follows the link. That can be arbitrarily
+    // slow (e.g. a autofs, dead network mount, FUSE, or such), and even in the typical case costs
+    // extra lookups in some different tree, so we don't want to pay that cost before even checking
+    // whether the name matches what's being completed below.
+    if entry.is_dir_fast() == Some(true)
+        && !executables_only
+        && !expand_flags.contains(ExpandFlags::GEN_DESCRIPTIONS)
     {
         return wildcard_complete(
             &(filename.to_owned() + L!("/")),

--- a/src/wutil/dir_iter.rs
+++ b/src/wutil/dir_iter.rs
@@ -68,6 +68,13 @@ impl DirEntry {
         self.check_type() == Some(DirEntryType::Dir)
     }
 
+    /// Return whether this is a directory, if that's already known. None means we don't know
+    /// yet (e.g. this is a symlink, whose target type can only be learned by following it,
+    /// i.e. calling stat()).
+    pub fn is_dir_fast(&self) -> Option<bool> {
+        self.typ.get().map(|t| t == DirEntryType::Dir)
+    }
+
     /// Return false if we know this can't be a link via d_type, true if it could be.
     pub fn is_possible_link(&self) -> Option<bool> {
         self.possible_link
@@ -480,5 +487,44 @@ mod tests {
             );
         }
         assert_eq!(seen, names.len());
+    }
+
+    #[test]
+    fn test_is_dir_fast() {
+        // is_dir_fast() must not require a stat(): for a symlink it should report None
+        // (unknown) until something else (e.g. is_dir()) has resolved and cached the type.
+        // This is the property completion code relies on to avoid following symlinks that
+        // point at something slow (e.g. a stalled network mount) unless it actually has to.
+        let temp_dir = fish_tempfile::new_dir().unwrap();
+        let basepath = WString::from(temp_dir.path().to_str().unwrap());
+        let makepath = |s: &str| -> PathBuf { temp_dir.path().join(s) };
+
+        nix::unistd::mkdir(&makepath("dir"), Mode::from_bits(0o700).unwrap()).unwrap();
+        File::create(makepath("reg")).unwrap();
+        #[cfg(not(cygwin))]
+        {
+            use std::os::unix::fs::symlink;
+            symlink(makepath("dir"), makepath("dirlink")).unwrap();
+            symlink(makepath("reg"), makepath("reglink")).unwrap();
+        }
+
+        let mut iter = DirIter::new(&basepath).expect("Should be able to open directory");
+        while let Some(entry) = iter.next() {
+            let entry = entry.expect("Should not have gotten error");
+            match entry.name.to_string().as_str() {
+                "dir" => assert_eq!(entry.is_dir_fast(), Some(true)),
+                "reg" => assert_eq!(entry.is_dir_fast(), Some(false)),
+                #[cfg(not(cygwin))]
+                name @ ("dirlink" | "reglink") => {
+                    // Unknown before we've resolved the symlink...
+                    assert_eq!(entry.is_dir_fast(), None);
+                    // ...and correctly known, without a further stat(), once we have.
+                    let expected = name == "dirlink";
+                    assert_eq!(entry.is_dir(), expected);
+                    assert_eq!(entry.is_dir_fast(), Some(expected));
+                }
+                other => panic!("Unexpected entry {other}"),
+            }
+        }
     }
 }


### PR DESCRIPTION
wildcard_test_flags_then_complete() called entry.is_dir() as its very first check for every directory entry, before checking whether the name even matched what was being completed. For a symlink, is_dir() falls back to a stat() that follows the link, which can block indefinitely if the target is slow or unreachable (e.g. a stalled sshfs/FUSE mount). This meant any symlink in a directory being completed could hang tab completion, even for entries with completely unrelated names.

Add DirEntry::is_dir_fast(), which reports directory-ness only when already known from readdir()'s d_type (None for symlinks), and use it for the fast-path check instead. The cheap name-match check now always runs first; only entries that actually match pay for a stat().



## TODOs:
<!-- Check off what what has been done so far. -->
- [x] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
