### PR TITLE
Replace external commands with fish builtins

### DIFF
--- a/share/completions/aura.fish
+++ b/share/completions/aura.fish
@@ -1,6 +1,6 @@
 # This can't currently be wrapped as the pacman completions rely on variables whose value this needs to change
 # complete -c aura -w pacman
-set -l listinstalled "(pacman -Q | tr ' ' \t)"
+set -l listinstalled "(pacman -Q | string replace -a ' ' \t)"
 set -l listall "(__fish_print_pacman_packages)"
 set -l listrepos "(__fish_print_pacman_repos)"
 set -l listgroups "(pacman -Sg | sed 's/\(.*\)/\1\tPackage group/g')"

--- a/share/completions/fossil.fish
+++ b/share/completions/fossil.fish
@@ -155,7 +155,7 @@ complete -c fossil -n '__fish_fossil_command clone' -l ssl-identity -r -d 'Use S
 
 # commit
 complete -c fossil -n __fish_fossil_needs_command -a 'ci commit' -d 'Create new revision'
-complete -c fossil -n '__fish_fossil_command ci commit' -a '(__fish_fossil changes --rel-paths | cut -c12-)' -x -d File
+complete -c fossil -n '__fish_fossil_command ci commit' -a '(__fish_fossil changes --rel-paths | strings sub -s 12)' -x -d File
 complete -c fossil -n '__fish_fossil_command ci commit' -l allow-conflict -d 'Allow unresolved merge conflicts'
 complete -c fossil -n '__fish_fossil_command ci commit' -l allow-empty -d 'Allow empty check-ins'
 complete -c fossil -n '__fish_fossil_command ci commit' -l allow-fork -d 'Allow forking'

--- a/share/completions/machinectl.fish
+++ b/share/completions/machinectl.fish
@@ -120,7 +120,7 @@ complete -f -c machinectl -n "__fish_seen_subcommand_from login bind copy-to cop
 
 complete -f -c machinectl -n "__fish_seen_subcommand_from login bind copy-to copy-from shell; and not __fish_systemd_has_machine" -a "(__fish_systemd_machines)"
 # This is imperfect as we print the _local_ users
-complete -f -c machinectl -n "__fish_seen_subcommand_from shell; and not __fish_systemd_has_machine (commandline -xpc | cut -d"@" -f2-)" -a "(__fish_print_users)@(__fish_systemd_machines)"
+complete -f -c machinectl -n "__fish_seen_subcommand_from shell; and not __fish_systemd_has_machine (commandline -xpc | string split -f2 '@')" -a "(__fish_print_users)@(__fish_systemd_machines)"
 
 complete -f -c machinectl -n "__fish_seen_subcommand_from read-only; and not __fish_systemd_has_machine_image" -a "(__fish_systemd_machine_images)"
 complete -f -c machinectl -n "__fish_seen_subcommand_from read-only; and __fish_systemd_has_machine_image" -a "yes no"

--- a/share/completions/modprobe.fish
+++ b/share/completions/modprobe.fish
@@ -1,4 +1,4 @@
-complete -c modprobe -n "__fish_contains_opt -s r remove" --no-files -d Module -a "(lsmod | cut -d' ' -f1)"
+complete -c modprobe -n "__fish_contains_opt -s r remove" --no-files -d Module -a "(lsmod | string split ' ' -f1)"
 complete -c modprobe -n "not __fish_contains_opt -s r remove" --no-files -d Module -a "(__fish_print_modules)"
 complete -c modprobe -s v -l verbose -d "Print messages about what the program is doing"
 complete -c modprobe -s C -l config -d "Configuration file" -r

--- a/share/completions/reg.fish
+++ b/share/completions/reg.fish
@@ -1,5 +1,5 @@
 function __reg_run_reg_safely
-    set -l output (reg $argv | tr -d '\r' | tail --lines +2 | string collect)
+    set -l output (reg $argv | string replace -a '\r' '' | tail --lines +2 | string collect)
     if not string match -q -r "reg: Invalid syntax*" -- $output
         set output (string split \n -- $output)
         echo $output | string replace -a " " \n

