### PR TITLE
__fish_complete_path: preserve equals signs in prefixes

### DIFF
--- a/share/functions/__fish_complete_path.fish
+++ b/share/functions/__fish_complete_path.fish
@@ -11,7 +11,9 @@ function __fish_complete_path --description "Complete using path"
             set target "$argv[1]"
             set description "$argv[2]"
     end
-    set -l targets (complete -C"'' $target")
+    # Prevent `complete` from treating `=` as an option or assignment delimiter.
+    set -l completion_target (string replace -a = '\=' -- "$target")
+    set -l targets (complete -C"'' $completion_target")
     if set -q targets[1]
         printf "%s\n" $targets\t"$description"
     end

--- a/tests/checks/complete_path.fish
+++ b/tests/checks/complete_path.fish
@@ -1,0 +1,18 @@
+#RUN: %fish --interactive %s
+
+mkdir -p __fish_complete_path
+cd __fish_complete_path
+touch foo
+touch -- --bar
+
+__fish_complete_path --bar
+# CHECK: --bar{{\t}}
+
+__fish_complete_path --bar=
+
+touch -- --bar=baz
+__fish_complete_path --bar=
+# CHECK: --bar=baz{{\t}}
+
+echo done
+# CHECK: done


### PR DESCRIPTION
## Description

`__fish_complete_path --bar=` currently treats the equals sign as an option or assignment delimiter, then offers unrelated files with `--bar=` prepended. This escapes the equals sign only in the synthetic command line passed to `complete`, keeping it part of the path prefix. A real match such as `--bar=baz` still completes normally.

Fixes #12885.

## Testing

- `python3 tests/test_driver.py target/debug tests/checks/complete_path.fish`
- `target/debug/fish_indent --check share/functions/__fish_complete_path.fish tests/checks/complete_path.fish`
- `TERM=xterm-256color cargo xtask check` passed formatting, Clippy, unit tests, doc tests, docs, and 204 of 207 integration checks. The remaining checks were blocked by local Sphinx deprecation warnings and a tmux process-group permission error; none exercise these files.

## TODOs

- [x] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [x] Changes to fish usage are reflected in user documentation/manpages. No user documentation changes are needed for this private completion helper.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst. Skipped for this completion-only change.