### PR TITLE
expand: combine adjacent variables in slices

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Interactive improvements
 Scripting improvements
 ----------------------
 - List indexing can now be nested in more cases; for example ``$foo[$bar[1] 2]`` is now allowed (:issue:`12903`).
+- Adjacent variable expansions in list indices now combine as they do in regular arguments (:issue:`12892`).
 - Builtin help pages now respect an override of the ``man`` function (:issue:`12886`).
 - Commands like ``status=123 echo $status`` now throw an error instead of silently ignore the variable override (:issue:`7790`).
 

--- a/crates/widestring/src/lib.rs
+++ b/crates/widestring/src/lib.rs
@@ -97,9 +97,12 @@ pub const INTERNAL_SEPARATOR: char = char_offset(EXPAND_RESERVED_BASE, 8);
 /// Character representing an empty variable expansion. Only used transitively while expanding
 /// variables.
 pub const VARIABLE_EXPAND_EMPTY: char = char_offset(EXPAND_RESERVED_BASE, 9);
+/// Character separating adjacent variable expansions without separating their eventual values.
+/// Only used transitively while expanding variables.
+pub const VARIABLE_EXPAND_JOIN: char = char_offset(EXPAND_RESERVED_BASE, 10);
 
 const _: () = assert!(
-    EXPAND_RESERVED_END as u32 > VARIABLE_EXPAND_EMPTY as u32,
+    EXPAND_RESERVED_END as u32 > VARIABLE_EXPAND_JOIN as u32,
     "Characters used in expansions must stay within private use area"
 );
 

--- a/src/expand.rs
+++ b/src/expand.rs
@@ -33,7 +33,7 @@ use fish_wcstringutil::{join_strings, trim};
 use fish_widestring::{
     ANY_CHAR, ANY_STRING, ANY_STRING_RECURSIVE, BRACE_BEGIN, BRACE_END, BRACE_SEP, BRACE_SPACE,
     HOME_DIRECTORY, INTERNAL_SEPARATOR, PROCESS_EXPAND_SELF, VARIABLE_EXPAND,
-    VARIABLE_EXPAND_EMPTY, VARIABLE_EXPAND_SINGLE, osstr2wcstring,
+    VARIABLE_EXPAND_EMPTY, VARIABLE_EXPAND_JOIN, VARIABLE_EXPAND_SINGLE, osstr2wcstring,
 };
 use nix::unistd::{User, getpid};
 
