### PR TITLE
kitty protocol: only consider base layout fallbacks for modified keys

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 fish ?.?.? (released ???)
 =========================
 
+Regression fixes:
+-----------------
+- (From 4.9.0) Text-oriented bindings were also matched against unmodified keys in the base layout when kitty keyboard protocol is supported (:issue:`12968`).
+
 fish 4.9.0 (released September 03, 2026)
 ========================================
 

--- a/src/builtins/fish_key_reader.rs
+++ b/src/builtins/fish_key_reader.rs
@@ -131,7 +131,7 @@ fn process_input(
                 ));
             }
         }
-        if kevt.key.base_layout_codepoint != '\0' {
+        if kevt.key.base_layout_codepoint != '\0' && kevt.key.modifiers.is_some() {
             let mut base_layout_key = kevt.key.key;
             base_layout_key.codepoint = kevt.key.base_layout_codepoint;
             keys.push((base_layout_key, "physical key"));

--- a/src/input/binding.rs
+++ b/src/input/binding.rs
@@ -38,7 +38,7 @@ pub(crate) fn match_key_event_to_key(event: &KeyEvent, key: &Key) -> Option<KeyM
         return Some(KeyMatchQuality::ModuloShift);
     }
 
-    if event.base_layout_codepoint != '\0' {
+    if event.base_layout_codepoint != '\0' && event.modifiers.is_some() {
         let mut base_layout_key = event.key;
         base_layout_key.codepoint = event.base_layout_codepoint;
         if base_layout_key == *key {
@@ -1168,10 +1168,14 @@ mod tests {
         validate!(KeyEvent::new(none, 'Ä'), Key::new(none, 'Ä'), Some(exact));
         validate!(KeyEvent::new(none, 'Ä'), Key::new(shift, 'ä'), None);
 
+        // Unmodified codepoints should not be matched against base layout
+        let text = Default::default();
+        let dvorak_s = KeyEvent::new_with(none, false, 's', None, Some(';'), text);
+        validate!(dvorak_s, Key::new(none, ';'), None);
+
         // FYI: for codepoints that are not letters with uppercase/lowercase versions, we use
         // the shifted key in the canonical notation, because the unshifted one may depend on the
         // keyboard layout.
-        let text = Default::default();
         let ctrl_shift_equals = KeyEvent::new_with(ctrl_shift, true, '=', Some('+'), None, text);
         validate!(ctrl_shift_equals, Key::new(ctrl_shift, '='), Some(exact));
         validate!(ctrl_shift_equals, Key::new(ctrl, '+'), Some(modulo_shift)); // canonical notation


### PR DESCRIPTION
Commit 7a79728df3a5061f1ed967ad00dce58808db4686 introduced the ability to match against base layout keys, with the aim of allowing "ctrl-ц" inputs to match against defined bindings for "ctrl-w" for PC-101 layout, which occupied the same physical location on the keyboard.

While this behavior is useful for modified keys, matching bare "ц" against "w" would be unexpected for the user, as they would likely refer to the logical letter instead of the physical backing key. This did not affect users until 681eb4e41004f8a7e94760810a1f6ee081543f36 which caused text-producing keys to also report their physical counterparts.

This commit disables base layout matching behavior against unmodified keys.

Closes #12968

## TODOs:
<!-- Check off what what has been done so far. -->
- [x] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
