### PR TITLE
setenv: return 0 on success

### DIFF
--- a/share/functions/setenv.fish
+++ b/share/functions/setenv.fish
@@ -42,4 +42,8 @@ function setenv
     else
         set -gx $var $val
     end
+
+    # contains leaves its exit status (1 for a non-path var) as the command status, and
+    # set does not touch it, so a successful setenv would otherwise report failure.
+    return 0
 end

--- a/tests/checks/setenv.fish
+++ b/tests/checks/setenv.fish
@@ -26,3 +26,9 @@ setenv var hello you
 setenv setenv3 'hello you'
 setenv | grep '^setenv3=hello you'
 # CHECK: setenv3=hello you
+
+# A successful setenv should exit 0, including for a non-path var where the
+# contains check alone would leave the status at 1.
+setenv setenv4 some_value
+echo $status
+# CHECK: 0


### PR DESCRIPTION
## Problem

`setenv x y; echo $status` prints `1` even though the command succeeded.

## Root cause

`contains` leaves its exit status (1 when the var is not PATH/CDPATH/MANPATH) as the command status, and `set` does not touch it. So every successful `setenv` for a non-path variable returns exit status 1.

## Fix

Add an explicit `return 0` after the `contains` block, and a littlecheck regression test.

## Verification

- `setenv x y; echo $status` now prints `0`
- `setenv PATH /usr/bin; echo $status` unchanged (0)
- Error paths (too many args, invalid name) unchanged (1)