### PR TITLE
Support scrolling overflowing command lines

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ fish ?.?.? (released ???)
 
 Interactive improvements
 ------------------------
+- Commands that are taller than the terminal can now be browsed with the mouse wheel. The viewport follows keyboard cursor movement only when the cursor crosses an edge, and its status line reminds users what :kbd:`enter` does. Fish captures the wheel only while the command-line viewport is scrollable and returns it to the terminal when the command fits again (:issue:`11029`).
 - On some terminals like kitty, keys like :kbd:`shift-space` and :kbd:`space` can now be mapped independently (:issue:`12898`).
 - Fix slow tab completion in directories that contain slow-to-resolve symlinks (e.g. links targeting a network mount) (:issue:`12905`).
 

--- a/doc_src/interactive.rst
+++ b/doc_src/interactive.rst
@@ -666,6 +666,10 @@ The fish commandline editor can be used to work on commands that are several lin
 
 The fish commandline editor works exactly the same in single line mode and in multiline mode. To move between lines use the left and right arrow keys and other such keyboard shortcuts.
 
+When a command is taller than the terminal, fish shows a viewport over it and a ``rows X to Y of N`` status line. The status line also reminds you that :kbd:`enter` executes a complete command or continues an incomplete one. The mouse wheel scrolls this viewport three visual rows at a time without moving the command-line cursor. Editing the command, moving the cursor with the keyboard, or clicking visible command text returns to cursor-following mode; the viewport then moves only when the cursor would leave its visible rows.
+
+Fish only captures the mouse while this command-line viewport is scrollable. Once the command fits in the terminal again, the wheel controls the terminal's scrollback as usual. To access terminal scrollback while a long command still overflows, use the terminal's mouse-protocol bypass if it has one (for example, :kbd:`shift`-wheel in kitty).
+
 .. _history-search:
 
 Searchable command history

