### PR TITLE
completion: don't escape at end of quoted string

### DIFF
--- a/src/reader/reader.rs
+++ b/src/reader/reader.rs
@@ -6721,7 +6721,7 @@ pub(crate) fn get_quote(cmd_str: &wstr, len: usize) -> Option<char> {
         } else if cmd[i] == '\'' || cmd[i] == '"' {
             match quote_end(cmd_str, i, cmd[i]) {
                 Some(end) => {
-                    if end > len {
+                    if end >= len {
                         return Some(cmd[i]);
                     }
                     i = end + 1;
@@ -7455,6 +7455,39 @@ mod tests {
 
         // See #6130
         validate!(": (:^ ''", "", CompleteFlags::default(), false, ": (: ^''");
+
+        // Completion inside quotes should not escape
+        validate!(
+            "'fo^o'",
+            "bar baz",
+            CompleteFlags::NO_SPACE,
+            false,
+            "'fobar baz^o'"
+        );
+
+        // Regression test for the case where the cursor is just before the closing quote (#12981)
+        validate!(
+            "'foo^'",
+            "bar baz",
+            CompleteFlags::NO_SPACE,
+            false,
+            "'foobar baz^'"
+        );
+        validate!(
+            "\"foo^\"",
+            "bar baz",
+            CompleteFlags::NO_SPACE,
+            false,
+            "\"foobar baz^\""
+        );
+        // And a test for off-by-one in the other direction so we don't regress that way
+        validate!(
+            "'foo'^",
+            "bar baz",
+            CompleteFlags::NO_SPACE,
+            true,
+            "'foo'bar\\ baz^"
+        );
     }
 
     #[test]


### PR DESCRIPTION
When working with `rsync`, I noticed that if there's a remote file with, say, a space in the name, and I type `rsync 'host:beforespace'` and then press tab while the cursor is just before the closing `'`, it gets auto-completed to `rsync 'host:beforespace\\ afterspace'`. This is doubly-incorrect. First, escaping isn't needed since the argument is already in single quotes. And second, even if it was to be escaped, it should be a single `\`, not a double. The latter is https://github.com/fish-shell/fish-shell/pull/12984, so is now already fixed, but the former is still a bug.

`get_quote()` takes a cursor offset, which names the gap *before* the character at that index. A quoted region that ends at index `end` still contains the cursor when the index equals `end`, but we had an off-by-one error there, so that case would consider the insertion site as _not_ in a quoted region and so (incorrectly) inject escaped text.

## TODOs:
<!-- Check off what what has been done so far. -->
- [ ] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [x] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->

Let me know if you want this to go in `CHANGELOG.rst`!