### PR TITLE
Align the Sphinx `source_suffix` value with the current data shape

### DIFF
--- a/doc_src/conf.py
+++ b/doc_src/conf.py
@@ -130,11 +130,8 @@ version = release.rsplit(".", 1)[0]
 
 # -- General configuration ---------------------------------------------------
 
-# The suffix(es) of source filenames.
-# You can specify multiple suffix as a list of string:
-#
-# source_suffix = ['.rst', '.md']
-source_suffix = ".rst"
+# The suffix(es) and type(s) of source filenames.
+source_suffix = {".rst": "restructuredtext"}
 
 # The master toctree document.
 master_doc = "index"


### PR DESCRIPTION
When building the documentation, Sphinx prints this note:

```
Converting `source_suffix = '.rst'` to `source_suffix = {'.rst': 'restructuredtext'}`.
```

This PR updates the Sphinx config to align with the converted value.

AI was not used in any way to create this change. I just noticed the opportunity when building the docs locally.

## TODOs:

Note: I've checked these off to indicate that I've reviewed them, but none of these appear to apply to this PR.

<!-- Check off what what has been done so far. -->
- [x] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [x] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [x] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
