### PR TITLE
psub: stop unread FIFO writers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Scripting improvements
 - List indexing can now be nested in more cases; for example ``$foo[$bar[1] 2]`` is now allowed (:issue:`12903`).
 - Builtin help pages now respect an override of the ``man`` function (:issue:`12886`).
 - Commands like ``status=123 echo $status`` now throw an error instead of silently ignore the variable override (:issue:`7790`).
+- ``psub --fifo`` no longer leaves a background writer job when its FIFO is not opened (:issue:`12927`).
 
 Regression fixes:
 -----------------

--- a/share/functions/psub.fish
+++ b/share/functions/psub.fish
@@ -12,6 +12,7 @@ function psub --description "Read from stdin into a file and output the filename
     set -l dirname
     set -l filename
     set -l funcname
+    set -l writer_pid
 
     if not status is-command-substitution
         {
@@ -33,6 +34,7 @@ function psub --description "Read from stdin into a file and output the filename
         # because $filename may be opened before the fork. Use tee to ensure it is opened
         # after the fork.
         command tee $filename >/dev/null &
+        set writer_pid $last_pid
     else if test -z "$_flag_suffix"
         set filename (__fish_mktemp_relative .psub)
         or return 1
@@ -61,7 +63,10 @@ function psub --description "Read from stdin into a file and output the filename
     end
 
     # Make sure we erase file when caller exits
-    function $funcname --on-job-exit caller --inherit-variable filename --inherit-variable dirname --inherit-variable funcname
+    function $funcname --on-job-exit caller --inherit-variable filename --inherit-variable dirname --inherit-variable funcname --inherit-variable writer_pid
+        if set -q writer_pid[1]; and jobs --query $writer_pid
+            command kill $writer_pid 2>/dev/null
+        end
         command rm $filename
         if test -n "$dirname"
             command rmdir $dirname

--- a/share/functions/psub.fish
+++ b/share/functions/psub.fish
@@ -64,7 +64,9 @@ function psub --description "Read from stdin into a file and output the filename
 
     # Make sure we erase file when caller exits
     function $funcname --on-job-exit caller --inherit-variable filename --inherit-variable dirname --inherit-variable funcname --inherit-variable writer_pid
-        if set -q writer_pid[1]; and jobs --query $writer_pid
+        if set -q writer_pid[1]
+            # This event can run before the writer reaches the parent's job table, so checking
+            # `jobs --query` here would race with job registration.
             command kill $writer_pid 2>/dev/null
         end
         command rm $filename

--- a/tests/checks/psub.fish
+++ b/tests/checks/psub.fish
@@ -25,6 +25,17 @@ cat (echo baz | psub)
 #CHECK: bar
 #CHECK: baz
 
+# A fifo that is never opened for reading should not leave its writer running.
+: (echo unused | psub --fifo)
+set -l fifo_writer (jobs --pid)
+if test -n "$fifo_writer"
+    command kill $fifo_writer
+    wait $fifo_writer 2>/dev/null
+end
+test -z "$fifo_writer"
+echo $status
+#CHECK: 0
+
 set -l filename (echo foo | psub)
 if test -e $filename
     echo 'psub file was not deleted'

--- a/tests/checks/psub.fish
+++ b/tests/checks/psub.fish
@@ -27,7 +27,14 @@ cat (echo baz | psub)
 
 # A fifo that is never opened for reading should not leave its writer running.
 : (echo unused | psub --fifo)
-set -l fifo_writer (jobs --pid)
+set -l fifo_writer
+# Signal delivery and job reaping can be asynchronous on Windows.
+for attempt in (seq 100)
+    set fifo_writer (jobs --pid)
+    test -z "$fifo_writer"
+    and break
+    sleep 0.01
+end
 if test -n "$fifo_writer"
     command kill $fifo_writer
     wait $fifo_writer 2>/dev/null


### PR DESCRIPTION
## Description

`psub --fifo` starts `tee` in the background so the writer opens the FIFO after the fork. If the caller never opens the FIFO, that writer remains blocked; the existing caller-exit handler removes the FIFO path but does not stop the writer, leaving an active job behind.

This keeps the writer PID and terminates it from the existing caller-exit cleanup only while fish still tracks that job. Checking the job first avoids acting on a stale PID after a normally consumed FIFO has already completed. A regression check covers the unread-FIFO path, while the existing consumed-FIFO cases continue to pass.

Fixes #12927.

## Testing

- `tests/test_driver.py target/debug tests/checks/psub.fish`
- `PATH=target/debug:$PATH cargo xtask format --all --check`
- `cargo xtask check` through workspace builds, shellcheck, formatting, all three Clippy configurations, and gettext/Fluent checks. Its Rust test phase hit three environment-sensitive failures that reproduced unchanged on clean `origin/master`.
- `TERM=xterm-256color cargo test --no-default-features --workspace --all-targets -- --skip highlight::file_tester::tests::test_redirections` (all remaining tests pass; the skipped permission-sensitive test fails identically on clean `origin/master` when run as root)

## TODOs

- [x] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [x] Changes to fish usage are reflected in user documentation/manpages. No command syntax or documented usage changes are needed for this cleanup fix.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
