### PR TITLE
completions/passwd: fix typo

### DIFF
--- a/share/completions/passwd.fish
+++ b/share/completions/passwd.fish
@@ -22,7 +22,7 @@ if passwd --help >/dev/null 2>&1
     complete -c passwd -s S -l status -f -d "Display account status"
     complete -c passwd -s u -l unlock -f -d "Unlock password"
     complete -c passwd -s w -l warndays -x -d "Define warning period before mandatory password change"
-    complete -c passwd -s w -l warndays -x -d "Define maximum period of password validity"
+    complete -c passwd -s x -l maxdays -x -d "Define maximum period of password validity"
     complete -c passwd -n '__fish_not_contain_opt -s A all' -f -a '(__fish_complete_users)' -d "Account to be altered"
 else # Not Linux, so let's see what it is, with the ugly uname
     set -l os_type (uname)


### PR DESCRIPTION

## TODOs:
<!-- Check off what what has been done so far. -->
- [ ] If addressing an issue, a commit message mentions `Fixes issue #<issue-number>`
- [ ] Changes to fish usage are reflected in user documentation/manpages.
- [ ] Tests have been added for regressions fixed
- [ ] User-visible changes noted in CHANGELOG.rst <!-- Usually skipped for changes to completions -->

---

## Side note:

Shadow removed the --mindays option in 4.20.0, but since plenty of systems still run older versions, I've left it as is.

https://github.com/shadow-maint/shadow/pull/1482/changes/1e77d4f1de696f130b741db40d25178e3db0a5e0

Should I go ahead and remove them here as well?
