### PR TITLE
completions: Add kak -C command line completion

### DIFF
--- a/localization/po/de.po
+++ b/localization/po/de.po
@@ -75267,6 +75267,9 @@ msgstr ""
 msgid "connect to given session"
 msgstr ""
 
+msgid "connect to or create given session"
+msgstr ""
+
 msgid "connect to the system bus"
 msgstr ""
 

--- a/localization/po/es.po
+++ b/localization/po/es.po
@@ -75267,6 +75267,9 @@ msgstr ""
 msgid "connect to given session"
 msgstr ""
 
+msgid "connect to or create given session"
+msgstr ""
+
 msgid "connect to the system bus"
 msgstr ""
 

--- a/localization/po/fr.po
+++ b/localization/po/fr.po
@@ -75396,6 +75396,9 @@ msgstr ""
 msgid "connect to given session"
 msgstr ""
 
+msgid "connect to or create given session"
+msgstr ""
+
 msgid "connect to the system bus"
 msgstr ""
 

--- a/localization/po/ja_JP.po
+++ b/localization/po/ja_JP.po
@@ -75270,6 +75270,9 @@ msgstr ""
 msgid "connect to given session"
 msgstr ""
 
+msgid "connect to or create given session"
+msgstr ""
+
 msgid "connect to the system bus"
 msgstr ""
 

--- a/localization/po/pl.po
+++ b/localization/po/pl.po
@@ -75263,6 +75263,9 @@ msgstr ""
 msgid "connect to given session"
 msgstr ""
 
+msgid "connect to or create given session"
+msgstr ""
+
 msgid "connect to the system bus"
 msgstr ""
 

--- a/localization/po/pt_BR.po
+++ b/localization/po/pt_BR.po
@@ -75268,6 +75268,9 @@ msgstr ""
 msgid "connect to given session"
 msgstr ""
 
+msgid "connect to or create given session"
+msgstr ""
+
 msgid "connect to the system bus"
 msgstr ""
 

--- a/localization/po/sv.po
+++ b/localization/po/sv.po
@@ -75264,6 +75264,9 @@ msgstr ""
 msgid "connect to given session"
 msgstr ""
 
+msgid "connect to or create given session"
+msgstr ""
+
 msgid "connect to the system bus"
 msgstr ""
 

--- a/localization/po/zh_CN.po
+++ b/localization/po/zh_CN.po
@@ -75288,6 +75288,9 @@ msgstr ""
 msgid "connect to given session"
 msgstr ""
 
+msgid "connect to or create given session"
+msgstr ""
+
 msgid "connect to the system bus"
 msgstr ""
 

--- a/localization/po/zh_TW.po
+++ b/localization/po/zh_TW.po
@@ -75265,6 +75265,9 @@ msgstr ""
 msgid "connect to given session"
 msgstr ""
 
+msgid "connect to or create given session"
+msgstr ""
+
 msgid "connect to the system bus"
 msgstr ""
 

--- a/share/completions/kak.fish
+++ b/share/completions/kak.fish
@@ -1,5 +1,6 @@
 # Kakoune editor - https://kakoune.org/
 complete -c kak -o c -x -a '(command kak -l)' -d 'connect to given session'
+complete -c kak -o C -x -a '(command kak -l)' -d 'connect to or create given session'
 complete -c kak -o e -x -d 'execute argument on client initialisation'
 complete -c kak -o E -x -d 'execute argument on server initialisation'
 complete -c kak -o n -d 'do not source kakrc files on startup'


### PR DESCRIPTION
Add `-C` commandline flag to `kak` completions. @krobelus

This flag was introduced by https://github.com/mawww/kakoune/commit/7ee28e3e321f68a9dc842ea0ba70c1afa0412633 and then first included in the `v2026.04.12` release.