### PR TITLE
fish_jj_prompt: redirect stdin from /dev/null in jj log call

### DIFF
--- a/share/functions/fish_jj_prompt.fish
+++ b/share/functions/fish_jj_prompt.fish
@@ -5,7 +5,7 @@ function fish_jj_prompt
         return 1
     end
     set -l info "$(
-        jj log 2>/dev/null --no-graph --ignore-working-copy --color=always --revisions @ \
+        jj log </dev/null 2>/dev/null --no-graph --ignore-working-copy --color=always --revisions @ \
             --template '
                 separate(" ",
                     if(conflict, label("conflict", "×")),


### PR DESCRIPTION
## Summary
- Redirects stdin from `/dev/null` for the `jj log` call in `fish_jj_prompt.fish`, as suggested by @krobelus in #12936.
- Prevents fish from hanging indefinitely if the resolved `jj` binary reads from stdin (e.g. a PATH collision with an unrelated program), since fish otherwise blocks forever waiting for the command substitution to finish.

Fixes #12936

## Test plan
- [x] Reproduced the hang locally (jj resolved to an unrelated stdin-reading binary via a PATH shadow), confirmed fish froze right after the welcome message.
- [x] Applied the patch, confirmed `fish_jj_prompt` no longer hangs in that scenario.