### PR TITLE
rsync completions: handle rsync version suffix

### DIFF
--- a/share/completions/rsync.fish
+++ b/share/completions/rsync.fish
@@ -183,12 +183,14 @@ complete -c rsync -d Hostname -a "
 # ... (and then a ton of lines about capabilities)
 #
 # This includes multiple spaces, the version might start with "v" depending on whether it's
-# built from a git tag or not...
+# built from a git tag or not, and it may contain a pre-release suffix or a trailing git
+# commit to it. For example, on Arch at the time of writing the version line is:
+# rsync  version 3.5.0-g471e17dc  protocol version 32
 
 set -l new_escaping # has an element if the new escaping style introduced in 3.2.4 is required
 
 set -l rsync_ver (rsync --version |
-                  string replace -rf '^rsync +version\D+([\d.]+) .*' '$1' |
+                  string replace -rf '^rsync +version\D+([\d.]+).*' '$1' |
                   string split .)
 
 if test "$rsync_ver[1]" -gt 3 2>/dev/null


### PR DESCRIPTION
Currently, the Arch version string for `rsync` is:

    rsync  version 3.5.0-g471e17dc  protocol version 32

This fails to parse under the current version regex, and so fish assumes we're running an older rsync version and incorrectly falls back to the older escaping behavior.

This fixes that by no longer requiring there to be a space immediately after the version number. I considered `[ -]`, but that doesn't work for rsync pre-releases (like `3.6.9pre1`), so just removed the ` ` instead.

I think there's a decent argument that we should change the fallback so that if the version cannot be detected correctly we should assume that it's a _new_ rsync, not an old one, but decided to keep the diff small.

Related to #12981.



## TODOs:
<!-- Check off what what has been done so far. -->
- [ ] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->