@@ -393,6 +393,32 @@ fn parse_slice(
     idx: &mut Vec<i64>,
     array_size: usize,
 ) -> Result<usize, (usize, ParseSliceError)> {
+    // Adjacent variable expansions use VARIABLE_EXPAND_JOIN to terminate the preceding variable
+    // name without separating the resulting values. Remove those markers before parsing the
+    // numbers, while retaining a map back to offsets in the unnormalised input.
+    if input.contains(VARIABLE_EXPAND_JOIN) {
+        let mut normalized = WString::with_capacity(input.len());
+        let mut source_offsets = Vec::with_capacity(input.len());
+        for (source_offset, c) in input.chars().enumerate() {
+            if c != VARIABLE_EXPAND_JOIN {
+                normalized.push(c);
+                source_offsets.push(source_offset);
+            }
+        }
+
+        return match parse_slice(&normalized, idx, array_size) {
+            Ok(offset) => Ok(if offset == 0 {
+                0
+            } else {
+                source_offsets[offset - 1] + 1
+            }),
+            Err((bad_pos, error)) => Err((
+                source_offsets.get(bad_pos).copied().unwrap_or(input.len()),
+                error,
+            )),
+        };
+    }
+
     let size = i64::try_from(array_size).unwrap();
     let mut pos = 1; // skip past the opening square bracket
 
@@ -505,6 +531,43 @@ fn parse_slice(
     }
 
     Ok(pos)
+}
+
+/// Return whether `input` ends with an unquoted variable expansion, optionally including a slice.
+fn ends_with_variable_expansion(input: &wstr) -> bool {
+    let mut name_end = input.len();
+    if name_end == 0 {
+        return false;
+    }
+
+    if input.char_at(name_end - 1) == ']' {
+        let mut depth = 1;
+        let mut pos = name_end - 1;
+        while pos > 0 {
+            pos -= 1;
+            match input.char_at(pos) {
+                ']' => depth += 1,
+                '[' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        name_end = pos;
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        if depth != 0 {
+            return false;
+        }
+    }
+
+    let mut name_start = name_end;
+    while name_start > 0 && valid_var_name_char(input.char_at(name_start - 1)) {
+        name_start -= 1;
+    }
+
+    name_start < name_end && name_start > 0 && input.char_at(name_start - 1) == VARIABLE_EXPAND
 }
 
 /// Expand all environment variables in the string *ptr.
@@ -727,6 +790,7 @@ fn expand_variables(
         return expand_variables(res, out, varexp_char_idx, vars, errors);
     } else {
         // Normal cartesian-product expansion.
+        let joins_previous_variable = ends_with_variable_expansion(&instr[..varexp_char_idx]);
         for item in var_item_list {
             if varexp_char_idx == 0 && var_name_and_slice_stop == instr.len() {
                 if !out.add(item) {
@@ -736,7 +800,11 @@ fn expand_variables(
                 let mut new_in = instr[..varexp_char_idx].to_owned();
                 if !new_in.is_empty() {
                     if new_in.as_char_slice().last() != Some(&VARIABLE_EXPAND) {
-                        new_in.push(INTERNAL_SEPARATOR);
+                        if joins_previous_variable {
+                            new_in.push(VARIABLE_EXPAND_JOIN);
+                        } else {
+                            new_in.push(INTERNAL_SEPARATOR);
+                        }
                     } else if item.is_empty() {
                         new_in.push(VARIABLE_EXPAND_EMPTY);
                     }
@@ -1145,11 +1213,10 @@ fn expand_percent_self(input: &mut WString) {
     }
 }
 
-/// Remove any internal separators. Also optionally convert wildcard characters to regular
-/// equivalents. This is done to support skip_wildcards.
+/// Remove any internal expansion separators. Also optionally convert wildcard characters to
+/// regular equivalents. This is done to support skip_wildcards.
 fn remove_internal_separator(s: &mut WString, conv: bool) {
-    // Remove all instances of INTERNAL_SEPARATOR.
-    s.retain(|c| c != INTERNAL_SEPARATOR);
+    s.retain(|c| ![INTERNAL_SEPARATOR, VARIABLE_EXPAND_JOIN].contains(&c));
 
     // If conv is true, replace all instances of ANY_STRING with '*',
     // ANY_STRING_RECURSIVE with '*'.

--- a/tests/checks/expansion.fish
+++ b/tests/checks/expansion.fish
@@ -260,6 +260,29 @@ echo $outer[$inner[2]]
 echo $outer[$inner[2..1]]
 #CHECK: out2 out1
 
+# Adjacent expansions in a slice combine just like they do in a regular argument.
+set -l letters a b c d e f g h i j k l m n o p q r s t u v w x y z
+set -l tens 1 2
+set -l ones 3 4
+echo $tens$ones
+#CHECK: 13 23 14 24
+echo $letters[$tens$ones]
+#CHECK: m w n x
+echo $letters[$tens[1]$ones]
+#CHECK: m n
+set -l empty ''
+echo $letters[$tens$empty]
+#CHECK: a b
+set -l sign -
+echo $letters[$sign$ones]
+#CHECK: x w
+
+# Whitespace still separates indices, and range endpoints remain separate expressions.
+echo $letters[$tens $ones]
+#CHECK: a c b c a d b d
+echo $letters[$tens..$ones]
+#CHECK: a b c b c a b c d b c d
+
 # Percent self
 echo %selfNOT NOT%self \%self "%self" '%self'
 echo %self | string match -qr '^\\d+$'


### PR DESCRIPTION
## Summary

- distinguish adjacency between unquoted variable expansions from the existing slice separators
- remove that transient join marker before parsing indices while preserving source offsets for diagnostics
- cover cartesian, sliced, empty, and negative adjacent values, plus unchanged whitespace and range behavior

This makes `$letters[$tens$ones]` select the same indices produced by expanding `$tens$ones` as a regular argument, without changing the established boundaries around literals, quotes, or command substitutions.

Fixes #12892.

## Tests

- `cargo test --no-default-features --workspace --all-targets -- --skip highlight::file_tester::tests::test_redirections`
- `tests/checks/expansion.fish` and `tests/checks/slices.fish` via `tests/test_driver.py`
- `cargo fmt --all -- --check`
- `cargo xtask check` (formatting, ShellCheck, all Clippy variants, and localization checks pass; the Rust test phase hits the existing root-only permission failure in `highlight::file_tester::tests::test_redirections`)

The complete script/pexpect run passes 199 of 242 tests with 9 skipped; the remaining failures are the environment-sensitive root permission and unavailable tmux-socket cases.

## TODOs

- [x] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [x] Changes to fish usage are reflected in user documentation/manpages (the existing adjacent-expansion rules describe the intended behavior)
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst
