### PR TITLE
Rust: use libc fpathconf for _PC_CASE_SENSITIVE on macos (Fixes #12913)

### DIFF
--- a/src/highlight/file_tester.rs
+++ b/src/highlight/file_tester.rs
@@ -21,9 +21,9 @@ use fish_widestring::{
 };
 use libc::PATH_MAX;
 use nix::unistd::AccessFlags;
-#[cfg(any(target_os = "macos", target_os = "ios"))]
-use nix::unistd::{PathconfVar, fpathconf};
 use std::collections::{HashMap, hash_map};
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+use std::os::fd::AsRawFd as _;
 use std::os::fd::BorrowedFd;
 
 // This is used only internally to this file, and is exposed only for testing.
@@ -423,7 +423,9 @@ fn fs_is_case_insensitive(
     }
     // Ask the system. A -1 value means error (so assume case sensitive), a 1 value means case
     // sensitive, and a 0 value means case insensitive.
-    let icase = fd.is_some_and(|fd| fpathconf(fd, PathconfVar::_PC_CASE_SENSITIVE).is_ok());
+    let icase = fd.is_some_and(|fd| unsafe {
+        libc::fpathconf(fd.as_raw_fd(), libc::_PC_CASE_SENSITIVE) == 0
+    });
     case_sensitivity_cache.insert(path.to_owned(), icase);
     icase
 }


### PR DESCRIPTION
This PR fixes a macOS/iOS build failure in the Rust highlighter path logic caused by using a nix PathconfVar variant that is not available across nix versions.

## Problem

Building fish on macOS failed with E0599:

- no variant or associated item named _PC_CASE_SENSITIVE for PathconfVar
- Failure occurred in file_tester.rs

## Root Cause

The code depended on nix::unistd::PathconfVar::_PC_CASE_SENSITIVE, which is version-sensitive.
The previous check also only tested whether the call succeeded, instead of interpreting the returned value.

## What Changed

- Replaced the Apple-only PathconfVar call with libc::fpathconf(fd.as_raw_fd(), libc::_PC_CASE_SENSITIVE).
- Kept behavior conservative on error.
- Interprets results correctly:
- 0 means case-insensitive
- 1 means case-sensitive
- -1 or error is treated as case-sensitive fallback

## Why This Is Better

- Avoids nix API surface differences for this platform-specific constant.
- Uses stable libc constants for Darwin.
- Preserves intended behavior while making the code compile reliably.

## Validation

Build succeeded:
cd build && ninja fish

Focused Rust tests passed:

```sh
cargo test --lib test_ispath --no-default-features --features=localize-messages
cargo test --lib test_iscdpath --no-default-features --features=localize-messages
```

- [X] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`

_Fixes #12913_

- [X] Changes to fish usage are reflected in user documentation/manpages.

_Doesn't affect fish usage, fixes a build issue_

- [X] Tests have been added for regressions fixed

_Existing tests already cover this code._

- [X] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->

_No user-visible changes, other than the compille working._