### PR TITLE
is_potential_path: avoid allocation + use earlier return

### DIFF
--- a/src/highlight/file_tester.rs
+++ b/src/highlight/file_tester.rs
@@ -242,33 +242,32 @@ fn is_potential_path(
     }
 
     let require_dir = flags.require_dir;
-    let mut clean_potential_path_fragment = WString::new();
-    let mut has_magic = false;
 
-    let mut path_with_magic = potential_path_fragment.to_owned();
+    let mut path_fragment = potential_path_fragment.to_owned();
     if flags.expand_tilde {
-        expand_tilde(&mut path_with_magic, ctx.vars());
+        expand_tilde(&mut path_fragment, ctx.vars());
     }
 
-    for c in path_with_magic.chars() {
-        match c {
-            PROCESS_EXPAND_SELF
-            | VARIABLE_EXPAND
-            | VARIABLE_EXPAND_SINGLE
-            | BRACE_BEGIN
-            | BRACE_END
-            | BRACE_SEP
-            | ANY_CHAR
-            | ANY_STRING
-            | ANY_STRING_RECURSIVE => {
-                has_magic = true;
-            }
-            INTERNAL_SEPARATOR => (),
-            _ => clean_potential_path_fragment.push(c),
-        }
+    if path_fragment.chars().any(|c| {
+        [
+            PROCESS_EXPAND_SELF,
+            VARIABLE_EXPAND,
+            VARIABLE_EXPAND_SINGLE,
+            BRACE_BEGIN,
+            BRACE_END,
+            BRACE_SEP,
+            ANY_CHAR,
+            ANY_STRING,
+            ANY_STRING_RECURSIVE,
+        ]
+        .contains(&c)
+    }) {
+        // It has magic, we don't know what the real fragment is
+        return false;
     }
+    path_fragment.retain(|c| c != INTERNAL_SEPARATOR);
 
-    if has_magic || clean_potential_path_fragment.is_empty() {
+    if path_fragment.is_empty() {
         return false;
     }
 
@@ -284,7 +283,7 @@ fn is_potential_path(
         if ctx.check_cancel() {
             return false;
         }
-        let mut abs_path = path_apply_working_directory(&clean_potential_path_fragment, wd);
+        let mut abs_path = path_apply_working_directory(&path_fragment, wd);
         let must_be_full_dir = abs_path.chars().next_back() == Some('/');
         if flags.for_cd {
             abs_path = normalize_path(&abs_path, /*allow_leading_double_slashes=*/ true);


### PR DESCRIPTION
This change removes a memory allocation and can return more quickly. Maybe a tad more idiomatic as well.

However given the I/O and other memory allocations, I don't know if it's worth it. So I'm pushing it as a PR for a 2nd opinion.