--- a/share/functions/fish_svn_prompt.fish
+++ b/share/functions/fish_svn_prompt.fish
@@ -104,7 +104,7 @@ function fish_svn_prompt --description "Prompt function for svn"
     # 1. perform `svn status`
     # 2. remove extra lines that aren't necessary
     # 3. cut the output down to the first 7 columns, as these contain the information needed
-    set -l svn_status_lines (command svn status | sed -e 's=^Summary of conflicts.*==' -e 's=^  Text conflicts.*==' -e 's=^  Property conflicts.*==' -e 's=^  Tree conflicts.*==' -e 's=.*incoming .* upon update.*==' | cut -c 1-7)
+    set -l svn_status_lines (command svn status | sed -e 's=^Summary of conflicts.*==' -e 's=^  Text conflicts.*==' -e 's=^  Property conflicts.*==' -e 's=^  Tree conflicts.*==' -e 's=.*incoming .* upon update.*==' | string sub -l7)
 
     # track the last column to contain a status flag
     set -l last_column 0
@@ -116,7 +116,7 @@ function fish_svn_prompt --description "Prompt function for svn"
         # 2. cut out the current column of characters
         # 3. remove duplicates
         # 4. remove spaces
-        set -l column_status (printf '%s\n' $svn_status_lines | cut -c $col | sort -u | tr -d ' ')
+        set -l column_status (printf '%s\n' $svn_status_lines | string -s $col -e $col | sort -u | string trim)
 
         # check that the column status list does not only contain an empty element (if it does, this column is empty)
         if test (count $column_status) -gt 1 -o -n "$column_status[1]"

--- a/share/functions/fish_svn_prompt.fish
+++ b/share/functions/fish_svn_prompt.fish
@@ -116,7 +116,7 @@ function fish_svn_prompt --description "Prompt function for svn"
         # 2. cut out the current column of characters
         # 3. remove duplicates
         # 4. remove spaces
-        set -l column_status (printf '%s\n' $svn_status_lines | string -s $col -e $col | sort -u | string trim)
+        set -l column_status (printf '%s\n' $svn_status_lines | string -s $col -e $col | sort -u | string replace -a ' ' '')
 
         # check that the column status list does not only contain an empty element (if it does, this column is empty)
         if test (count $column_status) -gt 1 -o -n "$column_status[1]"


### PR DESCRIPTION
Get's rid of all leftover occurrences of 'cut' and one occurence of 'tr' in the fish completions.

Fixes part of issue #6520

List of all open fixes from that issue under their category. I've added the commit for files where the command has already been replaced and I could find out where. I've written 'already done?' where there was no occurrence and I couldn't easily find out where it was replaced. All other entries in this list have been fixed by me.

`cut`
- [x] `completions/fossil.fish`
- [x] `completions/machinectl.fish`
- [x] `completions/modprobe.fish`
- [x] `completions/pactree.fish` already done?
- [x] `completions/pkgfile.fish` already done?
- [x] `completions/xprop.fish` f66285d7
- [x] `functions/__fish_complete_groups.fish` f66285d7
- [x] `functions/__fish_complete_gpg_user_id.fish` f66285d7
- [x] `functions/__fish_crux_packages.fish` f66285d7
- [x] `functions/__fish_is_zfs_feature_enabled.fish` 21ddfabb
- [x] `functions/__fish_print_packages.fish` already done?
- [x] `functions/__fish_systemctl_services.fish` f66285d7
- [x] `functions/fish_svn_prompt.fish`

`tr`
- [x] `completions/aura.fish`
- [x] `completions/grunt.fish` already done?
- [x] `completions/pactree.fish` already done?
- [x] `completions/pkgfile.fish` already done?
- [x] `completions/rfkill.fish` already done?
- [x] `completions/rsync.fish` already done?
- [x] `functions/__fish_make_completion_signals.fish`
- [x] `functions/__fish_parse_configure.fish` file gone?
- [x] `functions/__fish_print_packages.fish` already done?
- [x] `functions/__fish_print_xdg_desktop_file_ids.fish` file gone?
- [x] `functions/fish_svn_prompt.fish`

## TODOs:
<!-- Check off what what has been done so far. -->
- [x] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
