### PR TITLE
fix contrast on .data_table row hover

### DIFF
--- a/share/tools/web_config/fishconfig.css
+++ b/share/tools/web_config/fishconfig.css
@@ -58,7 +58,7 @@ tt {
 .color_scheme_choice_container:hover,
 .data_table > tr:hover,
 .prompt_choices_list > .ng-scope:hover {
-    background-color: #DDE;
+    background-color: #fff2;
 }
 
 #tab_parent {

--- a/share/tools/web_config/fishconfig.css
+++ b/share/tools/web_config/fishconfig.css
@@ -669,6 +669,7 @@ button.delete_button:hover {
     }
 
     .tab:hover,
+    .data_table > tr:hover,
     #tab_contents .master_element:hover,
     .color_scheme_choice_container:hover,
     .prompt_choices_list > .ng-scope:hover {

--- a/share/tools/web_config/fishconfig.css
+++ b/share/tools/web_config/fishconfig.css
@@ -58,7 +58,7 @@ tt {
 .color_scheme_choice_container:hover,
 .data_table > tr:hover,
 .prompt_choices_list > .ng-scope:hover {
-    background-color: #fff2;
+    background-color: #DDE;
 }
 
 #tab_parent {


### PR DESCRIPTION
the hover background is white and since the text stays white.... the hover background overlaps with the text color hence the text becomes impossible to read

### screenshot

**before:**
<img width="1303" height="604" alt="screenshot_20260826_153625" src="https://github.com/user-attachments/assets/94971ca6-62c4-41e4-aa64-1018aa511543" />

**after:**
<img width="1303" height="604" alt="screenshot_20260826_153640" src="https://github.com/user-attachments/assets/feda66e0-43e7-46a9-a34a-e52bfde05366" />