--- a/doc_src/terminal-compatibility.rst
+++ b/doc_src/terminal-compatibility.rst
@@ -205,6 +205,22 @@ Optional Commands
    * - ``\e[?25h``
      - cvvis
      - Enable cursor visibility (DECTCEM).
+   * - ``\e[?25l``
+     - civis
+     - Disable cursor visibility (DECTCEM).
+       Fish uses this while the editing cursor is outside the visible part of an overflowing command line.
+   * - ``\e[?9;1000;1001;1002;1003;1005;1006;1015;1016s``, ``\e[?1016;1015;1006;1005;1003;1002;1001;1000;9r``
+     - n/a
+     - Save and restore the mutually exclusive mouse protocol and coordinate encoding modes (XTSAVE / XTRESTORE).
+       Fish uses these to preserve the terminal's previous mouse-tracking state while temporarily handling the wheel for an overflowing command line.
+   * - ``\e[?1000h``, ``\e[?1000l``
+     - n/a
+     - Enable and disable normal mouse tracking.
+       Wheel events are reported as button presses; fish does not enable motion tracking.
+   * - ``\e[?1006h``, ``\e[?1006l``
+     - n/a
+     - Enable and disable SGR extended mouse-coordinate reporting.
+       With this enabled, a wheel press is reported as ``\e[< Ps ; Ps ; Ps M``.
    * - ``\e[?1004h``
      - n/a
      - Enable focus reporting.

--- a/localization/po/de.po
+++ b/localization/po/de.po
@@ -560,6 +560,9 @@ msgstr "Leerer Ordnerpfad '%s' existiert nicht"
 msgid "End a block of commands"
 msgstr "Befehlsblock beenden"
 
+msgid "Enter executes or continues"
+msgstr ""
+
 #, c-format
 msgid "Error encountered while sourcing file '%s':"
 msgstr "Fehler beim Einladen von '%s':"

--- a/localization/po/es.po
+++ b/localization/po/es.po
@@ -560,6 +560,9 @@ msgstr "El directorio vacío '%s' no existe"
 msgid "End a block of commands"
 msgstr "Finalizar un bloque de comandos"
 
+msgid "Enter executes or continues"
+msgstr ""
+
 #, c-format
 msgid "Error encountered while sourcing file '%s':"
 msgstr "Error encontrado al importar el archivo '%s':"

--- a/localization/po/fr.po
+++ b/localization/po/fr.po
@@ -689,6 +689,9 @@ msgstr "Le dossier vide « %s » n’existe pas"
 msgid "End a block of commands"
 msgstr "Termine un bloc de commandes"
 
+msgid "Enter executes or continues"
+msgstr ""
+
 #, c-format
 msgid "Error encountered while sourcing file '%s':"
 msgstr "Erreur lors de l’inclusion du fichier « %s »"

--- a/localization/po/ja_JP.po
+++ b/localization/po/ja_JP.po
@@ -559,6 +559,9 @@ msgstr "空のディレクトリ '%s' は存在しません"
 msgid "End a block of commands"
 msgstr "コマンドブロックを終了"
 
+msgid "Enter executes or continues"
+msgstr ""
+
 #, c-format
 msgid "Error encountered while sourcing file '%s':"
 msgstr "ファイル '%s' の読み込み中にエラーが発生しました:"

--- a/localization/po/pl.po
+++ b/localization/po/pl.po
@@ -556,6 +556,9 @@ msgstr ""
 msgid "End a block of commands"
 msgstr "Zakończ zestaw komend"
 
+msgid "Enter executes or continues"
+msgstr ""
+
 #, c-format
 msgid "Error encountered while sourcing file '%s':"
 msgstr ""

--- a/localization/po/pt_BR.po
+++ b/localization/po/pt_BR.po
@@ -561,6 +561,9 @@ msgstr ""
 msgid "End a block of commands"
 msgstr "Finaliza um bloco de comandos"
 
+msgid "Enter executes or continues"
+msgstr ""
+
 #, c-format
 msgid "Error encountered while sourcing file '%s':"
 msgstr "Erro encontrado ao interpretar arquivo “%s”:"

--- a/localization/po/sv.po
+++ b/localization/po/sv.po
@@ -557,6 +557,9 @@ msgstr ""
 msgid "End a block of commands"
 msgstr "Avsluta ett block av kommandon"
 
+msgid "Enter executes or continues"
+msgstr ""
+
 #, c-format
 msgid "Error encountered while sourcing file '%s':"
 msgstr "Ett fel uppstod medan filen '%s' lästes in"

--- a/localization/po/zh_CN.po
+++ b/localization/po/zh_CN.po
@@ -581,6 +581,9 @@ msgstr "空目录 '%s' 不存在"
 msgid "End a block of commands"
 msgstr "结束一个命令块"
 
+msgid "Enter executes or continues"
+msgstr ""
+
 #, c-format
 msgid "Error encountered while sourcing file '%s':"
 msgstr "加载源文件 '%s' 时遇到错误："

--- a/localization/po/zh_TW.po
+++ b/localization/po/zh_TW.po
@@ -554,6 +554,9 @@ msgstr "空目錄「%s」不存在"
 msgid "End a block of commands"
 msgstr "結束一個程式碼區塊"
 
+msgid "Enter executes or continues"
+msgstr ""
+
 #, c-format
 msgid "Error encountered while sourcing file '%s':"
 msgstr "載入檔案「%s」時遇到錯誤："

--- a/src/builtins/fish_key_reader.rs
+++ b/src/builtins/fish_key_reader.rs
@@ -32,7 +32,7 @@ use crate::{
     },
     threads,
     topic_monitor::topic_monitor_init,
-    tty_handoff::TtyHandoff,
+    tty_handoff::{TtyHandoff, push_tty_reader_mode_request},
 };
 use fish_wgetopt::{ArgType, WGetopter, WOption, wopt};
 use fish_widestring::osstr2wcstring;
@@ -91,6 +91,9 @@ fn process_input(
     let mut recent_chars = vec![];
     streams.err.appendln("Press a key:\n");
 
+    // A fish_key_reader invoked from a binding is a nested reader. It must not inherit an outer
+    // commandline viewport's mouse capture or hidden cursor request.
+    let _reader_mode = push_tty_reader_mode_request(|| {});
     let mut handoff = TtyHandoff::new(|| {});
     handoff.enable_tty_protocols();
 

--- a/src/input/decode.rs
+++ b/src/input/decode.rs
@@ -1,8 +1,9 @@
 use super::{
     binding::match_key_event_to_key,
     input::{
-        CharEvent, ImplicitEvent, InputEventQueuer, InputEventTrigger, KeyEvent, QueryResponse,
-        QueryResultEvent, is_event_blocked_when_querying, next_input_event, stop_query,
+        CharEvent, ImplicitEvent, InputEventQueuer, InputEventTrigger, KeyEvent,
+        MouseWheelDirection, QueryResponse, QueryResultEvent, is_event_blocked_when_querying,
+        next_input_event, stop_query,
     },
 };
 use crate::{
@@ -344,11 +345,25 @@ trait InputEventQueuerExt: InputEventQueuer {
                 };
                 let position = ViewportPosition { x, y };
                 let (modifiers, _caps_lock) = parse_mask((button >> 2) & 0x07);
-                let code = button & 0x43;
-                if code != 0 || c != b'M' || modifiers.is_some() {
+                // Ignore modifiers, but preserve motion and extended-button bits so they cannot be
+                // mistaken for an ordinary left click or wheel report.
+                let code = button & !0x1c;
+                if c != b'M' || modifiers.is_some() {
                     return None;
                 }
-                return Some(CharEvent::Implicit(ImplicitEvent::MouseLeft(position)));
+                let event = match code {
+                    0 => ImplicitEvent::MouseLeft(position),
+                    64 => ImplicitEvent::MouseWheel {
+                        direction: MouseWheelDirection::Up,
+                        position,
+                    },
+                    65 => ImplicitEvent::MouseWheel {
+                        direction: MouseWheelDirection::Down,
+                        position,
+                    },
+                    _ => return None,
+                };
+                return Some(CharEvent::Implicit(event));
             }
             b't' => {
                 flog!(reader, "mouse event");
@@ -857,10 +872,11 @@ mod tests {
     use super::parse_hex;
     use crate::{
         input::{
-            CharEvent, KeyEvent, MockInputEventQueuer, QueryResponse,
+            CharEvent, ImplicitEvent, KeyEvent, MockInputEventQueuer, MouseWheelDirection,
+            QueryResponse,
             decode::{InputEventQueuerExt as _, query_response},
         },
-        key::{self, Key, Modifiers, alt},
+        key::{self, Key, Modifiers, ViewportPosition, alt},
     };
 
     #[test]
@@ -891,6 +907,12 @@ mod tests {
         let text = Default::default();
         let kitty_a = KeyEvent::new_with(Modifiers::default(), true, 'a', None, None, text);
         let kitty_alt_a = KeyEvent::new_with(Modifiers::ALT, true, 'a', None, None, text);
+        let wheel = |direction, x, y| {
+            CharEvent::Implicit(ImplicitEvent::MouseWheel {
+                direction,
+                position: ViewportPosition { x, y },
+            })
+        };
         validate!(b"A", &[e(Key::from_single_char('A'), "A")]);
         validate!(b"\x1b", &[legacy_escape()]);
         validate!(b"\x1bA", &[e(alt('A'), "\x1bA")]);
@@ -917,5 +939,13 @@ mod tests {
                 )),
             ]
         );
+        validate!(b"\x1b[<64;2;3M", &[wheel(MouseWheelDirection::Up, 1, 2)]);
+        validate!(b"\x1b[<65;4;5M", &[wheel(MouseWheelDirection::Down, 3, 4)]);
+        validate!(b"\x1b[M`!!", &[wheel(MouseWheelDirection::Up, 0, 0)]);
+        validate!(b"\x1b[Ma!!", &[wheel(MouseWheelDirection::Down, 0, 0)]);
+        validate!(b"\x1b[<64;2;3m", &[]);
+        validate!(b"\x1b[<68;2;3M", &[]);
+        validate!(b"\x1b[<32;2;3M", &[]);
+        validate!(b"\x1b[<128;2;3M", &[]);
     }
 }

--- a/src/input/input.rs
+++ b/src/input/input.rs
@@ -45,6 +45,12 @@ pub struct KeyInputEvent {
     pub seq: WString,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum MouseWheelDirection {
+    Up,
+    Down,
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum ImplicitEvent {
     /// end-of-file was reached.
@@ -58,6 +64,11 @@ pub enum ImplicitEvent {
     FocusOut,
     /// Mouse left click.
     MouseLeft(ViewportPosition),
+    /// Mouse wheel movement captured for an overflowing commandline viewport.
+    MouseWheel {
+        direction: MouseWheelDirection,
+        position: ViewportPosition,
+    },
     /// Terminal color theme change (light/dark mode).
     NewColorTheme,
     /// Window height changed.

--- a/src/pager.rs
+++ b/src/pager.rs
@@ -1180,7 +1180,7 @@ fn print_max_impl(
     max.checked_sub(remaining).unwrap()
 }
 
-fn print_max(
+pub(crate) fn print_max(
     offset_in_cmdline: CharOffset,
     chars: impl IntoIterator<Item = char>,
     color: HighlightSpec,

--- a/src/reader/reader.rs
+++ b/src/reader/reader.rs
@@ -56,8 +56,8 @@ use crate::{
     input::{
         BackgroundColorQuery, CharEvent, CharInputStyle, CursorPositionQuery,
         CursorPositionQueryReason, ImplicitEvent, InputData, InputEventQueue,
-        InputEventQueuer as _, LONG_READ_TIMEOUT, QueryResponse, QueryResultEvent, ReadlineCmd,
-        RecurrentQuery, TerminalQuery, stop_query,
+        InputEventQueuer as _, LONG_READ_TIMEOUT, MouseWheelDirection, QueryResponse,
+        QueryResultEvent, ReadlineCmd, RecurrentQuery, TerminalQuery, stop_query,
     },
     io::IoChain,
     key::ViewportPosition,
@@ -104,8 +104,9 @@ use crate::{
         variable_assignment_equals_pos,
     },
     tty_handoff::{
-        SCROLL_CONTENT_UP_TERMINFO_CODE, TtyHandoff, XTGETTCAP_QUERY_OS_NAME,
+        SCROLL_CONTENT_UP_TERMINFO_CODE, TtyHandoff, TtyReaderModeRequest, XTGETTCAP_QUERY_OS_NAME,
         deactivate_tty_protocols, get_tty_protocols_active, initialize_tty_protocols,
+        push_tty_reader_mode_request, set_tty_reader_mode_request,
     },
     wildcard::wildcard_has,
     wutil::{fstat, perror_nix, wstat},
@@ -641,6 +642,12 @@ struct LayoutData {
     mode_prompt_buff: WString,
     right_prompt_buff: WString,
 }
+
+fn layout_change_follows_commandline_cursor(previous: &LayoutData, next: &LayoutData) -> bool {
+    previous.text != next.text || previous.position != next.position
+}
+
+const COMMANDLINE_VIEWPORT_SCROLL_ROWS: isize = 3;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum EditableLineTag {
@@ -1629,7 +1636,7 @@ impl ReaderData {
         true
     }
 
-    pub fn mouse_left_click(&mut self, click_position: ViewportPosition) {
+    pub fn mouse_left_click(&mut self, click_position: ViewportPosition) -> bool {
         flog!(
             reader,
             "Received left mouse click at",
@@ -1637,14 +1644,19 @@ impl ReaderData {
         );
         match self.screen.offset_in_cmdline_given_cursor(click_position) {
             CharOffset::Cmd(new_pos) | CharOffset::Pointer(new_pos) => {
-                let (elt, _el) = self.active_edit_line();
-                self.update_buff_pos(elt, Some(new_pos));
+                // An overflowing commandline withholds the pager. If its search field had focus,
+                // move that focus back to the commandline before handling subsequent input.
+                self.pager.set_search_field_shown(false);
+                self.screen.follow_commandline_cursor();
+                self.update_buff_pos(EditableLineTag::Commandline, Some(new_pos));
+                true
             }
             CharOffset::Pager(idx) if self.pager.selected_completion_idx != Some(idx) => {
                 self.pager.selected_completion_idx = Some(idx);
                 self.pager_selection_changed();
+                false
             }
-            CharOffset::Pager(_) | CharOffset::None => {}
+            CharOffset::Pager(_) | CharOffset::None => false,
         }
     }
 
@@ -1816,7 +1828,11 @@ impl<'a> Reader<'a> {
     /// Generate a new layout data from the current state of the world, and paint with it.
     /// If `mcolors` has a value, then apply it; otherwise extend existing colors.
     fn layout_and_repaint(&mut self, reason: &wstr) {
-        self.rendered_layout = self.make_layout_data();
+        let next_layout = self.make_layout_data();
+        if layout_change_follows_commandline_cursor(&self.rendered_layout, &next_layout) {
+            self.screen.follow_commandline_cursor();
+        }
+        self.rendered_layout = next_layout;
         self.paint_layout(reason, false);
     }
 
@@ -1908,8 +1924,14 @@ impl<'a> Reader<'a> {
             ],
         );
 
-        // Compute the indentation.
-        let indents = compute_indents(&full_line);
+        // Computing indentation parses the whole commandline. When no autosuggestion is present,
+        // reuse that result for the explicit layout instead of parsing identical text twice.
+        let explicit_indents = compute_indents(cmd_line.text());
+        let indents = if matches!(&full_line, Cow::Borrowed(_)) {
+            explicit_indents.clone()
+        } else {
+            compute_indents(&full_line)
+        };
 
         let screen = &mut self.data.screen;
         let pager = &mut self.data.pager;
@@ -1924,6 +1946,7 @@ impl<'a> Reader<'a> {
             autosuggested_range,
             colors,
             indents,
+            explicit_indents,
             data.position,
             data.pager_search_field_position,
             self.parser.vars(),
@@ -1932,6 +1955,23 @@ impl<'a> Reader<'a> {
             is_final_rendering,
         );
         screen.autoscroll(curr_termsize.height());
+        let viewport = screen.commandline_viewport_status();
+        if viewport.scrollable {
+            // The pager is withheld while the commandline has its own viewport. Do not leave input
+            // focused on a search field the user cannot see.
+            pager.set_search_field_shown(false);
+        }
+        let screen_usable = !is_dumb() && curr_termsize.width() >= 4 && curr_termsize.height() > 0;
+        set_tty_reader_mode_request(
+            TtyReaderModeRequest {
+                mouse_tracking: screen_usable
+                    && !is_final_rendering
+                    && self.conf.inputfd == STDIN_FILENO
+                    && viewport.scrollable,
+                cursor_hidden: screen_usable && !is_final_rendering && viewport.cursor_hidden,
+            },
+            reader_save_screen_state,
+        );
     }
 }
 
@@ -2568,6 +2608,7 @@ impl<'a> Reader<'a> {
         old_modes: Option<Termios>,
         nchars: Option<NonZeroUsize>,
     ) -> Option<WString> {
+        let _reader_mode = push_tty_reader_mode_request(reader_save_screen_state);
         let mut tty = TtyHandoff::new(reader_save_screen_state);
 
         self.rls = Some(ReadlineLoopState::new());
@@ -2628,16 +2669,21 @@ impl<'a> Reader<'a> {
             self.exec_prompt(true, true);
         }
 
-        // Redraw the command line. This is what ensures the autosuggestion is hidden, etc. after the
-        // user presses enter.
-        if self.is_repaint_needed(None) || self.screen.scrolled || self.conf.inputfd != STDIN_FILENO
-        {
-            self.layout_and_repaint_before_execution();
-        }
+        // Capture whether execution needs a final repaint before highlighting updates the normal
+        // rendered-layout cache below.
+        let repaint_before_execution = self.is_repaint_needed(None)
+            || self.screen.scrolled
+            || self.conf.inputfd != STDIN_FILENO;
 
         // Finish syntax highlighting (but do not wait forever).
         if self.rls().finished {
             self.finish_highlighting_before_exec();
+        }
+
+        // This must be the final paint before emitting the command. In particular, a completed
+        // highlight must not switch an overflowing commandline back to its interactive viewport.
+        if repaint_before_execution {
+            self.layout_and_repaint_before_execution();
         }
 
         // Emit a newline so that the output is on the line after the command.
@@ -2900,7 +2946,22 @@ impl<'a> Reader<'a> {
                     }
                     MouseLeft(position) => {
                         flog!(reader, "Mouse left click", position);
-                        self.mouse_left_click(position);
+                        if self.mouse_left_click(position) {
+                            self.layout_and_repaint(L!("mouse left click"));
+                        }
+                    }
+                    MouseWheel {
+                        direction,
+                        position,
+                    } => {
+                        flog!(reader, "Mouse wheel", format!("{direction:?}"), position);
+                        let delta = match direction {
+                            MouseWheelDirection::Up => -COMMANDLINE_VIEWPORT_SCROLL_ROWS,
+                            MouseWheelDirection::Down => COMMANDLINE_VIEWPORT_SCROLL_ROWS,
+                        };
+                        if self.screen.scroll_commandline_viewport(delta) {
+                            self.paint_layout(L!("mouse wheel"), false);
+                        }
                     }
                     NewColorTheme => {
                         self.query(RecurrentQuery {
@@ -7220,11 +7281,39 @@ impl<'a> Reader<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::{combine_command_and_autosuggestion, completion_apply_to_command_line};
+    use super::{
+        COMMANDLINE_VIEWPORT_SCROLL_ROWS, LayoutData, combine_command_and_autosuggestion,
+        completion_apply_to_command_line, layout_change_follows_commandline_cursor,
+    };
     use crate::complete::CompleteFlags;
+    use crate::highlight::HighlightSpec;
     use crate::operation_context::{OperationContext, no_cancel};
     use crate::prelude::*;
     use crate::tests::prelude::*;
+
+    #[test]
+    fn test_layout_changes_that_follow_commandline_cursor() {
+        assert_eq!(COMMANDLINE_VIEWPORT_SCROLL_ROWS, 3);
+        let previous = LayoutData {
+            text: L!("echo one").to_owned(),
+            position: 8,
+            autosuggestion: L!("echo one two").to_owned(),
+            left_prompt_buff: L!("> ").to_owned(),
+            ..Default::default()
+        };
+
+        let mut next = previous.clone();
+        next.colors = vec![HighlightSpec::default(); next.text.len()];
+        next.autosuggestion = L!("echo one three").to_owned();
+        next.left_prompt_buff = L!("fish> ").to_owned();
+        assert!(!layout_change_follows_commandline_cursor(&previous, &next));
+
+        next.position = 0;
+        assert!(layout_change_follows_commandline_cursor(&previous, &next));
+        next.position = previous.position;
+        next.text.push('!');
+        assert!(layout_change_follows_commandline_cursor(&previous, &next));
+    }
 
     #[test]
     fn test_autosuggestion_combining() {

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -14,7 +14,7 @@ use crate::flog::{flog, flogf};
 use crate::global_safety::RelaxedAtomicBool;
 use crate::highlight::{HighlightColorResolver, HighlightRole, HighlightSpec};
 use crate::key::ViewportPosition;
-use crate::pager::{PAGER_MIN_HEIGHT, PageRendering, Pager};
+use crate::pager::{PAGER_MIN_HEIGHT, PageRendering, Pager, print_max};
 use crate::prelude::*;
 use crate::terminal::SgrTerminalCommand::EnterDimMode;
 use crate::terminal::TerminalCommand::{
@@ -48,6 +48,13 @@ pub enum CharOffset {
     Pager(usize),
 }
 
+fn next_char_offset(offset: CharOffset) -> CharOffset {
+    match offset {
+        CharOffset::Cmd(offset) => CharOffset::Cmd(offset + 1),
+        offset => offset,
+    }
+}
+
 #[derive(Clone, Default)]
 pub struct HighlightedChar {
     highlight: HighlightSpec,
@@ -63,6 +70,9 @@ pub struct Line {
     pub text: Vec<HighlightedChar>,
     pub is_soft_wrapped: bool,
     pub indentation: usize,
+    /// Commandline offset represented by an otherwise empty visual row. This is used for viewport
+    /// rows whose preceding logical row was not materialized.
+    empty_offset_in_cmdline: CharOffset,
 }
 
 impl Line {
@@ -73,6 +83,7 @@ impl Line {
     /// Clear the line's contents.
     fn clear(&mut self) {
         self.text.clear();
+        self.empty_offset_in_cmdline = CharOffset::None;
     }
 
     /// Append a single character `txt` to the line with color `c`.
@@ -139,16 +150,344 @@ impl Line {
 }
 
 /// Where the cursor is in (x, y) coordinates.
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct Cursor {
     x: usize,
     y: usize,
+}
+
+/// The state shared by visual commandline measurement and materialization.
+///
+/// `line_count` is deliberately separate from `cursor.y`: writing into the last terminal column
+/// advances the virtual cursor to an as-yet-unmaterialized phantom line.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct VisualLayoutState {
+    cursor: Cursor,
+    line_count: usize,
+}
+
+trait VisualLayoutSink {
+    fn create_line(&mut self, idx: usize);
+    fn clear_line(&mut self, idx: usize);
+    fn set_soft_wrapped(&mut self, idx: usize, value: bool);
+    fn set_indentation(&mut self, idx: usize, indentation: usize);
+    fn set_empty_offset(&mut self, idx: usize, offset_in_cmdline: CharOffset);
+    fn append(
+        &mut self,
+        idx: usize,
+        character: char,
+        highlight: HighlightSpec,
+        offset_in_cmdline: CharOffset,
+    );
+}
+
+struct ScreenDataSink<'a> {
+    data: &'a mut ScreenData,
+}
+
+impl VisualLayoutSink for ScreenDataSink<'_> {
+    fn create_line(&mut self, idx: usize) {
+        self.data.create_line(idx);
+    }
+
+    fn clear_line(&mut self, idx: usize) {
+        self.data.line_mut(idx).clear();
+    }
+
+    fn set_soft_wrapped(&mut self, idx: usize, value: bool) {
+        self.data.line_mut(idx).is_soft_wrapped = value;
+    }
+
+    fn set_indentation(&mut self, idx: usize, indentation: usize) {
+        self.data.line_mut(idx).indentation = indentation;
+    }
+
+    fn set_empty_offset(&mut self, idx: usize, offset_in_cmdline: CharOffset) {
+        if idx < self.data.line_count() {
+            self.data.line_mut(idx).empty_offset_in_cmdline = offset_in_cmdline;
+        }
+    }
+
+    fn append(
+        &mut self,
+        idx: usize,
+        character: char,
+        highlight: HighlightSpec,
+        offset_in_cmdline: CharOffset,
+    ) {
+        self.data
+            .line_mut(idx)
+            .append(character, highlight, offset_in_cmdline);
+    }
+}
+
+struct VisualLayoutBuilder<S> {
+    state: VisualLayoutState,
+    screen_width: Option<usize>,
+    max_y: usize,
+    sink: S,
+}
+
+impl<S: VisualLayoutSink> VisualLayoutBuilder<S> {
+    fn new(state: VisualLayoutState, screen_width: Option<usize>, max_y: usize, sink: S) -> Self {
+        Self {
+            state,
+            screen_width,
+            max_y,
+            sink,
+        }
+    }
+
+    fn create_line(&mut self, idx: usize) {
+        self.sink.create_line(idx);
+        self.state.line_count = self.state.line_count.max(idx + 1);
+    }
+
+    /// Append a character using the one visual-layout state machine shared by all sinks.
+    #[allow(clippy::too_many_arguments)]
+    fn append_char(
+        &mut self,
+        offset_in_cmdline: CharOffset,
+        character: char,
+        highlight: HighlightSpec,
+        indent: usize,
+        prompt_width: usize,
+        character_width: usize,
+    ) -> bool {
+        let mut line_no = self.state.cursor.y;
+
+        if character == '\n' {
+            // Current line is definitely hard wrapped.
+            if self.state.cursor.y + 1 > self.max_y {
+                return false;
+            }
+            self.create_line(self.state.cursor.y + 1);
+            self.sink.set_soft_wrapped(self.state.cursor.y, false);
+            self.state.cursor.y += 1;
+            line_no = self.state.cursor.y;
+            self.state.cursor.x = 0;
+            self.sink
+                .set_empty_offset(line_no, next_char_offset(offset_in_cmdline));
+            let indentation = prompt_width + indent * INDENT_STEP;
+            self.sink.set_indentation(line_no, indentation);
+            for _ in 0..indentation {
+                if !self.append_char(
+                    offset_in_cmdline,
+                    ' ',
+                    HighlightSpec::default(),
+                    indent,
+                    prompt_width,
+                    1,
+                ) {
+                    return false;
+                }
+            }
+        } else if character == '\r' {
+            if line_no > self.max_y {
+                return false;
+            }
+            self.create_line(line_no);
+            self.sink.clear_line(line_no);
+            self.sink
+                .set_empty_offset(line_no, next_char_offset(offset_in_cmdline));
+            self.state.cursor.x = 0;
+        } else {
+            if line_no > self.max_y {
+                return false;
+            }
+            self.create_line(line_no);
+
+            // Check if we are at the end of the line. If so, continue on the next line.
+            if self
+                .screen_width
+                .is_none_or(|width| self.state.cursor.x + character_width > width)
+            {
+                if self.state.cursor.y + 1 > self.max_y {
+                    return false;
+                }
+                self.sink.set_soft_wrapped(self.state.cursor.y, true);
+
+                line_no = self.state.line_count;
+                self.create_line(line_no);
+                self.state.cursor.y += 1;
+                self.state.cursor.x = 0;
+            }
+
+            self.sink
+                .append(line_no, character, highlight, offset_in_cmdline);
+            self.state.cursor.x += character_width;
+
+            // Maybe wrap the cursor to the next line, even if the line itself did not wrap. This
+            // avoids wonkiness in the last column.
+            if self
+                .screen_width
+                .is_none_or(|width| self.state.cursor.x >= width)
+            {
+                self.sink.set_soft_wrapped(line_no, true);
+                self.state.cursor.x = 0;
+                self.state.cursor.y += 1;
+                self.sink
+                    .set_empty_offset(self.state.cursor.y, next_char_offset(offset_in_cmdline));
+            }
+        }
+        true
+    }
+}
+
+#[derive(Default)]
+struct MeasuringVisualLayoutSink;
+
+impl VisualLayoutSink for MeasuringVisualLayoutSink {
+    fn create_line(&mut self, _idx: usize) {}
+    fn clear_line(&mut self, _idx: usize) {}
+    fn set_soft_wrapped(&mut self, _idx: usize, _value: bool) {}
+    fn set_indentation(&mut self, _idx: usize, _indentation: usize) {}
+    fn set_empty_offset(&mut self, _idx: usize, _offset_in_cmdline: CharOffset) {}
+    fn append(
+        &mut self,
+        _idx: usize,
+        _character: char,
+        _highlight: HighlightSpec,
+        _offset_in_cmdline: CharOffset,
+    ) {
+    }
+}
+
+struct WindowedScreenDataSink<'a> {
+    data: &'a mut ScreenData,
+    top: usize,
+    bottom: usize,
+}
+
+impl WindowedScreenDataSink<'_> {
+    fn physical_line(&self, logical_line: usize) -> Option<usize> {
+        (self.top..self.bottom)
+            .contains(&logical_line)
+            .then(|| logical_line - self.top)
+    }
+}
+
+impl VisualLayoutSink for WindowedScreenDataSink<'_> {
+    fn create_line(&mut self, idx: usize) {
+        if let Some(idx) = self.physical_line(idx) {
+            self.data.create_line(idx);
+        }
+    }
+
+    fn clear_line(&mut self, idx: usize) {
+        if let Some(idx) = self.physical_line(idx) {
+            self.data.line_mut(idx).clear();
+        }
+    }
+
+    fn set_soft_wrapped(&mut self, idx: usize, value: bool) {
+        if let Some(idx) = self.physical_line(idx) {
+            self.data.line_mut(idx).is_soft_wrapped = value;
+        }
+    }
+
+    fn set_indentation(&mut self, idx: usize, indentation: usize) {
+        if let Some(idx) = self.physical_line(idx) {
+            self.data.line_mut(idx).indentation = indentation;
+        }
+    }
+
+    fn set_empty_offset(&mut self, idx: usize, offset_in_cmdline: CharOffset) {
+        if let Some(idx) = self.physical_line(idx) {
+            self.data.line_mut(idx).empty_offset_in_cmdline = offset_in_cmdline;
+        }
+    }
+
+    fn append(
+        &mut self,
+        idx: usize,
+        character: char,
+        highlight: HighlightSpec,
+        offset_in_cmdline: CharOffset,
+    ) {
+        if let Some(idx) = self.physical_line(idx) {
+            self.data
+                .line_mut(idx)
+                .append(character, highlight, offset_in_cmdline);
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn append_explicit_commandline<S: VisualLayoutSink>(
+    builder: &mut VisualLayoutBuilder<S>,
+    prompt_offset: CharOffset,
+    prompt_space: usize,
+    commandline_indent: usize,
+    explicit_before_suggestion: &wstr,
+    explicit_after_suggestion: &wstr,
+    displayed_suggestion_len: usize,
+    colors: &[HighlightSpec],
+    explicit_indent: &[i32],
+    cursor_pos: usize,
+) -> Option<Cursor> {
+    for _ in 0..prompt_space {
+        if !builder.append_char(prompt_offset, ' ', HighlightSpec::new(), 0, prompt_space, 1) {
+            return None;
+        }
+    }
+
+    let commandline_len = explicit_before_suggestion.len() + explicit_after_suggestion.len();
+    assert!(cursor_pos <= commandline_len);
+    assert_eq!(explicit_indent.len(), commandline_len);
+    let mut commandline_offset = 0;
+    let mut cursor = None;
+
+    for (idx, character) in explicit_before_suggestion.chars().enumerate() {
+        if commandline_offset == cursor_pos {
+            cursor = Some(builder.state.cursor);
+        }
+        if !builder.append_char(
+            CharOffset::Cmd(commandline_offset),
+            character,
+            colors[idx],
+            usize::try_from(explicit_indent[commandline_offset]).unwrap(),
+            commandline_indent,
+            wcwidth_rendered_min_0(character),
+        ) {
+            return cursor;
+        }
+        commandline_offset += 1;
+    }
+
+    let effective_after_start = explicit_before_suggestion.len() + displayed_suggestion_len;
+    for (idx, character) in explicit_after_suggestion.chars().enumerate() {
+        if commandline_offset == cursor_pos {
+            cursor = Some(builder.state.cursor);
+        }
+        let effective_idx = effective_after_start + idx;
+        if !builder.append_char(
+            CharOffset::Cmd(commandline_offset),
+            character,
+            colors[effective_idx],
+            usize::try_from(explicit_indent[commandline_offset]).unwrap(),
+            commandline_indent,
+            wcwidth_rendered_min_0(character),
+        ) {
+            return cursor;
+        }
+        commandline_offset += 1;
+    }
+
+    if commandline_offset == cursor_pos {
+        cursor = Some(builder.state.cursor);
+    }
+    cursor
 }
 
 /// A class representing screen contents.
 #[derive(Clone, Default)]
 pub struct ScreenData {
     line_datas: Vec<Line>,
+
+    /// Logical visual row represented by physical row zero. This lets incremental rendering
+    /// distinguish a stable viewport from a different slice with coincidentally similar text.
+    logical_line_offset: usize,
 
     /// The width of the screen once we have rendered.
     screen_width: Option<usize>,
@@ -169,6 +508,7 @@ impl ScreenData {
 
     pub fn clear_lines(&mut self) {
         self.line_datas.clear();
+        self.logical_line_offset = 0;
     }
 
     pub fn resize(&mut self, size: usize) {
@@ -209,6 +549,174 @@ impl ScreenData {
     }
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+enum CommandlineViewportMode {
+    #[default]
+    FollowCursor,
+    Manual,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct CommandlineViewportWindow {
+    top: usize,
+    bottom: usize,
+    min_top: usize,
+    max_top: usize,
+    total_line_count: usize,
+    show_indicator: bool,
+    cursor_hidden: bool,
+}
+
+impl CommandlineViewportWindow {
+    fn scrollable(self) -> bool {
+        self.min_top < self.max_top
+    }
+
+    fn indicator_range(self) -> Option<(usize, usize, usize)> {
+        self.show_indicator.then(|| {
+            (
+                self.top - self.min_top + 1,
+                self.bottom - self.min_top,
+                self.total_line_count - self.min_top,
+            )
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct CommandlineViewportGeometry {
+    screen_width: usize,
+    prompt_lines: usize,
+    prompt_width: usize,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct CommandlineViewport {
+    mode: CommandlineViewportMode,
+    top: usize,
+    geometry: Option<CommandlineViewportGeometry>,
+    window: CommandlineViewportWindow,
+}
+
+impl CommandlineViewport {
+    #[allow(clippy::too_many_arguments)]
+    fn reconcile(
+        &mut self,
+        screen_width: usize,
+        screen_height: usize,
+        prompt_lines: usize,
+        prompt_width: usize,
+        total_line_count: usize,
+        cursor_y: usize,
+        is_final_rendering: bool,
+    ) -> CommandlineViewportWindow {
+        assert!(screen_height > 0);
+        assert!(total_line_count >= prompt_lines);
+
+        let previous_window = self.window;
+        let geometry = CommandlineViewportGeometry {
+            screen_width,
+            prompt_lines,
+            prompt_width,
+        };
+        let geometry_changed = self.geometry.is_some_and(|previous| previous != geometry);
+        if geometry_changed {
+            self.mode = CommandlineViewportMode::FollowCursor;
+        }
+        self.geometry = Some(geometry);
+
+        if is_final_rendering {
+            self.mode = CommandlineViewportMode::FollowCursor;
+            self.top = 0;
+            self.window = CommandlineViewportWindow {
+                bottom: total_line_count,
+                total_line_count,
+                ..Default::default()
+            };
+            return self.window;
+        }
+
+        // First determine whether the commandline itself adds a scrollable range. A prompt that is
+        // taller than the terminal is cropped as before, but does not by itself capture the wheel.
+        let base_min_top = prompt_lines.saturating_sub(screen_height);
+        let base_max_top = total_line_count.saturating_sub(screen_height);
+        let scrollable = base_min_top < base_max_top;
+        if !scrollable {
+            self.mode = CommandlineViewportMode::FollowCursor;
+        }
+        let show_indicator = scrollable && screen_height >= 2;
+        let visible_rows = screen_height - usize::from(show_indicator);
+        let min_top = prompt_lines.saturating_sub(visible_rows);
+        let max_top = total_line_count.saturating_sub(visible_rows);
+
+        self.top = match self.mode {
+            CommandlineViewportMode::FollowCursor => {
+                let recenter = geometry_changed || !previous_window.scrollable();
+                let top = if recenter {
+                    cursor_y.saturating_sub(visible_rows - 1)
+                } else if cursor_y < self.top {
+                    cursor_y
+                } else if cursor_y >= self.top.saturating_add(visible_rows) {
+                    cursor_y.saturating_add(1).saturating_sub(visible_rows)
+                } else {
+                    self.top
+                };
+                top.clamp(min_top, max_top)
+            }
+            CommandlineViewportMode::Manual => self.top.clamp(min_top, max_top),
+        };
+        let bottom = (self.top + visible_rows).min(total_line_count);
+        self.window = CommandlineViewportWindow {
+            top: self.top,
+            bottom,
+            min_top,
+            max_top,
+            total_line_count,
+            show_indicator,
+            cursor_hidden: cursor_y < self.top || cursor_y >= bottom,
+        };
+        self.window
+    }
+
+    fn follow_cursor(&mut self) {
+        self.mode = CommandlineViewportMode::FollowCursor;
+    }
+
+    fn scroll(&mut self, delta: isize) -> bool {
+        if !self.window.scrollable() {
+            return false;
+        }
+        // Do not skip rows in very short terminals. The normal three-row wheel step still applies
+        // whenever at least three commandline rows are visible.
+        let step = delta
+            .unsigned_abs()
+            .min((self.window.bottom - self.window.top).max(1));
+        let next = if delta < 0 {
+            self.top.saturating_sub(step)
+        } else {
+            self.top.saturating_add(step)
+        }
+        .clamp(self.window.min_top, self.window.max_top);
+        if next == self.top {
+            return false;
+        }
+        self.top = next;
+        self.mode = CommandlineViewportMode::Manual;
+        true
+    }
+
+    fn reset(&mut self) {
+        *self = Self::default();
+    }
+}
+
+/// State the reader needs to synchronize transient terminal modes after a repaint.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct CommandlineViewportStatus {
+    pub scrollable: bool,
+    pub cursor_hidden: bool,
+}
+
 /// The class representing the current and desired screen contents.
 pub struct Screen {
     /// Whether the last-drawn autosuggestion (if any) is truncated, or hidden entirely.
@@ -221,6 +729,8 @@ pub struct Screen {
 
     /// Vertical offset of the screen contents within the terminal window.
     viewport_y: Option<usize>,
+    /// Independent viewport over the visual rows of an overflowing commandline.
+    commandline_viewport: CommandlineViewport,
     /// The internal representation of the desired screen contents.
     desired: ScreenData,
     /// The internal representation of the actual screen contents.
@@ -254,6 +764,7 @@ impl Default for Screen {
             scrolled: Default::default(),
             outp: Outputter::stdoutput(),
             viewport_y: Default::default(),
+            commandline_viewport: Default::default(),
             desired: Default::default(),
             actual: Default::default(),
             actual_left_prompt: Default::default(),
@@ -289,6 +800,7 @@ impl Screen {
         autosuggested_range: Range<usize>,
         mut colors: Vec<HighlightSpec>,
         mut indent: Vec<i32>,
+        explicit_indent: Vec<i32>,
         cursor_pos: usize,
         pager_search_field_position: Option<usize>,
         vars: &dyn Environment,
@@ -385,6 +897,148 @@ impl Screen {
         } else {
             layout.left_prompt_space
         };
+
+        // Measure the explicit commandline without retaining its visual rows. Autosuggestions must
+        // never make the commandline viewport scrollable; if the explicit text overflows, the
+        // autosuggestion and completion pager are hidden until it fits again.
+        let initial_layout_state = VisualLayoutState {
+            cursor: Cursor {
+                x: 0,
+                y: layout.left_prompt_lines - 1,
+            },
+            line_count: layout.left_prompt_lines,
+        };
+        let mut measuring_builder = VisualLayoutBuilder::new(
+            initial_layout_state,
+            Some(screen_width),
+            usize::MAX,
+            MeasuringVisualLayoutSink,
+        );
+        let explicit_cursor = append_explicit_commandline(
+            &mut measuring_builder,
+            prompt_offset,
+            layout.left_prompt_space,
+            commandline_indent,
+            explicit_before_suggestion,
+            explicit_after_suggestion,
+            layout.autosuggestion.len(),
+            &colors,
+            &explicit_indent,
+            cursor_pos,
+        )
+        .expect("unbounded commandline measurement must reach its cursor");
+        // Include an empty phantom row when the command cursor sits immediately after a character
+        // in the terminal's final column.
+        let explicit_line_count = measuring_builder
+            .state
+            .line_count
+            .max(explicit_cursor.y + 1);
+        let commandline_window = self.commandline_viewport.reconcile(
+            screen_width,
+            screen_height,
+            layout.left_prompt_lines,
+            layout.left_prompt_space,
+            explicit_line_count,
+            explicit_cursor.y,
+            is_final_rendering,
+        );
+        flogf!(
+            screen,
+            "Commandline viewport: lines=%u cursor-y=%u top=%u bottom=%u scrollable=%s",
+            explicit_line_count,
+            explicit_cursor.y,
+            commandline_window.top,
+            commandline_window.bottom,
+            if commandline_window.scrollable() {
+                "true"
+            } else {
+                "false"
+            },
+        );
+
+        if commandline_window.scrollable() {
+            self.autosuggestion_is_truncated = !autosuggestion.is_empty();
+            self.desired.screen_width = Some(screen_width);
+            self.desired.clear_lines();
+            self.desired.logical_line_offset = commandline_window.top;
+            self.desired
+                .resize(commandline_window.bottom - commandline_window.top);
+
+            let mut window_builder = VisualLayoutBuilder::new(
+                initial_layout_state,
+                Some(screen_width),
+                commandline_window.bottom - 1,
+                WindowedScreenDataSink {
+                    data: &mut self.desired,
+                    top: commandline_window.top,
+                    bottom: commandline_window.bottom,
+                },
+            );
+            let materialized_cursor = append_explicit_commandline(
+                &mut window_builder,
+                prompt_offset,
+                layout.left_prompt_space,
+                commandline_indent,
+                explicit_before_suggestion,
+                explicit_after_suggestion,
+                layout.autosuggestion.len(),
+                &colors,
+                &explicit_indent,
+                cursor_pos,
+            );
+            debug_assert!(materialized_cursor.is_none_or(|cursor| cursor == explicit_cursor));
+
+            self.desired.visible_prompt_lines = layout
+                .left_prompt_lines
+                .saturating_sub(commandline_window.top)
+                .min(commandline_window.bottom - commandline_window.top);
+            self.desired.cursor = if commandline_window.cursor_hidden {
+                Cursor::default()
+            } else {
+                Cursor {
+                    x: explicit_cursor.x,
+                    y: explicit_cursor.y - commandline_window.top,
+                }
+            };
+
+            if let Some((start, stop, total)) = commandline_window.indicator_range() {
+                // The status is UI, not a continuation of the final commandline row. Preserve the
+                // commandline's logical soft-wrap only in the layout model, not across this boundary.
+                if let Some(line) = self.desired.line_datas.last_mut() {
+                    line.is_soft_wrapped = false;
+                }
+                let mut progress = wgettext_fmt!("rows %u to %u of %u", start, stop, total);
+                progress.push_str(". ");
+                progress.push_utfstr(wgettext!("Enter executes or continues"));
+                let spec = HighlightSpec::with_both(HighlightRole::PagerProgress);
+                let line = self.desired.add_line();
+                print_max(
+                    CharOffset::None,
+                    progress.chars(),
+                    spec,
+                    screen_width,
+                    /*has_more=*/ true,
+                    line,
+                );
+            }
+
+            // Keep the pager's cache coherent while withholding it from the overflowing view.
+            pager.set_term_size(&Termsize::new(curr_termsize.width_u16(), NonZeroU16::MIN));
+            pager.update_rendering(page_rendering);
+
+            // Rows from different logical windows must never be treated as a shared-prefix update.
+            self.scrolled = true;
+            let visible_right_prompt = if self.desired.visible_prompt_lines == 0 {
+                L!("")
+            } else {
+                &layout.right_prompt
+            };
+            self.with_buffered_output(|zelf| {
+                zelf.update(vars, &layout.left_prompt, visible_right_prompt);
+            });
+            self.save_status();
+            return;
+        }
 
         // Reconstruct the command line.
         let effective_commandline = explicit_before_suggestion.to_owned()
@@ -500,6 +1154,7 @@ impl Screen {
                 } = scrolled_cursor;
                 if scroll_amount != 0 && !is_final_rendering {
                     self.desired.line_datas = self.desired.line_datas.split_off(scroll_amount);
+                    self.desired.logical_line_offset = scroll_amount;
                     cursor.y -= scroll_amount;
                 }
                 cursor
@@ -585,6 +1240,22 @@ impl Screen {
         self.viewport_y = viewport_y;
     }
 
+    pub fn follow_commandline_cursor(&mut self) {
+        self.commandline_viewport.follow_cursor();
+    }
+
+    /// Scroll the independent commandline viewport by a signed number of visual rows.
+    pub fn scroll_commandline_viewport(&mut self, delta: isize) -> bool {
+        self.commandline_viewport.scroll(delta)
+    }
+
+    pub fn commandline_viewport_status(&self) -> CommandlineViewportStatus {
+        CommandlineViewportStatus {
+            scrollable: self.commandline_viewport.window.scrollable(),
+            cursor_hidden: self.commandline_viewport.window.cursor_hidden,
+        }
+    }
+
     pub fn autoscroll(&mut self, screen_height: usize) {
         let Some(viewport_y) = self.viewport_y else {
             return;
@@ -644,19 +1315,49 @@ impl Screen {
             .min(self.actual.line_count() - 1);
         let line = self.actual.line(y);
         let x = viewport_position.x.max(line.indentation);
-        let offset = line
-            .text
-            .get(x)
-            .or(line.text.last())
-            .or(if y > 0 {
-                self.actual.line(y - 1).text.last()
-            } else {
-                None
-            })
-            .map_or(CharOffset::Pointer(0), |char| char.offset_in_cmdline);
-        match offset {
-            CharOffset::Cmd(value) if x >= line.len() => CharOffset::Cmd(value + 1),
-            CharOffset::Pager(_) if x >= line.len() => CharOffset::None,
+        if line.text.is_empty() {
+            return match line.empty_offset_in_cmdline {
+                CharOffset::None if y > 0 => self
+                    .actual
+                    .line(y - 1)
+                    .text
+                    .last()
+                    .map_or(CharOffset::Pointer(0), |char| {
+                        next_char_offset(char.offset_in_cmdline)
+                    }),
+                CharOffset::None => CharOffset::Pointer(0),
+                offset => offset,
+            };
+        }
+        let mut column = 0;
+        for (char_index, highlighted_char) in line.text.iter().enumerate() {
+            let width = wcwidth_rendered_min_0(highlighted_char.character);
+            if width == 0 {
+                continue;
+            }
+            let next_column = column + width;
+            if x < next_column {
+                // A click in the right half of a wide character belongs to the following cursor
+                // boundary. Skip combining characters, which do not have an independent cell.
+                if x - column >= width.div_ceil(2) {
+                    if let Some(next) = line.text[char_index + 1..]
+                        .iter()
+                        .find(|char| wcwidth_rendered_min_0(char.character) > 0)
+                    {
+                        return next.offset_in_cmdline;
+                    }
+                    return line.text.last().map_or(CharOffset::Pointer(0), |char| {
+                        next_char_offset(char.offset_in_cmdline)
+                    });
+                }
+                return highlighted_char.offset_in_cmdline;
+            }
+            column = next_column;
+        }
+        match line.text.last().map_or(CharOffset::Pointer(0), |char| {
+            next_char_offset(char.offset_in_cmdline)
+        }) {
+            CharOffset::Pager(_) => CharOffset::None,
             offset => offset,
         }
     }
@@ -666,6 +1367,7 @@ impl Screen {
     /// If clear_to_eos is set,
     /// The screen width must be provided for the PROMPT_SP hack.
     pub fn reset_abandoning_line(&mut self, screen_width: Option<usize>) {
+        self.commandline_viewport.reset();
         self.actual.cursor.y = 0;
         self.actual.clear_lines();
         self.actual_left_prompt = None;
@@ -736,6 +1438,7 @@ impl Screen {
     pub fn cursor_is_wrapped_to_own_line(&self) -> bool {
         // Don't consider dumb terminals to have wrapping for the purposes of this function.
         self.actual.cursor.x == 0
+            && self.actual.cursor.y > 0
             && self.actual.cursor.y + 1 != self.actual.visible_prompt_lines
             && self.actual.cursor.y + 1 == self.actual.line_count()
             && self.actual.line(self.actual.cursor.y - 1).is_soft_wrapped
@@ -749,82 +1452,37 @@ impl Screen {
         &mut self,
         offset_in_cmdline: CharOffset,
         max_y: usize,
-        b: char,
-        c: HighlightSpec,
+        character: char,
+        highlight: HighlightSpec,
         indent: usize,
         prompt_width: usize,
-        bwidth: usize,
+        character_width: usize,
     ) -> bool {
-        let mut line_no = self.desired.cursor.y;
-
-        if b == '\n' {
-            // Current line is definitely hard wrapped.
-            // Create the next line.
-            if self.desired.cursor.y + 1 > max_y {
-                return false;
-            }
-            self.desired.create_line(self.desired.cursor.y + 1);
-            self.desired.line_mut(self.desired.cursor.y).is_soft_wrapped = false;
-            self.desired.cursor.y += 1;
-            let line_no = self.desired.cursor.y;
-            self.desired.cursor.x = 0;
-            let indentation = prompt_width + indent * INDENT_STEP;
-            let line = self.desired.line_mut(line_no);
-            line.indentation = indentation;
-            for _ in 0..indentation {
-                if !self.desired_append_char(
-                    offset_in_cmdline,
-                    max_y,
-                    ' ',
-                    HighlightSpec::default(),
-                    indent,
-                    prompt_width,
-                    1,
-                ) {
-                    return false;
-                }
-            }
-        } else if b == '\r' {
-            let current = self.desired.line_mut(line_no);
-            current.clear();
-            self.desired.cursor.x = 0;
-        } else {
-            let screen_width = self.desired.screen_width;
-            let cw = bwidth;
-
-            if line_no > max_y {
-                return false;
-            }
-            self.desired.create_line(line_no);
-
-            // Check if we are at the end of the line. If so, continue on the next line.
-            if screen_width.is_none_or(|sw| (self.desired.cursor.x + cw) > sw) {
-                if self.desired.cursor.y + 1 > max_y {
-                    return false;
-                }
-                // Current line is soft wrapped (assuming we support it).
-                self.desired.line_mut(self.desired.cursor.y).is_soft_wrapped = true;
-
-                line_no = self.desired.line_count();
-                self.desired.add_line();
-                self.desired.cursor.y += 1;
-                self.desired.cursor.x = 0;
-            }
-
-            self.desired
-                .line_mut(line_no)
-                .append(b, c, offset_in_cmdline);
-            self.desired.cursor.x += cw;
-
-            // Maybe wrap the cursor to the next line, even if the line itself did not wrap. This
-            // avoids wonkiness in the last column.
-            if screen_width.is_none_or(|sw| self.desired.cursor.x >= sw) {
-                self.desired.line_mut(line_no).is_soft_wrapped = true;
-                self.desired.cursor.x = 0;
-                self.desired.cursor.y += 1;
-            }
-        }
-        true
+        let state = VisualLayoutState {
+            cursor: self.desired.cursor,
+            line_count: self.desired.line_count(),
+        };
+        let screen_width = self.desired.screen_width;
+        let mut builder = VisualLayoutBuilder::new(
+            state,
+            screen_width,
+            max_y,
+            ScreenDataSink {
+                data: &mut self.desired,
+            },
+        );
+        let result = builder.append_char(
+            offset_in_cmdline,
+            character,
+            highlight,
+            indent,
+            prompt_width,
+            character_width,
+        );
+        let state = builder.state;
+        self.desired.cursor = state.cursor;
+        debug_assert_eq!(self.desired.line_count(), state.line_count);
+        result
     }
 
     /// Stat stdout and stderr and compare result to previous result in reader_save_status. Repaint
@@ -1150,11 +1808,12 @@ impl Screen {
 
             let previously_prompt_line = self.actual.visible_prompt_lines > i + 1;
 
-            let shared_prefix = if self.scrolled || previously_prompt_line {
-                0
-            } else {
-                line_shared_prefix(o_line(self, i), s_line(self, i))
-            };
+            let shared_prefix = screen_data_line_shared_prefix(
+                &self.actual,
+                &self.desired,
+                i,
+                previously_prompt_line,
+            );
             let mut skip_prefix = shared_prefix;
             if shared_prefix < o_line(self, i).indentation || previously_prompt_line {
                 if !has_cleared_screen
@@ -1816,6 +2475,19 @@ fn line_shared_prefix(a: &Line, b: &Line) -> usize {
     idx
 }
 
+fn screen_data_line_shared_prefix(
+    actual: &ScreenData,
+    desired: &ScreenData,
+    line: usize,
+    previously_prompt_line: bool,
+) -> usize {
+    if actual.logical_line_offset != desired.logical_line_offset || previously_prompt_line {
+        0
+    } else {
+        line_shared_prefix(desired.line(line), actual.line(line))
+    }
+}
+
 pub(crate) static IS_DUMB: RelaxedAtomicBool = RelaxedAtomicBool::new(false);
 pub(crate) static ONLY_GRAYSCALE: RelaxedAtomicBool = RelaxedAtomicBool::new(false);
 
@@ -2074,14 +2746,559 @@ pub fn wcswidth_rendered(s: &wstr) -> usize {
 #[cfg(test)]
 mod tests {
     use crate::highlight::HighlightSpec;
+    use crate::key::ViewportPosition;
     use crate::parse_util::compute_indents;
     use crate::prelude::*;
     use crate::screen::{
-        LayoutCache, PromptCacheEntry, PromptLayout, ScreenLayout, compute_layout,
+        CharOffset, CommandlineViewport, CommandlineViewportMode, Cursor, LayoutCache,
+        PromptCacheEntry, PromptLayout, ScreenData, ScreenDataSink, ScreenLayout,
+        VisualLayoutBuilder, VisualLayoutSink, VisualLayoutState, WindowedScreenDataSink,
+        append_explicit_commandline, compute_layout, screen_data_line_shared_prefix,
     };
     use crate::tests::prelude::*;
     use fish_wcstringutil::join_strings;
     use fish_widestring::ELLIPSIS_CHAR;
+
+    #[derive(Default)]
+    struct MeasuringSink;
+
+    impl VisualLayoutSink for MeasuringSink {
+        fn create_line(&mut self, _idx: usize) {}
+        fn clear_line(&mut self, _idx: usize) {}
+        fn set_soft_wrapped(&mut self, _idx: usize, _value: bool) {}
+        fn set_indentation(&mut self, _idx: usize, _indentation: usize) {}
+        fn set_empty_offset(&mut self, _idx: usize, _offset_in_cmdline: CharOffset) {}
+        fn append(
+            &mut self,
+            _idx: usize,
+            _character: char,
+            _highlight: HighlightSpec,
+            _offset_in_cmdline: CharOffset,
+        ) {
+        }
+    }
+
+    fn append_layout_chars<S: VisualLayoutSink>(
+        builder: &mut VisualLayoutBuilder<S>,
+        chars: &[(char, usize, usize)],
+    ) {
+        for (idx, &(character, width, indent)) in chars.iter().enumerate() {
+            assert!(builder.append_char(
+                CharOffset::Cmd(idx),
+                character,
+                HighlightSpec::default(),
+                indent,
+                1,
+                width,
+            ));
+        }
+    }
+
+    fn line_text(data: &ScreenData, idx: usize) -> String {
+        data.line(idx).text.iter().map(|c| c.character).collect()
+    }
+
+    #[test]
+    fn test_visual_layout_builder_wraps_and_phantom_line() {
+        let mut data = ScreenData {
+            screen_width: Some(4),
+            ..Default::default()
+        };
+        data.resize(1);
+        let state = VisualLayoutState {
+            cursor: Cursor::default(),
+            line_count: data.line_count(),
+        };
+        let mut builder = VisualLayoutBuilder::new(
+            state,
+            data.screen_width,
+            usize::MAX,
+            ScreenDataSink { data: &mut data },
+        );
+
+        append_layout_chars(
+            &mut builder,
+            &[('a', 1, 0), ('\u{301}', 0, 0), ('界', 2, 0), ('b', 1, 0)],
+        );
+        assert_eq!(
+            builder.state,
+            VisualLayoutState {
+                cursor: Cursor { x: 0, y: 1 },
+                line_count: 1,
+            }
+        );
+        assert_eq!(line_text(builder.sink.data, 0), "a\u{301}界b");
+        assert!(builder.sink.data.line(0).is_soft_wrapped);
+        // The terminal cursor occupies a phantom row after an exact-width commandline even though
+        // that row has not been materialized yet.
+        assert_eq!(builder.state.line_count.max(builder.state.cursor.y + 1), 2);
+
+        append_layout_chars(&mut builder, &[('\r', 0, 0)]);
+        assert_eq!(builder.state.cursor, Cursor { x: 0, y: 1 });
+        assert_eq!(builder.state.line_count, 2);
+        assert_eq!(line_text(builder.sink.data, 1), "");
+
+        append_layout_chars(&mut builder, &[('c', 1, 0)]);
+        assert_eq!(builder.state.cursor, Cursor { x: 1, y: 1 });
+        assert_eq!(builder.state.line_count, 2);
+        assert_eq!(line_text(builder.sink.data, 1), "c");
+    }
+
+    #[test]
+    fn test_visual_layout_builder_newline_indent_wide_and_carriage_return() {
+        let mut data = ScreenData {
+            screen_width: Some(6),
+            ..Default::default()
+        };
+        data.resize(1);
+        let state = VisualLayoutState {
+            cursor: Cursor::default(),
+            line_count: data.line_count(),
+        };
+        let mut builder = VisualLayoutBuilder::new(
+            state,
+            data.screen_width,
+            usize::MAX,
+            ScreenDataSink { data: &mut data },
+        );
+
+        append_layout_chars(
+            &mut builder,
+            &[
+                ('a', 1, 0),
+                ('b', 1, 0),
+                ('\r', 0, 0),
+                ('z', 1, 0),
+                ('\n', 0, 1),
+                ('界', 2, 0),
+            ],
+        );
+
+        assert_eq!(line_text(builder.sink.data, 0), "z");
+        assert!(!builder.sink.data.line(0).is_soft_wrapped);
+        assert_eq!(line_text(builder.sink.data, 1), "     ");
+        assert_eq!(builder.sink.data.line(1).indentation, 5);
+        assert!(builder.sink.data.line(1).is_soft_wrapped);
+        assert_eq!(line_text(builder.sink.data, 2), "界");
+        assert_eq!(builder.state.cursor, Cursor { x: 2, y: 2 });
+    }
+
+    #[test]
+    fn test_visual_layout_measurement_matches_materialization_and_is_bounded() {
+        let chars = [
+            ('a', 1, 0),
+            ('界', 2, 0),
+            ('\u{301}', 0, 0),
+            ('b', 1, 0),
+            ('\n', 0, 1),
+            ('c', 1, 0),
+            ('\r', 0, 0),
+            ('d', 1, 0),
+        ];
+        let state = VisualLayoutState {
+            cursor: Cursor::default(),
+            line_count: 1,
+        };
+        let mut measured = VisualLayoutBuilder::new(state, Some(5), usize::MAX, MeasuringSink);
+        append_layout_chars(&mut measured, &chars);
+
+        let mut data = ScreenData {
+            screen_width: Some(5),
+            ..Default::default()
+        };
+        data.resize(1);
+        let mut materialized = VisualLayoutBuilder::new(
+            state,
+            data.screen_width,
+            usize::MAX,
+            ScreenDataSink { data: &mut data },
+        );
+        append_layout_chars(&mut materialized, &chars);
+        assert_eq!(measured.state, materialized.state);
+
+        let mut large = VisualLayoutBuilder::new(state, Some(10), usize::MAX, MeasuringSink);
+        for idx in 0..100_000 {
+            assert!(large.append_char(
+                CharOffset::Cmd(idx),
+                'x',
+                HighlightSpec::default(),
+                0,
+                0,
+                1,
+            ));
+        }
+        assert_eq!(large.state.cursor, Cursor { x: 0, y: 10_000 });
+        assert_eq!(large.state.line_count, 10_000);
+    }
+
+    #[test]
+    fn test_commandline_viewport_follow_manual_and_range() {
+        let mut viewport = CommandlineViewport::default();
+        let window = viewport.reconcile(30, 6, 1, 2, 20, 19, false);
+        assert!(window.scrollable());
+        assert_eq!((window.top, window.bottom), (15, 20));
+        assert_eq!(window.indicator_range(), Some((16, 20, 20)));
+        assert!(!window.cursor_hidden);
+
+        assert!(viewport.scroll(-3));
+        let window = viewport.reconcile(30, 6, 1, 2, 20, 19, false);
+        assert_eq!(viewport.mode, CommandlineViewportMode::Manual);
+        assert_eq!((window.top, window.bottom), (12, 17));
+        assert_eq!(window.indicator_range(), Some((13, 17, 20)));
+        assert!(window.cursor_hidden);
+
+        assert!(viewport.scroll(3));
+        assert!(!viewport.scroll(3));
+        let window = viewport.reconcile(30, 6, 1, 2, 20, 19, false);
+        assert_eq!((window.top, window.bottom), (15, 20));
+        assert!(!window.cursor_hidden);
+    }
+
+    #[test]
+    fn test_commandline_viewport_follows_cursor_only_across_edges() {
+        let mut viewport = CommandlineViewport::default();
+        let window = viewport.reconcile(30, 6, 1, 2, 20, 19, false);
+        assert_eq!((window.top, window.bottom), (15, 20));
+
+        for cursor_y in [18, 15] {
+            let window = viewport.reconcile(30, 6, 1, 2, 20, cursor_y, false);
+            assert_eq!((window.top, window.bottom), (15, 20));
+        }
+
+        let window = viewport.reconcile(30, 6, 1, 2, 20, 14, false);
+        assert_eq!((window.top, window.bottom), (14, 19));
+        let window = viewport.reconcile(30, 6, 1, 2, 20, 18, false);
+        assert_eq!((window.top, window.bottom), (14, 19));
+        let window = viewport.reconcile(30, 6, 1, 2, 20, 19, false);
+        assert_eq!((window.top, window.bottom), (15, 20));
+
+        assert!(viewport.scroll(-3));
+        viewport.follow_cursor();
+        let window = viewport.reconcile(30, 6, 1, 2, 20, 14, false);
+        assert_eq!((window.top, window.bottom), (12, 17));
+        let window = viewport.reconcile(30, 6, 1, 2, 20, 19, false);
+        assert_eq!((window.top, window.bottom), (15, 20));
+    }
+
+    #[test]
+    fn test_screen_data_shared_prefix_requires_same_logical_window() {
+        let mut actual = ScreenData::default();
+        actual.resize(1);
+        actual
+            .line_mut(0)
+            .append_str(L!("abcdef"), HighlightSpec::default(), CharOffset::Cmd(0));
+        actual.logical_line_offset = 10;
+        let mut desired = actual.clone();
+
+        assert_eq!(
+            screen_data_line_shared_prefix(&actual, &desired, 0, false),
+            6
+        );
+        assert_eq!(
+            screen_data_line_shared_prefix(&actual, &desired, 0, true),
+            0
+        );
+        desired.logical_line_offset = 11;
+        assert_eq!(
+            screen_data_line_shared_prefix(&actual, &desired, 0, false),
+            0
+        );
+    }
+
+    #[test]
+    fn test_windowed_materialization_stops_after_visible_rows() {
+        let commandline = L!("a\nb\nc\nd\ne");
+        let mut data = ScreenData {
+            screen_width: Some(10),
+            ..Default::default()
+        };
+        data.resize(2);
+        let mut builder = VisualLayoutBuilder::new(
+            VisualLayoutState {
+                cursor: Cursor::default(),
+                line_count: 1,
+            },
+            data.screen_width,
+            2,
+            WindowedScreenDataSink {
+                data: &mut data,
+                top: 1,
+                bottom: 3,
+            },
+        );
+        let cursor = append_explicit_commandline(
+            &mut builder,
+            CharOffset::Pointer(0),
+            0,
+            0,
+            commandline,
+            L!(""),
+            0,
+            &[HighlightSpec::default(); 9],
+            &[0; 9],
+            commandline.len(),
+        );
+        assert_eq!(cursor, None);
+        assert_eq!(builder.state.line_count, 3);
+        assert_eq!(line_text(builder.sink.data, 0), "b");
+        assert_eq!(line_text(builder.sink.data, 1), "c");
+    }
+
+    #[test]
+    fn test_commandline_viewport_resize_and_geometry_follow_rules() {
+        let mut viewport = CommandlineViewport::default();
+        viewport.reconcile(30, 6, 1, 2, 20, 19, false);
+        assert!(viewport.scroll(-6));
+
+        // Height-only changes preserve Manual mode and clamp the current top if necessary.
+        let window = viewport.reconcile(30, 15, 1, 2, 20, 19, false);
+        assert_eq!(viewport.mode, CommandlineViewportMode::Manual);
+        assert_eq!(window.top, 6);
+        let window = viewport.reconcile(30, 4, 1, 2, 20, 19, false);
+        assert_eq!(viewport.mode, CommandlineViewportMode::Manual);
+        assert_eq!(window.top, 6);
+
+        // Once the whole commandline fits, a later overflow starts by following the cursor again.
+        let window = viewport.reconcile(30, 30, 1, 2, 20, 19, false);
+        assert_eq!(viewport.mode, CommandlineViewportMode::FollowCursor);
+        assert_eq!(window.top, 0);
+        let window = viewport.reconcile(30, 4, 1, 2, 20, 19, false);
+        assert_eq!(viewport.mode, CommandlineViewportMode::FollowCursor);
+        assert_eq!(window.top, 17);
+        assert!(!window.cursor_hidden);
+
+        assert!(viewport.scroll(-6));
+
+        // Width or prompt geometry changes invalidate visual row coordinates and resume Follow.
+        let window = viewport.reconcile(31, 4, 1, 2, 20, 19, false);
+        assert_eq!(viewport.mode, CommandlineViewportMode::FollowCursor);
+        assert_eq!(window.top, 17);
+        assert!(!window.cursor_hidden);
+
+        assert!(viewport.scroll(-3));
+        let window = viewport.reconcile(31, 4, 2, 3, 20, 19, false);
+        assert_eq!(viewport.mode, CommandlineViewportMode::FollowCursor);
+        assert_eq!(window.top, 17);
+    }
+
+    #[test]
+    fn test_commandline_viewport_nonoverflow_final_and_one_line_terminal() {
+        let mut viewport = CommandlineViewport::default();
+        let window = viewport.reconcile(30, 6, 1, 2, 4, 3, false);
+        assert!(!window.scrollable());
+        assert!(!window.show_indicator);
+        assert_eq!((window.top, window.bottom), (0, 4));
+        assert!(!viewport.scroll(-3));
+
+        let window = viewport.reconcile(30, 1, 1, 2, 4, 3, false);
+        assert!(window.scrollable());
+        assert!(!window.show_indicator);
+        assert_eq!((window.top, window.bottom), (3, 4));
+        assert!(viewport.scroll(-3));
+        let window = viewport.reconcile(30, 1, 1, 2, 4, 3, false);
+        assert_eq!((window.top, window.bottom), (2, 3));
+        assert!(viewport.scroll(-3));
+        let window = viewport.reconcile(30, 1, 1, 2, 4, 3, false);
+        assert_eq!((window.top, window.bottom), (1, 2));
+        assert!(viewport.scroll(-3));
+        let window = viewport.reconcile(30, 1, 1, 2, 4, 3, false);
+        assert_eq!((window.top, window.bottom), (0, 1));
+        assert!(!viewport.scroll(-3));
+
+        let window = viewport.reconcile(30, 1, 1, 2, 4, 3, true);
+        assert!(!window.scrollable());
+        assert!(!window.show_indicator);
+        assert_eq!((window.top, window.bottom), (0, 4));
+        assert!(!window.cursor_hidden);
+
+        viewport.reset();
+        assert_eq!(viewport, CommandlineViewport::default());
+    }
+
+    #[test]
+    #[serial]
+    fn test_commandline_viewport_materialization_and_click_offsets() {
+        test_init();
+        let commandline = L!("a\nb\nc\nd");
+        let colors = vec![HighlightSpec::default(); commandline.len()];
+        let indent = vec![0; commandline.len()];
+        let mut data = ScreenData {
+            screen_width: Some(10),
+            ..Default::default()
+        };
+        data.resize(2);
+        let mut builder = VisualLayoutBuilder::new(
+            VisualLayoutState {
+                cursor: Cursor::default(),
+                line_count: 1,
+            },
+            data.screen_width,
+            usize::MAX,
+            WindowedScreenDataSink {
+                data: &mut data,
+                top: 2,
+                bottom: 4,
+            },
+        );
+        let cursor = append_explicit_commandline(
+            &mut builder,
+            CharOffset::Pointer(0),
+            0,
+            0,
+            commandline,
+            L!(""),
+            0,
+            &colors,
+            &indent,
+            commandline.len(),
+        )
+        .unwrap();
+        assert_eq!(cursor, Cursor { x: 1, y: 3 });
+        assert_eq!(line_text(builder.sink.data, 0), "c");
+        assert_eq!(line_text(builder.sink.data, 1), "d");
+        builder.sink.data.add_line().append_str(
+            L!("rows 3 to 4 of 4"),
+            HighlightSpec::with_both(crate::highlight::HighlightRole::PagerProgress),
+            CharOffset::None,
+        );
+
+        let mut screen = crate::screen::Screen {
+            viewport_y: Some(0),
+            actual: builder.sink.data.clone(),
+            ..Default::default()
+        };
+        screen.actual.visible_prompt_lines = 0;
+        assert!(matches!(
+            screen.offset_in_cmdline_given_cursor(ViewportPosition { x: 0, y: 0 }),
+            CharOffset::Cmd(4)
+        ));
+        assert!(matches!(
+            screen.offset_in_cmdline_given_cursor(ViewportPosition { x: 2, y: 0 }),
+            CharOffset::Cmd(5)
+        ));
+        assert!(matches!(
+            screen.offset_in_cmdline_given_cursor(ViewportPosition { x: 0, y: 2 }),
+            CharOffset::None
+        ));
+
+        let mut phantom = ScreenData {
+            screen_width: Some(4),
+            ..Default::default()
+        };
+        phantom.resize(1);
+        let mut phantom_builder = VisualLayoutBuilder::new(
+            VisualLayoutState {
+                cursor: Cursor::default(),
+                line_count: 1,
+            },
+            phantom.screen_width,
+            usize::MAX,
+            WindowedScreenDataSink {
+                data: &mut phantom,
+                top: 2,
+                bottom: 3,
+            },
+        );
+        append_explicit_commandline(
+            &mut phantom_builder,
+            CharOffset::Pointer(0),
+            0,
+            0,
+            L!("abcdefgh"),
+            L!(""),
+            0,
+            &[HighlightSpec::default(); 8],
+            &[0; 8],
+            8,
+        );
+        let mut phantom_screen = crate::screen::Screen {
+            viewport_y: Some(0),
+            actual: phantom,
+            ..Default::default()
+        };
+        assert!(matches!(
+            phantom_screen.offset_in_cmdline_given_cursor(ViewportPosition { x: 0, y: 0 }),
+            CharOffset::Cmd(8)
+        ));
+
+        let mut empty = ScreenData {
+            screen_width: Some(4),
+            ..Default::default()
+        };
+        empty.resize(1);
+        let mut empty_builder = VisualLayoutBuilder::new(
+            VisualLayoutState {
+                cursor: Cursor::default(),
+                line_count: 1,
+            },
+            empty.screen_width,
+            usize::MAX,
+            WindowedScreenDataSink {
+                data: &mut empty,
+                top: 1,
+                bottom: 2,
+            },
+        );
+        append_explicit_commandline(
+            &mut empty_builder,
+            CharOffset::Pointer(0),
+            0,
+            0,
+            L!("a\n\nb"),
+            L!(""),
+            0,
+            &[HighlightSpec::default(); 4],
+            &[0; 4],
+            4,
+        );
+        let mut empty_screen = crate::screen::Screen {
+            viewport_y: Some(0),
+            actual: empty,
+            ..Default::default()
+        };
+        assert!(matches!(
+            empty_screen.offset_in_cmdline_given_cursor(ViewportPosition { x: 0, y: 0 }),
+            CharOffset::Cmd(2)
+        ));
+
+        let mut wide = ScreenData::default();
+        wide.resize(1);
+        for (idx, char) in L!("界界x").chars().enumerate() {
+            wide.line_mut(0)
+                .append(char, HighlightSpec::default(), CharOffset::Cmd(idx));
+        }
+        let mut wide_screen = crate::screen::Screen {
+            viewport_y: Some(0),
+            actual: wide,
+            ..Default::default()
+        };
+        assert!(matches!(
+            wide_screen.offset_in_cmdline_given_cursor(ViewportPosition { x: 3, y: 0 }),
+            CharOffset::Cmd(2)
+        ));
+
+        let mut combining = ScreenData::default();
+        combining.resize(1);
+        for (idx, char) in L!("a\u{301}b").chars().enumerate() {
+            combining
+                .line_mut(0)
+                .append(char, HighlightSpec::default(), CharOffset::Cmd(idx));
+        }
+        let mut combining_screen = crate::screen::Screen {
+            viewport_y: Some(0),
+            actual: combining,
+            ..Default::default()
+        };
+        assert!(matches!(
+            combining_screen.offset_in_cmdline_given_cursor(ViewportPosition { x: 1, y: 0 }),
+            CharOffset::Cmd(2)
+        ));
+
+        screen.actual.line_datas.truncate(1);
+        screen.actual.cursor = Cursor::default();
+        screen.actual.visible_prompt_lines = 0;
+        assert!(!screen.cursor_is_wrapped_to_own_line());
+    }
 
     #[test]
     #[serial]

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -119,6 +119,13 @@ pub(crate) enum TerminalCommand<'a> {
     ScrollContentUp { lines: usize },
 
     DecsetShowCursor,
+    DecrstShowCursor,
+    XtsaveMouseTrackingModes,
+    XtrestoreMouseTrackingModes,
+    DecsetMouseButtonTracking,
+    DecrstMouseButtonTracking,
+    DecsetMouseSgrEncoding,
+    DecrstMouseSgrEncoding,
     DecsetFocusReporting,
     DecrstFocusReporting,
     DecsetBracketedPaste,
@@ -324,6 +331,17 @@ impl Outputter {
             QueryBackgroundColor => write(self, b"\x1b]11;?\x1b\\"),
             ScrollContentUp { lines } => scroll_content_up(self, lines),
             DecsetShowCursor => write(self, b"\x1b[?25h"),
+            DecrstShowCursor => write(self, b"\x1b[?25l"),
+            XtsaveMouseTrackingModes => {
+                write(self, b"\x1b[?9;1000;1001;1002;1003;1005;1006;1015;1016s")
+            }
+            XtrestoreMouseTrackingModes => {
+                write(self, b"\x1b[?1016;1015;1006;1005;1003;1002;1001;1000;9r")
+            }
+            DecsetMouseButtonTracking => write(self, b"\x1b[?1000h"),
+            DecrstMouseButtonTracking => write(self, b"\x1b[?1000l"),
+            DecsetMouseSgrEncoding => write(self, b"\x1b[?1006h"),
+            DecrstMouseSgrEncoding => write(self, b"\x1b[?1006l"),
             DecsetFocusReporting => write(self, b"\x1b[?1004h"),
             DecrstFocusReporting => write(self, b"\x1b[?1004l"),
             DecsetBracketedPaste => write(self, b"\x1b[?2004h"),

--- a/src/tty_handoff.rs
+++ b/src/tty_handoff.rs
@@ -11,13 +11,16 @@ use crate::proc::JobGroupRef;
 use crate::terminal::Outputter;
 use crate::terminal::TerminalCommand::{
     self, ApplicationKeypadModeDisable, ApplicationKeypadModeEnable, DecrstBracketedPaste,
-    DecrstColorThemeReporting, DecrstFocusReporting, DecsetBracketedPaste,
-    DecsetColorThemeReporting, DecsetFocusReporting, KittyKeyboardProgressiveEnhancementsDisable,
-    KittyKeyboardProgressiveEnhancementsEnable, ModifyOtherKeysDisable, ModifyOtherKeysEnable,
+    DecrstColorThemeReporting, DecrstFocusReporting, DecrstMouseButtonTracking,
+    DecrstMouseSgrEncoding, DecrstShowCursor, DecsetBracketedPaste, DecsetColorThemeReporting,
+    DecsetFocusReporting, DecsetMouseButtonTracking, DecsetMouseSgrEncoding, DecsetShowCursor,
+    KittyKeyboardProgressiveEnhancementsDisable, KittyKeyboardProgressiveEnhancementsEnable,
+    ModifyOtherKeysDisable, ModifyOtherKeysEnable, XtrestoreMouseTrackingModes,
+    XtsaveMouseTrackingModes,
 };
 use crate::threads::assert_is_main_thread;
 use crate::wutil::{perror_nix, wcstoi};
-use fish_common::{STDIN_FD, write_loop};
+use fish_common::{STDIN_FD, STDOUT_FD, write_loop};
 use fish_util::perror;
 use libc::{STDIN_FILENO, WNOHANG};
 use nix::errno::Errno;
@@ -258,8 +261,137 @@ pub fn initialize_tty_protocols(vars: &dyn Environment) {
 // A marker of the current state of the tty protocols.
 static TTY_PROTOCOLS_ACTIVE: RelaxedAtomicBool = RelaxedAtomicBool::new(false);
 
+/// Dynamic terminal modes requested by the active reader. These are kept separate from
+/// `TTY_PROTOCOLS_ACTIVE`: a reader may update its request while terminal protocols are suspended
+/// for a child process, prompt command, or nested reader.
+static MOUSE_TRACKING_REQUESTED: RelaxedAtomicBool = RelaxedAtomicBool::new(false);
+static MOUSE_TRACKING_APPLIED: RelaxedAtomicBool = RelaxedAtomicBool::new(false);
+static CURSOR_HIDDEN_REQUESTED: RelaxedAtomicBool = RelaxedAtomicBool::new(false);
+static CURSOR_HIDDEN_APPLIED: RelaxedAtomicBool = RelaxedAtomicBool::new(false);
+
 // A marker that the tty has been closed (SIGHUP, etc) and so we should not try to write to it.
 static TTY_INVALID: RelaxedAtomicBool = RelaxedAtomicBool::new(false);
+
+/// Dynamic terminal modes required by the active reader viewport.
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
+pub struct TtyReaderModeRequest {
+    pub mouse_tracking: bool,
+    pub cursor_hidden: bool,
+}
+
+fn tty_reader_mode_request() -> TtyReaderModeRequest {
+    TtyReaderModeRequest {
+        mouse_tracking: MOUSE_TRACKING_REQUESTED.load(),
+        cursor_hidden: CURSOR_HIDDEN_REQUESTED.load(),
+    }
+}
+
+fn tty_reader_mode_applied() -> TtyReaderModeRequest {
+    TtyReaderModeRequest {
+        mouse_tracking: MOUSE_TRACKING_APPLIED.load(),
+        cursor_hidden: CURSOR_HIDDEN_APPLIED.load(),
+    }
+}
+
+fn store_tty_reader_mode_applied(applied: TtyReaderModeRequest) {
+    MOUSE_TRACKING_APPLIED.store(applied.mouse_tracking);
+    CURSOR_HIDDEN_APPLIED.store(applied.cursor_hidden);
+}
+
+/// Append commands which transition dynamic reader modes, returning whether anything changed.
+fn append_tty_reader_mode_commands(
+    out: &mut Outputter,
+    applied: &mut TtyReaderModeRequest,
+    desired: TtyReaderModeRequest,
+) -> bool {
+    if *applied == desired {
+        return false;
+    }
+
+    // Restore user-facing state before relinquishing the terminal.
+    if applied.cursor_hidden && !desired.cursor_hidden {
+        out.write_command(DecsetShowCursor);
+        applied.cursor_hidden = false;
+    }
+    if applied.mouse_tracking && !desired.mouse_tracking {
+        out.write_command(DecrstMouseButtonTracking);
+        out.write_command(DecrstMouseSgrEncoding);
+        out.write_command(XtrestoreMouseTrackingModes);
+        applied.mouse_tracking = false;
+    }
+
+    // Apply mouse capture before hiding the cursor when entering reader viewport mode.
+    if !applied.mouse_tracking && desired.mouse_tracking {
+        out.write_command(XtsaveMouseTrackingModes);
+        out.write_command(DecsetMouseSgrEncoding);
+        out.write_command(DecsetMouseButtonTracking);
+        applied.mouse_tracking = true;
+    }
+    if !applied.cursor_hidden && desired.cursor_hidden {
+        out.write_command(DecrstShowCursor);
+        applied.cursor_hidden = true;
+    }
+    true
+}
+
+/// Synchronize the applied reader modes with the current request and protocol-active state.
+/// Returns whether any terminal commands were written.
+fn sync_tty_reader_modes() -> bool {
+    assert_is_main_thread();
+
+    let protocols_active = TTY_PROTOCOLS_ACTIVE.load();
+    let desired = TtyReaderModeRequest {
+        mouse_tracking: protocols_active && MOUSE_TRACKING_REQUESTED.load(),
+        cursor_hidden: protocols_active && CURSOR_HIDDEN_REQUESTED.load(),
+    };
+
+    // Normal synchronization stops once the tty is invalid. The disabling path may still perform
+    // one best-effort cleanup if it confirms that stdout remains a usable tty.
+    if TTY_INVALID.load() {
+        store_tty_reader_mode_applied(TtyReaderModeRequest::default());
+        return false;
+    }
+
+    let mut applied = tty_reader_mode_applied();
+    let mut out = Outputter::new_buffering();
+    if !append_tty_reader_mode_commands(&mut out, &mut applied, desired) {
+        return false;
+    }
+    store_tty_reader_mode_applied(applied);
+    let _ = write_loop(&libc::STDOUT_FILENO, out.contents());
+    true
+}
+
+/// Update dynamic reader terminal modes. Requests are remembered while protocols are suspended and
+/// applied when the enclosing [`TtyHandoff`] enables them again.
+pub fn set_tty_reader_mode_request(request: TtyReaderModeRequest, on_write: fn()) {
+    assert_is_main_thread();
+    MOUSE_TRACKING_REQUESTED.store(request.mouse_tracking);
+    CURSOR_HIDDEN_REQUESTED.store(request.cursor_hidden);
+    if sync_tty_reader_modes() {
+        (on_write)();
+    }
+}
+
+/// A scoped reader-mode request. Nested readers start with no dynamic modes and restore the outer
+/// reader's current request on drop.
+pub struct TtyReaderModeRequestGuard {
+    previous: TtyReaderModeRequest,
+    on_write: fn(),
+}
+
+pub fn push_tty_reader_mode_request(on_write: fn()) -> TtyReaderModeRequestGuard {
+    assert_is_main_thread();
+    let previous = tty_reader_mode_request();
+    set_tty_reader_mode_request(TtyReaderModeRequest::default(), on_write);
+    TtyReaderModeRequestGuard { previous, on_write }
+}
+
+impl Drop for TtyReaderModeRequestGuard {
+    fn drop(&mut self) {
+        set_tty_reader_mode_request(self.previous, self.on_write);
+    }
+}
 
 // Enable or disable TTY protocols by writing the appropriate commands to the tty.
 // Note this does NOT intialize the TTY protocols if not already initialized.
@@ -275,20 +407,38 @@ fn set_tty_protocols_active(on_write: fn(), enable: bool) {
     if TTY_PROTOCOLS_ACTIVE.load() == enable {
         return;
     }
-    if enable {
-        TTY_PROTOCOLS_ACTIVE.store(true);
-    }
+    // Update logical state before checking TTY_INVALID. In particular, a handoff that happens
+    // after SIGHUP must not leave our active marker stuck at true merely because writes are unsafe.
+    TTY_PROTOCOLS_ACTIVE.store(enable);
 
-    // Did we get SIGHUP?
-    if TTY_INVALID.load() {
+    // Enabling after SIGHUP is never useful. When disabling, however, a parent may have sent HUP
+    // while the PTY is still usable. In that case perform one final best-effort cleanup before the
+    // reader redirects genuinely unusable descriptors.
+    if TTY_INVALID.load() && (enable || tcgetattr(STDOUT_FD).is_err()) {
+        store_tty_reader_mode_applied(TtyReaderModeRequest::default());
         return;
     }
 
-    // Write the commands to the tty, ignoring errors.
+    // Dynamic reader modes must not leak to child processes. Restore them before disabling the
+    // baseline protocols, and reapply the latest request after enabling the baseline protocols.
+    let mut did_write = false;
+    if !enable {
+        // Transition directly instead of using sync_tty_reader_modes(), which deliberately avoids
+        // writes after SIGHUP. We are on the main thread and just confirmed stdout is still a TTY.
+        let mut applied = tty_reader_mode_applied();
+        let mut out = Outputter::new_buffering();
+        if append_tty_reader_mode_commands(&mut out, &mut applied, TtyReaderModeRequest::default())
+        {
+            store_tty_reader_mode_applied(applied);
+            let _ = write_loop(&libc::STDOUT_FILENO, out.contents());
+            did_write = true;
+        }
+    }
     let commands = protocols.get_commands(enable);
     let _ = write_loop(&libc::STDOUT_FILENO, commands);
-    if !enable {
-        TTY_PROTOCOLS_ACTIVE.store(false);
+    did_write |= !commands.is_empty();
+    if enable {
+        did_write |= sync_tty_reader_modes();
     }
 
     // Flog any terminal protocol changes of interest.
@@ -299,7 +449,9 @@ fn set_tty_protocols_active(on_write: fn(), enable: bool) {
         ProtocolKind::WorkAroundWezTerm => flog!(reader, mode, "wezterm; no modifyOtherKeys"),
         ProtocolKind::None => (),
     }
-    (on_write)();
+    if did_write {
+        (on_write)();
+    }
 }
 
 // Helper to check if TTY protocols are active.
@@ -312,29 +464,21 @@ pub fn deactivate_tty_protocols() {
     if !cfg!(test) {
         assert_is_main_thread();
     }
-    // Safety: TTY_PROTOCOLS is never modified after initialization.
-    let protocols = unsafe { TTY_PROTOCOLS.load(Ordering::Acquire).as_ref() };
-    let Some(protocols) = protocols else {
-        // No protocols set, nothing to do.
-        return;
-    };
     if !TTY_PROTOCOLS_ACTIVE.load() {
+        // Even if baseline protocols are already inactive, discard any stale logical applied state
+        // after an invalid tty.
+        if TTY_INVALID.load() {
+            MOUSE_TRACKING_APPLIED.store(false);
+            CURSOR_HIDDEN_APPLIED.store(false);
+        }
         return;
     }
-
-    // Did we get SIGHUP?
-    if TTY_INVALID.load() {
-        return;
-    }
-
-    let commands = protocols.get_commands(false);
-    // Safety: just writing data to stdout.
-    let _ = write_loop(&libc::STDOUT_FILENO, commands);
-    TTY_PROTOCOLS_ACTIVE.store(false);
+    set_tty_protocols_active(|| {}, false);
 }
 
 // Called from a signal handler to mark the tty as invalid (e.g. SIGHUP).
-// This suppresses any further attempts to write protocols to the tty,
+// This suppresses normal protocol writes; disabling may still perform one best-effort cleanup if
+// the main thread confirms that stdout remains a usable tty.
 pub fn signal_safe_mark_tty_invalid() {
     TTY_INVALID.store(true);
 }
@@ -610,4 +754,74 @@ fn get_tmux_version(xtversion: &wstr) -> Option<(u32, u32)> {
     }
     let mut version = xtversion.next()?.split('.');
     Some((wcstoi(version.next()?).ok()?, wcstoi(version.next()?).ok()?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn transition(
+        mut applied: TtyReaderModeRequest,
+        desired: TtyReaderModeRequest,
+    ) -> (TtyReaderModeRequest, Vec<u8>, bool) {
+        let mut out = Outputter::new_buffering();
+        let changed = append_tty_reader_mode_commands(&mut out, &mut applied, desired);
+        (applied, out.contents().to_vec(), changed)
+    }
+
+    #[test]
+    fn tty_reader_modes_enable_and_disable_in_safe_order() {
+        let both = TtyReaderModeRequest {
+            mouse_tracking: true,
+            cursor_hidden: true,
+        };
+        let (applied, commands, changed) = transition(TtyReaderModeRequest::default(), both);
+        assert!(changed);
+        assert_eq!(applied, both);
+        assert_eq!(
+            commands,
+            b"\x1b[?9;1000;1001;1002;1003;1005;1006;1015;1016s\x1b[?1006h\x1b[?1000h\x1b[?25l"
+        );
+
+        let (applied, commands, changed) = transition(both, TtyReaderModeRequest::default());
+        assert!(changed);
+        assert_eq!(applied, TtyReaderModeRequest::default());
+        assert_eq!(
+            commands,
+            b"\x1b[?25h\x1b[?1000l\x1b[?1006l\x1b[?1016;1015;1006;1005;1003;1002;1001;1000;9r"
+        );
+    }
+
+    #[test]
+    fn tty_reader_modes_do_not_emit_for_unchanged_state() {
+        let request = TtyReaderModeRequest {
+            mouse_tracking: true,
+            cursor_hidden: false,
+        };
+        let (applied, commands, changed) = transition(request, request);
+        assert!(!changed);
+        assert_eq!(applied, request);
+        assert!(commands.is_empty());
+    }
+
+    #[test]
+    fn tty_reader_modes_transition_independently() {
+        let mouse = TtyReaderModeRequest {
+            mouse_tracking: true,
+            cursor_hidden: false,
+        };
+        let both = TtyReaderModeRequest {
+            mouse_tracking: true,
+            cursor_hidden: true,
+        };
+        let (applied, commands, changed) = transition(mouse, both);
+        assert!(changed);
+        assert_eq!(applied, both);
+        assert_eq!(commands, b"\x1b[?25l");
+
+        let (applied, commands, changed) = transition(both, mouse);
+        assert!(changed);
+        assert_eq!(applied, mouse);
+        assert_eq!(commands, b"\x1b[?25h");
+    }
 }

--- a/tests/checks/tmux-commandline.fish
+++ b/tests/checks/tmux-commandline.fish
@@ -28,7 +28,6 @@ isolated-tmux capture-pane -p
 isolated-tmux send-keys C-k C-u C-l 'commandline -i "\'$(seq $LINES)" scroll_here' Enter
 tmux-sleep
 isolated-tmux capture-pane -p
-# CHECK: 2
 # CHECK: 3
 # CHECK: 4
 # CHECK: 5
@@ -38,6 +37,7 @@ isolated-tmux capture-pane -p
 # CHECK: 9
 # CHECK: 10
 # CHECK: scroll_here
+# CHECK: rows 3 to 11 of 11. Enter executes or continues
 
 isolated-tmux send-keys C-c
 tmux-sleep

--- a/tests/pexpects/commandline_viewport.py
+++ b/tests/pexpects/commandline_viewport.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+
+import os
+
+import pexpect
+
+from pexpect_helper import SpawnedProc, control
+
+env = os.environ.copy()
+env["TERM"] = "xterm-kitty"
+env["FISH_TEST_NO_RECURRENT_QUERIES"] = ""
+sp = SpawnedProc(dimensions=(6, 30), env=env)
+sp.send_cursor_position_report(y=1, x=1)
+sp.expect_prompt()
+sp.sendline("set -g FISH_TEST_NO_RECURRENT_QUERIES 1")
+sp.send_primary_device_attribute()
+sp.expect_prompt()
+sp.expect_str("\x1b[?1000h", shouldfail=True, timeout=0.1)
+sp.sendline("stty size")
+sp.expect_prompt("6 30")
+sp.sendline("echo $LINES $COLUMNS")
+sp.expect_prompt("6 30")
+
+
+def read_available():
+    chunks = []
+    while True:
+        try:
+            chunks.append(sp.spawn.read_nonblocking(65536, timeout=0.02))
+        except pexpect.TIMEOUT:
+            return "".join(chunks)
+
+
+# Capture the commandline cursor without modifying the commandline. We inspect it
+# after cancelling the pending command. Direct input-function bindings make cursor
+# motion deterministic without temporarily handing the terminal away.
+sp.sendline(
+    "bind ctrl-g 'set -g viewport_cursor (commandline --cursor)'; "
+    "bind ctrl-y up-line; bind ctrl-x down-line"
+)
+sp.expect_prompt()
+
+# Leave some ordinary output in terminal scrollback, then paste a command whose
+# visual height is greater than the terminal height without executing it.
+sp.sendline("seq 20")
+sp.expect_prompt("20")
+commandline = "begin\n" + "\n".join(f"# viewport-{i:02d}" for i in range(16))
+sp.send("\x1b[200~" + commandline + "\x1b[201~")
+initial_status = sp.expect_re(r"rows (\d+) to (\d+) of (\d+)\. Enter")
+initial_start, initial_stop, total = map(int, initial_status.groups())
+
+# Fish owns the wheel only while its commandline viewport is scrollable. Normal
+# button tracking is sufficient for wheel reports; motion tracking must remain
+# disabled.
+sp.expect_str("\x1b[?9;1000;1001;1002;1003;1005;1006;1015;1016s")
+sp.expect_str("\x1b[?1006h")
+sp.expect_str("\x1b[?1000h")
+sp.expect_str("\x1b[?1002h", shouldfail=True, timeout=0.1)
+
+# Moving within the visible window changes only the terminal cursor. The fifth line
+# move crosses an edge and advances the visual window by exactly one row.
+sp.send(control("y") * 4)
+sp.sleep(0.1)
+movement_output = read_available()
+assert "viewport-" not in movement_output
+assert "rows " not in movement_output
+sp.send(control("y"))
+sp.expect_re(rf"rows {initial_start - 1} to {initial_stop - 1} of {total}\. Enter")
+
+sp.send(control("x") * 4)
+sp.sleep(0.1)
+movement_output = read_available()
+assert "viewport-" not in movement_output
+assert "rows " not in movement_output
+sp.send(control("x"))
+sp.expect_re(rf"rows {initial_start} to {initial_stop} of {total}\. Enter")
+
+# SGR wheel-up changes the independent viewport by three visual rows. It must
+# reveal older command text without moving the commandline cursor.
+sp.send("\x1b[<64;1;1M")
+sp.expect_str("viewport-10")
+sp.expect_re(r"rows 10 to 14 of 17")
+sp.expect_str("\x1b[?25l")
+sp.send(control("g"))
+
+# A binding temporarily hands the tty away, then restores the still-requested
+# viewport modes. Cancelling the command releases them for good.
+sp.expect_str("\x1b[?25h")
+sp.expect_str("\x1b[?1000l")
+sp.expect_str("\x1b[?1006l")
+sp.expect_str("\x1b[?1016;1015;1006;1005;1003;1002;1001;1000;9r")
+sp.expect_str("\x1b[?9;1000;1001;1002;1003;1005;1006;1015;1016s")
+sp.expect_str("\x1b[?1006h")
+sp.expect_str("\x1b[?1000h")
+sp.expect_str("\x1b[?25l")
+sp.sleep(0.1)
+sp.send(control("c"))
+sp.expect_str("\x1b[?25h")
+sp.expect_str("\x1b[?1000l")
+sp.expect_str("\x1b[?1006l")
+sp.expect_str("\x1b[?1016;1015;1006;1005;1003;1002;1001;1000;9r")
+
+# Executing an overflowing command performs one final full repaint after any
+# in-flight highlighting, so every visual row reaches terminal scrollback.
+exec_commandline = (
+    "\n".join(
+        [
+            "function viewport_exec",
+            "# EXEC-FIRST",
+            "# " + "y" * 150,
+            "# EXEC-MIDDLE",
+            "# " + "z" * 150,
+            "# EXEC-LAST",
+        ]
+    )
+    + "\n"
+)
+sp.send("\x1b[200~" + exec_commandline + "\x1b[201~")
+sp.expect_re(r"rows \d+ to \d+ of \d+\. Enter")
+assert "# EXEC-FIRST" not in sp.spawn.before
+assert "# EXEC-MIDDLE" not in sp.spawn.before
+sp.expect_str("\x1b[?1000h")
+# One Enter completes and executes the command immediately; no viewport-confirmation
+# Enter is required.
+sp.sendline("end")
+sp.expect_str("\x1b[?1000l")
+sp.expect_str("\x1b[?1006l")
+sp.expect_str("\x1b[?1016;1015;1006;1005;1003;1002;1001;1000;9r")
+sp.expect_str("# EXEC-FIRST")
+sp.expect_str("# EXEC-MIDDLE")
+sp.expect_str("# EXEC-LAST")
+sp.expect_str("\x1b[?25h")
+sp.expect_prompt()
+sp.sendline("functions -q viewport_exec; and echo single-enter-executed")
+sp.expect_prompt("single-enter-executed")
+
+sp.sendline(f"echo cursor=$viewport_cursor expected={len(commandline)}")
+sp.expect_prompt(f"cursor={len(commandline)} expected={len(commandline)}")
+
+# A single long logical line exercises automatic soft wrapping, which is the
+# primary issue #11029 scenario. Wheel-down returns to the cursor, while a
+# commandline edit exits overflow and gives the wheel back immediately.
+soft_commandline = "# " + "x" * 240
+sp.send("\x1b[200~" + soft_commandline + "\x1b[201~")
+sp.expect_re(r"rows \d+ to \d+ of \d+")
+sp.expect_str("\x1b[?1000h")
+sp.send("\x1b[<64;1;1M")
+sp.expect_str("\x1b[?25l")
+sp.send("\x1b[<65;1;1M")
+sp.expect_str("\x1b[?25h")
+sp.send(control("u"))
+sp.expect_str("\x1b[?1000l")
+sp.expect_str("\x1b[?1006l")
+sp.expect_str("\x1b[?1016;1015;1006;1005;1003;1002;1001;1000;9r")
+
+# A pager search cannot retain input focus while the overflowing viewport withholds it. Clicking a
+# command row must likewise keep subsequent input on the visible commandline.
+sp.sendline("complete -c viewport_search -f -a 'alpha beta gamma'")
+sp.expect_prompt()
+sp.sendline(
+    "bind ctrl-g 'set -g viewport_text (commandline); "
+    "set -g viewport_focus (commandline --search-field 2>/dev/null; or echo commandline); "
+    'set -g viewport_q (string match -q "*q*" -- $viewport_text; '
+    "and echo q; or echo missing); "
+    "set -g FISH_TEST_NO_RECURRENT_QUERIES 1; "
+    'printf "\\e]0;viewport-focus-recorded:%s:%s:%s\\a" '
+    "$viewport_pre_focus $viewport_focus $viewport_q'; "
+    "bind ctrl-o 'set -g viewport_pre_focus "
+    "(commandline --search-field 2>/dev/null; or echo commandline); "
+    'printf "\\e]0;viewport-pre-focus=%s\\a" $viewport_pre_focus\''
+)
+sp.expect_prompt()
+sp.sendline("set -e FISH_TEST_NO_RECURRENT_QUERIES; bind ctrl-l clear-screen")
+sp.send(control("l"))
+sp.expect_str("\x1b[6n")
+sp.send_cursor_position_report(y=1, x=1)
+sp.send_primary_device_attribute()
+search_commandline = "viewport_search " + "arg " * 70
+sp.send("\x1b[200~" + search_commandline + "\x1b[201~")
+sp.expect_str("\x1b[?1000h")
+sp.send("\t\t" + control("s") + "z")
+sp.send(control("o"))
+sp.expect_str("\x1b]0;viewport-pre-focus=commandline\x07")
+sp.expect_str("\x1b[?1000h")
+# Incremental repainting intentionally leaves the unchanged viewport status in
+# place, so wait for the binding handoff and repaint to settle instead of
+# requiring Fish to retransmit it.
+sp.sleep(0.1)
+read_available()
+sp.send("\x1b[<0;1;1M")
+sp.send("q" + control("g"))
+sp.expect_str("\x1b]0;viewport-focus-recorded:commandline:commandline:q\x07")
+sp.expect_str("\x1b[?1000h")
+sp.sleep(0.1)
+read_available()
+sp.send(control("c"))
+sp.expect_prompt()
+sp.expect_str("\x1b[?1000l")
+sp.expect_str("\x1b[?1006l")
+sp.expect_str("\x1b[?1016;1015;1006;1005;1003;1002;1001;1000;9r")
+
+# A nested key reader starts with its own default reader modes; the outer
+# viewport request is restored only after it returns.
+sp.sendline("bind ctrl-g fish_key_reader")
+sp.expect_prompt()
+sp.send("\x1b[200~" + soft_commandline + "\x1b[201~")
+sp.expect_str("\x1b[?1000h")
+sp.send("\x1b[<64;1;1M")
+sp.expect_str("\x1b[?25l")
+sp.send(control("g"))
+sp.expect_str("\x1b[?25h")
+sp.expect_str("\x1b[?1000l")
+sp.expect_str("Press a key:")
+sp.expect_str("\x1b[?1000h", shouldfail=True, timeout=0.1)
+sp.expect_str("\x1b[?25l", shouldfail=True, timeout=0.1)
+sp.send("q")
+sp.expect_str("\x1b[?1000h")
+sp.expect_str("\x1b[?25l")
+sp.send(control("c"))
+sp.expect_str("\x1b[?25h")
+sp.expect_str("\x1b[?1000l")
+sp.expect_str("\x1b[?1006l")
+sp.expect_str("\x1b[?1016;1015;1006;1005;1003;1002;1001;1000;9r")

--- a/tests/pexpects/commandline_viewport_sighup.py
+++ b/tests/pexpects/commandline_viewport_sighup.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+import os
+import signal
+
+from pexpect_helper import SpawnedProc
+
+env = os.environ.copy()
+env["TERM"] = "xterm-kitty"
+sp = SpawnedProc(dimensions=(6, 30), env=env)
+sp.expect_prompt()
+sp.send("# " + "x" * 240)
+sp.expect_str("\x1b[?1000h")
+sp.send("\x1b[<64;1;1M")
+sp.expect_str("\x1b[?25l")
+
+# A HUP normally means the PTY disappeared, but if it is still writable Fish
+# must restore both viewport-specific and baseline reader protocols for a parent shell.
+os.kill(sp.spawn.pid, signal.SIGHUP)
+sp.expect_str("\x1b[?25h")
+sp.expect_str("\x1b[?1000l")
+sp.expect_str("\x1b[?1006l")
+sp.expect_str("\x1b[?1016;1015;1006;1005;1003;1002;1001;1000;9r")
+sp.expect_str("\x1b[?2004l")
+sp.expect_str("\x1b[?2031l")
+sp.expect_str("\x1b[>4;0m")
+sp.expect_str("\x1b>")
+sp.spawn.wait()


### PR DESCRIPTION
## Summary

This implements the command-line viewport approach discussed in #11029 instead of attempting to reconstruct unrendered input from terminal scrollback.

- measure the complete explicit command line, then materialize only the visible visual-row window
- capture normal/SGR mouse wheel reporting only while that window is scrollable
- keep wheel scrolling independent from the editing cursor and repaint unchanged rows incrementally
- restore prior mouse state and cursor visibility across execution, cancellation, nested readers, child handoff, and SIGHUP cleanup
- show a `rows X to Y of N. Enter executes or continues` indicator and document the interaction

Keyboard cursor movement follows the viewport only when it crosses an edge. Enter semantics are unchanged: a complete command executes immediately, while an incomplete command continues editing.

## Testing

- `cargo xtask check` (245 passed, 8 environment-dependent tests skipped)
- `cargo +1.85.0 clippy --workspace --all-targets -- --deny=warnings`
- `cargo xtask format --all --check` with Ruff available
- targeted pexpect/tmux coverage for wheel decoding, soft wrapping, clicks, execution scrollback, nested readers, TTY ownership, and SIGHUP cleanup
- repeated the main command-line viewport pexpect test 8 times
- manual testing on Fedora 44 with kitty 0.47.4

## TODOs

- [x] If addressing an issue, a commit message mentions `Fixes #<issue-number>`
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst

Fixes #11029