### PR TITLE
tokenizer: report last unclosed expression + other improvements

### DIFF
--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -637,6 +637,12 @@ impl<'c> Tokenizer<'c> {
         let buff_start = self.token_cursor;
         let mut is_token_begin = true;
 
+        #[derive(Debug, PartialEq)]
+        enum Expecting {
+            Paren,
+            Brace,
+            Slice,
+        }
         struct QuotedSubst {
             quote_location: usize,
             subst_depth: usize, // aka index in paren_offsets
@@ -696,16 +702,16 @@ impl<'c> Tokenizer<'c> {
                 self.token_cursor = comment_end(self.start, self.token_cursor) - 1;
             } else if c == '(' {
                 paren_offsets.push(self.token_cursor);
-                expecting.push(')');
+                expecting.push(Expecting::Paren);
             } else if c == '{' {
                 brace_offsets.push(self.token_cursor);
-                expecting.push('}');
+                expecting.push(Expecting::Brace);
             } else if c == ')' {
                 match expecting.pop() {
-                    Some(')') => {
+                    Some(Expecting::Paren) => {
                         paren_offsets.pop();
                     }
-                    Some('}') => {
+                    Some(Expecting::Brace) => {
                         return self.call_error(
                             TokenizerError::UnexpectedPcloseWantedBclose,
                             self.token_cursor,
@@ -714,7 +720,7 @@ impl<'c> Tokenizer<'c> {
                             1,
                         );
                     }
-                    Some(']') => {
+                    Some(Expecting::Slice) => {
                         return self.call_error(
                             TokenizerError::UnexpectedPcloseWantedSclose,
                             self.token_cursor,
@@ -732,7 +738,6 @@ impl<'c> Tokenizer<'c> {
                             1,
                         );
                     }
-                    Some(_) => unreachable!(),
                 }
                 // Check if the ) completed a quoted command substitution.
                 if quoted_cmdsubs.last().map(|cmd| cmd.subst_depth) == Some(paren_offsets.len()) {
@@ -762,10 +767,10 @@ impl<'c> Tokenizer<'c> {
                 }
             } else if c == '}' {
                 match expecting.pop() {
-                    Some('}') => {
+                    Some(Expecting::Brace) => {
                         brace_offsets.pop();
                     }
-                    Some(')') => {
+                    Some(Expecting::Paren) => {
                         return self.call_error(
                             TokenizerError::UnexpectedBcloseWantedPclose,
                             self.token_cursor,
@@ -774,7 +779,7 @@ impl<'c> Tokenizer<'c> {
                             1,
                         );
                     }
-                    Some(']') => {
+                    Some(Expecting::Slice) => {
                         return self.call_error(
                             TokenizerError::UnexpectedBcloseWantedSclose,
                             self.token_cursor,
@@ -787,12 +792,11 @@ impl<'c> Tokenizer<'c> {
                         // Let the caller throw an error.
                         break;
                     }
-                    Some(_) => unreachable!(),
                 }
             } else if c == '[' {
                 if self.token_cursor != buff_start {
                     slice_offsets.push(self.token_cursor);
-                    expecting.push(']');
+                    expecting.push(Expecting::Slice);
                 } else {
                     // This is actually allowed so the test operator `[` can be used as the head of a
                     // command
@@ -802,7 +806,7 @@ impl<'c> Tokenizer<'c> {
             // any unclosed paren or brace since the opening of the slice. If we do, consider
             // the bracket to be a parameter, e.g. last parameter to `[` test alias,
             // e.g. `echo $argv[([ $x -eq $y ])]`
-            else if c == ']' && expecting.last() == Some(&']') {
+            else if c == ']' && expecting.last() == Some(&Expecting::Slice) {
                 slice_offsets.pop();
                 expecting.pop();
             } else if c == '\'' || c == '"' {
@@ -845,11 +849,11 @@ impl<'c> Tokenizer<'c> {
             self.token_cursor += 1;
         }
 
-        if !self.accept_unfinished && !expecting.is_empty() {
+        if !self.accept_unfinished {
             // These are all "unterminated", so the only char we can mark as an error
             // is the opener (the closing char could be anywhere!)
             match expecting.last() {
-                Some(')') => {
+                Some(Expecting::Paren) => {
                     let offset_of_open_paren =
                         *paren_offsets.last().expect("paren_offsets is empty");
                     return self.call_error(
@@ -860,7 +864,7 @@ impl<'c> Tokenizer<'c> {
                         1,
                     );
                 }
-                Some('}') => {
+                Some(Expecting::Brace) => {
                     let offset_of_open_brace =
                         *brace_offsets.last().expect("brace_offsets is empty");
                     return self.call_error(
@@ -871,7 +875,7 @@ impl<'c> Tokenizer<'c> {
                         1,
                     );
                 }
-                Some(']') => {
+                Some(Expecting::Slice) => {
                     let offset_of_open_slice =
                         *slice_offsets.last().expect("slice_offsets is empty");
                     return self.call_error(
@@ -882,14 +886,14 @@ impl<'c> Tokenizer<'c> {
                         1,
                     );
                 }
-                _ => unreachable!("Unexpected pending char"),
+                None => {}
             }
         }
 
         let mut result = Tok::new(TokenType::String);
         result.set_offset(buff_start);
         result.set_length(self.token_cursor - buff_start);
-        result.is_unterminated_brace = expecting.contains(&'}');
+        result.is_unterminated_brace = expecting.contains(&Expecting::Brace);
         result
     }
 }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -629,7 +629,6 @@ impl<'c> Tokenizer<'c> {
 impl<'c> Tokenizer<'c> {
     /// Read the next token as a string.
     fn read_string(&mut self) -> Tok {
-        let mut mode = TokModes::empty();
         let mut paren_offsets = vec![];
         let mut brace_offsets = vec![];
         let mut slice_offsets = vec![];
@@ -675,35 +674,36 @@ impl<'c> Tokenizer<'c> {
         while self.token_cursor != self.start.len() {
             let c = self.start.char_at(self.token_cursor);
 
-            // Make sure this character isn't being escaped before anything else
-            if mode.contains(TokModes::CHAR_ESCAPE) {
-                mode.remove(TokModes::CHAR_ESCAPE);
-                // and do nothing more
-            } else if myal(c) {
+            if myal(c) {
                 // Early exit optimization in case the character is just a letter,
                 // which has no special meaning to the tokenizer, i.e. the same mode continues.
             }
             // Now proceed with the evaluation of the token, first checking to see if the token
             // has been explicitly ignored (escaped).
             else if c == '\\' {
-                mode |= TokModes::CHAR_ESCAPE;
+                if self.token_cursor + 1 < self.start.len() {
+                    self.token_cursor += 1;
+                } else if !self.accept_unfinished {
+                    return self.call_error(
+                        TokenizerError::UnterminatedEscape,
+                        self.token_cursor,
+                        self.token_cursor,
+                        None,
+                        1,
+                    );
+                }
             } else if c == '#' && is_token_begin {
                 self.token_cursor = comment_end(self.start, self.token_cursor) - 1;
             } else if c == '(' {
                 paren_offsets.push(self.token_cursor);
                 expecting.push(')');
-                mode |= TokModes::SUBSHELL;
             } else if c == '{' {
                 brace_offsets.push(self.token_cursor);
                 expecting.push('}');
-                mode |= TokModes::CURLY_BRACES;
             } else if c == ')' {
                 match expecting.pop() {
                     Some(')') => {
                         paren_offsets.pop();
-                        if paren_offsets.is_empty() {
-                            mode.remove(TokModes::SUBSHELL);
-                        }
                     }
                     Some('}') => {
                         return self.call_error(
@@ -764,9 +764,6 @@ impl<'c> Tokenizer<'c> {
                 match expecting.pop() {
                     Some('}') => {
                         brace_offsets.pop();
-                        if brace_offsets.is_empty() {
-                            mode.remove(TokModes::CURLY_BRACES);
-                        }
                     }
                     Some(')') => {
                         return self.call_error(
@@ -796,7 +793,6 @@ impl<'c> Tokenizer<'c> {
                 if self.token_cursor != buff_start {
                     slice_offsets.push(self.token_cursor);
                     expecting.push(']');
-                    mode |= TokModes::ARRAY_SLICE;
                 } else {
                     // This is actually allowed so the test operator `[` can be used as the head of a
                     // command
@@ -808,9 +804,6 @@ impl<'c> Tokenizer<'c> {
             // e.g. `echo $argv[([ $x -eq $y ])]`
             else if c == ']' && expecting.last() == Some(&']') {
                 slice_offsets.pop();
-                if slice_offsets.is_empty() {
-                    mode.remove(TokModes::ARRAY_SLICE);
-                }
                 expecting.pop();
             } else if c == '\'' || c == '"' {
                 if let Err(error_loc) = process_opening_quote(
@@ -831,7 +824,7 @@ impl<'c> Tokenizer<'c> {
                     }
                     break;
                 }
-            } else if mode.is_empty()
+            } else if expecting.is_empty()
                 && !tok_is_string_character(
                     c,
                     self.start
@@ -852,81 +845,51 @@ impl<'c> Tokenizer<'c> {
             self.token_cursor += 1;
         }
 
-        if !self.accept_unfinished && !mode.is_empty() {
+        if !self.accept_unfinished && !expecting.is_empty() {
             // These are all "unterminated", so the only char we can mark as an error
             // is the opener (the closing char could be anywhere!)
-            //
-            // (except for TokModes::CHAR_ESCAPE, which is one long by definition)
-            if mode.contains(TokModes::CHAR_ESCAPE) {
-                return self.call_error(
-                    TokenizerError::UnterminatedEscape,
-                    buff_start,
-                    self.token_cursor - 1,
-                    None,
-                    1,
-                );
-            } else {
-                match expecting.pop() {
-                    Some(')') => {
-                        assert!(
-                            mode.contains(TokModes::SUBSHELL),
-                            "Unexpected pending close paren"
-                        );
-                        let offset_of_open_paren =
-                            *paren_offsets.last().expect("paren_offsets is empty");
-                        return self.call_error(
-                            TokenizerError::UnterminatedSubshell,
-                            buff_start,
-                            offset_of_open_paren,
-                            None,
-                            1,
-                        );
-                    }
-                    Some('}') => {
-                        assert!(
-                            mode.contains(TokModes::CURLY_BRACES),
-                            "Unexpected pending close brace"
-                        );
-                        let offset_of_open_brace =
-                            *brace_offsets.last().expect("brace_offsets is empty");
-                        return self.call_error(
-                            TokenizerError::UnterminatedBrace,
-                            buff_start,
-                            offset_of_open_brace,
-                            None,
-                            1,
-                        );
-                    }
-                    Some(']') => {
-                        assert!(
-                            mode.contains(TokModes::ARRAY_SLICE),
-                            "Unexpected pending close bracket"
-                        );
-                        let offset_of_open_slice =
-                            *slice_offsets.last().expect("slice_offsets is empty");
-                        return self.call_error(
-                            TokenizerError::UnterminatedSlice,
-                            buff_start,
-                            offset_of_open_slice,
-                            None,
-                            1,
-                        );
-                    }
-                    None => {
-                        // `expecting` should only be empty if `mode` is empty
-                        // or is `TokModes::CHAR_ESCAPE`, both of which have
-                        // been checked earlier
-                        unreachable!("`expecting` should not be empty");
-                    }
-                    _ => unreachable!("Unexpected pending char"),
+            match expecting.last() {
+                Some(')') => {
+                    let offset_of_open_paren =
+                        *paren_offsets.last().expect("paren_offsets is empty");
+                    return self.call_error(
+                        TokenizerError::UnterminatedSubshell,
+                        buff_start,
+                        offset_of_open_paren,
+                        None,
+                        1,
+                    );
                 }
+                Some('}') => {
+                    let offset_of_open_brace =
+                        *brace_offsets.last().expect("brace_offsets is empty");
+                    return self.call_error(
+                        TokenizerError::UnterminatedBrace,
+                        buff_start,
+                        offset_of_open_brace,
+                        None,
+                        1,
+                    );
+                }
+                Some(']') => {
+                    let offset_of_open_slice =
+                        *slice_offsets.last().expect("slice_offsets is empty");
+                    return self.call_error(
+                        TokenizerError::UnterminatedSlice,
+                        buff_start,
+                        offset_of_open_slice,
+                        None,
+                        1,
+                    );
+                }
+                _ => unreachable!("Unexpected pending char"),
             }
         }
 
         let mut result = Tok::new(TokenType::String);
         result.set_offset(buff_start);
         result.set_length(self.token_cursor - buff_start);
-        result.is_unterminated_brace = mode.contains(TokModes::CURLY_BRACES);
+        result.is_unterminated_brace = expecting.contains(&'}');
         result
     }
 }
@@ -980,16 +943,6 @@ pub fn tok_is_string_character(c: char, next: Option<char>) -> bool {
 /// replacement for iswalpha.
 fn myal(c: char) -> bool {
     c.is_ascii_alphabetic()
-}
-
-bitflags! {
-#[derive(Clone, Copy, PartialEq, Eq)]
-    struct TokModes: u8 {
-        const SUBSHELL = 1 << 0; // inside of subshell parentheses
-        const ARRAY_SLICE = 1 << 1; // inside of array brackets
-        const CURLY_BRACES = 1 << 2;
-        const CHAR_ESCAPE = 1 << 3;
-    }
 }
 
 /// Tests if this character can delimit tokens.
@@ -1375,7 +1328,8 @@ mod tests {
             let token = t.next().unwrap();
             assert_eq!(token.type_, TokenType::Error);
             assert_eq!(token.error, TokenizerError::UnterminatedEscape);
-            assert_eq!(token.error_offset_within_token, 3);
+            assert_eq!(token.offset, 3);
+            assert_eq!(token.error_offset_within_token, 0);
         }
 
         {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -856,7 +856,7 @@ impl<'c> Tokenizer<'c> {
             // These are all "unterminated", so the only char we can mark as an error
             // is the opener (the closing char could be anywhere!)
             //
-            // (except forTokModes::CHAR_ESCAPE, which is one long by definition)
+            // (except for TokModes::CHAR_ESCAPE, which is one long by definition)
             if mode.contains(TokModes::CHAR_ESCAPE) {
                 return self.call_error(
                     TokenizerError::UnterminatedEscape,
@@ -865,37 +865,61 @@ impl<'c> Tokenizer<'c> {
                     None,
                     1,
                 );
-            } else if mode.contains(TokModes::ARRAY_SLICE) {
-                let offset_of_open_slice = *slice_offsets.last().expect("slice_offsets is empty");
-                return self.call_error(
-                    TokenizerError::UnterminatedSlice,
-                    buff_start,
-                    offset_of_open_slice,
-                    None,
-                    1,
-                );
-            } else if mode.contains(TokModes::SUBSHELL) {
-                let offset_of_open_paren = *paren_offsets.last().expect("paren_offsets is empty");
-
-                return self.call_error(
-                    TokenizerError::UnterminatedSubshell,
-                    buff_start,
-                    offset_of_open_paren,
-                    None,
-                    1,
-                );
-            } else if mode.contains(TokModes::CURLY_BRACES) {
-                let offset_of_open_brace = *brace_offsets.last().expect("brace_offsets is empty");
-
-                return self.call_error(
-                    TokenizerError::UnterminatedBrace,
-                    buff_start,
-                    offset_of_open_brace,
-                    None,
-                    1,
-                );
             } else {
-                panic!("Unknown non-regular-text mode");
+                match expecting.pop() {
+                    Some(')') => {
+                        assert!(
+                            mode.contains(TokModes::SUBSHELL),
+                            "Unexpected pending close paren"
+                        );
+                        let offset_of_open_paren =
+                            *paren_offsets.last().expect("paren_offsets is empty");
+                        return self.call_error(
+                            TokenizerError::UnterminatedSubshell,
+                            buff_start,
+                            offset_of_open_paren,
+                            None,
+                            1,
+                        );
+                    }
+                    Some('}') => {
+                        assert!(
+                            mode.contains(TokModes::CURLY_BRACES),
+                            "Unexpected pending close brace"
+                        );
+                        let offset_of_open_brace =
+                            *brace_offsets.last().expect("brace_offsets is empty");
+                        return self.call_error(
+                            TokenizerError::UnterminatedBrace,
+                            buff_start,
+                            offset_of_open_brace,
+                            None,
+                            1,
+                        );
+                    }
+                    Some(']') => {
+                        assert!(
+                            mode.contains(TokModes::ARRAY_SLICE),
+                            "Unexpected pending close bracket"
+                        );
+                        let offset_of_open_slice =
+                            *slice_offsets.last().expect("slice_offsets is empty");
+                        return self.call_error(
+                            TokenizerError::UnterminatedSlice,
+                            buff_start,
+                            offset_of_open_slice,
+                            None,
+                            1,
+                        );
+                    }
+                    None => {
+                        // `expecting` should only be empty if `mode` is empty
+                        // or is `TokModes::CHAR_ESCAPE`, both of which have
+                        // been checked earlier
+                        unreachable!("`expecting` should not be empty");
+                    }
+                    _ => unreachable!("Unexpected pending char"),
+                }
             }
         }
 

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -707,37 +707,17 @@ impl<'c> Tokenizer<'c> {
                 brace_offsets.push(self.token_cursor);
                 expecting.push(Expecting::Brace);
             } else if c == ')' {
-                match expecting.pop() {
+                let result = match expecting.pop() {
                     Some(Expecting::Paren) => {
                         paren_offsets.pop();
+                        Ok(())
                     }
-                    Some(Expecting::Brace) => {
-                        return self.call_error(
-                            TokenizerError::UnexpectedPcloseWantedBclose,
-                            self.token_cursor,
-                            self.token_cursor,
-                            Some(1),
-                            1,
-                        );
-                    }
-                    Some(Expecting::Slice) => {
-                        return self.call_error(
-                            TokenizerError::UnexpectedPcloseWantedSclose,
-                            self.token_cursor,
-                            self.token_cursor,
-                            Some(1),
-                            1,
-                        );
-                    }
-                    None => {
-                        return self.call_error(
-                            TokenizerError::ClosingUnopenedSubshell,
-                            self.token_cursor,
-                            self.token_cursor,
-                            Some(1),
-                            1,
-                        );
-                    }
+                    Some(Expecting::Brace) => Err(TokenizerError::UnexpectedPcloseWantedBclose),
+                    Some(Expecting::Slice) => Err(TokenizerError::UnexpectedPcloseWantedSclose),
+                    None => Err(TokenizerError::ClosingUnopenedSubshell),
+                };
+                if let Err(err) = result {
+                    return self.call_error(err, self.token_cursor, self.token_cursor, Some(1), 1);
                 }
                 // Check if the ) completed a quoted command substitution.
                 if quoted_cmdsubs.last().map(|cmd| cmd.subst_depth) == Some(paren_offsets.len()) {
@@ -766,32 +746,20 @@ impl<'c> Tokenizer<'c> {
                     }
                 }
             } else if c == '}' {
-                match expecting.pop() {
+                let result = match expecting.pop() {
                     Some(Expecting::Brace) => {
                         brace_offsets.pop();
+                        Ok(())
                     }
-                    Some(Expecting::Paren) => {
-                        return self.call_error(
-                            TokenizerError::UnexpectedBcloseWantedPclose,
-                            self.token_cursor,
-                            self.token_cursor,
-                            Some(1),
-                            1,
-                        );
-                    }
-                    Some(Expecting::Slice) => {
-                        return self.call_error(
-                            TokenizerError::UnexpectedBcloseWantedSclose,
-                            self.token_cursor,
-                            self.token_cursor,
-                            Some(1),
-                            1,
-                        );
-                    }
+                    Some(Expecting::Paren) => Err(TokenizerError::UnexpectedBcloseWantedPclose),
+                    Some(Expecting::Slice) => Err(TokenizerError::UnexpectedBcloseWantedSclose),
                     None => {
                         // Let the caller throw an error.
                         break;
                     }
+                };
+                if let Err(err) = result {
+                    return self.call_error(err, self.token_cursor, self.token_cursor, Some(1), 1);
                 }
             } else if c == '[' {
                 if self.token_cursor != buff_start {
@@ -852,41 +820,23 @@ impl<'c> Tokenizer<'c> {
         if !self.accept_unfinished {
             // These are all "unterminated", so the only char we can mark as an error
             // is the opener (the closing char could be anywhere!)
-            match expecting.last() {
-                Some(Expecting::Paren) => {
-                    let offset_of_open_paren =
-                        *paren_offsets.last().expect("paren_offsets is empty");
-                    return self.call_error(
-                        TokenizerError::UnterminatedSubshell,
-                        buff_start,
-                        offset_of_open_paren,
-                        None,
-                        1,
-                    );
-                }
-                Some(Expecting::Brace) => {
-                    let offset_of_open_brace =
-                        *brace_offsets.last().expect("brace_offsets is empty");
-                    return self.call_error(
-                        TokenizerError::UnterminatedBrace,
-                        buff_start,
-                        offset_of_open_brace,
-                        None,
-                        1,
-                    );
-                }
-                Some(Expecting::Slice) => {
-                    let offset_of_open_slice =
-                        *slice_offsets.last().expect("slice_offsets is empty");
-                    return self.call_error(
-                        TokenizerError::UnterminatedSlice,
-                        buff_start,
-                        offset_of_open_slice,
-                        None,
-                        1,
-                    );
-                }
-                None => {}
+            let result = match expecting.last() {
+                Some(Expecting::Paren) => Err((
+                    *paren_offsets.last().expect("paren_offsets is empty"),
+                    TokenizerError::UnterminatedSubshell,
+                )),
+                Some(Expecting::Brace) => Err((
+                    *brace_offsets.last().expect("brace_offsets is empty"),
+                    TokenizerError::UnterminatedBrace,
+                )),
+                Some(Expecting::Slice) => Err((
+                    *slice_offsets.last().expect("slice_offsets is empty"),
+                    TokenizerError::UnterminatedSlice,
+                )),
+                None => Ok(()),
+            };
+            if let Err((offset, error)) = result {
+                return self.call_error(error, buff_start, offset, None, 1);
             }
         }
 

--- a/tests/checks/syntax-error-location.fish
+++ b/tests/checks/syntax-error-location.fish
@@ -167,3 +167,22 @@ $fish -c 'echo foo"bar$(echo)$(echo)bur'
 # CHECKERR: fish: Unexpected end of string, quotes are not balanced
 # CHECKERR: {{^}}echo foo"bar$(echo)$(echo)bur
 # CHECKERR: {{^}}        ^
+
+
+# Check that the error is on the last unclosed expression
+$fish -c 'echo abc"def$(ghi{jkl$mno[pqr'
+# CHECKERR: fish: Unexpected end of string, square brackets do not match
+# CHECKERR: {{^}}echo abc"def$(ghi{jkl$mno[pqr
+# CHECKERR: {{^}}                         ^
+$fish -c 'echo abc(def{ghi$jkl[mno"pqr'
+# CHECKERR: fish: Unexpected end of string, quotes are not balanced
+# CHECKERR: {{^}}echo abc(def{ghi$jkl[mno"pqr
+# CHECKERR: {{^}}                        ^
+$fish -c 'echo abc{def$ghi[jkl"mno$(pqr'
+# CHECKERR: fish: Unexpected end of string, expecting ')'
+# CHECKERR: {{^}}echo abc{def$ghi[jkl"mno$(pqr
+# CHECKERR: {{^}}                         ^
+$fish -c 'echo abc$def[ghi"jkl$(mno{pqr'
+# CHECKERR: fish: Unexpected end of string, incomplete parameter expansion
+# CHECKERR: {{^}}echo abc$def[ghi"jkl$(mno{pqr
+# CHECKERR: {{^}}                         ^


### PR DESCRIPTION
- The 1st commit reports an error on the last unclosed expression, instead of some "random" one (i.e. whichever gets checked first in the code).
  Alternatively, we could report the first unclosed expression.
- The previous point makes TokModes redundant with the `expecting` variable, except for escaping, which can be dealt with an early return anyway, so the 2nd commit removes it.
  - One side-effect is that in `foo\`, internally the unterminated escape was on the "token" `foo\` with the error at offset 3 (`\`). Now the error is on "token" `\` at offset 0. I don't think this has any effect on what the users sees though (only `\` is highlighted as an error with the caret pointing at it). So the side-effect makes it more in line with the user sees.
    I believe it's possible to remove the side-effect if necessary, but it's not as nice code-wise because of the weird semantics/side-effects in `call_error`, i.e. the code would need to increment `token_cursor`, for no apparent reason, before calling `call_error`.
- other improvements such as factorizing some error code and replacing a char with an enum

## TODOs:
- [X] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
